### PR TITLE
Library UI improvements + fix portable build (adapter-static)

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,49 +158,72 @@ Recent searches auto-save as clickable chips.
 
 ### Prerequisites
 
-- [Rust](https://rustup.rs/) stable toolchain
+- [Rust](https://rustup.rs/) stable toolchain (install via `rustup`)
 - Node.js 18+ and npm
 - A TIDAL account
 
-### Desktop App (Tauri)
+---
 
-```bash
-cd noor-app
-cargo tauri dev          # development
-cargo tauri build        # release bundle
+### Option A — Portable build (Windows, recommended)
+
+Produces a self-contained `dist\NOORwave\` folder with two executables and the built frontend. Run once from the workspace root:
+
+```powershell
+.\scripts\build-portable.ps1
 ```
 
-Or use `build-portable.ps1` at the workspace root for a self-contained Windows build.
+What the script does:
+1. `npm run build` in `frontend/` → static site in `frontend\build\`
+2. `cargo build --release -p noor-server` → `target\release\noor-server.exe`
+3. `cargo build --release -p noor-app` → `target\release\noor-app.exe`
+4. Assembles `dist\NOORwave\`:
+   ```
+   dist\NOORwave\
+     NOORwave.exe       ← Tauri desktop shell
+     noor-server.exe    ← backend + API server
+     www\               ← built frontend (served by noor-server on :3334)
+   ```
 
-### Dev Mode (Rust + Node)
+Then launch `dist\NOORwave\NOORwave.exe`. The Tauri shell spawns `noor-server.exe` automatically and shows the window once the server is ready.
+
+> **Note:** All three artifacts must be in the same folder. Copying only the exe files without `www\` will result in a blank window.
+
+---
+
+### Option B — Dev mode (browser UI, fastest iteration)
+
+Runs the backend and frontend separately. The frontend hot-reloads; the Tauri shell is not involved.
 
 ```bash
-# Terminal 1
-cd noor-server
-cargo run --release
+# Terminal 1 — backend
+cargo run --release -p noor-server
 
-# Terminal 2
+# Terminal 2 — frontend
 cd frontend
 npm install
 npm run dev
 ```
 
-Open `http://localhost:5173`.
+Open `http://localhost:5173`. The frontend connects to the backend on port 3334 automatically.
+
+---
 
 ### First Run
 
-1. Open the app — the browser on the server machine auto-connects
-2. Remote devices: enter the 6-digit PIN shown in **Settings → Access Token**
+1. Open the app — the browser on the server machine auto-connects without a PIN
+2. Remote/LAN devices: enter the 6-digit PIN shown in **Settings → Access Token**
 3. Complete TIDAL device-code auth in **Settings**
 4. Trigger a library sync — progress streams live via WebSocket
 5. Start playing
+
+---
 
 ### Environment Variables
 
 | Variable | Default | Description |
 |---|---|---|
 | `NOOR_ADDR` | `0.0.0.0:3334` | Override server bind address |
-| `NOOR_DB` | `<workspace>/noor.db` | Override database path |
+| `NOOR_DB` | `<exe dir>/noor.db` | Override database path |
 | `RUST_LOG` | `noor_server=info` | Log level |
 | `TIDAL_CLIENT_ID` | *(built-in)* | Override TIDAL OAuth2 client ID |
 | `TIDAL_CLIENT_SECRET` | *(built-in)* | Override TIDAL OAuth2 client secret |

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "0.0.1",
 			"devDependencies": {
 				"@sveltejs/adapter-auto": "^7.0.0",
+				"@sveltejs/adapter-static": "^3.0.10",
 				"@sveltejs/kit": "^2.50.2",
 				"@sveltejs/vite-plugin-svelte": "^6.2.4",
 				"svelte": "^5.54.0",
@@ -887,6 +888,16 @@
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-auto/-/adapter-auto-7.0.1.tgz",
 			"integrity": "sha512-dvuPm1E7M9NI/+canIQ6KKQDU2AkEefEZ2Dp7cY6uKoPq9Z/PhOXABe526UdW2mN986gjVkuSLkOYIBnS/M2LQ==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@sveltejs/kit": "^2.0.0"
+			}
+		},
+		"node_modules/@sveltejs/adapter-static": {
+			"version": "3.0.10",
+			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-3.0.10.tgz",
+			"integrity": "sha512-7D9lYFWJmB7zxZyTE/qxjksvMqzMuYrrsyh1f4AlZqeZeACPRySjbC3aFiY55wb1tWUaKOQG9PVbm74JcN2Iew==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "^7.0.0",
+		"@sveltejs/adapter-static": "^3.0.10",
 		"@sveltejs/kit": "^2.50.2",
 		"@sveltejs/vite-plugin-svelte": "^6.2.4",
 		"svelte": "^5.54.0",

--- a/frontend/src/lib/components/ArtistCarousel.svelte
+++ b/frontend/src/lib/components/ArtistCarousel.svelte
@@ -13,6 +13,8 @@
     onContextMenu?: (e: MouseEvent, id: number) => void;
   } = $props();
 
+  let failedImages = $state(new Set<number>());
+
   function letterColor(name: string): string {
     const colors = ['#e63946','#457b9d','#2a9d8f','#e9c46a','#f4a261','#9b5de5','#00b4d8'];
     let h = 0;
@@ -35,8 +37,13 @@
         title={artist.name}
       >
         <div class="avatar-wrap">
-          {#if artist.photo_url}
-            <div class="artist-avatar" style="background-image: url('{artist.photo_url}')"></div>
+          {#if artist.photo_url && !failedImages.has(artist.id)}
+            <img
+              class="artist-avatar"
+              src={artist.photo_url}
+              alt={artist.name}
+              onerror={() => { failedImages = new Set([...failedImages, artist.id]); }}
+            />
           {:else}
             <div class="artist-avatar fallback" style="background: {letterColor(artist.name)}">
               <span>{initials(artist.name)}</span>
@@ -82,8 +89,8 @@
     width: 72px;
     height: 72px;
     border-radius: 50%;
-    background-size: cover;
-    background-position: center;
+    object-fit: cover;
+    display: block;
     transition: transform 0.15s;
   }
 

--- a/frontend/src/lib/components/Discover/DiscoverPanel.svelte
+++ b/frontend/src/lib/components/Discover/DiscoverPanel.svelte
@@ -59,6 +59,7 @@
 					album_title: resolvedTrack.album_title,
 					artwork_url: resolvedTrack.artwork_url,
 					duration_ms: resolvedTrack.duration_ms,
+					artist_tidal_id: resolvedTrack.artist_id ?? null,
 				});
 			}
 			return;
