### PR TITLE
feat(search): right-click menus + Tidal song radio fallback via silent import

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build:
+    runs-on: windows-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: latest
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Build portable
+        shell: pwsh
+        run: .\scripts\build-portable.ps1
+
+      - name: Rename artifact with version tag
+        shell: pwsh
+        run: |
+          $tag = "${{ github.ref_name }}"
+          Rename-Item dist\NOORwave-portable.zip "NOORwave-$tag-windows-x64.zip"
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/NOORwave-${{ github.ref_name }}-windows-x64.zip
+          generate_release_notes: true
+          body: |
+            **Windows portable — no install required. Unzip anywhere and run NOORwave.exe.**
+
+            ### Contents
+            - `NOORwave.exe` — app window + system tray
+            - `noor-server.exe` — local music server
+            - `www/` — bundled UI (do not delete)
+
+            ### Usage
+            1. Unzip to any folder
+            2. Double-click `NOORwave.exe`
+            3. Window opens when server is ready (~2s)

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -901,6 +901,20 @@ export const api = {
 		);
 	},
 
+	importTidalTrackForRadio(track: TidalPlayable) {
+		return fetchApi<{ tidal_id: number; local_id: number }>('/api/tidal/tracks/import', undefined, {
+			method: 'POST',
+			body: JSON.stringify({
+				tidal_id: track.tidal_id,
+				title: track.title,
+				artist_name: track.artist_name,
+				artist_tidal_id: track.artist_tidal_id ?? null,
+				album_title: track.album_title,
+				duration_ms: track.duration_ms,
+			}),
+		});
+	},
+
 	getGenres() {
 		return fetchApi<{ genres: Genre[] }>('/api/genres');
 	},

--- a/frontend/src/lib/stores/player.ts
+++ b/frontend/src/lib/stores/player.ts
@@ -629,21 +629,34 @@ export async function playTidalAlbum(tidalAlbumId: number): Promise<void> {
 }
 
 export async function startTidalSongRadio(track: TidalPlayable): Promise<void> {
+	// Try discovery radio seeded directly by Tidal ID (only works if track is already in library)
 	try {
 		const { tracks } = await api.getRadioTracks({ seed_tidal_id: track.tidal_id, limit: 40 });
 		const radioIds = tracks.map((t) => t.track_id);
 		if (radioIds.length > 0) {
-			// Tidal seed cannot be prepended to the library queue (queue only accepts library track IDs).
-			// Radio plays from the first library neighbour found.
 			await loadQueueAndPlay(radioIds);
 			showToast(`Radio from ${trackLabel(track)}`, 'success');
-		} else {
-			// No library tracks matched — fall back to playing the seed directly.
-			await playTidalTrackNow(track);
+			playerError.set(null);
+			return;
 		}
-		playerError.set(null);
 	} catch (error) {
-		playerError.set(`Tidal radio failed: ${error}`);
-		showToast(`Radio failed`, 'error');
+		// 404 = track not yet in library index — fall through to silent import.
+		// Any other error is a real failure.
+		if (!(error instanceof Error && error.message.includes('404'))) {
+			playerError.set(`Tidal radio failed: ${error}`);
+			showToast(`Radio failed`, 'error');
+			return;
+		}
+	}
+
+	// Fallback: silently import the track as a tidal_stream entry (invisible in library grids)
+	// so the radio engine can use it as a seed, then run song radio from the resulting local ID.
+	try {
+		const { local_id } = await api.importTidalTrackForRadio(track);
+		await startSongRadio(local_id);
+		playerError.set(null);
+	} catch {
+		showToast(`No radio results for "${trackLabel(track)}"`, 'info');
+		playerError.set(null);
 	}
 }

--- a/frontend/src/routes/search/+page.svelte
+++ b/frontend/src/routes/search/+page.svelte
@@ -43,6 +43,15 @@
   let audioResults = $state<AudioSearchResult[] | null>(null)
   let loading = $state(false)
   let error = $state<string | null>(null)
