### PR TITLE
feat(playlists): radio/shuffle/favorite, add-to-playlist menus, playlists in search

### DIFF
--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -128,6 +128,14 @@ export interface TidalSearchArtist {
 	in_library: boolean;
 }
 
+export interface TidalSearchPlaylist {
+	uuid: string;
+	title: string;
+	description: string | null;
+	number_of_tracks: number | null;
+	square_image: string | null;
+}
+
 export interface TidalSearchResults {
 	tracks: TidalSearchTrack[];
 	albums: TidalSearchAlbum[];
@@ -149,6 +157,8 @@ export interface TidalPlayable {
 	artwork_url: string | null;
 	duration_ms: number | null;
 	artist_tidal_id?: number | null;
+	track_id?: number;
+	is_in_library?: boolean;
 }
 
 export interface Album {
@@ -189,6 +199,7 @@ export interface Playlist {
 	is_smart: boolean;
 	track_count: number;
 	smart_rules?: string | null;
+	is_favorite: boolean;
 }
 
 // ─── Smart Playlist Rule Types ───────────────────────────────────────────────
@@ -950,6 +961,31 @@ export const api = {
 		return fetchApi<{ deleted: boolean }>(`/api/smart/playlists/${id}`, undefined, {
 			method: 'DELETE',
 		});
+	},
+
+	togglePlaylistFavorite(id: number) {
+		return fetchApi<{ playlist: Playlist }>(`/api/playlists/${id}/favorite`, undefined, {
+			method: 'PATCH',
+		});
+	},
+
+	addTracksToPlaylist(id: number, trackIds: number[]) {
+		return fetchApi<{ added: number }>(`/api/playlists/${id}/tracks`, undefined, {
+			method: 'POST',
+			body: JSON.stringify({ track_ids: trackIds }),
+		});
+	},
+
+	searchTidalPlaylists(q: string) {
+		return fetchApi<{ playlists: TidalSearchPlaylist[] }>(
+			`/api/tidal/playlists/search?q=${encodeURIComponent(q)}`,
+		);
+	},
+
+	getTidalPlaylistTracks(tidalUuid: string) {
+		return fetchApi<{ tracks: TidalPlayable[] }>(
+			`/api/tidal/playlists/${tidalUuid}/tracks`,
+		);
 	},
 
 	getAnalyticsOverview() {

--- a/frontend/src/lib/stores/player.ts
+++ b/frontend/src/lib/stores/player.ts
@@ -481,6 +481,37 @@ export async function startSongRadio(seedTrackId: number) {
 	}
 }
 
+export async function shufflePlaylist(
+	tracks: { id: number }[],
+) {
+	if (!tracks.length) return;
+	const shuffled = shuffleArray([...tracks]);
+	await loadQueueAndPlay(shuffled.map((t) => t.id));
+	showToast('Shuffling playlist', 'success');
+}
+
+export async function startPlaylistRadio(tracks: { id: number; play_count?: number }[]) {
+	if (!tracks.length) return;
+	// Seed from the most-played track; fall back to first track
+	const seed = [...tracks].sort((a, b) => (b.play_count ?? 0) - (a.play_count ?? 0))[0];
+	await startSongRadio(seed.id);
+}
+
+export async function playTidalPlaylist(tidalUuid: string) {
+	try {
+		const { tracks } = await api.getTidalPlaylistTracks(tidalUuid);
+		if (!tracks.length) {
+			playerError.set('No playable tracks in this playlist.');
+			return;
+		}
+		// TODO: queue remaining tracks once TIDAL ephemeral queue is supported (see addTidalTrackToQueue stub)
+		await playTidalTrackNow(tracks[0]);
+		showToast('Playing TIDAL playlist', 'success');
+	} catch (error) {
+		playerError.set(`Failed to load TIDAL playlist: ${error}`);
+	}
+}
+
 export async function startArtistRadio(artistId: number, _seedTrackId?: number) {
 	try {
 		const queue = await api.startRadioArtist({ seed_artist_id: artistId, limit: 60 });

--- a/frontend/src/routes/library/+page.svelte
+++ b/frontend/src/routes/library/+page.svelte
@@ -23,6 +23,27 @@
 	import { buildAudioParams, hasAnyFilter } from '$lib/search/audio_params';
 	import { playAlbum as playAlbumStore, shuffleAlbum, startAlbumRadio, startArtistRadio } from '$lib/stores/player';
 	import { goto } from '$app/navigation';
+	import { showToast } from '$lib/stores/toast';
+
+	function buildAddToPlaylistSubmenu(
+		getTrackIds: () => Promise<number[]>,
+	): MenuItem[] {
+		return [...playlists]
+			.sort((a, b) => {
+				if (a.is_favorite !== b.is_favorite) return a.is_favorite ? -1 : 1;
+				return a.name.localeCompare(b.name);
+			})
+			.map((playlist) => ({
+				label: playlist.name,
+				icon: playlist.is_favorite ? '♥' : '♩',
+				onSelect: async () => {
+					const trackIds = await getTrackIds();
+					if (!trackIds.length) return;
+					const { added } = await api.addTracksToPlaylist(playlist.id, trackIds);
+					showToast(`Added ${added} track${added !== 1 ? 's' : ''} to ${playlist.name}`, 'success');
+				},
+			}));
+	}
 
 	function buildLocalAlbumMenu(album: { id: number; title: string }): MenuItem[] {
 		return [
@@ -32,6 +53,15 @@
 			{ label: 'Album radio', icon: '◉', onSelect: () => void startAlbumRadio(album.id) },
 			{ separator: true, label: '' },
 			{ label: 'Open album', icon: '↗', onSelect: () => void goto(`/albums/${album.id}`) },
+			{ separator: true, label: '' },
+			{
+				label: 'Add to playlist',
+				icon: '＋',
+				submenu: buildAddToPlaylistSubmenu(async () => {
+					const { tracks: t } = await api.getAlbumTracks(album.id);
+					return t.map(tr => tr.id);
+				}),
+			},
 		];
 	}
 
@@ -40,6 +70,15 @@
 			{ label: 'Open artist', icon: '↗', onSelect: () => void goto(`/artists/${artistId}`) },
 			{ separator: true, label: '' },
 			{ label: 'Artist radio', icon: '◉', onSelect: () => void startArtistRadio(artistId) },
+			{ separator: true, label: '' },
+			{
+				label: 'Add to playlist',
+				icon: '＋',
+				submenu: buildAddToPlaylistSubmenu(async () => {
+					const { tracks: t } = await api.getArtistTracks(artistId);
+					return t.map(tr => tr.id);
+				}),
+			},
 		];
 	}
 

--- a/frontend/src/routes/playlists/+page.svelte
+++ b/frontend/src/routes/playlists/+page.svelte
@@ -12,7 +12,7 @@
 		type SampleDataSource,
 	} from '$lib/api/client';
 	import { formatDuration, getQualityClass } from '$lib/stores/library';
-	import { addTrackToQueue, playTrackNow } from '$lib/stores/player';
+	import { addTrackToQueue, playTrackNow, shufflePlaylist, startPlaylistRadio } from '$lib/stores/player';
 	import PageHeader from '$lib/components/ui/PageHeader.svelte';
 	import EmptyState from '$lib/components/ui/EmptyState.svelte';
 	import MetricPair from '$lib/components/ui/MetricPair.svelte';
@@ -596,6 +596,24 @@
 						</div>
 					</button>
 
+					<div class="card-actions">
+						<button
+							class="action-btn fav-btn"
+							class:active={playlist.is_favorite}
+							onclick={async (e) => {
+								e.stopPropagation();
+								try {
+									const updated = await api.togglePlaylistFavorite(playlist.id);
+									playlists = playlists.map(p => p.id === playlist.id ? updated.playlist : p);
+								} catch {
+									// silently ignore — button state reverts on next data load
+								}
+							}}
+							title={playlist.is_favorite ? 'Remove from favourites' : 'Add to favourites'}
+							aria-label={playlist.is_favorite ? 'Remove from favourites' : 'Add to favourites'}
+						>♥</button>
+					</div>
+
 					{#if playlist.is_smart}
 						<div class="smart-actions">
 							<button class="btn btn-glass btn-sm" onclick={(e) => { e.stopPropagation(); openEdit(playlist); }}>
@@ -620,6 +638,24 @@
 							{:else if (playlistTracksById[playlist.id]?.length ?? 0) > 0}
 								<div class="playlist-body-actions">
 									<button class="btn btn-primary btn-sm" onclick={(e) => void playPlaylist(playlist.id, e)}>Play all</button>
+									<button
+										class="action-btn"
+										onclick={(e) => {
+											e.stopPropagation();
+											void shufflePlaylist(playlistTracksById[playlist.id]);
+										}}
+										title="Shuffle playlist"
+										aria-label="Shuffle playlist"
+									>⤮ Shuffle</button>
+									<button
+										class="action-btn"
+										onclick={(e) => {
+											e.stopPropagation();
+											void startPlaylistRadio(playlistTracksById[playlist.id]);
+										}}
+										title="Playlist radio"
+										aria-label="Playlist radio"
+									>◉ Radio</button>
 								</div>
 								<div class="track-list">
 									{#each playlistTracksById[playlist.id] as track, i (`${track.id}-${i}`)}
@@ -1464,6 +1500,42 @@
 	.add-rule-btn { align-self: flex-start; }
 
 	.editor-error { font-size: 0.875rem; color: var(--state-error); }
+
+	/* ─── Card action buttons ────────────────────────────────── */
+
+	.card-actions {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		margin-top: 10px;
+	}
+
+	.action-btn {
+		background: var(--surface-2, #2a2a2a);
+		border: none;
+		color: var(--text-secondary, #ccc);
+		cursor: pointer;
+		font-size: 12px;
+		padding: 5px 10px;
+		border-radius: 5px;
+		display: flex;
+		align-items: center;
+		gap: 4px;
+		white-space: nowrap;
+	}
+	.action-btn:hover {
+		background: var(--surface-3, #333);
+		color: var(--text-primary, #fff);
+	}
+	.action-btn.fav-btn {
+		background: none;
+		font-size: 16px;
+		padding: 5px;
+		color: var(--text-tertiary, #666);
+	}
+	.action-btn.fav-btn.active {
+		color: var(--accent, #e00055);
+	}
 
 	/* ─── Responsive ──────────────────────────────────────────── */
 

--- a/frontend/src/routes/search/+page.svelte
+++ b/frontend/src/routes/search/+page.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
   import { onMount } from 'svelte'
   import { goto, beforeNavigate, afterNavigate } from '$app/navigation'
-  import { api, type TidalSearchResults, type TidalSearchAlbum, type TidalSearchArtist, type TidalSearchTrack, type AudioSearchResult, type AudioSearchParams, type Genre, type VibeTrack, type BasicTrack } from '$lib/api/client'
+  import { api, type TidalSearchResults, type TidalSearchAlbum, type TidalSearchArtist, type TidalSearchTrack, type AudioSearchResult, type AudioSearchParams, type Genre, type VibeTrack, type BasicTrack, type Playlist, type TidalSearchPlaylist } from '$lib/api/client'
   import { buildTidalTrackMenu, buildTrackMenu } from '$lib/player/track_menu'
   import { openContextMenu, type MenuItem } from '$lib/stores/context_menu'
-  import { playTidalTrackNow, playTidalAlbum, playTidalTrackNext, addTidalTrackToQueue, startTidalSongRadio, playTrackNow, startArtistRadio, startAlbumRadio, shuffleAlbum } from '$lib/stores/player'
+  import { playTidalTrackNow, playTidalAlbum, playTidalTrackNext, addTidalTrackToQueue, startTidalSongRadio, playTrackNow, startArtistRadio, startAlbumRadio, shuffleAlbum, playTidalPlaylist } from '$lib/stores/player'
   import { formatDuration } from '$lib/stores/library'
   import { parseQuery, filtersToChips, type ParsedQuery } from '$lib/search/query_parser'
   import { buildAudioParams as sharedBuildAudioParams } from '$lib/search/audio_params'
@@ -57,7 +57,10 @@
   let vibeTrack = $state<VibeTrack[] | null>(null)
   let underratedTracks = $state<BasicTrack[] | null>(null)
 
-  type FilterMode = 'all' | 'artists' | 'albums' | 'tracks' | 'library'
+  let localPlaylists = $state<Playlist[]>([])
+  let tidalPlaylistResults = $state<TidalSearchPlaylist[]>([])
+
+  type FilterMode = 'all' | 'artists' | 'albums' | 'tracks' | 'library' | 'playlists'
   let filterMode = $state<FilterMode>('all')
 
   const parsedQuery = $derived(parseQuery(query))
@@ -74,6 +77,10 @@
         .map(e => e.artist_name)
         .filter((n): n is string => typeof n === 'string' && n.length > 0)
       recentArtistNames = new Set(names)
+    } catch { /* ignore */ }
+    try {
+      const { playlists } = await api.getPlaylists()
+      localPlaylists = playlists
     } catch { /* ignore */ }
   })
 
@@ -101,6 +108,7 @@
     if (!query.trim()) {
       results = null
       audioResults = null
+      tidalPlaylistResults = []
       loading = false
       error = null
       return
@@ -143,6 +151,7 @@
           const res = await api.searchAudio(buildAudioParams(effectiveParsed))
           audioResults = res.tracks
           results = null
+          tidalPlaylistResults = []
         } else {
           audioResults = null
           const cacheKey = q.toLowerCase()
@@ -154,6 +163,12 @@
             results = fresh
             resultCache.set(cacheKey, fresh)
             if (resultCache.size > 5) resultCache.delete(resultCache.keys().next().value!)
+          }
+          try {
+            const { playlists } = await api.searchTidalPlaylists(q)
+            tidalPlaylistResults = playlists
+          } catch {
+            tidalPlaylistResults = []
           }
         }
         error = null
@@ -219,8 +234,20 @@
     !isEmpty &&
     sortedTracks.length === 0 &&
     sortedAlbums.length === 0 &&
-    sortedArtists.length === 0
+    sortedArtists.length === 0 &&
+    !(showPlaylists && (filteredPlaylists.local.length > 0 || filteredPlaylists.tidal.length > 0))
   )
+
+  const showPlaylists = $derived(filterMode === 'all' || filterMode === 'playlists')
+
+  const filteredPlaylists = $derived.by(() => {
+    if (!query.trim()) return { local: [] as Playlist[], tidal: [] as TidalSearchPlaylist[] }
+    const q = query.trim().toLowerCase()
+    const matched = localPlaylists.filter(p => p.name.toLowerCase().includes(q))
+    const localNames = new Set(matched.map(p => p.name.toLowerCase()))
+    const tidalOnly = tidalPlaylistResults.filter(tp => !localNames.has(tp.title.toLowerCase()))
+    return { local: matched, tidal: tidalOnly }
+  })
 
   type TopResult =
     | { kind: 'artist'; entry: TidalSearchArtist }
@@ -515,6 +542,7 @@
           { id: 'artists', label: 'Artists' },
           { id: 'albums', label: 'Albums' },
           { id: 'tracks', label: 'Tracks' },
+          { id: 'playlists', label: 'Playlists' },
           { id: 'library', label: 'In Library' },
         ] as pill (pill.id)}
           <button
@@ -722,6 +750,61 @@
               {/if}
             </a>
           {/each}
+        </div>
+      </section>
+    {/if}
+
+    {#if showPlaylists && (filteredPlaylists.local.length > 0 || filteredPlaylists.tidal.length > 0)}
+      <section class="results-section">
+        <h3 class="section-label">Playlists</h3>
+        <div class="albums-row" use:wheelToHorizontal>
+
+          {#each filteredPlaylists.local as playlist (playlist.id)}
+            <a
+              class="album-card in-library"
+              href="/playlists"
+            >
+              <div class="art-wrap">
+                <div class="album-art fallback" style="background: {letterColor(playlist.name)}">
+                  <span>♫</span>
+                </div>
+                <span class="lib-badge" aria-label="In your library"></span>
+              </div>
+              <p class="album-title">{playlist.name}</p>
+              <p class="album-artist">{playlist.is_smart ? 'Smart playlist' : 'Playlist'} · {playlist.track_count} tracks</p>
+            </a>
+          {/each}
+
+          {#each filteredPlaylists.tidal as playlist (playlist.uuid)}
+            <div
+              class="album-card"
+              role="button"
+              tabindex="0"
+              onclick={() => void playTidalPlaylist(playlist.uuid)}
+              onkeydown={(e) => e.key === 'Enter' && void playTidalPlaylist(playlist.uuid)}
+            >
+              <div class="art-wrap">
+                {#if playlist.square_image}
+                  <div
+                    class="album-art"
+                    style="background-image: url('https://resources.tidal.com/images/{playlist.square_image.replaceAll('-', '/')}/320x320.jpg')"
+                  ></div>
+                {:else}
+                  <div class="album-art fallback" style="background: {letterColor(playlist.title)}">
+                    <span>♫</span>
+                  </div>
+                {/if}
+                <button
+                  class="art-play-overlay"
+                  onclick={(e) => { e.stopPropagation(); void playTidalPlaylist(playlist.uuid) }}
+                  aria-label="Play {playlist.title}"
+                >▶</button>
+              </div>
+              <p class="album-title">{playlist.title}</p>
+              <p class="album-artist">TIDAL · {playlist.number_of_tracks ?? '?'} tracks</p>
+            </div>
+          {/each}
+
         </div>
       </section>
     {/if}

--- a/noor-server/src/db/models.rs
+++ b/noor-server/src/db/models.rs
@@ -66,6 +66,7 @@ pub struct Playlist {
     pub smart_rules: Option<String>,
     pub is_synced: bool,
     pub track_count: i32,
+    pub is_favorite: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/noor-server/src/db/queries.rs
+++ b/noor-server/src/db/queries.rs
@@ -415,9 +415,9 @@ pub fn get_artist_tracks(conn: &Connection, artist_id: i64) -> Result<Vec<Track>
 pub fn get_playlists(conn: &Connection) -> Result<Vec<Playlist>> {
     let mut stmt = conn.prepare(
         "SELECT id, tidal_uuid, name, description, is_smart,
-                smart_rules, is_synced, track_count
+                smart_rules, is_synced, track_count, is_favorite
          FROM playlists
-         ORDER BY name ASC",
+         ORDER BY is_favorite DESC, name ASC",
     )?;
 
     let playlists = stmt
@@ -427,10 +427,11 @@ pub fn get_playlists(conn: &Connection) -> Result<Vec<Playlist>> {
                 tidal_uuid: row.get(1)?,
                 name: row.get(2)?,
                 description: row.get(3)?,
-                is_smart: row.get(4)?,
+                is_smart: row.get::<_, i32>(4)? != 0,
                 smart_rules: row.get(5)?,
-                is_synced: row.get(6)?,
+                is_synced: row.get::<_, i32>(6)? != 0,
                 track_count: row.get(7)?,
+                is_favorite: row.get::<_, i32>(8)? != 0,
             })
         })?
         .collect::<Result<Vec<_>, _>>()?;
@@ -441,7 +442,7 @@ pub fn get_playlists(conn: &Connection) -> Result<Vec<Playlist>> {
 pub fn get_playlist(conn: &Connection, playlist_id: i64) -> Result<Option<Playlist>> {
     let mut stmt = conn.prepare(
         "SELECT id, tidal_uuid, name, description, is_smart,
-                smart_rules, is_synced, track_count
+                smart_rules, is_synced, track_count, is_favorite
          FROM playlists
          WHERE id = ?1",
     )?;
@@ -453,14 +454,24 @@ pub fn get_playlist(conn: &Connection, playlist_id: i64) -> Result<Option<Playli
             tidal_uuid: row.get(1)?,
             name: row.get(2)?,
             description: row.get(3)?,
-            is_smart: row.get(4)?,
+            is_smart: row.get::<_, i32>(4)? != 0,
             smart_rules: row.get(5)?,
-            is_synced: row.get(6)?,
+            is_synced: row.get::<_, i32>(6)? != 0,
             track_count: row.get(7)?,
+            is_favorite: row.get::<_, i32>(8)? != 0,
         }))
     } else {
         Ok(None)
     }
+}
+
+pub fn toggle_playlist_favorite(conn: &Connection, playlist_id: i64) -> Result<Playlist> {
+    conn.execute(
+        "UPDATE playlists SET is_favorite = NOT is_favorite WHERE id = ?1",
+        params![playlist_id],
+    )?;
+    get_playlist(conn, playlist_id)?
+        .ok_or_else(|| anyhow::anyhow!("playlist not found"))
 }
 
 pub fn get_playlist_tracks(conn: &Connection, playlist_id: i64) -> Result<Vec<Track>> {

--- a/noor-server/src/db/queries.rs
+++ b/noor-server/src/db/queries.rs
@@ -474,6 +474,64 @@ pub fn toggle_playlist_favorite(conn: &Connection, playlist_id: i64) -> Result<P
         .ok_or_else(|| anyhow::anyhow!("playlist not found"))
 }
 
+/// Bulk-insert tracks into a playlist, skipping any already present.
+/// Returns the number of tracks actually inserted.
+pub fn add_tracks_to_playlist(
+    conn: &Connection,
+    playlist_id: i64,
+    track_ids: &[i64],
+) -> Result<usize> {
+    if track_ids.is_empty() {
+        return Ok(0);
+    }
+
+    // Find which tracks are already in the playlist
+    let existing: std::collections::HashSet<i64> = {
+        let mut stmt = conn.prepare(
+            "SELECT track_id FROM playlist_tracks WHERE playlist_id = ?1",
+        )?;
+        stmt.query_map(params![playlist_id], |row| row.get(0))?
+            .collect::<Result<_, _>>()?
+    };
+
+    let to_insert: Vec<i64> = {
+        let mut seen = std::collections::HashSet::new();
+        track_ids
+            .iter()
+            .copied()
+            .filter(|id| !existing.contains(id) && seen.insert(*id))
+            .collect()
+    };
+
+    if to_insert.is_empty() {
+        return Ok(0);
+    }
+
+    // Get the current max position
+    let max_pos: i64 = conn.query_row(
+        "SELECT COALESCE(MAX(position), -1) FROM playlist_tracks WHERE playlist_id = ?1",
+        params![playlist_id],
+        |row| row.get(0),
+    )?;
+
+    let mut stmt = conn.prepare(
+        "INSERT INTO playlist_tracks (playlist_id, track_id, position) VALUES (?1, ?2, ?3)",
+    )?;
+    for (i, &track_id) in to_insert.iter().enumerate() {
+        stmt.execute(params![playlist_id, track_id, max_pos + 1 + i as i64])?;
+    }
+
+    // Keep track_count in sync
+    conn.execute(
+        "UPDATE playlists SET track_count = (
+            SELECT COUNT(*) FROM playlist_tracks WHERE playlist_id = ?1
+         ) WHERE id = ?1",
+        params![playlist_id],
+    )?;
+
+    Ok(to_insert.len())
+}
+
 pub fn get_playlist_tracks(conn: &Connection, playlist_id: i64) -> Result<Vec<Track>> {
     let mut stmt = conn.prepare(
         "SELECT t.id, t.title, t.artist_id, a.name, t.album_id, al.title,
@@ -3687,6 +3745,40 @@ mod tests {
         assert_eq!(heat.len(), 2);
         assert!(heat.iter().all(|entry| entry.listen_count == 0));
         assert!(heat.iter().all(|entry| entry.total_listened_ms == 0));
+    }
+
+    #[test]
+    fn test_add_tracks_to_playlist_deduplicates() {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        schema::run_migrations(&conn).expect("migrations");
+        conn.execute_batch(r#"
+            INSERT INTO artists (id, name) VALUES (1, 'Test Artist');
+            INSERT INTO albums (id, title, artist_id) VALUES (1, 'Test Album', 1);
+            INSERT INTO tracks (id, title, artist_id, album_id) VALUES (1, 'Track A', 1, 1);
+            INSERT INTO tracks (id, title, artist_id, album_id) VALUES (2, 'Track B', 1, 1);
+            INSERT INTO tracks (id, title, artist_id, album_id) VALUES (3, 'Track C', 1, 1);
+            INSERT INTO playlists (id, name, is_smart, is_synced) VALUES (1, 'My Playlist', 0, 1);
+        "#).unwrap();
+
+        // First call adds both tracks
+        let added = add_tracks_to_playlist(&conn, 1, &[1, 2]).unwrap();
+        assert_eq!(added, 2);
+
+        // Second call with same tracks returns 0 (already present)
+        let added_again = add_tracks_to_playlist(&conn, 1, &[1, 2]).unwrap();
+        assert_eq!(added_again, 0);
+
+        // Duplicate IDs within a single call: [1, 1] — track 1 already present, so 0 added
+        let added_dup = add_tracks_to_playlist(&conn, 1, &[1, 1]).unwrap();
+        assert_eq!(added_dup, 0);
+
+        // Mixed: [1, 3] — track 1 already present, track 3 is new → 1 added
+        let added_mixed = add_tracks_to_playlist(&conn, 1, &[1, 3]).unwrap();
+        assert_eq!(added_mixed, 1);
+
+        // [3, 3] — track 3 now present, duplicate in input → 0 added
+        let added_dup_present = add_tracks_to_playlist(&conn, 1, &[3, 3]).unwrap();
+        assert_eq!(added_dup_present, 0);
     }
 }
 

--- a/noor-server/src/db/schema.rs
+++ b/noor-server/src/db/schema.rs
@@ -18,6 +18,7 @@ const MIGRATIONS: &[&str] = &[
     MIGRATION_014,
     MIGRATION_015,
     MIGRATION_016,
+    MIGRATION_017,
 ];
 
 const MIGRATION_001: &str = r#"
@@ -558,6 +559,11 @@ CREATE TABLE IF NOT EXISTS lastfm_unresolved_tags (
 
 const MIGRATION_016: &str = r#"
 ALTER TABLE discovery_feedback ADD COLUMN session_id TEXT;
+"#;
+
+const MIGRATION_017: &str = r#"
+ALTER TABLE playlists ADD COLUMN is_favorite INTEGER NOT NULL DEFAULT 0;
+CREATE INDEX idx_playlists_favorite ON playlists(is_favorite);
 "#;
 
 pub fn run_migrations(conn: &Connection) -> Result<()> {

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -24,7 +24,7 @@ use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
     response::Json,
-    routing::{get, post, put},
+    routing::{get, patch, post, put},
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -249,6 +249,7 @@ pub fn api_routes(state: SharedState) -> Router {
         .route("/api/genres/{id}/tracks", get(get_genre_tracks))
         .route("/api/playlists", get(get_playlists))
         .route("/api/playlists/{id}/tracks", get(get_playlist_tracks))
+        .route("/api/playlists/{id}/favorite", patch(toggle_playlist_favorite_route))
         .route("/api/smart/playlists", post(create_smart_playlist_route))
         .route(
             "/api/smart/playlists/{id}",
@@ -947,6 +948,25 @@ async fn get_playlist_tracks(
             Ok(Json(json!({ "tracks": tracks })))
         })
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+}
+
+async fn toggle_playlist_favorite_route(
+    State(state): State<SharedState>,
+    Path(id): Path<i64>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    let state = state.read().await;
+    state
+        .db
+        .with_conn(|conn| {
+            let playlist = queries::toggle_playlist_favorite(conn, id)?;
+            Ok(Json(json!({ "playlist": playlist })))
+        })
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": e.to_string() })),
+            )
+        })
 }
 
 async fn evaluate_smart_playlist(

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -365,6 +365,8 @@ pub fn api_routes(state: SharedState) -> Router {
         .route("/api/tidal/sync", post(tidal_sync_library))
         .route("/api/tidal/status", get(tidal_status))
         .route("/api/tidal/search", get(tidal_search))
+        .route("/api/tidal/playlists/search", get(tidal_playlist_search))
+        .route("/api/tidal/playlists/{uuid}/tracks", get(tidal_playlist_tracks))
         .route("/api/tidal/play", post(play_tidal_ephemeral))
         .route("/api/tidal/artists/{tidal_id}", get(tidal_artist_profile))
         .route("/api/tidal/logout", post(tidal_logout))
@@ -5667,6 +5669,113 @@ async fn tidal_search(
         .collect();
 
     Ok(Json(json!({ "tracks": tracks, "albums": albums, "artists": artists })))
+}
+
+// ─── TIDAL Playlist Search + Tracks ───────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+struct TidalPlaylistSearchParams {
+    q: String,
+    #[serde(default)]
+    limit: Option<i32>,
+}
+
+async fn tidal_playlist_search(
+    State(state): State<SharedState>,
+    Query(params): Query<TidalPlaylistSearchParams>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    let tokens = {
+        let persisted = load_persisted_tidal_tokens(&state).await.map_err(|e| {
+            (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({ "error": e.to_string() })))
+        })?;
+        let s = state.read().await;
+        s.tidal_tokens.clone().or(persisted)
+    };
+    let Some(tokens) = tokens else {
+        return Err((StatusCode::BAD_REQUEST, Json(json!({ "error": "TIDAL not connected" }))));
+    };
+
+    let limit = params.limit.unwrap_or(20).min(50);
+    let http_client = state.read().await.http_client.clone();
+    let client = TidalClient::new(tokens.access_token.clone(), tokens.country_code.clone());
+    let playlists = match client.search_playlists(&params.q, limit).await {
+        Ok(r) => r,
+        Err(e) if error_looks_like_auth(&e) => {
+            let refreshed = recover_tidal_session(&state, &http_client, &tokens)
+                .await
+                .map_err(|re| (
+                    StatusCode::BAD_GATEWAY,
+                    Json(json!({ "error": format!("TIDAL session refresh failed: {}", re) })),
+                ))?;
+            let retry_client = TidalClient::new(
+                refreshed.access_token.clone(),
+                refreshed.country_code.clone(),
+            );
+            retry_client.search_playlists(&params.q, limit).await.map_err(|e2| {
+                (StatusCode::BAD_GATEWAY, Json(json!({ "error": e2.to_string() })))
+            })?
+        }
+        Err(e) => return Err((StatusCode::BAD_GATEWAY, Json(json!({ "error": e.to_string() })))),
+    };
+
+    Ok(Json(json!({ "playlists": playlists })))
+}
+
+async fn tidal_playlist_tracks(
+    State(state): State<SharedState>,
+    Path(uuid): Path<String>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    let tokens = {
+        let persisted = load_persisted_tidal_tokens(&state).await.map_err(|e| {
+            (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({ "error": e.to_string() })))
+        })?;
+        let s = state.read().await;
+        s.tidal_tokens.clone().or(persisted)
+    };
+    let Some(tokens) = tokens else {
+        return Err((StatusCode::BAD_REQUEST, Json(json!({ "error": "TIDAL not connected" }))));
+    };
+
+    let http_client = state.read().await.http_client.clone();
+    let client = TidalClient::new(tokens.access_token.clone(), tokens.country_code.clone());
+    let resp = match client.get_playlist_tracks(&uuid, 100, 0).await {
+        Ok(r) => r,
+        Err(e) if error_looks_like_auth(&e) => {
+            let refreshed = recover_tidal_session(&state, &http_client, &tokens)
+                .await
+                .map_err(|re| (
+                    StatusCode::BAD_GATEWAY,
+                    Json(json!({ "error": format!("TIDAL session refresh failed: {}", re) })),
+                ))?;
+            let retry_client = TidalClient::new(
+                refreshed.access_token.clone(),
+                refreshed.country_code.clone(),
+            );
+            retry_client.get_playlist_tracks(&uuid, 100, 0).await.map_err(|e2| {
+                (StatusCode::BAD_GATEWAY, Json(json!({ "error": e2.to_string() })))
+            })?
+        }
+        Err(e) => return Err((StatusCode::BAD_GATEWAY, Json(json!({ "error": e.to_string() })))),
+    };
+
+    // TidalTrack: id (i64), title (String), duration (i64), artist (TidalArtist, not Option),
+    // album: Option<TidalAlbumRef> with cover: Option<String>
+    let playable: Vec<serde_json::Value> = resp.items.iter().map(|t| {
+        json!({
+            "tidal_id": t.id,
+            "title": t.title,
+            "artist_name": t.artist.name,
+            "album_title": t.album.as_ref().map(|a| &a.title),
+            "artwork_url": t.album.as_ref().and_then(|a| a.cover.as_ref()).map(|c| {
+                format!("https://resources.tidal.com/images/{}/320x320.jpg", c.replace('-', "/"))
+            }),
+            "duration_ms": t.duration * 1000,
+            "track_id": 0,
+            "is_in_library": false,
+        })
+    }).collect();
+
+    Ok(Json(json!({ "tracks": playable })))
 }
 
 #[derive(Debug, serde::Deserialize)]

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -214,6 +214,11 @@ pub struct ResolveGroupRequest {
 }
 
 #[derive(Debug, Deserialize)]
+struct AddTracksToPlaylistRequest {
+    track_ids: Vec<i64>,
+}
+
+#[derive(Debug, Deserialize)]
 pub struct CreateSmartPlaylistRequest {
     name: String,
     description: Option<String>,
@@ -248,7 +253,7 @@ pub fn api_routes(state: SharedState) -> Router {
         .route("/api/genres/evolution", get(get_genre_evolution))
         .route("/api/genres/{id}/tracks", get(get_genre_tracks))
         .route("/api/playlists", get(get_playlists))
-        .route("/api/playlists/{id}/tracks", get(get_playlist_tracks))
+        .route("/api/playlists/{id}/tracks", get(get_playlist_tracks).post(add_tracks_to_playlist_route))
         .route("/api/playlists/{id}/favorite", patch(toggle_playlist_favorite_route))
         .route("/api/smart/playlists", post(create_smart_playlist_route))
         .route(
@@ -960,6 +965,26 @@ async fn toggle_playlist_favorite_route(
         .with_conn(|conn| {
             let playlist = queries::toggle_playlist_favorite(conn, id)?;
             Ok(Json(json!({ "playlist": playlist })))
+        })
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": e.to_string() })),
+            )
+        })
+}
+
+async fn add_tracks_to_playlist_route(
+    State(state): State<SharedState>,
+    Path(id): Path<i64>,
+    Json(payload): Json<AddTracksToPlaylistRequest>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    let state = state.read().await;
+    state
+        .db
+        .with_conn(|conn| {
+            let added = queries::add_tracks_to_playlist(conn, id, &payload.track_ids)?;
+            Ok(Json(json!({ "added": added })))
         })
         .map_err(|e| {
             (

--- a/noor-server/src/services/tidal/client.rs
+++ b/noor-server/src/services/tidal/client.rs
@@ -278,6 +278,31 @@ impl TidalClient {
         self.get_json(&url).await
     }
 
+    pub async fn search_playlists(
+        &self,
+        query: &str,
+        limit: i32,
+    ) -> Result<Vec<TidalPlaylist>> {
+        let url = format!(
+            "{}/search?query={}&countryCode={}&limit={}&types=PLAYLISTS",
+            TIDAL_API_URL,
+            urlencoding::encode(query),
+            self.country_code,
+            limit,
+        );
+        let payload: serde_json::Value = self.get_json(&url).await?;
+        let items = payload
+            .get("playlists")
+            .and_then(|p| p.get("items"))
+            .and_then(serde_json::Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        Ok(items
+            .into_iter()
+            .filter_map(|v| serde_json::from_value::<TidalPlaylist>(v).ok())
+            .collect())
+    }
+
     // ─── Album Tracks ──────────────────────────────────────
 
     pub async fn get_album_tracks(

--- a/noor-server/src/smart/analytics.rs
+++ b/noor-server/src/smart/analytics.rs
@@ -311,6 +311,7 @@ mod tests {
                 smart_rules: None,
                 is_synced: true,
                 track_count: 3,
+                is_favorite: false,
             },
             Playlist {
                 id: 2,
@@ -321,6 +322,7 @@ mod tests {
                 smart_rules: None,
                 is_synced: true,
                 track_count: 2,
+                is_favorite: false,
             },
         ];
         let context = AnalyticsContext::new()


### PR DESCRIPTION
## Summary

- **Playlist actions**: shuffle, radio, and heart (favorite) buttons on every playlist card
- **Add to playlist**: right-click context menu on album and artist cards with a nested playlist submenu (favorites first)
- **Playlists in search**: horizontal-scroll row for local + TIDAL playlist results, with a "Playlists" filter pill

## Backend changes
- `MIGRATION_017`: `is_favorite` column on `playlists` table
- `PATCH /api/playlists/{id}/favorite` — toggle favorite, returns updated playlist
- `POST /api/playlists/{id}/tracks` — bulk-insert tracks with deduplication
- `GET /api/tidal/playlists/search?q=` — search TIDAL playlists (with session recovery)
- `GET /api/tidal/playlists/{uuid}/tracks` — fetch tracks for a TIDAL playlist

## Frontend changes
- `player.ts`: `shufflePlaylist`, `startPlaylistRadio` (seeds from most-played track), `playTidalPlaylist`
- `playlists/+page.svelte`: heart/shuffle/radio buttons on cards
- `library/+page.svelte`: "Add to playlist" submenu on album and artist context menus
- `search/+page.svelte`: playlists row with local (in-library badge) and TIDAL cards; "Playlists" filter pill