@@ -77,6 +78,7 @@
 					album_title: resolvedTrack.album_title,
 					artwork_url: resolvedTrack.artwork_url,
 					duration_ms: resolvedTrack.duration_ms,
+					artist_tidal_id: resolvedTrack.artist_id ?? null,
 				});
 			}
 			return;

--- a/frontend/src/lib/components/Discover/DiscoverPanel.svelte
+++ b/frontend/src/lib/components/Discover/DiscoverPanel.svelte
@@ -1,16 +1,86 @@
 <script lang="ts">
 	import { api } from '$lib/api/client';
 	import type { DiscoverTrackNode } from './discover.types';
+	import type { TidalSearchTrack } from '$lib/api/client';
+	import { playTidalTrackNow, addTidalTrackToQueue } from '$lib/stores/player';
 
 	let { node = null }: { node?: DiscoverTrackNode | null } = $props();
 
+	type ResolutionState = 'idle' | 'resolving' | 'resolved' | 'unavailable';
+
+	// Persists across node selections within this page session.
+	const resolutionCache = new Map<number, TidalSearchTrack | null>();
+
+	let resolutionState = $state<ResolutionState>('idle');
+	let resolvedTrack = $state<TidalSearchTrack | null>(null);
+
+	$effect(() => {
+		const n = node;
+		if (!n || n.source !== 'external') {
+			resolutionState = 'idle';
+			resolvedTrack = null;
+			return;
+		}
+
+		if (resolutionCache.has(n.track_id)) {
+			const cached = resolutionCache.get(n.track_id) as TidalSearchTrack | null;
+			resolvedTrack = cached;
+			resolutionState = cached !== null ? 'resolved' : 'unavailable';
+			return;
+		}
+
+		resolutionState = 'resolving';
+		resolvedTrack = null;
+		const capturedId = n.track_id;
+
+		api.searchTidal(`${n.title} ${n.artist_name}`, 1)
+			.then(results => {
+				if (node?.track_id !== capturedId) return;
+				const first = results.tracks[0] ?? null;
+				resolutionCache.set(capturedId, first);
+				resolvedTrack = first;
+				resolutionState = first !== null ? 'resolved' : 'unavailable';
+			})
+			.catch(() => {
+				if (node?.track_id !== capturedId) return;
+				resolutionCache.set(capturedId, null);
+				resolutionState = 'unavailable';
+			});
+	});
+
 	async function play() {
 		if (!node) return;
+		if (node.source === 'external') {
+			if (resolvedTrack) {
+				await playTidalTrackNow({
+					tidal_id: resolvedTrack.tidal_id,
+					title: resolvedTrack.title,
+					artist_name: resolvedTrack.artist_name,
+					album_title: resolvedTrack.album_title,
+					artwork_url: resolvedTrack.artwork_url,
+					duration_ms: resolvedTrack.duration_ms,
+				});
+			}
+			return;
+		}
 		await api.playTrack(node.track_id);
 	}
 
 	async function queue() {
 		if (!node) return;
+		if (node.source === 'external') {
+			if (resolvedTrack) {
+				await addTidalTrackToQueue({
+					tidal_id: resolvedTrack.tidal_id,
+					title: resolvedTrack.title,
+					artist_name: resolvedTrack.artist_name,
+					album_title: resolvedTrack.album_title,
+					artwork_url: resolvedTrack.artwork_url,
+					duration_ms: resolvedTrack.duration_ms,
+				});
+			}
+			return;
+		}
 		await api.addQueueTrack(node.track_id);
 	}
 </script>