+  let failedArtistImages = $state(new Set<number>())
+  let topArtistImageFailed = $state(false)
+  $effect(() => {
+    // reset image error state when search results change
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    results
+    failedArtistImages = new Set()
+    topArtistImageFailed = false
+  })
   let debounceTimer: ReturnType<typeof setTimeout>
 
   // D5 — in-memory result cache (last 5 queries, keyed by normalised query string)
@@ -359,7 +368,7 @@
         album_title: track.album_title ?? null,
       })
     }
-    return buildTidalTrackMenu(track)
+    return buildTidalTrackMenu(toPlayable(track))
   }
 
   // ─── Keyboard navigation ────────────────────────────────────────────────
@@ -596,6 +605,7 @@
               tabindex="0"
               onclick={() => void playLibraryTrack(track)}
               onkeydown={(e) => e.key === 'Enter' && void playLibraryTrack(track)}
+              oncontextmenu={(e) => { e.preventDefault(); openContextMenu(e, buildTrackMenu({ id: track.id, title: track.title, artist_name: track.artist_name, album_title: track.album_title, is_favorite: track.is_favorite })) }}
             >
               {#if track.artwork_url}
                 <div class="track-art" style={`background-image: url('${track.artwork_url}')`}></div>
@@ -620,6 +630,12 @@
                   title="Play now"
                   aria-label="Play {track.title}"
                 >▶</button>
+                <button
+                  class="row-btn"
+                  onclick={(e) => { e.stopPropagation(); openContextMenu(e, buildTrackMenu({ id: track.id, title: track.title, artist_name: track.artist_name, album_title: track.album_title, is_favorite: track.is_favorite })) }}
+                  title="More options"
+                  aria-label="More options"
+                >⋯</button>
               </div>
             </li>
           {/each}
@@ -644,13 +660,19 @@
           class:artist-hero={top.kind === 'artist'}
           role="button"
           tabindex="0"
-          style={top.kind === 'artist' && artistBg ? `background-image: url('${artistBg}'); background-size: cover; background-position: center top;` : ''}
+          style={top.kind === 'artist' && artistBg && !topArtistImageFailed ? `background-image: url('${artistBg}'); background-size: cover; background-position: center top;` : ''}
           onclick={() => void goto(topResultHref(top))}
           onkeydown={(e) => (e.key === 'Enter' || e.key === ' ') && (e.preventDefault(), void goto(topResultHref(top)))}
+          oncontextmenu={(e) => { e.preventDefault(); openContextMenu(e, top.kind === 'track' ? trackContextMenu(top.entry) : top.kind === 'album' ? buildAlbumMenu(top.entry) : buildArtistMenu(top.entry)) }}
         >
           {#if top.kind === 'artist'}
-            {#if artistBg}
-              <div class="top-art top-art--circle" style={`background-image: url('${artistBg}')`}></div>
+            {#if artistBg && !topArtistImageFailed}
+              <img
+                class="top-art top-art--circle"
+                src={artistBg}
+                alt={top.entry.name}
+                onerror={() => { topArtistImageFailed = true }}
+              />
             {:else}
               <div class="top-art top-art--circle fallback" style={`background: ${letterColor(top.entry.name)}`}>
                 <span>{initials(top.entry.name)}</span>
@@ -696,8 +718,13 @@
               oncontextmenu={(e) => { e.preventDefault(); openContextMenu(e, buildArtistMenu(artist)) }}
             >
               <div class="avatar-wrap">
-                {#if artist.artwork_url}
-                  <div class="artist-avatar" style={`background-image: url('${artist.artwork_url}')`}></div>
+                {#if artist.artwork_url && !failedArtistImages.has(artist.tidal_id)}
+                  <img
+                    class="artist-avatar"
+                    src={artist.artwork_url}
+                    alt={artist.name}
+                    onerror={() => { failedArtistImages = new Set([...failedArtistImages, artist.tidal_id]) }}
+                  />
                 {:else}
                   <div class="artist-avatar fallback" style={`background: ${letterColor(artist.name)}`}>
                     <span>{initials(artist.name)}</span>
@@ -893,6 +920,7 @@
               tabindex="0"
               onclick={() => void playTrackNow(track.id)}
               onkeydown={(e) => e.key === 'Enter' && void playTrackNow(track.id)}
+              oncontextmenu={(e) => { e.preventDefault(); openContextMenu(e, buildTrackMenu({ id: track.id, title: track.title, artist_name: track.artist_name, album_title: track.album_title })) }}
             >
               {#if track.artwork_url}
                 <div class="track-art" style="background-image:url('{track.artwork_url}')"></div>
@@ -924,6 +952,7 @@
               tabindex="0"
               onclick={() => void playTrackNow(track.id)}
               onkeydown={(e) => e.key === 'Enter' && void playTrackNow(track.id)}
+              oncontextmenu={(e) => { e.preventDefault(); openContextMenu(e, buildTrackMenu({ id: track.id, title: track.title, artist_name: track.artist_name, album_title: track.album_title })) }}
             >
               {#if track.artwork_url}
                 <div class="track-art" style="background-image:url('{track.artwork_url}')"></div>
@@ -1132,10 +1161,13 @@
     background-size: cover;
     background-position: center;
     background-color: var(--bg-raised);
+    box-shadow: 0 12px 28px -12px rgba(0,0,0,0.6);
+    object-fit: cover;
+  }
+  .top-art.fallback {
     display: flex;
     align-items: center;
     justify-content: center;
-    box-shadow: 0 12px 28px -12px rgba(0,0,0,0.6);
   }
   .top-art--circle { border-radius: 50%; }
   .top-art.fallback span {
@@ -1253,9 +1285,11 @@
     height: 72px;
     border-radius: 50%;
     background: var(--bg-raised);
-    background-size: cover;
-    background-position: center;
+    object-fit: cover;
+    display: block;
     transition: opacity 0.15s;
+  }
+  .artist-avatar.fallback {
     display: flex;
     align-items: center;
     justify-content: center;

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -246,6 +246,7 @@ pub fn api_routes(state: SharedState) -> Router {
         .route("/api/artists/{id}/discography", get(get_artist_discography))
         .route("/api/tidal/albums/{id}/tracks", get(get_tidal_album_tracks))
         .route("/api/tidal/albums/{id}/import", post(import_tidal_album))
+        .route("/api/tidal/tracks/import", post(import_tidal_track_for_radio))
         .route("/api/genres", get(get_genres))
         .route("/api/genres/heat", get(get_genre_heat))
         .route("/api/genres/co-occurrence", get(get_genre_co_occurrence))
@@ -792,6 +793,46 @@ async fn import_tidal_album(
     Ok(Json(json!({
         "album_id": imported.album_id,
         "tracks": tracks,
+    })))
+}
+
+#[derive(Debug, Deserialize)]
+struct ImportTidalTrackBody {
+    tidal_id: i64,
+    title: String,
+    artist_name: String,
+    artist_tidal_id: Option<i64>,
+    album_title: Option<String>,
+    duration_ms: Option<i64>,
+}
+
+async fn import_tidal_track_for_radio(
+    State(state): State<SharedState>,
+    Json(body): Json<ImportTidalTrackBody>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    let db = {
+        let s = state.read().await;
+        s.db.clone()
+    };
+    let imported = tidal_import::import_track_from_metadata(
+        &db,
+        body.tidal_id,
+        body.title,
+        body.artist_name,
+        body.artist_tidal_id,
+        body.album_title,
+        body.duration_ms,
+    )
+    .await
+    .map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": e.to_string() })),
+        )
+    })?;
+    Ok(Json(json!({
+        "tidal_id": imported.tidal_id,
+        "local_id": imported.local_id,
     })))
 }
 

--- a/noor-server/src/services/tidal/import.rs
+++ b/noor-server/src/services/tidal/import.rs
@@ -156,6 +156,75 @@ fn upsert_album_tx(
     Ok(tx.last_insert_rowid())
 }
 
+pub async fn import_track_from_metadata(
+    conn_pool: &crate::db::Database,
+    tidal_id: i64,
+    title: String,
+    artist_name: String,
+    artist_tidal_id: Option<i64>,
+    album_title: Option<String>,
+    duration_ms: Option<i64>,
+) -> Result<ImportedTrack> {
+    conn_pool.with_conn(move |conn| {
+        let tx = conn.unchecked_transaction()?;
+
+        let artist_id = upsert_artist_tx(&tx, artist_tidal_id.unwrap_or(0), &artist_name)?;
+
+        let album_id: Option<i64> = if let Some(ref atitle) = album_title {
+            let existing: Option<i64> = tx
+                .query_row(
+                    "SELECT id FROM albums WHERE artist_id = ?1 AND title = ?2 LIMIT 1",
+                    params![artist_id, atitle],
+                    |row| row.get(0),
+                )
+                .optional()?;
+            if let Some(id) = existing {
+                Some(id)
+            } else {
+                tx.execute(
+                    "INSERT INTO albums (title, artist_id, source) VALUES (?1, ?2, ?3)",
+                    params![atitle, artist_id, TIDAL_STREAM_SOURCE],
+                )?;
+                Some(tx.last_insert_rowid())
+            }
+        } else {
+            None
+        };
+
+        let existing: Option<i64> = tx
+            .query_row(
+                "SELECT id FROM tracks WHERE tidal_id = ?1",
+                params![tidal_id],
+                |row| row.get(0),
+            )
+            .optional()?;
+
+        let local_id = if let Some(id) = existing {
+            id
+        } else {
+            tx.execute(
+                "INSERT INTO tracks (
+                    tidal_id, title, artist_id, album_id,
+                    duration_ms, best_quality, best_source, fidelity_score,
+                    is_favorite, source
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, 'LOSSLESS', 'tidal', 700, 0, ?6)",
+                params![
+                    tidal_id,
+                    title,
+                    artist_id,
+                    album_id,
+                    duration_ms.unwrap_or(0),
+                    TIDAL_STREAM_SOURCE,
+                ],
+            )?;
+            tx.last_insert_rowid()
+        };
+
+        tx.commit()?;
+        Ok(ImportedTrack { tidal_id, local_id })
+    })
+}
+
 fn upsert_track_tx(
     tx: &rusqlite::Transaction<'_>,
     t: &TidalTrack,

--- a/scripts/build-portable.ps1
+++ b/scripts/build-portable.ps1
@@ -17,8 +17,8 @@ Write-Host "=== NOORwave Portable Build ===" -ForegroundColor Cyan
 # 1. Build frontend
 Write-Host "1/4 Building frontend..." -ForegroundColor Yellow
 Push-Location frontend
-npm ci --silent
-npm run build
+pnpm install --frozen-lockfile
+pnpm run build
 Pop-Location
 Write-Host "    Frontend built -> frontend/build/" -ForegroundColor Green
 


### PR DESCRIPTION
## Summary

- Add `oncontextmenu` to all search track sections that were missing it: audioResults (filter mode), "Same vibe", "Unplayed in your library", and the top-result card. Also adds a ⋯ button to audioResults rows.
- Fix `trackContextMenu` to pass `toPlayable(track)` to `buildTidalTrackMenu` so `artist_tidal_id` is correctly mapped.
- Fix song radio for non-library Tidal tracks: previously 404'd because `/api/discovery/radio` requires a library-indexed seed. New flow silently upserts the track as `source='tidal_stream'` (invisible in library grids) then runs song radio from the resulting local ID, using the Last.fm blend to find similar tracks.

## Backend changes

- `noor-server/src/services/tidal/import.rs` — add `import_track_from_metadata()` to insert a single Tidal track without a Tidal API call, using the metadata already available on the client.
- `noor-server/src/server/routes.rs` — add `POST /api/tidal/tracks/import` route and handler.

## Test plan

- [ ] Right-click any track row in the search track list → context menu appears
- [ ] Right-click a track in the audio filter results (BPM/energy filters) → context menu appears
- [ ] Right-click a "Same vibe" or "Unplayed in your library" row → context menu appears
- [ ] Right-click the top-result card (track/album/artist) → correct context menu appears
- [ ] Click "Song radio" on a non-library Tidal track → radio starts (first try silently imports, second try uses cached entry)
- [ ] Library grids do not show the silently-imported tracks