### PR TITLE
feat(library): QOL power tools — sort, scroll, keyboard nav, decade filter, discography

### DIFF
--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -639,6 +639,40 @@ export interface AudioDspFeatures {
 	analysis_version: string;
 }
 
+export interface AudioSearchResult {
+	id: number;
+	title: string;
+	artist_name: string | null;
+	album_title: string | null;
+	artwork_url: string | null;
+	duration_ms: number | null;
+	bpm: number | null;
+	energy: number | null;
+	danceability: number | null;
+	key_signature: string | null;
+	camelot_key: string | null;
+	play_count: number;
+	is_favorite: boolean;
+	tidal_id: number | null;
+	source: string;
+}
+
+export interface AudioSearchParams {
+	free_text?: string;
+	bpm_min?: number | null;
+	bpm_max?: number | null;
+	energy_min?: number | null;
+	energy_max?: number | null;
+	danceability_min?: number | null;
+	danceability_max?: number | null;
+	key_signature?: string | null;
+	camelot_key?: string | null;
+	year_min?: number | null;
+	year_max?: number | null;
+	genre_ids?: number[];
+	is_instrumental?: boolean | null;
+}
+
 export interface AudioFeaturesStats {
 	total_analyzed: number;
 	avg_bpm: number | null;
@@ -997,6 +1031,18 @@ export const api = {
 
 	search(query: string, limit = 20) {
 		return fetchApi<SearchResults>('/api/search', { q: query, limit: String(limit) });
+	},
+
+	searchAudio(params: AudioSearchParams) {
+		// Strip null/undefined fields before sending
+		const body: Record<string, unknown> = {};
+		for (const [k, v] of Object.entries(params)) {
+			if (v !== null && v !== undefined) body[k] = v;
+		}
+		return fetchApi<{ tracks: AudioSearchResult[] }>('/api/search/audio', undefined, {
+			method: 'POST',
+			body: JSON.stringify(body),
+		});
 	},
 
 	getStatus() {

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -823,6 +823,14 @@ export const api = {
 		);
 	},
 
+	importTidalAlbum(tidalAlbumId: number) {
+		return fetchApi<{ album_id: number; tracks: { tidal_id: number; local_id: number }[] }>(
+			`/api/tidal/albums/${tidalAlbumId}/import`,
+			undefined,
+			{ method: 'POST' }
+		);
+	},
+
 	getGenres() {
 		return fetchApi<{ genres: Genre[] }>('/api/genres');
 	},

--- a/frontend/src/lib/components/CommandPalette.svelte
+++ b/frontend/src/lib/components/CommandPalette.svelte
@@ -1,0 +1,341 @@
+<script lang="ts">
+	import { fly, fade } from 'svelte/transition';
+	import { quintOut } from 'svelte/easing';
+	import { goto } from '$app/navigation';
+	import { api, type TidalSearchTrack, type TidalSearchAlbum, type TidalSearchArtist } from '$lib/api/client';
+	import { commandPaletteOpen } from '$lib/stores/command_palette';
+	import { playTidalTrackNow } from '$lib/stores/player';
+	import { matchCommands, parseSlashInput, type SlashCommand } from '$lib/search/commands';
+
+	let inputEl = $state<HTMLInputElement | null>(null);
+	let query = $state('');
+	let loading = $state(false);
+	let tracks = $state<TidalSearchTrack[]>([]);
+	let albums = $state<TidalSearchAlbum[]>([]);
+	let artists = $state<TidalSearchArtist[]>([]);
+	let cursor = $state(0);
+	let debounceTimer: ReturnType<typeof setTimeout>;
+
+	const isSlashMode = $derived(query.startsWith('/'));
+	const slashMatches = $derived(isSlashMode ? matchCommands(query) : []);
+
+	// Total navigable items count (for cursor wrapping)
+	const totalItems = $derived(
+		isSlashMode ? slashMatches.length : tracks.length + albums.length + artists.length
+	);
+
+	$effect(() => {
+		if ($commandPaletteOpen) {
+			// focus input on next tick
+			setTimeout(() => inputEl?.focus(), 10);
+			query = '';
+			tracks = [];
+			albums = [];
+			artists = [];
+			cursor = 0;
+		}
+	});
+
+	function close() {
+		commandPaletteOpen.set(false);
+	}
+
+	function onInput() {
+		clearTimeout(debounceTimer);
+		cursor = 0;
+		if (!query.trim() || isSlashMode) {
+			tracks = [];
+			albums = [];
+			artists = [];
+			loading = false;
+			return;
+		}
+		loading = true;
+		debounceTimer = setTimeout(async () => {
+			try {
+				const res = await api.searchTidal(query.trim());
+				tracks = res.tracks.slice(0, 5);
+				albums = res.albums.slice(0, 3);
+				artists = res.artists.slice(0, 3);
+			} catch { /* silent */ } finally {
+				loading = false;
+			}
+		}, 220);
+	}
+
+	async function selectTrack(track: TidalSearchTrack) {
+		close();
+		await playTidalTrackNow({ ...track, artist_tidal_id: track.artist_id ?? null });
+	}
+
+	function selectAlbum(album: TidalSearchAlbum) {
+		close();
+		goto(album.local_id ? `/albums/${album.local_id}` : `/tidal/albums/${album.tidal_id}`);
+	}
+
+	function selectArtist(artist: TidalSearchArtist) {
+		close();
+		goto(artist.local_id ? `/artists/${artist.local_id}` : `/tidal/artists/${artist.tidal_id}`);
+	}
+
+	async function executeSlashCommand() {
+		const { command, arg } = parseSlashInput(query);
+		if (!command) return;
+		close();
+		await command.execute(arg);
+	}
+
+	function onKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') { e.preventDefault(); close(); return; }
+		if (e.key === 'ArrowDown') { e.preventDefault(); cursor = (cursor + 1) % Math.max(totalItems, 1); return; }
+		if (e.key === 'ArrowUp') { e.preventDefault(); cursor = (cursor - 1 + Math.max(totalItems, 1)) % Math.max(totalItems, 1); return; }
+		if (e.key === 'Enter') {
+			e.preventDefault();
+			if (isSlashMode) {
+				if (slashMatches.length > 0) {
+					const cmd = slashMatches[cursor] ?? slashMatches[0];
+					// If user typed full command + space + arg, execute immediately
+					const { command: parsed } = parseSlashInput(query);
+					if (parsed) { void executeSlashCommand(); }
+					else {
+						// Autocomplete to the command
+						query = `/${cmd.prefix} `;
+					}
+				}
+				return;
+			}
+			// Normal search mode: activate cursor item
+			const allItems = [...artists, ...albums, ...tracks];
+			const item = allItems[cursor];
+			if (!item) return;
+			if ('name' in item) selectArtist(item as TidalSearchArtist);
+			else if (!('duration_ms' in item)) selectAlbum(item as TidalSearchAlbum);
+			else void selectTrack(item as TidalSearchTrack);
+		}
+	}
+</script>
+
+{#if $commandPaletteOpen}
+	<!-- svelte-ignore a11y_click_events_have_key_events -->
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
+	<div class="palette-backdrop" onclick={close} transition:fade={{ duration: 140 }}></div>
+
+	<div
+		class="palette-panel"
+		role="dialog"
+		aria-modal="true"
+		aria-label="Command palette"
+		transition:fly={{ y: -12, duration: 180, easing: quintOut }}
+	>
+		<div class="palette-input-wrap">
+			<span class="palette-icon">{isSlashMode ? '/' : '⌘'}</span>
+			<input
+				bind:this={inputEl}
+				bind:value={query}
+				oninput={onInput}
+				onkeydown={onKeydown}
+				class="palette-input"
+				placeholder={isSlashMode ? 'Type a command…' : 'Search or type / for commands'}
+				autocomplete="off"
+				spellcheck={false}
+			/>
+			{#if loading}<span class="palette-spinner">⟳</span>{/if}
+		</div>
+
+		{#if isSlashMode && slashMatches.length > 0}
+			<ul class="palette-list">
+				{#each slashMatches as cmd, i (cmd.prefix)}
+					<li>
+						<button
+							class="palette-row"
+							class:palette-row--active={cursor === i}
+							onclick={() => { query = `/${cmd.prefix} `; inputEl?.focus(); }}
+						>
+							<span class="cmd-prefix">/{cmd.prefix}</span>
+							{#if cmd.args}<span class="cmd-args">{cmd.args}</span>{/if}
+							<span class="cmd-desc">{cmd.description}</span>
+						</button>
+					</li>
+				{/each}
+			</ul>
+		{:else if !isSlashMode && (tracks.length > 0 || albums.length > 0 || artists.length > 0)}
+			<ul class="palette-list">
+				{#each artists as artist, i (artist.tidal_id)}
+					<li>
+						<button
+							class="palette-row"
+							class:palette-row--active={cursor === i}
+							onclick={() => selectArtist(artist)}
+						>
+							{#if artist.artwork_url}
+								<div class="row-art row-art--circle" style="background-image:url('{artist.artwork_url}')"></div>
+							{:else}
+								<div class="row-art row-art--circle row-art--fallback">♪</div>
+							{/if}
+							<span class="row-title">{artist.name}</span>
+							<span class="row-kind">Artist</span>
+							{#if artist.in_library}<span class="row-lib">✓</span>{/if}
+						</button>
+					</li>
+				{/each}
+				{#each albums as album, i (album.tidal_id)}
+					<li>
+						<button
+							class="palette-row"
+							class:palette-row--active={cursor === artists.length + i}
+							onclick={() => selectAlbum(album)}
+						>
+							{#if album.artwork_url}
+								<div class="row-art" style="background-image:url('{album.artwork_url}')"></div>
+							{:else}
+								<div class="row-art row-art--fallback">♫</div>
+							{/if}
+							<span class="row-title">{album.title}</span>
+							<span class="row-kind">Album</span>
+							{#if album.in_library}<span class="row-lib">✓</span>{/if}
+						</button>
+					</li>
+				{/each}
+				{#each tracks as track, i (track.tidal_id)}
+					<li>
+						<button
+							class="palette-row"
+							class:palette-row--active={cursor === artists.length + albums.length + i}
+							onclick={() => void selectTrack(track)}
+						>
+							{#if track.artwork_url}
+								<div class="row-art" style="background-image:url('{track.artwork_url}')"></div>
+							{:else}
+								<div class="row-art row-art--fallback">♫</div>
+							{/if}
+							<div class="row-meta">
+								<span class="row-title">{track.title}</span>
+								{#if track.artist_name}<span class="row-sub">{track.artist_name}</span>{/if}
+							</div>
+							<span class="row-kind">Track</span>
+							{#if track.in_library}<span class="row-lib">✓</span>{/if}
+						</button>
+					</li>
+				{/each}
+			</ul>
+		{:else if query.trim() && !loading && !isSlashMode}
+			<p class="palette-empty">No results</p>
+		{:else if !query.trim()}
+			<p class="palette-hint">Search Tidal or type <kbd>/</kbd> for commands</p>
+		{/if}
+	</div>
+{/if}
+
+<style>
+	.palette-backdrop {
+		position: fixed;
+		inset: 0;
+		background: rgba(0,0,0,0.45);
+		z-index: 1400;
+	}
+	.palette-panel {
+		position: fixed;
+		top: 18vh;
+		left: 50%;
+		transform: translateX(-50%);
+		width: min(600px, calc(100vw - 32px));
+		background: var(--bg-elevated);
+		border: 1px solid var(--border-strong);
+		border-radius: 14px;
+		box-shadow: 0 32px 64px -16px rgba(0,0,0,0.7);
+		z-index: 1401;
+		overflow: hidden;
+	}
+	.palette-input-wrap {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		padding: 14px 18px;
+		border-bottom: 1px solid var(--border-subtle);
+	}
+	.palette-icon {
+		color: var(--text-muted);
+		font-size: 16px;
+		flex-shrink: 0;
+		width: 16px;
+		text-align: center;
+	}
+	.palette-input {
+		flex: 1;
+		background: none;
+		border: none;
+		outline: none;
+		font-size: 15px;
+		color: var(--text-primary);
+		font-family: inherit;
+	}
+	.palette-input::placeholder { color: var(--text-muted); }
+	.palette-spinner {
+		color: var(--text-muted);
+		font-size: 14px;
+		animation: spin 0.8s linear infinite;
+	}
+	@keyframes spin { to { transform: rotate(360deg); } }
+	.palette-list {
+		list-style: none;
+		padding: 6px 0;
+		margin: 0;
+		max-height: 400px;
+		overflow-y: auto;
+	}
+	.palette-row {
+		width: 100%;
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		padding: 8px 18px;
+		background: none;
+		border: none;
+		color: var(--text-primary);
+		font-family: inherit;
+		font-size: 13px;
+		cursor: pointer;
+		text-align: left;
+	}
+	.palette-row:hover, .palette-row--active {
+		background: var(--bg-hover);
+	}
+	.row-art {
+		width: 32px; height: 32px;
+		border-radius: 4px;
+		background: var(--bg-raised);
+		background-size: cover;
+		background-position: center;
+		flex-shrink: 0;
+	}
+	.row-art--circle { border-radius: 50%; }
+	.row-art--fallback {
+		display: grid;
+		place-items: center;
+		font-size: 14px;
+		color: var(--text-muted);
+	}
+	.row-meta { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
+	.row-title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; min-width: 0; }
+	.row-sub { font-size: 11px; color: var(--text-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+	.row-kind { font-size: 10px; color: var(--text-muted); margin-left: auto; flex-shrink: 0; }
+	.row-lib { font-size: 10px; color: var(--accent); flex-shrink: 0; }
+	.cmd-prefix { font-weight: 600; color: var(--accent); font-family: monospace; flex-shrink: 0; }
+	.cmd-args { font-size: 11px; color: var(--text-muted); font-family: monospace; flex-shrink: 0; }
+	.cmd-desc { color: var(--text-secondary); margin-left: auto; font-size: 12px; }
+	.palette-empty, .palette-hint {
+		padding: 20px 18px;
+		color: var(--text-muted);
+		font-size: 13px;
+		margin: 0;
+	}
+	kbd {
+		background: var(--bg-raised);
+		border: 1px solid var(--border-subtle);
+		border-radius: 4px;
+		padding: 1px 5px;
+		font-size: 11px;
+		font-family: monospace;
+		color: var(--text-secondary);
+	}
+</style>

--- a/frontend/src/lib/search/commands.ts
+++ b/frontend/src/lib/search/commands.ts
@@ -1,0 +1,112 @@
+import { goto } from '$app/navigation';
+import { get } from 'svelte/store';
+import { currentTrack } from '$lib/stores/player';
+import { api } from '$lib/api/client';
+
+export interface SlashCommand {
+	prefix: string;         // e.g. 'play', 'queue', 'radio', 'jump'
+	description: string;    // shown in suggestions
+	args?: string;          // optional hint, e.g. '<query>' or 'on|off'
+	// execute receives the rest of the input after the command word (trimmed)
+	execute: (arg: string) => Promise<void> | void;
+}
+
+export const SLASH_COMMANDS: SlashCommand[] = [
+	{
+		prefix: 'play',
+		description: 'Play first search result',
+		args: '<query>',
+		execute: async (arg) => {
+			if (!arg) return;
+			try {
+				const res = await api.searchTidal(arg);
+				const first = res.tracks[0];
+				if (first) {
+					const { playTidalTrackNow } = await import('$lib/stores/player');
+					await playTidalTrackNow({ ...first, artist_tidal_id: first.artist_id ?? null });
+				}
+			} catch { /* silent */ }
+		},
+	},
+	{
+		prefix: 'queue',
+		description: 'Add first result to queue',
+		args: '<query>',
+		execute: async (arg) => {
+			if (!arg) return;
+			try {
+				const res = await api.searchTidal(arg);
+				const first = res.tracks[0];
+				if (first) {
+					const { addTidalTrackToQueue } = await import('$lib/stores/player');
+					await addTidalTrackToQueue({ ...first, artist_tidal_id: first.artist_id ?? null });
+				}
+			} catch { /* silent */ }
+		},
+	},
+	{
+		prefix: 'radio',
+		description: 'Start radio from current or query',
+		args: '[query]',
+		execute: async (arg) => {
+			if (arg) {
+				try {
+					const res = await api.searchTidal(arg);
+					const first = res.tracks[0];
+					if (first) {
+						const { startTidalSongRadio } = await import('$lib/stores/player');
+						await startTidalSongRadio({ ...first, artist_tidal_id: first.artist_id ?? null });
+					}
+				} catch { /* silent */ }
+			} else {
+				const track = get(currentTrack);
+				if (track && track.id > 0) {
+					const { startSongRadio } = await import('$lib/stores/player');
+					await startSongRadio(track.id);
+				} else if (track?.tidal_id) {
+					const { startTidalSongRadio } = await import('$lib/stores/player');
+					await startTidalSongRadio({
+						tidal_id: track.tidal_id,
+						title: track.title,
+						artist_name: track.artist_name,
+						album_title: track.album_title,
+						artwork_url: track.artwork_url,
+						duration_ms: track.duration_ms,
+					});
+				}
+			}
+		},
+	},
+	{
+		prefix: 'jump',
+		description: 'Navigate to a page',
+		args: 'library|genres|playlists|discover|settings|search',
+		execute: (arg) => { if (arg) goto(`/${arg}`); },
+	},
+	{
+		prefix: 'automix',
+		description: 'Toggle automix',
+		args: 'on|off',
+		execute: async (arg) => {
+			const enabled = arg === 'on';
+			const { setPlayerAutomixEnabled } = await import('$lib/stores/player');
+			await setPlayerAutomixEnabled(enabled);
+		},
+	},
+];
+
+export function matchCommands(input: string): SlashCommand[] {
+	if (!input.startsWith('/')) return [];
+	const typed = input.slice(1).toLowerCase();
+	return SLASH_COMMANDS.filter(
+		(c) => c.prefix.startsWith(typed) || (typed.includes(' ') && c.prefix === typed.split(' ')[0])
+	);
+}
+
+export function parseSlashInput(input: string): { command: SlashCommand | null; arg: string } {
+	const parts = input.slice(1).split(/\s+/);
+	const prefix = parts[0]?.toLowerCase() ?? '';
+	const arg = parts.slice(1).join(' ').trim();
+	const command = SLASH_COMMANDS.find((c) => c.prefix === prefix) ?? null;
+	return { command, arg };
+}

--- a/frontend/src/lib/search/query_parser.ts
+++ b/frontend/src/lib/search/query_parser.ts
@@ -1,10 +1,3 @@
-/**
- * Query Parser for NOORwave Search
- *
- * Parses free-text search strings into structured tokens, separating human-readable
- * text from special filter tokens. Supports a power filter syntax for precise queries.
- */
-
 export type FilterValue =
   | { type: 'exact'; value: string }
   | { type: 'range'; min: number; max: number }
@@ -16,7 +9,6 @@ export interface ParsedQuery {
   filters: Record<string, FilterValue>;
 }
 
-// Supported filter keys for power search
 const SUPPORTED_KEYS = new Set([
   'bpm',
   'key',
@@ -33,17 +25,6 @@ const SUPPORTED_KEYS = new Set([
   'vocal'
 ]);
 
-/**
- * Parse a free-text search string into filters and remaining text
- *
- * Syntax rules:
- * - key:value → exact filter
- * - key:min-max → range filter (if both sides are numeric)
- * - key>value / key<value / key>=value / key<=value → comparison filters
- * - key:a|b|c → multi-value filter
- *
- * Unrecognized tokens are kept as free_text.
- */
 export function parseQuery(input: string): ParsedQuery {
   const tokens = input.trim().split(/\s+/).filter(t => t.length > 0);
   const filters: Record<string, FilterValue> = {};
@@ -65,10 +46,6 @@ export function parseQuery(input: string): ParsedQuery {
   };
 }
 
-/**
- * Attempt to parse a single token as a filter
- * Returns { key, value } if successful, null otherwise
- */
 function parseToken(
   token: string
 ): { key: string; value: FilterValue } | null {
@@ -133,10 +110,6 @@ function parseToken(
   return null;
 }
 
-/**
- * Convert filters to display chips for UI
- * Each filter becomes a readable string representation
- */
 export function filtersToChips(
   filters: Record<string, FilterValue>
 ): Array<{ key: string; display: string }> {

--- a/frontend/src/lib/stores/command_palette.ts
+++ b/frontend/src/lib/stores/command_palette.ts
@@ -1,0 +1,2 @@
+import { writable } from 'svelte/store';
+export const commandPaletteOpen = writable(false);

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -6,6 +6,7 @@
 	import StateBadge from '$lib/components/ui/StateBadge.svelte';
 	import {
 		currentTrack,
+		currentStreamDisplay,
 		isPlaying,
 		position,
 		volume,
@@ -35,6 +36,8 @@
 	import { api, getStoredToken, setStoredToken, clearStoredToken } from '$lib/api/client';
 	import ContextMenu from '$lib/components/ContextMenu.svelte';
 	import Toast from '$lib/components/Toast.svelte';
+	import CommandPalette from '$lib/components/CommandPalette.svelte';
+	import { commandPaletteOpen } from '$lib/stores/command_palette';
 	import { openContextMenu, openMenuAtElement } from '$lib/stores/context_menu';
 	import { buildTrackMenu } from '$lib/player/track_menu';
 	import ShaderWallpaper from '$lib/components/wallpaper/ShaderWallpaper.svelte';
@@ -202,6 +205,12 @@
 	}
 
 	function handleGlobalKeydown(event: KeyboardEvent) {
+		// Cmd/Ctrl+K → open command palette
+		if ((event.ctrlKey || event.metaKey) && event.key === 'k') {
+			event.preventDefault();
+			commandPaletteOpen.update(v => !v);
+			return;
+		}
 		if (event.ctrlKey || event.metaKey || event.altKey) return;
 		if (isTypingTarget(event.target)) return;
 
@@ -331,6 +340,17 @@
 		if (q === 'HIGH') return 'High';
 		if (q === 'LOW') return 'Low';
 		return q.replaceAll('_', ' ');
+	}
+
+	function formatStreamDetail(stream: { sample_rate: number | null; bit_depth: number | null } | null): string {
+		if (!stream) return '';
+		const parts: string[] = [];
+		if (stream.sample_rate) {
+			const khz = stream.sample_rate / 1000;
+			parts.push(Number.isInteger(khz) ? `${khz} kHz` : `${khz.toFixed(1)} kHz`);
+		}
+		if (stream.bit_depth) parts.push(`${stream.bit_depth}-bit`);
+		return parts.join(' · ');
 	}
 
 	function formatQueueSource(source: string): string {
@@ -525,6 +545,7 @@
 
 <ContextMenu />
 <Toast />
+<CommandPalette />
 
 <div class="app-shell" class:mobile-player-active={mobilePlayerVisible} class:has-wallpaper={$wallpaper !== 'none'}>
 	<header class="mobile-top-bar">
@@ -618,7 +639,11 @@
 					{/if}
 				{/key}
 
-				{#if $currentTrack?.best_quality}
+				{#if $currentStreamDisplay}
+					<span class={`quality-badge np-quality ${getQualityClass($currentStreamDisplay.audio_quality)}`}>
+						{formatQuality($currentStreamDisplay.audio_quality)}
+					</span>
+				{:else if $currentTrack?.best_quality}
 					<span class={`quality-badge np-quality ${getQualityClass($currentTrack.best_quality)}`}>
 						{formatQuality($currentTrack.best_quality)}
 					</span>
@@ -646,6 +671,9 @@
 						</a>
 					{:else}
 						<p class="np-album">{$currentTrack?.album_title ?? 'Playback controls stay docked here.'}</p>
+					{/if}
+					{#if formatStreamDetail($currentStreamDisplay)}
+						<p class="np-stream-detail">{formatStreamDetail($currentStreamDisplay)}</p>
 					{/if}
 				</div>
 
@@ -1002,7 +1030,11 @@
 						<div class="mobile-np-art placeholder">♫</div>
 					{/if}
 				{/key}
-				{#if $currentTrack.best_quality}
+				{#if $currentStreamDisplay}
+					<span class={`quality-badge mobile-np-quality ${getQualityClass($currentStreamDisplay.audio_quality)}`}>
+						{formatQuality($currentStreamDisplay.audio_quality)}
+					</span>
+				{:else if $currentTrack.best_quality}
 					<span class={`quality-badge mobile-np-quality ${getQualityClass($currentTrack.best_quality)}`}>
 						{formatQuality($currentTrack.best_quality)}
 					</span>
@@ -1531,6 +1563,15 @@
 	.np-album {
 		color: var(--text-secondary);
 		font-size: 0.8rem;
+	}
+
+	.np-stream-detail {
+		font-size: 0.7rem;
+		color: var(--text-secondary);
+		opacity: 0.6;
+		font-variant-numeric: tabular-nums;
+		letter-spacing: 0.02em;
+		margin-top: 0.1rem;
 	}
 
 	a.np-link {

--- a/frontend/src/routes/library/+page.svelte
+++ b/frontend/src/routes/library/+page.svelte
@@ -46,6 +46,9 @@
 	// Keyboard cursor for track list
 	let cursorIndex = $state(-1);
 
+	// Decade filter for albums tab
+	let activeDecade = $state<number | null>(null);
+
 	// Track detail panel
 	let expandedTrackId = $state<number | null>(null);
 	let detailTrack = $state<Track | null>(null);
@@ -582,7 +585,18 @@
 	);
 	let isSearchMode = $derived(Boolean($searchQuery.trim()));
 	let visibleTracks = $derived($searchQuery.trim() ? searchResults.tracks : $tracks);
-	let visibleAlbums = $derived($searchQuery.trim() ? searchResults.albums : $albums);
+	let decadeBuckets = $derived.by(() => {
+		const seen = new Set<number>();
+		for (const a of $albums) {
+			if (a.year != null) seen.add(Math.floor(a.year / 10) * 10);
+		}
+		return [...seen].sort((a, b) => a - b);
+	});
+	let visibleAlbums = $derived.by(() => {
+		const base = $searchQuery.trim() ? searchResults.albums : $albums;
+		if (!activeDecade) return base;
+		return base.filter(a => a.year != null && Math.floor(a.year / 10) * 10 === activeDecade);
+	});
 	let canLoadMore = $derived(
 		!$searchQuery.trim() &&
 		(activeTab === 'tracks' ? $tracks.length < $totalTracks : activeTab === 'albums' ? $albums.length < $totalAlbums : false)
@@ -679,6 +693,11 @@
 		// eslint-disable-next-line @typescript-eslint/no-unused-expressions
 		activeTab; $searchQuery;
 		cursorIndex = -1;
+	})
+
+	// Reset decade filter when leaving albums tab.
+	$effect(() => {
+		if (activeTab !== 'albums') activeDecade = null;
 	})
 
 	// Keep the highlighted track in view as the cursor moves.
@@ -873,6 +892,18 @@
 		<div class="loading"><div class="spinner"></div><span>Loading library…</span></div>
 
 	{:else if activeTab === 'albums'}
+		{#if decadeBuckets.length > 1}
+			<div class="decade-strip">
+				<button class="decade-chip" class:active={activeDecade === null} onclick={() => activeDecade = null}>All</button>
+				{#each decadeBuckets as decade}
+					<button
+						class="decade-chip"
+						class:active={activeDecade === decade}
+						onclick={() => activeDecade = activeDecade === decade ? null : decade}
+					>{decade}s</button>
+				{/each}
+			</div>
+		{/if}
 		<!-- Album Grid -->
 		<div class="album-grid" class:album-list={$viewMode === 'list'}>
 			{#each visibleAlbums as album (album.id)}
@@ -1565,6 +1596,34 @@
 		color: var(--text-primary);
 		background: rgba(124, 128, 255, 0.12);
 		border-color: rgba(124, 128, 255, 0.22);
+	}
+
+	.decade-strip {
+		display: flex;
+		gap: 6px;
+		flex-wrap: wrap;
+		margin-bottom: 16px;
+	}
+	.decade-chip {
+		padding: 4px 13px;
+		border-radius: 14px;
+		font-size: 11px;
+		font-weight: 600;
+		cursor: pointer;
+		border: 1px solid rgba(255,255,255,0.08);
+		background: transparent;
+		color: var(--text-secondary);
+		font-family: inherit;
+		transition: border-color 0.15s, background 0.15s, color 0.15s;
+	}
+	.decade-chip:hover {
+		border-color: var(--accent-line);
+		color: var(--text-primary);
+	}
+	.decade-chip.active {
+		background: var(--accent);
+		border-color: var(--accent);
+		color: #fff;
 	}
 
 	.library-hero-subtitle {

--- a/frontend/src/routes/library/+page.svelte
+++ b/frontend/src/routes/library/+page.svelte
@@ -11,7 +11,7 @@
 		selectTrackIds, selectAlbumIds, clearSelection,
 	} from '$lib/stores/library';
 	import { api, type Album, type Artist, type Genre, type Playlist, type Track } from '$lib/api/client';
-	import { currentTrack, isPlaying, playTrackNow, addTrackToQueue } from '$lib/stores/player';
+	import { currentTrack, isPlaying, playTrackNow, addTrackToQueue, playTrackNext } from '$lib/stores/player';
 	import SelectionBar from '$lib/components/ui/SelectionBar.svelte';
 	import EmptyState from '$lib/components/ui/EmptyState.svelte';
 
@@ -42,6 +42,9 @@
 	let expandedArtistId = $state<number | null>(null);
 	let artistTracksById = $state<Record<number, Track[]>>({});
 	let artistTracksLoadingId = $state<number | null>(null);
+
+	// Keyboard cursor for track list
+	let cursorIndex = $state(-1);
 
 	// Track detail panel
 	let expandedTrackId = $state<number | null>(null);
@@ -346,6 +349,35 @@
 		runOnActivation(event, () => updateTrackSelection(trackId));
 	}
 
+	function handleTrackListKeydown(event: KeyboardEvent) {
+		if (activeTab !== 'tracks') return;
+		if (event.key === 'ArrowDown') {
+			event.preventDefault();
+			if (visibleTracks.length === 0) return;
+			cursorIndex = cursorIndex < 0 ? 0 : Math.min(cursorIndex + 1, visibleTracks.length - 1);
+			return;
+		}
+		if (event.key === 'ArrowUp') {
+			event.preventDefault();
+			if (visibleTracks.length === 0) return;
+			cursorIndex = cursorIndex <= 0 ? -1 : cursorIndex - 1;
+			return;
+		}
+		if (event.key === 'Enter') {
+			event.preventDefault();
+			const track = cursorIndex >= 0 ? visibleTracks[cursorIndex] : null;
+			if (!track) return;
+			if (event.shiftKey) {
+				void addTrackToQueue(track.id);
+			} else if (event.metaKey || event.ctrlKey) {
+				void playTrackNext(track.id);
+			} else {
+				void playTrackNow(track.id);
+			}
+			return;
+		}
+	}
+
 	function handleAlbumCardKeydown(albumId: number, event: KeyboardEvent) {
 		runOnActivation(event, () => updateAlbumSelection(albumId));
 	}
@@ -639,6 +671,20 @@
 			pendingRestoreScroll = null
 			requestAnimationFrame(() => window.scrollTo({ top: target, behavior: 'auto' }))
 		}
+	})
+
+	// Reset cursor when switching tabs or changing the search query.
+	$effect(() => {
+		// eslint-disable-next-line @typescript-eslint/no-unused-expressions
+		activeTab; $searchQuery;
+		cursorIndex = -1;
+	})
+
+	// Keep the highlighted track in view as the cursor moves.
+	$effect(() => {
+		if (cursorIndex < 0) return;
+		const el = document.querySelector<HTMLElement>(`.track-row[data-cursor-idx="${cursorIndex}"]`);
+		el?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
 	})
 </script>
 
@@ -1003,7 +1049,8 @@
 
 	{:else if activeTab === 'tracks'}
 		<!-- Track List -->
-		<div class="track-list">
+		<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+		<div class="track-list" role="list" onkeydown={handleTrackListKeydown}>
 			<div class="track-header">
 				<span class="col-num">#</span>
 				<button
@@ -1106,9 +1153,11 @@
 					class="track-row"
 					class:selected={$selectedTrackIds.has(track.id)}
 					class:playing={$currentTrack?.id === track.id}
+					class:cursor={cursorIndex === i}
 					role="button"
 					tabindex="0"
 					aria-pressed={$selectedTrackIds.has(track.id)}
+					data-cursor-idx={i}
 					ondblclick={() => void playTrack(track)}
 					onclick={(event) => handleTrackRowClick(track.id, event)}
 					onkeydown={(event) => handleTrackRowKeydown(track.id, event)}
@@ -2660,6 +2709,11 @@
 
 	.track-row.selected {
 		background: var(--accent-soft);
+	}
+
+	.track-row.cursor {
+		outline: 2px solid rgba(155, 111, 255, 0.7);
+		outline-offset: -2px;
 	}
 
 	.col-actions {

--- a/frontend/src/routes/library/+page.svelte
+++ b/frontend/src/routes/library/+page.svelte
@@ -1005,6 +1005,17 @@
 						Date Added <span class="sort-arrow">{$sortBy === 'date_added' ? ($sortDir === 'asc' ? '↑' : '↓') : '⇅'}</span>
 					</button>
 				{/if}
+				{#if showDateColumn}
+					<button
+						type="button"
+						class="header-sort col-date"
+						class:sorted={$sortBy === 'last_played_at'}
+						onclick={() => handleSort('last_played_at')}
+						onkeydown={(event) => handleSortKeydown('last_played_at', event)}
+					>
+						Last Played <span class="sort-arrow">{$sortBy === 'last_played_at' ? ($sortDir === 'asc' ? '↑' : '↓') : '⇅'}</span>
+					</button>
+				{/if}
 				{#if showBpmColumn}
 					<button
 						type="button"

--- a/frontend/src/routes/library/+page.svelte
+++ b/frontend/src/routes/library/+page.svelte
@@ -614,7 +614,7 @@
 		)
 	})
 
-	let pendingRestoreScroll: number | null = null
+	let pendingRestoreScroll = $state<number | null>(null)
 
 	afterNavigate((nav) => {
 		if (typeof sessionStorage === 'undefined') return
@@ -626,17 +626,18 @@
 			if (typeof saved.activeTab === 'string' && (saved.activeTab === 'tracks' || saved.activeTab === 'albums' || saved.activeTab === 'artists')) {
 				activeTab = saved.activeTab
 				expandedArtistId = saved.expandedArtistId
-				pendingRestoreScroll = saved.scrollY
+				if (typeof saved.scrollY === 'number') pendingRestoreScroll = saved.scrollY
 			}
 		} catch {
 			/* ignore corrupted state */
 		}
 	})
 
-	$effect.pre(() => {
+	$effect(() => {
 		if (pendingRestoreScroll !== null) {
-			window.scrollTo(0, pendingRestoreScroll)
+			const target = pendingRestoreScroll
 			pendingRestoreScroll = null
+			requestAnimationFrame(() => window.scrollTo({ top: target, behavior: 'auto' }))
 		}
 	})
 </script>

--- a/frontend/src/routes/library/+page.svelte
+++ b/frontend/src/routes/library/+page.svelte
@@ -10,7 +10,7 @@
 		lastSelectedTrackId, lastSelectedAlbumId,
 		selectTrackIds, selectAlbumIds, clearSelection,
 	} from '$lib/stores/library';
-	import { api, type Album, type Artist, type Genre, type Playlist, type Track } from '$lib/api/client';
+	import { api, type Album, type Artist, type Genre, type Playlist, type Track, type TidalDiscographyAlbum } from '$lib/api/client';
 	import { currentTrack, isPlaying, playTrackNow, addTrackToQueue, playTrackNext } from '$lib/stores/player';
 	import SelectionBar from '$lib/components/ui/SelectionBar.svelte';
 	import EmptyState from '$lib/components/ui/EmptyState.svelte';
@@ -42,6 +42,9 @@
 	let expandedArtistId = $state<number | null>(null);
 	let artistTracksById = $state<Record<number, Track[]>>({});
 	let artistTracksLoadingId = $state<number | null>(null);
+	let artistDiscographyById = $state<Record<number, TidalDiscographyAlbum[]>>({});
+	let artistDiscographyLoadingId = $state<number | null>(null);
+	let importingAlbumTidalId = $state<number | null>(null);
 
 	// Keyboard cursor for track list
 	let cursorIndex = $state(-1);
@@ -177,16 +180,50 @@
 			return;
 		}
 		expandedArtistId = artist.id;
-		if (artistTracksById[artist.id]) return;
-		artistTracksLoadingId = artist.id;
+		if (!artistTracksById[artist.id]) {
+			artistTracksLoadingId = artist.id;
+			try {
+				const data = await api.getArtistTracks(artist.id);
+				artistTracksById = { ...artistTracksById, [artist.id]: data.tracks };
+			} catch (err) {
+				console.error('Failed to load artist tracks:', err);
+				artistTracksById = { ...artistTracksById, [artist.id]: [] };
+			} finally {
+				artistTracksLoadingId = null;
+			}
+		}
+		if (!artistDiscographyById[artist.id] && artist.tidal_id) {
+			artistDiscographyLoadingId = artist.id;
+			try {
+				const data = await api.getArtistDiscography(artist.id);
+				if (data.available) {
+					artistDiscographyById = { ...artistDiscographyById, [artist.id]: data.albums };
+				}
+			} catch {
+				// Discography is best-effort; don't show an error
+			} finally {
+				artistDiscographyLoadingId = null;
+			}
+		}
+	}
+
+	async function importAlbum(tidalAlbumId: number, artistId: number) {
+		if (importingAlbumTidalId !== null) return;
+		importingAlbumTidalId = tidalAlbumId;
 		try {
-			const data = await api.getArtistTracks(artist.id);
-			artistTracksById = { ...artistTracksById, [artist.id]: data.tracks };
+			await api.importTidalAlbum(tidalAlbumId);
+			// Mark album as in-library in local discography state
+			const albums = artistDiscographyById[artistId];
+			if (albums) {
+				artistDiscographyById = {
+					...artistDiscographyById,
+					[artistId]: albums.map(a => a.tidal_id === tidalAlbumId ? { ...a, in_library: true } : a),
+				};
+			}
 		} catch (err) {
-			console.error('Failed to load artist tracks:', err);
-			artistTracksById = { ...artistTracksById, [artist.id]: [] };
+			console.error('Failed to import album:', err);
 		} finally {
-			artistTracksLoadingId = null;
+			importingAlbumTidalId = null;
 		}
 	}
 
@@ -1039,6 +1076,32 @@
 								<button class="btn btn-glass btn-sm" onclick={() => expandedArtistId = null}>Close</button>
 							</div>
 						</div>
+
+						{#if (artistDiscographyById[expandedArtist.id]?.filter(a => !a.in_library).length ?? 0) > 0}
+							<div class="artist-discography-section">
+								<p class="artist-discography-label">Also on Tidal</p>
+								<div class="artist-discography-row">
+									{#each artistDiscographyById[expandedArtist.id].filter(a => !a.in_library) as album (album.tidal_id)}
+										<div class="discography-card">
+											{#if album.artwork_url}
+												<img class="discography-art" src={album.artwork_url} alt={album.title} loading="lazy" />
+											{:else}
+												<div class="discography-art placeholder">♫</div>
+											{/if}
+											<p class="discography-title">{album.title}</p>
+											{#if album.release_date}
+												<p class="discography-year">{album.release_date.slice(0, 4)}</p>
+											{/if}
+											<button
+												class="btn btn-glass btn-xs"
+												disabled={importingAlbumTidalId === album.tidal_id}
+												onclick={() => void importAlbum(album.tidal_id, expandedArtist.id)}
+											>{importingAlbumTidalId === album.tidal_id ? 'Adding…' : '+ Add'}</button>
+										</div>
+									{/each}
+								</div>
+							</div>
+						{/if}
 
 						{#if artistTracksLoadingId === expandedArtist.id}
 							<p class="artist-panel-loading">Loading tracks…</p>
@@ -3134,6 +3197,63 @@
 		color: var(--text-muted);
 		font-size: 0.85rem;
 		padding: 8px 0;
+	}
+
+	.artist-discography-section {
+		margin-bottom: 16px;
+	}
+	.artist-discography-label {
+		font-size: 10px;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 1.4px;
+		color: var(--accent);
+		margin-bottom: 10px;
+	}
+	.artist-discography-row {
+		display: flex;
+		gap: 12px;
+		overflow-x: auto;
+		padding-bottom: 4px;
+		scrollbar-width: none;
+	}
+	.artist-discography-row::-webkit-scrollbar { display: none; }
+	.discography-card {
+		flex-shrink: 0;
+		width: 96px;
+		text-align: center;
+	}
+	.discography-art {
+		width: 96px;
+		height: 96px;
+		border-radius: 6px;
+		object-fit: cover;
+		margin-bottom: 5px;
+		background: var(--bg-raised);
+	}
+	.discography-art.placeholder {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		font-size: 28px;
+		color: rgba(255,255,255,0.3);
+	}
+	.discography-title {
+		font-size: 10px;
+		color: var(--text-primary);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		margin-bottom: 2px;
+	}
+	.discography-year {
+		font-size: 9px;
+		color: var(--text-muted);
+		margin-bottom: 5px;
+	}
+	.btn-xs {
+		padding: 3px 9px;
+		font-size: 10px;
 	}
 
 	.artist-track-list {

--- a/frontend/src/routes/library/+page.svelte
+++ b/frontend/src/routes/library/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { beforeNavigate, afterNavigate } from '$app/navigation';
 	import {
 		tracks, albums, isLoading, isLoadingMore, totalTracks, totalAlbums,
 		sortBy, sortDir, viewMode, searchQuery,
@@ -595,6 +596,49 @@
 			infiniteObserver = null;
 		};
 	});
+
+	// ─── Position memory ────────────────────────────────────────────────────
+	// Save the active tab + scroll position on navigation away. Restore when the
+	// user returns via browser-back (popstate) so they land where they were.
+	const POS_KEY = 'noor-library-scroll'
+
+	beforeNavigate(() => {
+		if (typeof sessionStorage === 'undefined') return
+		sessionStorage.setItem(
+			POS_KEY,
+			JSON.stringify({
+				activeTab,
+				expandedArtistId,
+				scrollY: window.scrollY
+			})
+		)
+	})
+
+	let pendingRestoreScroll: number | null = null
+
+	afterNavigate((nav) => {
+		if (typeof sessionStorage === 'undefined') return
+		if (nav.type !== 'popstate') return
+		const raw = sessionStorage.getItem(POS_KEY)
+		if (!raw) return
+		try {
+			const saved = JSON.parse(raw) as { activeTab: string; expandedArtistId: number | null; scrollY: number }
+			if (typeof saved.activeTab === 'string' && (saved.activeTab === 'tracks' || saved.activeTab === 'albums' || saved.activeTab === 'artists')) {
+				activeTab = saved.activeTab
+				expandedArtistId = saved.expandedArtistId
+				pendingRestoreScroll = saved.scrollY
+			}
+		} catch {
+			/* ignore corrupted state */
+		}
+	})
+
+	$effect.pre(() => {
+		if (pendingRestoreScroll !== null) {
+			window.scrollTo(0, pendingRestoreScroll)
+			pendingRestoreScroll = null
+		}
+	})
 </script>
 
 <svelte:window onclick={closeMenus} onkeydown={(e) => {

--- a/frontend/src/routes/library/+page.svelte
+++ b/frontend/src/routes/library/+page.svelte
@@ -347,6 +347,7 @@
 
 	function handleTrackRowKeydown(trackId: number, event: KeyboardEvent) {
 		runOnActivation(event, () => updateTrackSelection(trackId));
+		if (event.key === 'Enter' || event.key === ' ') event.stopPropagation();
 	}
 
 	function handleTrackListKeydown(event: KeyboardEvent) {
@@ -2712,8 +2713,8 @@
 	}
 
 	.track-row.cursor {
-		outline: 2px solid rgba(155, 111, 255, 0.7);
-		outline-offset: -2px;
+		background: var(--bg-glass-hover);
+		box-shadow: inset 2px 0 0 var(--accent);
 	}
 
 	.col-actions {

--- a/frontend/src/routes/library/+page.svelte
+++ b/frontend/src/routes/library/+page.svelte
@@ -1109,7 +1109,11 @@
 					{/if}
 					{#if showDateColumn}
 						<span class="col-date">
-							<span class="date-added">{track.date_added ? formatDateShort(track.date_added) : '—'}</span>
+							{#if $sortBy === 'last_played_at'}
+								<span class="last-played">{track.last_played_at ? formatDateShort(track.last_played_at) : '—'}</span>
+							{:else}
+								<span class="date-added">{track.date_added ? formatDateShort(track.date_added) : '—'}</span>
+							{/if}
 						</span>
 					{/if}
 					{#if showBpmColumn}

--- a/frontend/src/routes/search/+page.svelte
+++ b/frontend/src/routes/search/+page.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
+  import { onMount } from 'svelte'
   import { goto, beforeNavigate, afterNavigate } from '$app/navigation'
-  import { api, type TidalSearchResults, type TidalSearchAlbum, type TidalSearchArtist, type TidalSearchTrack } from '$lib/api/client'
+  import { api, type TidalSearchResults, type TidalSearchAlbum, type TidalSearchArtist, type TidalSearchTrack, type AudioSearchResult, type AudioSearchParams, type Genre } from '$lib/api/client'
   import { buildTidalTrackMenu } from '$lib/player/track_menu'
   import { openContextMenu, type MenuItem } from '$lib/stores/context_menu'
-  import { playTidalTrackNow, playTidalAlbum, playTidalTrackNext, addTidalTrackToQueue, startTidalSongRadio } from '$lib/stores/player'
+  import { playTidalTrackNow, playTidalAlbum, playTidalTrackNext, addTidalTrackToQueue, startTidalSongRadio, playTrackNow } from '$lib/stores/player'
   import { formatDuration } from '$lib/stores/library'
+  import { parseQuery, filtersToChips, type ParsedQuery, type FilterValue } from '$lib/search/query_parser'
 
   const RECENT_KEY = 'noor_recent_searches'
   const RECENT_MAX = 8
@@ -35,18 +37,109 @@
 
   let query = $state('')
   let results = $state<TidalSearchResults | null>(null)
+  let audioResults = $state<AudioSearchResult[] | null>(null)
   let loading = $state(false)
   let error = $state<string | null>(null)
   let debounceTimer: ReturnType<typeof setTimeout>
   let recent = $state<string[]>(loadRecent())
+  let genreList = $state<Genre[]>([])
 
   type FilterMode = 'all' | 'artists' | 'albums' | 'tracks' | 'library'
   let filterMode = $state<FilterMode>('all')
+
+  const parsedQuery = $derived(parseQuery(query))
+  const hasFilters = $derived(Object.keys(parsedQuery.filters).length > 0)
+
+  onMount(async () => {
+    try {
+      const res = await api.getGenres()
+      genreList = res.genres
+    } catch { /* ignore */ }
+  })
+
+  function resolveGenreIds(filter: FilterValue, genres: Genre[]): number[] {
+    const slugs = filter.type === 'multi' ? filter.values
+      : filter.type === 'exact' ? [filter.value]
+      : []
+    const found: number[] = []
+    for (const slug of slugs) {
+      const match = genres.find(g => g.slug === slug || g.name.toLowerCase() === slug.toLowerCase())
+      if (match) {
+        found.push(match.id)
+        for (const child of (match.children ?? [])) found.push(child.id)
+      }
+    }
+    return found
+  }
+
+  function buildAudioParams(pq: ParsedQuery): AudioSearchParams {
+    const f = pq.filters
+    const params: AudioSearchParams = {}
+    if (pq.free_text) params.free_text = pq.free_text
+
+    const bpm = f['bpm']
+    if (bpm?.type === 'range') { params.bpm_min = bpm.min; params.bpm_max = bpm.max }
+    if (bpm?.type === 'comparison') {
+      if (bpm.op === '>') params.bpm_min = bpm.value
+      if (bpm.op === '<') params.bpm_max = bpm.value
+      if (bpm.op === '>=') params.bpm_min = bpm.value
+      if (bpm.op === '<=') params.bpm_max = bpm.value
+    }
+    const energy = f['energy']
+    if (energy?.type === 'range') { params.energy_min = energy.min; params.energy_max = energy.max }
+    if (energy?.type === 'comparison') {
+      if (energy.op === '>') params.energy_min = energy.value
+      if (energy.op === '<') params.energy_max = energy.value
+      if (energy.op === '>=') params.energy_min = energy.value
+      if (energy.op === '<=') params.energy_max = energy.value
+    }
+    const dance = f['danceability']
+    if (dance?.type === 'range') { params.danceability_min = dance.min; params.danceability_max = dance.max }
+    if (dance?.type === 'comparison') {
+      if (dance.op === '>') params.danceability_min = dance.value
+      if (dance.op === '<') params.danceability_max = dance.value
+      if (dance.op === '>=') params.danceability_min = dance.value
+      if (dance.op === '<=') params.danceability_max = dance.value
+    }
+    const key = f['key']
+    if (key?.type === 'exact') params.key_signature = key.value
+    const camelot = f['camelot']
+    if (camelot?.type === 'exact') params.camelot_key = camelot.value
+    const year = f['year']
+    if (year?.type === 'range') { params.year_min = year.min; params.year_max = year.max }
+    if (year?.type === 'exact') { params.year_min = parseInt(year.value); params.year_max = parseInt(year.value) }
+    const vocal = f['vocal']
+    if (vocal?.type === 'exact') params.is_instrumental = vocal.value === 'false'
+
+    const genreFilter = f['genre']
+    if (genreFilter) {
+      const ids = resolveGenreIds(genreFilter, genreList)
+      if (ids.length > 0) params.genre_ids = ids
+    }
+
+    return params
+  }
+
+  function removeFilter(key: string) {
+    // Rebuild query string by stripping tokens that start with key: or key>/</>=/<=
+    const tokens = query.trim().split(/\s+/).filter(t => t.length > 0)
+    const filtered = tokens.filter(t => {
+      // match key: or key>/</>=/<= prefix
+      return !t.match(new RegExp(`^${key}(:|>=|<=|>|<)`))
+    })
+    query = filtered.join(' ')
+    onInput()
+  }
+
+  async function playLibraryTrack(track: AudioSearchResult) {
+    await playTrackNow(track.id)
+  }
 
   function onInput() {
     clearTimeout(debounceTimer)
     if (!query.trim()) {
       results = null
+      audioResults = null
       loading = false
       error = null
       return
@@ -55,7 +148,14 @@
     debounceTimer = setTimeout(async () => {
       const q = query.trim()
       try {
-        results = await api.searchTidal(q)
+        if (hasFilters) {
+          const res = await api.searchAudio(buildAudioParams(parsedQuery))
+          audioResults = res.tracks
+          results = null
+        } else {
+          audioResults = null
+          results = await api.searchTidal(q)
+        }
         error = null
         pushRecent(q)
       } catch (e) {
@@ -355,6 +455,17 @@
       <kbd>Shift</kbd>+<kbd>Enter</kbd> queue &nbsp;·&nbsp;
       <kbd>Ctrl</kbd>+<kbd>Enter</kbd> next
     </p>
+    {#if hasFilters}
+      <div class="filter-chips">
+        {#each filtersToChips(parsedQuery.filters) as chip (chip.key)}
+          <button
+            class="filter-chip"
+            onclick={() => removeFilter(chip.key)}
+            title="Remove filter"
+          >{chip.display} <span class="chip-x">×</span></button>
+        {/each}
+      </div>
+    {/if}
     {#if results && query.trim()}
       <div class="filter-pills">
         {#each [
@@ -398,6 +509,54 @@
     <p class="search-hint">No results for "{query}"</p>
   {:else if isFilteredEmpty}
     <p class="search-hint">No {filterMode === 'library' ? 'library' : filterMode} matches for "{query}"</p>
+  {:else if audioResults !== null}
+    <section class="results-section">
+      <h3 class="section-label">Library matches</h3>
+      {#if audioResults.length === 0}
+        <p class="no-audio-results">No library tracks match these filters.</p>
+      {:else}
+        <ul class="tracks-list">
+          {#each audioResults as track (track.id)}
+            <!-- svelte-ignore a11y_no_noninteractive_element_to_interactive_role -->
+            <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+            <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+            <li
+              class="track-row"
+              role="button"
+              tabindex="0"
+              onclick={() => void playLibraryTrack(track)}
+              onkeydown={(e) => e.key === 'Enter' && void playLibraryTrack(track)}
+            >
+              {#if track.artwork_url}
+                <div class="track-art" style={`background-image: url('${track.artwork_url}')`}></div>
+              {:else}
+                <div class="track-art fallback" style={`background: ${letterColor(track.title)}`}>
+                  <span>♫</span>
+                </div>
+              {/if}
+              <div class="track-meta">
+                <p class="track-title">{track.title}</p>
+                <p class="track-subtitle">
+                  {#if track.artist_name}{track.artist_name}{/if}
+                  {#if track.artist_name && track.album_title} — {/if}
+                  {#if track.album_title}{track.album_title}{/if}
+                </p>
+              </div>
+              <span class="track-duration">{formatDuration(track.duration_ms)}</span>
+              <div class="row-actions">
+                <button
+                  class="row-btn"
+                  onclick={(e) => { e.stopPropagation(); void playLibraryTrack(track) }}
+                  title="Play now"
+                  aria-label="Play {track.title}"
+                >▶</button>
+              </div>
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    </section>
+
   {:else if results}
 
     {#if topResult}
@@ -622,6 +781,43 @@
     flex-wrap: wrap;
     align-items: center;
     gap: 2px;
+  }
+  .filter-chips {
+    margin: 10px 0 0;
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+  }
+  .filter-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    background: var(--bg-elevated);
+    border: 1px solid var(--accent-line);
+    color: var(--text-secondary);
+    border-radius: 14px;
+    padding: 4px 12px;
+    font-size: 12px;
+    cursor: pointer;
+    font-family: inherit;
+    transition: background 0.15s, border-color 0.15s, color 0.15s;
+  }
+  .filter-chip:hover {
+    background: var(--bg-hover);
+    border-color: var(--accent);
+    color: var(--text-primary);
+  }
+  .chip-x {
+    font-size: 14px;
+    line-height: 1;
+    color: var(--text-tertiary);
+    margin-left: 2px;
+  }
+  .filter-chip:hover .chip-x { color: var(--text-primary); }
+  .no-audio-results {
+    color: var(--text-muted);
+    font-size: 13px;
+    margin: 0;
   }
   .filter-pills {
     margin: 14px 0 0;

--- a/noor-server/src/db/queries.rs
+++ b/noor-server/src/db/queries.rs
@@ -3548,3 +3548,188 @@ pub fn load_external_seed_from_track(
         normalized_genres: genres,
     }))
 }
+
+// ─── Audio Feature Search ─────────────────────────────────
+
+#[derive(Debug, Default)]
+pub struct AudioFilters {
+    pub bpm_min: Option<f64>,
+    pub bpm_max: Option<f64>,
+    pub energy_min: Option<f64>,
+    pub energy_max: Option<f64>,
+    pub danceability_min: Option<f64>,
+    pub danceability_max: Option<f64>,
+    pub key_signature: Option<String>,   // exact match
+    pub camelot_key: Option<String>,     // exact match
+    pub year_min: Option<i64>,
+    pub year_max: Option<i64>,
+    pub genre_ids: Vec<i64>,             // track must belong to at least one
+    pub track_type: Option<String>,      // placeholder, always "track"
+    pub is_instrumental: Option<bool>,   // true → vocal:false filter
+}
+
+#[derive(Debug, Serialize)]
+pub struct AudioSearchResult {
+    pub id: i64,
+    pub title: String,
+    pub artist_name: Option<String>,
+    pub album_title: Option<String>,
+    pub artwork_url: Option<String>,
+    pub duration_ms: Option<i64>,
+    pub bpm: Option<f64>,
+    pub energy: Option<f64>,
+    pub danceability: Option<f64>,
+    pub key_signature: Option<String>,
+    pub camelot_key: Option<String>,
+    pub play_count: i64,
+    pub is_favorite: bool,
+    pub tidal_id: Option<i64>,
+    pub source: String,
+}
+
+pub fn search_with_audio_filters(
+    conn: &Connection,
+    free_text: &str,
+    filters: &AudioFilters,
+    limit: usize,
+) -> Result<Vec<AudioSearchResult>> {
+    let normalized = free_text.trim().to_ascii_lowercase();
+
+    // Base SELECT — always JOIN audio_dsp_features so filter columns are available
+    let mut sql = String::from(
+        "SELECT t.id, t.title, a.name, al.title, al.artwork_url, t.duration_ms, \
+         d.bpm, d.energy, d.danceability, d.key_signature, d.camelot_key, \
+         t.play_count, t.is_favorite, t.tidal_id, t.source \
+         FROM tracks t \
+         LEFT JOIN audio_dsp_features d ON d.track_id = t.id \
+         LEFT JOIN artists a ON a.id = t.artist_id \
+         LEFT JOIN albums al ON al.id = t.album_id \
+         WHERE 1=1",
+    );
+
+    // Dynamic params: start with positional index 1
+    let mut params: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+    let mut param_idx: usize = 1;
+
+    // Free-text filter
+    if !normalized.is_empty() {
+        let pattern = format!("%{normalized}%");
+        sql.push_str(&format!(
+            " AND (LOWER(t.title) LIKE ?{0} \
+               OR LOWER(COALESCE(a.name, '')) LIKE ?{0} \
+               OR LOWER(COALESCE(al.title, '')) LIKE ?{0})",
+            param_idx
+        ));
+        params.push(Box::new(pattern));
+        param_idx += 1;
+    }
+
+    // BPM range
+    if let Some(v) = filters.bpm_min {
+        sql.push_str(&format!(" AND d.bpm >= ?{param_idx}"));
+        params.push(Box::new(v));
+        param_idx += 1;
+    }
+    if let Some(v) = filters.bpm_max {
+        sql.push_str(&format!(" AND d.bpm <= ?{param_idx}"));
+        params.push(Box::new(v));
+        param_idx += 1;
+    }
+
+    // Energy range
+    if let Some(v) = filters.energy_min {
+        sql.push_str(&format!(" AND d.energy >= ?{param_idx}"));
+        params.push(Box::new(v));
+        param_idx += 1;
+    }
+    if let Some(v) = filters.energy_max {
+        sql.push_str(&format!(" AND d.energy <= ?{param_idx}"));
+        params.push(Box::new(v));
+        param_idx += 1;
+    }
+
+    // Danceability range
+    if let Some(v) = filters.danceability_min {
+        sql.push_str(&format!(" AND d.danceability >= ?{param_idx}"));
+        params.push(Box::new(v));
+        param_idx += 1;
+    }
+    if let Some(v) = filters.danceability_max {
+        sql.push_str(&format!(" AND d.danceability <= ?{param_idx}"));
+        params.push(Box::new(v));
+        param_idx += 1;
+    }
+
+    // Key signature (exact)
+    if let Some(ref v) = filters.key_signature {
+        sql.push_str(&format!(" AND d.key_signature = ?{param_idx}"));
+        params.push(Box::new(v.clone()));
+        param_idx += 1;
+    }
+
+    // Camelot key (exact)
+    if let Some(ref v) = filters.camelot_key {
+        sql.push_str(&format!(" AND d.camelot_key = ?{param_idx}"));
+        params.push(Box::new(v.clone()));
+        param_idx += 1;
+    }
+
+    // Year range (via album)
+    if let Some(v) = filters.year_min {
+        sql.push_str(&format!(" AND al.year >= ?{param_idx}"));
+        params.push(Box::new(v));
+        param_idx += 1;
+    }
+    if let Some(v) = filters.year_max {
+        sql.push_str(&format!(" AND al.year <= ?{param_idx}"));
+        params.push(Box::new(v));
+        param_idx += 1;
+    }
+
+    // Genre filter — inline i64 IDs (safe, not user strings)
+    if !filters.genre_ids.is_empty() {
+        let id_list: Vec<String> = filters.genre_ids.iter().map(|id| id.to_string()).collect();
+        sql.push_str(&format!(
+            " AND t.id IN (SELECT track_id FROM track_genres WHERE genre_id IN ({}))",
+            id_list.join(", ")
+        ));
+    }
+
+    // Instrumental filter
+    if let Some(instrumental) = filters.is_instrumental {
+        sql.push_str(&format!(" AND d.is_instrumental = ?{param_idx}"));
+        params.push(Box::new(if instrumental { 1i64 } else { 0i64 }));
+        param_idx += 1;
+    }
+
+    // Ordering and limit
+    sql.push_str(&format!(
+        " ORDER BY t.play_count DESC, t.last_played_at DESC LIMIT ?{param_idx}"
+    ));
+    params.push(Box::new(limit as i64));
+
+    let mut stmt = conn.prepare(&sql)?;
+    let results = stmt
+        .query_map(params_from_iter(params.iter().map(|p| p.as_ref())), |row| {
+            Ok(AudioSearchResult {
+                id: row.get(0)?,
+                title: row.get(1)?,
+                artist_name: row.get(2)?,
+                album_title: row.get(3)?,
+                artwork_url: row.get(4)?,
+                duration_ms: row.get(5)?,
+                bpm: row.get(6)?,
+                energy: row.get(7)?,
+                danceability: row.get(8)?,
+                key_signature: row.get(9)?,
+                camelot_key: row.get(10)?,
+                play_count: row.get::<_, Option<i64>>(11)?.unwrap_or(0),
+                is_favorite: row.get::<_, i64>(12)? != 0,
+                tidal_id: row.get(13)?,
+                source: row.get(14)?,
+            })
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(results)
+}

--- a/noor-server/src/db/queries.rs
+++ b/noor-server/src/db/queries.rs
@@ -104,6 +104,7 @@ pub fn get_tracks_with_dsp(
         "bpm" => "COALESCE(a.bpm, 0)",
         "energy" => "COALESCE(a.energy, 0)",
         "danceability" => "COALESCE(a.danceability, 0)",
+        "last_played_at" => "t.last_played_at",
         _ => "t.date_added",
     };
     let dir = if sort_dir == "asc" { "ASC" } else { "DESC" };

--- a/noor-server/src/db/queries.rs
+++ b/noor-server/src/db/queries.rs
@@ -104,7 +104,7 @@ pub fn get_tracks_with_dsp(
         "bpm" => "COALESCE(a.bpm, 0)",
         "energy" => "COALESCE(a.energy, 0)",
         "danceability" => "COALESCE(a.danceability, 0)",
-        "last_played_at" => "t.last_played_at",
+        "last_played_at" => "COALESCE(t.last_played_at, '')",
         _ => "t.date_added",
     };
     let dir = if sort_dir == "asc" { "ASC" } else { "DESC" };

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -339,6 +339,7 @@ pub fn api_routes(state: SharedState) -> Router {
         .route("/api/playback/queue/remove", post(remove_queue_track))
         // Search
         .route("/api/search", get(search))
+        .route("/api/search/audio", post(search_audio))
         // TIDAL
         .route("/api/tidal/login", post(tidal_login))
         .route("/api/tidal/login/poll", post(tidal_poll))
@@ -4020,6 +4021,57 @@ async fn search(
         .with_conn(|conn| {
             let results = queries::search(conn, &params.q, limit)?;
             Ok(Json(json!(results)))
+        })
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+}
+
+#[derive(Debug, Deserialize)]
+struct AudioSearchRequest {
+    free_text: Option<String>,
+    bpm_min: Option<f64>,
+    bpm_max: Option<f64>,
+    energy_min: Option<f64>,
+    energy_max: Option<f64>,
+    danceability_min: Option<f64>,
+    danceability_max: Option<f64>,
+    key_signature: Option<String>,
+    camelot_key: Option<String>,
+    year_min: Option<i64>,
+    year_max: Option<i64>,
+    genre_ids: Option<Vec<i64>>,
+    track_type: Option<String>,
+    is_instrumental: Option<bool>,
+    limit: Option<usize>,
+}
+
+async fn search_audio(
+    State(state): State<SharedState>,
+    Json(body): Json<AudioSearchRequest>,
+) -> Result<Json<Value>, StatusCode> {
+    let filters = queries::AudioFilters {
+        bpm_min: body.bpm_min,
+        bpm_max: body.bpm_max,
+        energy_min: body.energy_min,
+        energy_max: body.energy_max,
+        danceability_min: body.danceability_min,
+        danceability_max: body.danceability_max,
+        key_signature: body.key_signature,
+        camelot_key: body.camelot_key,
+        year_min: body.year_min,
+        year_max: body.year_max,
+        genre_ids: body.genre_ids.unwrap_or_default(),
+        track_type: body.track_type,
+        is_instrumental: body.is_instrumental,
+    };
+    let free_text = body.free_text.unwrap_or_default();
+    let limit = body.limit.unwrap_or(50);
+
+    let state = state.read().await;
+    state
+        .db
+        .with_conn(|conn| {
+            let tracks = queries::search_with_audio_filters(conn, &free_text, &filters, limit)?;
+            Ok(Json(json!({ "tracks": tracks })))
         })
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
 }


### PR DESCRIPTION
## Summary

- **Sort by Last Played** — new sort option in track list; backend `COALESCE` fix for consistent null ordering
- **Scroll restoration** — saves/restores scroll position, active tab, and expanded artist on browser-back (mirrors Search page pattern)
- **Keyboard navigation** — ↑↓ moves cursor through track list, Enter plays, Shift+Enter queues, Ctrl+Enter plays next (mirrors Search page)
- **Decade strip filter** — horizontal chip row above Albums grid to filter by release decade; client-side, no backend needed
- **Artist discography view** — artist panel now shows full Tidal catalog alongside owned tracks; unowned albums get an "+ Add" button that imports via `POST /api/tidal/albums/{id}/import`

## Remaining work (next PR — backend required)

- Exclude from Automix flag (`automix_excluded` column + context menu toggle)
- Library Auditor (artist name inconsistencies + casing fixer)
- Batch Metadata Editor (overwrite Artist/Album/Year across selection)
- Custom Labels/Tags (`track_labels` table + `label:` search filter)
- Last.fm Scrobbling (write-back on ≥50% play completion)

## Test Plan

- [ ] Sort dropdown → "Last Played" reorders track list by recency; never-played tracks sink to bottom
- [ ] Scroll deep in Library → navigate to Search → back → position and tab restored
- [ ] Track list focused → ↓↓ moves cursor → Enter plays highlighted track
- [ ] Albums tab → click "1990s" chip → only 90s albums shown → "All" resets
- [ ] Click artist → "Also on Tidal" section shows unowned albums → "+ Add" imports and moves album to owned section