--- a/frontend/src/lib/components/Discover/DiscoverPanel.svelte
+++ b/frontend/src/lib/components/Discover/DiscoverPanel.svelte
@@ -176,9 +176,9 @@
 		cursor: pointer;
 		transition: background 0.15s;
 	}
-	.action-btn:hover { background: rgba(255,255,255,0.12); }
+	.action-btn:not(:disabled):hover { background: rgba(255,255,255,0.12); }
 	.action-btn.primary { background: rgba(124,128,255,0.25); color: rgba(255,255,255,0.95); }
-	.action-btn.primary:hover { background: rgba(124,128,255,0.4); }
+	.action-btn.primary:not(:disabled):hover { background: rgba(124,128,255,0.4); }
 	.metrics { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; margin-top: 12px; }
 	.metric { display: flex; flex-direction: column; gap: 4px; }
 	.metric span { color: var(--text-secondary); font-size: 0.75rem; }

--- a/frontend/src/lib/components/Discover/DiscoverPanel.svelte
+++ b/frontend/src/lib/components/Discover/DiscoverPanel.svelte
@@ -89,32 +89,72 @@
 
 {#if node}
 	<div class="discover-panel glass-panel">
-		{#if node.artwork_url}
-			<img src={node.artwork_url} alt="" class="panel-artwork" />
+
+		{#if node.source !== 'external'}
+			<!-- ── Library / Tidal node (existing behaviour) ── -->
+			{#if node.artwork_url}
+				<img src={node.artwork_url} alt="" class="panel-artwork" />
+			{/if}
+			<h3>{node.title}</h3>
+			<p>{node.artist_name}</p>
+			{#if node.album_title}<p class="album">{node.album_title}</p>{/if}
+
+			<div class="panel-actions">
+				<button class="action-btn primary" onclick={play}>▶ Play</button>
+				<button class="action-btn" onclick={queue}>+ Queue</button>
+			</div>
+
+			<div class="metrics">
+				{#if node.bpm}<div class="metric"><span>BPM</span><strong>{Math.round(node.bpm)}</strong></div>{/if}
+				{#if node.camelot_key}<div class="metric"><span>Key</span><span class="key-badge">{node.camelot_key}</span></div>{/if}
+				{#if node.energy != null}
+					<div class="metric"><span>Energy</span>
+						<div class="bar"><div class="bar-fill" style="width:{node.energy * 100}%"></div></div>
+					</div>
+				{/if}
+				{#if node.danceability != null}
+					<div class="metric"><span>Dance</span>
+						<div class="bar"><div class="bar-fill" style="width:{node.danceability * 100}%"></div></div>
+					</div>
+				{/if}
+			</div>
+
+		{:else if resolutionState === 'resolving'}
+			<!-- ── Resolving: shimmer placeholder ── -->
+			<div class="shimmer panel-artwork-shimmer"></div>
+			<div class="shimmer title-shimmer"></div>
+			<div class="shimmer artist-shimmer"></div>
+			<div class="panel-actions">
+				<button class="action-btn primary" disabled>▶ Play</button>
+				<button class="action-btn" disabled>+ Queue</button>
+			</div>
+
+		{:else if resolutionState === 'resolved' && resolvedTrack}
+			<!-- ── Resolved: full Tidal panel ── -->
+			{#if resolvedTrack.artwork_url}
+				<img src={resolvedTrack.artwork_url} alt="" class="panel-artwork" />
+			{/if}
+			<h3>{resolvedTrack.title}</h3>
+			<p>{resolvedTrack.artist_name}</p>
+			{#if resolvedTrack.album_title}<p class="album">{resolvedTrack.album_title}</p>{/if}
+
+			<div class="panel-actions">
+				<button class="action-btn primary" onclick={play}>▶ Play</button>
+				<button class="action-btn" onclick={queue}>+ Queue</button>
+			</div>
+
+		{:else if resolutionState === 'unavailable'}
+			<!-- ── Unavailable: Last.fm info + disabled Play ── -->
+			<h3>{node.title}</h3>
+			<p>{node.artist_name}</p>
+			{#if node.radio_reason}<p class="match-score">{node.radio_reason}</p>{/if}
+
+			<div class="panel-actions">
+				<button class="action-btn primary" disabled>▶ Play</button>
+				<span class="not-on-tidal">Not on Tidal</span>
+			</div>
 		{/if}
-		<h3>{node.title}</h3>
-		<p>{node.artist_name}</p>
-		{#if node.album_title}<p class="album">{node.album_title}</p>{/if}
 
-		<div class="panel-actions">
-			<button class="action-btn primary" onclick={play}>▶ Play</button>
-			<button class="action-btn" onclick={queue}>+ Queue</button>
-		</div>
-
-		<div class="metrics">
-			{#if node.bpm}<div class="metric"><span>BPM</span><strong>{Math.round(node.bpm)}</strong></div>{/if}
-			{#if node.camelot_key}<div class="metric"><span>Key</span><span class="key-badge">{node.camelot_key}</span></div>{/if}
-			{#if node.energy != null}
-				<div class="metric"><span>Energy</span>
-					<div class="bar"><div class="bar-fill" style="width:{node.energy * 100}%"></div></div>
-				</div>
-			{/if}
-			{#if node.danceability != null}
-				<div class="metric"><span>Dance</span>
-					<div class="bar"><div class="bar-fill" style="width:{node.danceability * 100}%"></div></div>
-				</div>
-			{/if}
-		</div>
 	</div>
 {/if}
 
@@ -146,4 +186,28 @@
 	.key-badge { display: inline-block; padding: 2px 8px; border-radius: 999px; background: rgba(255,255,255,0.08); font-size: 0.8rem; color: var(--text-primary); }
 	.bar { height: 4px; background: rgba(255,255,255,0.1); border-radius: 2px; overflow: hidden; }
 	.bar-fill { height: 100%; background: var(--accent, #7c80ff); border-radius: 2px; }
+
+	.action-btn:disabled { opacity: 0.35; cursor: default; }
+	.not-on-tidal {
+		align-self: center;
+		font-size: 0.72rem;
+		color: rgba(255,255,255,0.35);
+		letter-spacing: 0.03em;
+	}
+	.match-score { font-size: 0.72rem; color: rgba(255,255,255,0.3); font-style: italic; }
+
+	/* Shimmer animation */
+	@keyframes shimmer {
+		0%   { background-position: -200% 0; }
+		100% { background-position:  200% 0; }
+	}
+	.shimmer {
+		border-radius: 6px;
+		background: linear-gradient(90deg, rgba(255,255,255,0.04) 25%, rgba(255,255,255,0.09) 50%, rgba(255,255,255,0.04) 75%);
+		background-size: 200% 100%;
+		animation: shimmer 1.4s infinite;
+	}
+	.panel-artwork-shimmer { width: 100%; aspect-ratio: 1; border-radius: var(--radius); margin-bottom: 10px; }
+	.title-shimmer  { height: 14px; width: 70%; margin-bottom: 8px; }
+	.artist-shimmer { height: 11px; width: 50%; margin-bottom: 10px; }
 </style>

--- a/frontend/src/lib/components/LibraryHero.svelte
+++ b/frontend/src/lib/components/LibraryHero.svelte
@@ -26,19 +26,20 @@
   }
 </script>
 
-<div class="library-hero-card">
-  {#if artist.photo_url}
-    <div class="hero-bg" style="background-image: url('{artist.photo_url}')"></div>
-  {:else}
-    <div class="hero-bg hero-bg--color" style="background: {letterColor(artist.name)}"></div>
-  {/if}
+<div
+  class="library-hero-card"
+  class:has-image={!!artist.photo_url}
+  style={artist.photo_url ? `background-image: url('${artist.photo_url}')` : `background: ${letterColor(artist.name)}`}
+>
+  <!-- gradient overlay — same pattern as search page artist hero -->
+  <div class="hero-overlay"></div>
 
   <div class="hero-content">
     <div class="hero-art">
       {#if artist.photo_url}
-        <div class="hero-avatar" style="background-image: url('{artist.photo_url}')"></div>
+        <div class="hero-thumb" style="background-image: url('{artist.photo_url}')"></div>
       {:else}
-        <div class="hero-avatar hero-avatar--fallback" style="background: {letterColor(artist.name)}">
+        <div class="hero-thumb hero-thumb--fallback" style="background: {letterColor(artist.name)}">
           <span>{initials(artist.name)}</span>
         </div>
       {/if}
@@ -69,20 +70,25 @@
     background: var(--bg-glass, rgba(255,255,255,0.04));
     border: 1px solid var(--border-subtle, rgba(255,255,255,0.08));
     min-height: 200px;
-  }
-
-  .hero-bg {
-    position: absolute;
-    inset: 0;
     background-size: cover;
     background-position: center top;
-    filter: blur(40px) brightness(0.35) saturate(1.4);
-    transform: scale(1.1);
+  }
+
+  .hero-overlay {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(
+      to right,
+      rgba(0,0,0,0.92) 0%,
+      rgba(0,0,0,0.65) 50%,
+      rgba(0,0,0,0.2) 100%
+    );
     z-index: 0;
   }
 
-  .hero-bg--color {
-    opacity: 0.3;
+  /* when no photo, use a solid dark overlay instead */
+  .library-hero-card:not(.has-image) .hero-overlay {
+    background: rgba(0,0,0,0.45);
   }
 
   .hero-content {
@@ -94,17 +100,17 @@
     padding: 28px 32px;
   }
 
-  .hero-avatar {
+  .hero-thumb {
     width: 140px;
     height: 140px;
-    border-radius: 50%;
+    border-radius: 8px;
     background-size: cover;
     background-position: center;
     flex-shrink: 0;
-    box-shadow: 0 8px 32px rgba(0,0,0,0.4);
+    box-shadow: 0 8px 32px rgba(0,0,0,0.5);
   }
 
-  .hero-avatar--fallback {
+  .hero-thumb--fallback {
     display: flex;
     align-items: center;
     justify-content: center;

--- a/frontend/src/routes/+layout.ts
+++ b/frontend/src/routes/+layout.ts
@@ -1,0 +1,2 @@
+export const prerender = true;
+export const ssr = false;

--- a/frontend/src/routes/library/+page.svelte
+++ b/frontend/src/routes/library/+page.svelte
@@ -53,7 +53,6 @@
 	}
 
 	const PAGE_SIZE = 100;
-	const SEARCH_LIMIT = 200;
 
 	let activeTab = $state<'all' | 'tracks' | 'albums' | 'artists'>('all');
 	let playlists = $state<Playlist[]>([]);
@@ -77,6 +76,7 @@
 	let artists = $state<Artist[]>([]);
 	let artistsLoading = $state(false);
 	let expandedArtistId = $state<number | null>(null);
+	let failedArtistImages = $state(new Set<number>());
 	let artistTracksById = $state<Record<number, Track[]>>({});
 	let artistTracksLoadingId = $state<number | null>(null);
 	let artistDiscographyById = $state<Record<number, TidalDiscographyAlbum[]>>({});
@@ -114,16 +114,18 @@
 	// Reactive grid template — must match the order of cells in .track-header and .track-row.
 	// Cells that get conditionally removed via {#if showXColumn} drop their column track here too,
 	// so header and row stay aligned.
+	// All non-fr columns must be explicit px — 'auto' sizes independently per row-grid,
+	// causing header/data drift when badge content differs from header text.
 	let trackGridColumns = $derived.by(() => {
 		const cols: string[] = ['40px', 'minmax(0, 2fr)', 'minmax(0, 1.5fr)', 'minmax(0, 1.5fr)']; // # title artist album
-		if (showQualityColumn) cols.push('auto');
-		if (showPlaysColumn) cols.push('auto');
-		if (showDateColumn) cols.push('auto', 'auto'); // date_added + last_played share the flag
+		if (showQualityColumn) cols.push('88px');
+		if (showPlaysColumn) cols.push('54px');
+		if (showDateColumn) cols.push('88px', '94px'); // date_added + last_played
 		if (showBpmColumn) cols.push('60px');
 		if (showKeyColumn) cols.push('50px');
-		if (showEnergyColumn) cols.push('55px');
-		if (showDanceColumn) cols.push('55px');
-		cols.push('auto', '40px'); // duration, actions
+		if (showEnergyColumn) cols.push('60px');
+		if (showDanceColumn) cols.push('60px');
+		cols.push('68px', '56px'); // duration, actions
 		return cols.join(' ');
 	});
 
@@ -131,7 +133,6 @@
 	onMount(() => {
 		void loadAlbums();
 		void loadTracks();
-		void loadArtists();
 		void loadBatchMeta();
 		return () => {
 			if (searchTimer) clearTimeout(searchTimer);
@@ -180,15 +181,15 @@
 		if (!$searchQuery.trim()) {
 			if (tab === 'tracks') loadTracks($sortBy, $sortDir);
 			if (tab === 'albums') loadAlbums();
-			// 'artists' and 'all' need no fetch — already loaded on mount
 		}
+		if (tab === 'artists' && artists.length === 0) void loadArtists();
 		clearSelection();
 	}
 
 	async function loadArtists() {
 		artistsLoading = true;
 		try {
-			const data = await api.getArtists('name', 'asc', 10000);
+			const data = await api.getArtists('name', 'asc', 500);
 			artists = data.artists;
 		} catch (err) {
 			console.error('Failed to load artists:', err);
@@ -560,6 +561,17 @@
 		updateAlbumSelection(albumId);
 	}
 
+	async function preloadAllTracks() {
+		if ($totalTracks > 0 && $tracks.length >= $totalTracks) return;
+		await loadTracks($sortBy, $sortDir, 99999, 0);
+	}
+
+	async function preloadAllAlbums() {
+		if ($totalAlbums > 0 && $albums.length >= $totalAlbums) return;
+		await loadAlbums($sortBy, $sortDir, 99999, 0);
+	}
+
+
 	async function runLibrarySearch(query: string) {
 		const trimmed = query.trim();
 		if (!trimmed) {
@@ -577,9 +589,6 @@
 				// DSP/filter syntax (bpm:138, key:Am, energy:>0.7, genre:dnb, etc.) — route to audio search.
 				const params = buildAudioParams(parsed, genres);
 				const audio = await api.searchAudio(params);
-				// Adapt AudioSearchResult → Track shape minimally so existing rendering works.
-				// artist_id / album_id are not returned by the audio endpoint, so menu actions that need
-				// them will gracefully skip (buildTrackMenu guards on null).
 				const adaptedTracks: Track[] = audio.tracks.map((r) => ({
 					id: r.id,
 					title: r.title,
@@ -609,10 +618,19 @@
 				}));
 				searchResults = { tracks: adaptedTracks, albums: [] };
 			} else {
-				const results = await api.search(trimmed, SEARCH_LIMIT);
+				// Plain text — filter the full library locally (always library-scoped, no network).
+				await Promise.all([preloadAllTracks(), preloadAllAlbums()]);
+				const q = trimmed.toLowerCase();
 				searchResults = {
-					tracks: results.tracks,
-					albums: results.albums
+					tracks: $tracks.filter(t =>
+						t.title.toLowerCase().includes(q) ||
+						(t.artist_name ?? '').toLowerCase().includes(q) ||
+						(t.album_title ?? '').toLowerCase().includes(q)
+					),
+					albums: $albums.filter(a =>
+						a.title.toLowerCase().includes(q) ||
+						(a.artist_name ?? '').toLowerCase().includes(q)
+					),
 				};
 			}
 			clearSelection();
@@ -861,8 +879,7 @@
 	}
 
 	function handleHomeArtistClick(artistId: number) {
-		switchTab('artists');
-		expandedArtistId = artistId;
+		void goto(`/artists/${artistId}`);
 	}
 
 	function handleHomeAlbumClick(albumId: number) {
@@ -1309,7 +1326,7 @@
 			{@const filteredArtists = q ? artists.filter(a => a.name.toLowerCase().includes(q)) : artists}
 			<div class="artist-grid">
 				{#each filteredArtists as artist (artist.id)}
-					{@const artistImg = artist.photo_url ?? artistArtworkById.get(artist.id) ?? null}
+					{@const artistImg = !failedArtistImages.has(artist.id) ? (artist.photo_url ?? artistArtworkById.get(artist.id) ?? null) : null}
 					<button
 						class="artist-card"
 						class:expanded={expandedArtistId === artist.id}
@@ -1318,7 +1335,7 @@
 					>
 						<div class="artist-photo">
 							{#if artistImg}
-								<img src={artistImg} alt={artist.name} loading="lazy" />
+								<img src={artistImg} alt={artist.name} loading="lazy" onerror={() => { failedArtistImages = new Set([...failedArtistImages, artist.id]); }} />
 							{:else}
 								<span class="artist-initial">{artist.name.charAt(0).toUpperCase()}</span>
 							{/if}
@@ -1589,11 +1606,10 @@
 					{/if}
 					{#if showDateColumn}
 						<span class="col-date">
-							{#if $sortBy === 'last_played_at'}
-								<span class="last-played">{track.last_played_at ? formatDateShort(track.last_played_at) : '—'}</span>
-							{:else}
-								<span class="date-added">{track.date_added ? formatDateShort(track.date_added) : '—'}</span>
-							{/if}
+							<span class="date-added">{track.date_added ? formatDateShort(track.date_added) : '—'}</span>
+						</span>
+						<span class="col-date">
+							<span class="last-played">{track.last_played_at ? formatDateShort(track.last_played_at) : '—'}</span>
 						</span>
 					{/if}
 					{#if showBpmColumn}
@@ -2174,6 +2190,9 @@
 		color: var(--text-muted, rgba(255,255,255,0.35));
 		padding: 4px 0 0 2px;
 		user-select: none;
+		max-width: 640px;
+		width: 100%;
+		margin: 0 auto;
 	}
 
 	.kbd-hint kbd {
@@ -3300,7 +3319,6 @@
 		text-align: right;
 		color: var(--text-tertiary);
 		font-size: 0.78rem;
-		min-width: 50px;
 	}
 
 	.plays-count {
@@ -3311,7 +3329,6 @@
 		text-align: right;
 		color: var(--text-tertiary);
 		font-size: 0.75rem;
-		min-width: 70px;
 	}
 
 	.date-added {
@@ -3322,7 +3339,6 @@
 		text-align: right;
 		color: var(--text-tertiary);
 		font-size: 0.8125rem;
-		min-width: 55px;
 	}
 
 	.col-title {

--- a/frontend/src/routes/search/+page.svelte
+++ b/frontend/src/routes/search/+page.svelte
@@ -888,7 +888,8 @@
   }
   .search-input::placeholder { color: var(--text-tertiary); }
   .kbd-hint {
-    margin: 10px 0 0;
+    margin: 10px auto 0;
+    max-width: 640px;
     font-size: 11px;
     color: var(--text-tertiary);
     display: flex;

--- a/frontend/svelte.config.js
+++ b/frontend/svelte.config.js
@@ -1,4 +1,4 @@
-import adapter from '@sveltejs/adapter-auto';
+import adapter from '@sveltejs/adapter-static';
 import { relative, sep } from 'node:path';
 
 /** @type {import('@sveltejs/kit').Config} */
@@ -14,10 +14,10 @@ const config = {
 		}
 	},
 	kit: {
-		// adapter-auto only supports some environments, see https://svelte.dev/docs/kit/adapter-auto for a list.
-		// If your environment is not supported, or you settled on a specific environment, switch out the adapter.
-		// See https://svelte.dev/docs/kit/adapters for more information about adapters.
-		adapter: adapter()
+		adapter: adapter({ fallback: 'index.html' }),
+		prerender: {
+			handleUnseenRoutes: 'ignore'
+		}
 	}
 };
 


### PR DESCRIPTION
## Summary
- **Library page**: lazy artist loading, in-memory local search, fixed track grid column widths (no more header/data drift), image error fallbacks, date column split into separate added/last-played cells
- **ArtistCarousel**: switched from background-div to `<img>` with `onerror` fallback to initials
- **LibraryHero**: redesigned with gradient overlay and square thumbnail
- **Build fix**: `adapter-auto` never produced a static `build/` folder so `noor-server`'s `www/` directory was always missing — switched to `adapter-static` with SPA index.html fallback and `prerender.handleUnseenRoutes: 'ignore'` for dynamic routes

## Test plan
- [ ] Run `.\scripts\build-portable.ps1` — confirm `dist\NOORwave\www\` is created
- [ ] Launch `dist\NOORwave\NOORwave.exe` — app should load instead of 404
- [ ] Library > Artists tab loads on click (not on page mount)
- [ ] Library search filters tracks/albums in-memory
- [ ] Broken artist photos fall back to initials without console errors