### PR TITLE
feat(home): TIDAL Your Mixes shelf, Last.fm-API releases, server-side…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ build/
 noor.db
 noor.db-wal
 noor.db-shm
+.noor_secret
 *.exe
 .env
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2503,6 +2503,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2715,6 +2721,7 @@ dependencies = [
  "cpal",
  "futures",
  "hmac",
+ "md5",
  "num-complex",
  "rand 0.8.6",
  "rayon",

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -704,9 +704,53 @@ export interface RSSFeedItem {
 	category: string;
 }
 
-export interface HomeReleasesResponse {
-	releases: RSSFeedItem[];
+/// Last.fm-API-sourced new release. Different shape than `RSSFeedItem`:
+/// no description/category (Last.fm doesn't supply them).
+export interface ReleaseItem {
+	title: string;
+	link: string;
+	author: string;
+	image_url: string | null;
 	source: string;
+	published_at: string | null;
+}
+
+export interface HomeReleasesResponse {
+	releases: ReleaseItem[];
+	source: string;
+}
+
+export interface TidalMix {
+	id: string;
+	title: string;
+	sub_title?: string | null;
+	image_url?: string | null;
+	mix_type?: string | null;
+}
+
+export interface TidalMixesResponse {
+	mixes: TidalMix[];
+	source: string;
+}
+
+export interface LastfmStatus {
+	configured: boolean;
+	enrichment: boolean;
+	scrobbling: boolean;
+	scrobble_available: boolean;
+	user: string | null;
+}
+
+export interface LastfmAuthStartResponse {
+	status: 'awaiting' | 'error';
+	auth_url?: string;
+	message?: string;
+}
+
+export interface LastfmAuthCompleteResponse {
+	status: 'connected' | 'not_yet_authorized' | 'error';
+	user?: string;
+	message?: string;
 }
 
 export interface HomePickTrack {
@@ -899,13 +943,19 @@ async function fetchApi<T>(
 }
 
 export const api = {
-	getTracks(sortBy = 'date_added', sortDir = 'desc', limit = 50, offset = 0, favoriteOnly = true) {
+	// `favoriteOnly` is legacy: server-side it currently means "library tracks"
+	// (liked tracks ∪ tracks from favorited albums). Use `likedOnly` for a strict
+	// filter on tracks the user has actually liked. likedOnly takes precedence
+	// over favoriteOnly server-side.
+	// TODO: drop the favoriteOnly default once all call sites pass it explicitly.
+	getTracks(sortBy = 'date_added', sortDir = 'desc', limit = 50, offset = 0, favoriteOnly = true, likedOnly = false) {
 		return fetchApi<{ tracks: Track[]; total: number }>('/api/tracks', {
 			sort_by: sortBy,
 			sort_dir: sortDir,
 			limit: String(limit),
 			offset: String(offset),
 			favorite_only: String(favoriteOnly),
+			liked_only: String(likedOnly),
 		});
 	},
 
@@ -1570,6 +1620,62 @@ export const api = {
 
 	getHomeNews() {
 		return fetchApi<HomeNewsResponse>('/api/home/news');
+	},
+
+	// ─── TIDAL: Your Mixes ────────────────────────────────────────────────
+	// 503 here means TIDAL isn't connected — the YourMixesShelf surfaces a
+	// connect prompt rather than an error toast.
+	getTidalMixes() {
+		return fetchApi<TidalMixesResponse>('/api/tidal/mixes');
+	},
+
+	// Mix track list — used to queue + play a mix when a card is clicked.
+	getTidalMixTracks(mixId: string) {
+		return fetchApi<{ tracks: TidalDiscographyTrack[] }>(
+			`/api/tidal/mixes/${encodeURIComponent(mixId)}/tracks`
+		);
+	},
+
+	// Play the first track of a mix immediately and queue the rest as
+	// pending ephemeral tracks (server auto-advances on track-end).
+	playTidalMix(tracks: TidalPlayable[]) {
+		return fetchApi<void>('/api/tidal/play-mix', undefined, {
+			method: 'POST',
+			body: JSON.stringify({
+				tracks: tracks.map((t) => ({
+					tidal_track_id: t.tidal_id,
+					title: t.title,
+					artist_name: t.artist_name ?? null,
+					album_title: t.album_title ?? null,
+					artwork_url: t.artwork_url ?? null,
+					duration_ms: t.duration_ms ?? null,
+				})),
+			}),
+		});
+	},
+
+	// ─── Last.fm scrobble auth (server-side web-auth flow) ────────────────
+	getLastfmStatus() {
+		return fetchApi<LastfmStatus>('/api/lastfm/status');
+	},
+
+	// 501 here means LASTFM_API_SECRET isn't configured on the server.
+	lastfmAuthStart() {
+		return fetchApi<LastfmAuthStartResponse>('/api/lastfm/auth/start', undefined, {
+			method: 'POST',
+		});
+	},
+
+	lastfmAuthComplete() {
+		return fetchApi<LastfmAuthCompleteResponse>('/api/lastfm/auth/complete', undefined, {
+			method: 'POST',
+		});
+	},
+
+	lastfmAuthDisconnect() {
+		return fetchApi<{ status: string }>('/api/lastfm/auth/disconnect', undefined, {
+			method: 'POST',
+		});
 	},
 
 	// ─── Audio Analysis ───────────────────────────────────────────────

--- a/frontend/src/lib/components/home/YourMixesShelf.svelte
+++ b/frontend/src/lib/components/home/YourMixesShelf.svelte
@@ -1,0 +1,331 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { api, ApiError, type TidalMix } from '$lib/api/client';
+	import { playTidalMix } from '$lib/stores/player';
+
+	type State = 'loading' | 'ready' | 'empty' | 'disconnected' | 'error';
+
+	let mixes = $state<TidalMix[]>([]);
+	let viewState = $state<State>('loading');
+	let errorMsg = $state<string>('');
+
+	onMount(load);
+
+	async function load() {
+		viewState = 'loading';
+		errorMsg = '';
+		try {
+			const data = await api.getTidalMixes();
+			mixes = data.mixes ?? [];
+			viewState = mixes.length > 0 ? 'ready' : 'empty';
+		} catch (e) {
+			if (e instanceof ApiError && e.status === 503) {
+				viewState = 'disconnected';
+			} else {
+				viewState = 'error';
+				errorMsg = e instanceof Error ? e.message : 'Failed to load mixes';
+			}
+		}
+	}
+
+	// Translate vertical wheel scroll to horizontal scroll over the rail.
+	// Wheel events only fire on the hovered element, so this naturally
+	// activates only when the cursor is over the rail (per the user spec:
+	// "wheel should only be usable after a hover on card").
+	//
+	// Only preventDefault when there's actually room to scroll horizontally
+	// in the wheel direction — otherwise the page keeps scrolling vertically
+	// at the edges, so the rail doesn't trap the user mid-page.
+	function wheelToHorizontal(node: HTMLElement) {
+		const onWheel = (e: WheelEvent) => {
+			// Trackpads / native horizontal scroll devices already supply
+			// deltaX; only intervene when the user is genuinely scrolling
+			// vertically (deltaY dominant).
+			if (Math.abs(e.deltaY) <= Math.abs(e.deltaX)) return;
+
+			const max = node.scrollWidth - node.clientWidth;
+			if (max <= 0) return; // Nothing to scroll.
+
+			const goingRight = e.deltaY > 0;
+			const atStart = node.scrollLeft <= 0;
+			const atEnd = node.scrollLeft >= max - 1;
+			if ((goingRight && atEnd) || (!goingRight && atStart)) return;
+
+			e.preventDefault();
+			node.scrollLeft += e.deltaY;
+		};
+		node.addEventListener('wheel', onWheel, { passive: false });
+		return {
+			destroy() {
+				node.removeEventListener('wheel', onWheel);
+			},
+		};
+	}
+</script>
+
+<section class="discovery-section" data-section="your-mixes">
+	<div class="section-header">
+		<div class="section-title-group">
+			<p class="eyebrow">TIDAL</p>
+			<h2>Your Mixes</h2>
+		</div>
+		{#if viewState === 'loading'}
+			<span class="loading-indicator">Loading…</span>
+		{/if}
+	</div>
+
+	{#if viewState === 'loading'}
+		<div class="mix-rail" use:wheelToHorizontal>
+			{#each [0, 1, 2, 3, 4, 5] as i (i)}
+				<div class="mix-card skeleton">
+					<div class="art-wrap"><div class="art skeleton-art"></div></div>
+					<div class="meta">
+						<div class="skeleton-line skeleton-line-title"></div>
+						<div class="skeleton-line skeleton-line-sub"></div>
+					</div>
+				</div>
+			{/each}
+		</div>
+	{:else if viewState === 'ready'}
+		<div class="mix-rail" use:wheelToHorizontal>
+			{#each mixes as mix (mix.id)}
+				<button
+					type="button"
+					class="mix-card"
+					title={mix.sub_title ?? mix.title}
+					aria-label={`Play ${mix.title}`}
+					onclick={() => void playTidalMix(mix.id)}
+				>
+					<div class="art-wrap">
+						{#if mix.image_url}
+							<div
+								class="art"
+								style="background-image: url('{mix.image_url}')"
+							></div>
+						{:else}
+							<div class="art fallback">♫</div>
+						{/if}
+						<div class="play-overlay" aria-hidden="true">▶</div>
+					</div>
+					<div class="meta">
+						<h3 class="title">{mix.title}</h3>
+						{#if mix.sub_title}
+							<p class="artist">{mix.sub_title}</p>
+						{/if}
+					</div>
+				</button>
+			{/each}
+		</div>
+	{:else if viewState === 'empty'}
+		<p class="muted-line">TIDAL hasn't built mixes for you yet — keep listening.</p>
+	{:else if viewState === 'disconnected'}
+		<p class="muted-line">
+			Connect TIDAL to see your personal mixes.
+			<a class="inline-link" href="/settings#sources-tidal">Open settings</a>
+		</p>
+	{:else if viewState === 'error'}
+		<p class="muted-line">
+			Couldn't load your mixes{errorMsg ? `: ${errorMsg}` : '.'}
+			<button class="inline-link" onclick={load}>Retry</button>
+		</p>
+	{/if}
+</section>
+
+<style>
+	/* Mirrors the Trending shelf's visual language: borderless cards,
+	   transparent background, hover-zoom on artwork, ellipsised meta.
+	   Adapted to a horizontal rail (per the plan's carousel requirement)
+	   instead of Trending's auto-fill grid. */
+
+	.discovery-section {
+		display: flex;
+		flex-direction: column;
+		gap: 16px;
+	}
+	.section-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 16px;
+	}
+	.section-title-group {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+	}
+	.section-title-group h2 {
+		font-size: 1.15rem;
+		font-weight: 700;
+		margin: 0;
+	}
+	.loading-indicator {
+		font-size: 0.78rem;
+		color: var(--text-muted);
+		font-style: italic;
+	}
+
+	/* Horizontal rail */
+	.mix-rail {
+		display: flex;
+		gap: 14px;
+		overflow-x: auto;
+		padding-bottom: 8px;
+		scroll-snap-type: x mandatory;
+	}
+	.mix-rail::-webkit-scrollbar { height: 6px; }
+	.mix-rail::-webkit-scrollbar-track {
+		background: var(--bg-surface);
+		border-radius: 3px;
+	}
+	.mix-rail::-webkit-scrollbar-thumb {
+		background: var(--border-subtle);
+		border-radius: 3px;
+	}
+	.mix-rail::-webkit-scrollbar-thumb:hover {
+		background: var(--text-muted);
+	}
+
+	/* Card — transparent, borderless, hover-lift via background only.
+	   Width is locked with explicit min/max because flex-basis alone is
+	   negotiable when one item has a large intrinsic image (the Daily
+	   Discovery artwork was ballooning the first card before this). */
+	.mix-card {
+		flex: 0 0 180px;
+		width: 180px;
+		min-width: 180px;
+		max-width: 180px;
+		display: flex;
+		flex-direction: column;
+		gap: 10px;
+		background: none;
+		border: 1px solid transparent;
+		padding: 8px;
+		border-radius: 12px;
+		text-align: left;
+		scroll-snap-align: start;
+		transition: background 140ms ease, border-color 140ms ease;
+		box-sizing: border-box;
+		cursor: pointer;
+		font: inherit;
+		color: inherit;
+	}
+	.mix-card:hover,
+	.mix-card:focus-visible {
+		background: rgba(255, 255, 255, 0.04);
+		border-color: rgba(255, 255, 255, 0.08);
+		outline: none;
+	}
+	.mix-card:focus-visible {
+		border-color: var(--accent-line, rgba(125, 200, 175, 0.6));
+	}
+
+	.play-overlay {
+		position: absolute;
+		inset: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: linear-gradient(180deg, rgba(0, 0, 0, 0.05) 0%, rgba(0, 0, 0, 0.55) 100%);
+		opacity: 0;
+		color: #fff;
+		font-size: 28px;
+		transition: opacity 160ms ease;
+	}
+	.mix-card:hover .play-overlay,
+	.mix-card:focus-visible .play-overlay {
+		opacity: 1;
+	}
+
+	.art-wrap {
+		position: relative;
+		aspect-ratio: 1 / 1;
+		width: 100%;
+		border-radius: 8px;
+		overflow: hidden;
+		background: rgba(255, 255, 255, 0.04);
+	}
+	.art {
+		width: 100%;
+		height: 100%;
+		background-size: cover;
+		background-position: center;
+		transition: transform 220ms ease;
+	}
+	.mix-card:hover .art {
+		transform: scale(1.05);
+	}
+	.art.fallback {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		font-size: 48px;
+		color: rgba(255, 255, 255, 0.55);
+	}
+
+	.meta {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+		min-width: 0;
+	}
+	.title {
+		margin: 0;
+		font-size: 13.5px;
+		font-weight: 600;
+		color: var(--text-primary, #fff);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		line-height: 1.3;
+	}
+	.artist {
+		margin: 0;
+		font-size: 12px;
+		color: var(--text-secondary, rgba(255, 255, 255, 0.6));
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	/* Skeleton — same shape, shimmering art block */
+	.skeleton-art {
+		background: linear-gradient(
+			110deg,
+			rgba(255, 255, 255, 0.04) 30%,
+			rgba(255, 255, 255, 0.08) 50%,
+			rgba(255, 255, 255, 0.04) 70%
+		);
+		background-size: 200% 100%;
+		animation: shimmer 1.4s linear infinite;
+	}
+	.skeleton-line {
+		height: 0.7rem;
+		border-radius: 4px;
+		background: rgba(255, 255, 255, 0.08);
+	}
+	.skeleton-line-title { width: 75%; }
+	.skeleton-line-sub   { width: 50%; }
+	@keyframes shimmer {
+		0%   { background-position: 200% 0; }
+		100% { background-position: -200% 0; }
+	}
+
+	/* Inline empty / error / disconnected states — no boxed tile, just a
+	   muted line that sits in the rail's place. */
+	.muted-line {
+		margin: 0;
+		font-size: 13px;
+		color: var(--text-secondary, rgba(255, 255, 255, 0.6));
+	}
+	.inline-link {
+		background: none;
+		border: none;
+		padding: 0;
+		font: inherit;
+		color: var(--accent-line, #7dc8af);
+		cursor: pointer;
+		text-decoration: underline;
+		text-underline-offset: 2px;
+		margin-left: 6px;
+	}
+</style>

--- a/frontend/src/lib/components/onboarding/LastfmConnect.svelte
+++ b/frontend/src/lib/components/onboarding/LastfmConnect.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { authFetch, getApiBase } from '$lib/api/client';
+	import { onMount } from 'svelte';
+	import { authFetch, getApiBase, api } from '$lib/api/client';
 	import { openExternal } from '$lib/util/external';
 
 	let {
@@ -14,10 +15,50 @@
 		onskip?: () => void;
 	} = $props();
 
+	// ─── Tag-enrichment / API-key state ──────────────────────────────────
 	let apiKey = $state('');
 	let saving = $state(false);
 	let errorMsg = $state('');
 	let connected = $state(false);
+
+	// ─── Scrobble auth state ─────────────────────────────────────────────
+	// Mirrors the TidalConnect state machine in spirit, but for web-auth
+	// (NOT device-flow polling). We open the Last.fm authorize page, then
+	// the user clicks "I've authorized" to redeem the token server-side.
+	type ScrobbleState =
+		| 'idle'
+		| 'starting'
+		| 'awaiting_user'
+		| 'completing'
+		| 'connected'
+		| 'error'
+		| 'unavailable'; // Server has no LASTFM_API_SECRET set.
+	let scrobbleState = $state<ScrobbleState>('idle');
+	let scrobbleUser = $state<string | null>(null);
+	let scrobbleAvailable = $state(false);
+	let scrobbleError = $state('');
+	let pendingAuthUrl = $state<string | null>(null);
+
+	onMount(loadStatus);
+
+	async function loadStatus() {
+		try {
+			const status = await api.getLastfmStatus();
+			connected = status.enrichment;
+			scrobbleAvailable = status.scrobble_available;
+			scrobbleUser = status.user;
+			if (!status.scrobble_available) {
+				scrobbleState = 'unavailable';
+			} else if (status.scrobbling) {
+				scrobbleState = 'connected';
+			} else {
+				scrobbleState = 'idle';
+			}
+		} catch {
+			// Status endpoint failure shouldn't block the form — fall back to
+			// the legacy flow (start with `connected = false`).
+		}
+	}
 
 	async function save() {
 		if (!apiKey.trim()) {
@@ -37,6 +78,9 @@
 				connected = true;
 				apiKey = '';
 				onconnected?.();
+				// Refresh scrobble availability after the API key lands —
+				// it gates the scrobble auth flow.
+				void loadStatus();
 			} else {
 				errorMsg = data.message ?? 'Failed to save Last.fm API key.';
 			}
@@ -44,6 +88,75 @@
 			errorMsg = e instanceof Error ? e.message : String(e);
 		} finally {
 			saving = false;
+		}
+	}
+
+	async function startScrobbleAuth() {
+		scrobbleState = 'starting';
+		scrobbleError = '';
+		try {
+			const data = await api.lastfmAuthStart();
+			if (data.status === 'awaiting' && data.auth_url) {
+				pendingAuthUrl = data.auth_url;
+				scrobbleState = 'awaiting_user';
+				openExternal(data.auth_url);
+			} else {
+				scrobbleState = 'error';
+				scrobbleError = data.message ?? 'Could not start Last.fm auth.';
+			}
+		} catch (e: unknown) {
+			// 501 → server has no LASTFM_API_SECRET configured.
+			const status = (e as { status?: number })?.status;
+			if (status === 501) {
+				scrobbleState = 'unavailable';
+			} else {
+				scrobbleState = 'error';
+				scrobbleError = e instanceof Error ? e.message : 'Failed to start auth.';
+			}
+		}
+	}
+
+	async function completeScrobbleAuth() {
+		scrobbleState = 'completing';
+		scrobbleError = '';
+		try {
+			const data = await api.lastfmAuthComplete();
+			if (data.status === 'connected') {
+				scrobbleUser = data.user ?? null;
+				scrobbleState = 'connected';
+				pendingAuthUrl = null;
+			} else if (data.status === 'not_yet_authorized') {
+				// Stay in awaiting state so the user can retry after authorizing.
+				scrobbleState = 'awaiting_user';
+				scrobbleError = 'Not yet authorized — click "Yes, allow access" on Last.fm first.';
+			} else {
+				scrobbleState = 'error';
+				scrobbleError = data.message ?? 'Failed to complete Last.fm auth.';
+			}
+		} catch (e) {
+			scrobbleState = 'error';
+			scrobbleError = e instanceof Error ? e.message : 'Failed to complete auth.';
+		}
+	}
+
+	async function cancelScrobbleAuth() {
+		// Disconnect clears any stashed pending_token + session_key.
+		try {
+			await api.lastfmAuthDisconnect();
+		} catch {
+			// Best-effort — proceed regardless.
+		}
+		pendingAuthUrl = null;
+		scrobbleState = scrobbleAvailable ? 'idle' : 'unavailable';
+	}
+
+	async function disconnectScrobbling() {
+		try {
+			await api.lastfmAuthDisconnect();
+			scrobbleUser = null;
+			scrobbleState = scrobbleAvailable ? 'idle' : 'unavailable';
+		} catch (e) {
+			scrobbleError = e instanceof Error ? e.message : 'Failed to disconnect.';
 		}
 	}
 </script>
@@ -83,6 +196,63 @@
 		</div>
 	{:else}
 		<p class="success">Last.fm key saved.</p>
+
+		<!-- Enable scrobbling sub-section. Only meaningful in the settings
+		     variant — onboarding doesn't need to surface scrobble auth at
+		     first-run. -->
+		{#if variant === 'settings'}
+			<div class="scrobble-section">
+				<h3 class="scrobble-title">Enable scrobbling</h3>
+				<p class="muted scrobble-copy">
+					Scrobble TIDAL plays to your Last.fm profile. Eligible plays
+					(<span class="nowrap">≥ 50% of duration</span> or
+					<span class="nowrap">≥ 4 minutes</span>, with track ≥ 30s) are
+					scrobbled automatically.
+				</p>
+
+				{#if scrobbleState === 'connected'}
+					<p class="success">Scrobbling as @{scrobbleUser ?? 'you'}.</p>
+					<div class="actions">
+						<button class="btn btn-ghost" onclick={disconnectScrobbling}>Disconnect</button>
+					</div>
+				{:else if scrobbleState === 'unavailable'}
+					<p class="muted">
+						Server is not configured for Last.fm scrobbling. Ask the admin to set
+						<code>LASTFM_API_SECRET</code>.
+					</p>
+				{:else if scrobbleState === 'awaiting_user'}
+					<p class="muted">
+						A Last.fm authorization tab opened. Click <strong>"Yes, allow access"</strong>
+						there, then come back and click below.
+					</p>
+					{#if scrobbleError}
+						<p class="error">{scrobbleError}</p>
+					{/if}
+					<div class="actions">
+						<button class="btn btn-primary" onclick={completeScrobbleAuth}>I've authorized</button>
+						{#if pendingAuthUrl}
+							<button class="btn btn-ghost" onclick={() => pendingAuthUrl && openExternal(pendingAuthUrl)}>
+								Reopen auth page
+							</button>
+						{/if}
+						<button class="btn btn-ghost" onclick={cancelScrobbleAuth}>Cancel</button>
+					</div>
+				{:else if scrobbleState === 'completing'}
+					<p class="muted">Completing connection…</p>
+				{:else if scrobbleState === 'starting'}
+					<p class="muted">Starting Last.fm auth…</p>
+				{:else}
+					{#if scrobbleError}
+						<p class="error">{scrobbleError}</p>
+					{/if}
+					<div class="actions">
+						<button class="btn btn-primary" onclick={startScrobbleAuth}>
+							Connect Last.fm account
+						</button>
+					</div>
+				{/if}
+			</div>
+		{/if}
 	{/if}
 </div>
 
@@ -132,8 +302,11 @@
 	.actions {
 		display: flex;
 		gap: 12px;
-		justify-content: center;
+		justify-content: flex-start;
 		flex-wrap: wrap;
+	}
+	.variant-onboarding .actions {
+		justify-content: center;
 	}
 	.btn {
 		font: inherit;
@@ -155,4 +328,31 @@
 	.btn-ghost:hover { background: rgba(255, 255, 255, 0.04); color: #e7eaf2; }
 	.error { color: #ff8a8a; margin: 0; }
 	.success { color: #7fd99c; margin: 0; }
+	.scrobble-section {
+		margin-top: 8px;
+		padding-top: 14px;
+		border-top: 1px solid rgba(255, 255, 255, 0.06);
+		display: flex;
+		flex-direction: column;
+		gap: 10px;
+	}
+	.scrobble-title {
+		margin: 0;
+		font-size: 15px;
+		font-weight: 600;
+		letter-spacing: -0.005em;
+	}
+	.scrobble-copy {
+		max-width: 540px;
+	}
+	.nowrap {
+		white-space: nowrap;
+	}
+	code {
+		font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+		background: rgba(255, 255, 255, 0.06);
+		padding: 1px 5px;
+		border-radius: 4px;
+		font-size: 0.9em;
+	}
 </style>

--- a/frontend/src/lib/stores/player.ts
+++ b/frontend/src/lib/stores/player.ts
@@ -946,6 +946,66 @@ export async function playTidalAlbum(tidalAlbumId: number): Promise<void> {
 	}
 }
 
+/// Play a TIDAL mix by id — fetches the mix's track list and sends the WHOLE
+/// list to the server's `/api/tidal/play-mix` endpoint. The server starts the
+/// first track immediately and queues the rest behind it so playback
+/// auto-advances through the mix without a per-track round trip.
+export async function playTidalMix(mixId: string): Promise<void> {
+	if (!assertOnline()) return;
+	playerError.set(null);
+	try {
+		const { tracks } = await api.getTidalMixTracks(mixId);
+		if (tracks.length === 0) {
+			showToast('Mix has no tracks', 'error');
+			return;
+		}
+		// Optimistically reflect the first track in the now-playing UI so
+		// there's no flicker before the server's PlaybackStateChanged event
+		// arrives. Server will overwrite with authoritative data on Started.
+		const first = tracks[0];
+		currentTrack.set({
+			id: -first.tidal_id,
+			title: first.title,
+			artist_id: -1,
+			artist_name: first.artist_name ?? null,
+			artist_tidal_id: null,
+			album_id: null,
+			album_title: first.album_title ?? null,
+			disc_number: null,
+			track_number: null,
+			duration_ms: first.duration_ms,
+			isrc: null,
+			tidal_id: first.tidal_id,
+			best_quality: 'LOSSLESS',
+			best_source: 'tidal',
+			fidelity_score: 0,
+			is_favorite: false,
+			play_count: 0,
+			last_played_at: null,
+			date_added: null,
+			source: 'tidal_ephemeral',
+			artwork_url: first.artwork_url,
+		});
+		isPlaying.set(true);
+
+		await api.playTidalMix(
+			tracks.map((t) => ({
+				tidal_id: t.tidal_id,
+				title: t.title,
+				artist_name: t.artist_name ?? null,
+				album_title: t.album_title ?? null,
+				artwork_url: t.artwork_url,
+				duration_ms: t.duration_ms,
+			})),
+		);
+		noteSuccess();
+		showToast(`Playing mix (${tracks.length} tracks queued)`, 'success');
+	} catch (error) {
+		setError('play that Tidal mix', error, () => playTidalMix(mixId));
+		showToast(`Mix playback failed`, 'error');
+	}
+}
+
 export async function startTidalSongRadio(track: TidalPlayable): Promise<void> {
 	if (!assertOnline()) return;
 	playerError.set(null);

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -910,19 +910,8 @@
 	</header>
 
 	<aside class="sidebar">
-		<a href="/" class="brand" aria-label="NOOR home">
-			<span class="brand-mark">
-				<svg viewBox="184 292 656 440" fill="none" stroke="currentColor" stroke-width="56" aria-hidden="true">
-					<circle cx="384" cy="512" r="180"/>
-					<circle cx="384" cy="512" r="74"/>
-					<circle cx="640" cy="512" r="180"/>
-					<circle cx="640" cy="512" r="74"/>
-				</svg>
-			</span>
-			<div class="brand-text">
-				<span class="brand-name">NOOR</span>
-				<span class="brand-sub">Music command center</span>
-			</div>
+		<a href="/" class="brand" aria-label="NOORwave home">
+			<img class="brand-splash" src="/mark-animated-dark.svg" alt="NOORwave" />
 		</a>
 
 		<nav class="nav" aria-label="Primary">
@@ -1735,42 +1724,18 @@
 	.brand {
 		display: flex;
 		align-items: center;
-		gap: 12px;
+		justify-content: center;
 		padding: 4px 6px 18px;
 	}
 
-	.brand-mark {
-		width: 34px;
-		height: 34px;
-		border-radius: 10px;
-		background: var(--accent-soft);
-		border: 1px solid var(--accent-line);
-		color: var(--accent-strong);
-		display: grid;
-		place-items: center;
-		flex-shrink: 0;
-	}
-
-	.brand-mark svg {
-		width: 70%;
-		height: 70%;
-	}
-
-	.brand-text {
-		display: flex;
-		flex-direction: column;
-		min-width: 0;
-	}
-
-	.brand-name {
-		font-family: var(--font-display);
-		font-size: 1.08rem;
-		letter-spacing: 0.03em;
-	}
-
-	.brand-sub {
-		color: var(--text-secondary);
-		font-size: 0.77rem;
+	/* Animated NOORwave OO mark — replaces the small icon + "NOOR /
+	   Music command center" stack. The SVG is 320x160 (2:1) so it sits
+	   cleanly in the sidebar header without pushing nav items down. */
+	.brand-splash {
+		display: block;
+		width: 100%;
+		max-width: 100px;
+		height: auto;
 	}
 
 	.nav {

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -3,31 +3,24 @@
 	import type { Snapshot } from './$types';
 	import {
 		api,
-		getApiBase,
-		authFetch,
+		ApiError,
 		type RSSFeedItem,
+		type ReleaseItem,
 		type HomePickTrack,
 	} from '$lib/api/client';
 	import TrendingShelf from '$lib/components/charts/TrendingShelf.svelte';
-	import { wsConnected } from '$lib/api/ws';
-	import { currentTrack, currentTrackFeatures, isPlaying, playTrackNow } from '$lib/stores/player';
-	import { camelotFamily } from '$lib/utils/camelot';
-	import StateBadge from '$lib/components/ui/StateBadge.svelte';
+	import YourMixesShelf from '$lib/components/home/YourMixesShelf.svelte';
 	import EmptyState from '$lib/components/ui/EmptyState.svelte';
 	import TrendingCard from '$lib/components/TrendingCard.svelte';
 
 	// Home page data
-	let releases = $state<RSSFeedItem[]>([]);
+	let releases = $state<ReleaseItem[]>([]);
+	let releasesNotConfigured = $state(false);
 	let genrePicks = $state<HomePickTrack[]>([]);
 	let articles = $state<RSSFeedItem[]>([]);
 	let news = $state<RSSFeedItem[]>([]);
 
-	// Status data
-	let status = $state<{ name: string; version: string; status: string } | null>(null);
-	let tidalStatus = $state<'connected' | 'disconnected' | 'unknown'>('unknown');
-
 	// Loading states
-	let loading = $state(true);
 	let error = $state<string | null>(null);
 	let sectionsLoading = $state({
 		releases: true,
@@ -41,29 +34,8 @@
 	});
 
 	async function loadHome() {
-		loading = false; // Show page immediately, sections load independently
 		error = null;
-
-		try {
-			// Load status quickly
-			status = await api.getStatus();
-
-			// Load TIDAL status
-			try {
-				const tidalResponse = await authFetch(`${getApiBase()}/api/tidal/status`);
-				if (!tidalResponse.ok) throw new Error(`Server returned ${tidalResponse.status}`);
-				const tidalData = await tidalResponse.json();
-				tidalStatus = tidalData.connected ? 'connected' : 'disconnected';
-			} catch {
-				tidalStatus = 'unknown';
-			}
-		} catch {
-			error = 'NOOR could not reach the local server.';
-			loading = false;
-			return;
-		}
-
-		// Load all sections in parallel (don't await, let them populate as they finish)
+		// Load all sections in parallel — each handles its own error state.
 		loadReleases();
 		loadPicks();
 		loadArticles();
@@ -82,12 +54,20 @@
 
 	async function loadReleases() {
 		sectionsLoading.releases = true;
+		releasesNotConfigured = false;
 		try {
 			const data = await api.getHomeReleases();
 			releases = data.releases ?? [];
 		} catch (e) {
-			console.error('Failed to load releases:', e);
-			releases = [];
+			if (e instanceof ApiError && e.status === 503) {
+				// Backend signals "Last.fm not configured" via 503 so we can
+				// render a connect prompt instead of a generic error.
+				releasesNotConfigured = true;
+				releases = [];
+			} else {
+				console.error('Failed to load releases:', e);
+				releases = [];
+			}
 		} finally {
 			sectionsLoading.releases = false;
 		}
@@ -171,8 +151,7 @@
 <div class="page-shell home-page animate-in">
 	{#if error}
 		<section class="page-header">
-			<p class="eyebrow">NOOR</p>
-			<h1 class="display-face">Music command center</h1>
+			<img class="page-wordmark" src="/wordmark-dark.svg" alt="NOORwave" />
 		</section>
 		<EmptyState title="NOOR is offline" copy={error}>
 			{#snippet actions()}
@@ -181,20 +160,7 @@
 		</EmptyState>
 	{:else}
 		<section class="page-header">
-			<p class="eyebrow">NOOR</p>
-			<h1 class="display-face">Music command center</h1>
-			<div class="system-badges">
-				{#if status}
-					<StateBadge label={`Server v${status?.version}`} tone="success" />
-				{:else}
-					<StateBadge label="Loading..." tone="muted" />
-				{/if}
-				<StateBadge
-					label={tidalStatus === 'connected' ? 'TIDAL connected' : tidalStatus === 'disconnected' ? 'TIDAL offline' : 'TIDAL unknown'}
-					tone={tidalStatus === 'connected' ? 'active' : tidalStatus === 'disconnected' ? 'muted' : 'warning'}
-				/>
-				<StateBadge label={$wsConnected ? 'WS live' : 'WS offline'} tone={$wsConnected ? 'success' : 'muted'} />
-			</div>
+			<img class="page-wordmark" src="/wordmark-dark.svg" alt="NOORwave" />
 		</section>
 
 		<!-- Mobile quick-nav (hidden on desktop) -->
@@ -217,79 +183,12 @@
 			</a>
 		</nav>
 
-		{#if $currentTrack}
-			<section class="glass-panel now-playing-bar">
-				<div class="np-left">
-					{#if $currentTrack.artwork_url}
-						<img class="np-art" src={$currentTrack.artwork_url} alt="" />
-					{:else}
-						<div class="np-art placeholder">♫</div>
-					{/if}
-					<div class="np-meta">
-						<p class="eyebrow">{$isPlaying ? 'Now playing' : 'Paused'}</p>
-						<h3>{$currentTrack.title}</h3>
-						<span>{$currentTrack.artist_name ?? 'Unknown artist'}</span>
-						{#if $currentTrackFeatures}
-							<div class="now-playing-dsp">
-								{#if $currentTrackFeatures.camelot_key}
-									<span
-										class="camelot-badge camelot-{camelotFamily(
-											$currentTrackFeatures.camelot_key
-										)} camelot-letter-{$currentTrackFeatures.camelot_key.slice(-1).toUpperCase()}"
-									>
-										{$currentTrackFeatures.camelot_key}
-									</span>
-								{/if}
-								{#if $currentTrackFeatures.bpm}
-									<span class="bpm-label">{$currentTrackFeatures.bpm.toFixed(1)} BPM</span>
-								{/if}
-							</div>
-						{/if}
-					</div>
-				</div>
-			</section>
-		{/if}
 
-		<!-- New Releases Section -->
-		<section class="discovery-section">
-			<div class="section-header">
-				<div class="section-title-group">
-					<p class="eyebrow">AllMusic</p>
-					<h2>New releases</h2>
-				</div>
-				{#if sectionsLoading.releases}
-					<span class="loading-indicator">Loading...</span>
-				{/if}
-			</div>
-
-			{#if releases.length > 0}
-				<div class="horizontal-scroll">
-					{#each releases.slice(0, 12) as release (release.link)}
-						<a class="release-card glass-tile" href={release.link} target="_blank" rel="noopener">
-							{#if release.image_url}
-								<img class="release-art" src={release.image_url} alt="" />
-							{:else}
-								<div class="release-art placeholder">💿</div>
-							{/if}
-							<div class="release-info">
-								<h3 class="release-title">{release.title}</h3>
-								{#if release.author}
-									<p class="release-artist">{release.author}</p>
-								{/if}
-								<span class="release-source" style="color: {getSourceColor(release.source)}">
-									{release.source}
-								</span>
-							</div>
-						</a>
-					{/each}
-				</div>
-			{:else}
-				<EmptyState title="No new releases found" copy="AllMusic feed is currently unavailable." />
-			{/if}
-		</section>
+		<!-- Your Mixes (TIDAL) — replaces the prime above-Trending slot. -->
+		<YourMixesShelf />
 
 		<!-- Unified Trending shelf (Worldwide / Country / Genre / Tidal) -->
-		<section class="discovery-section">
+		<section class="discovery-section" data-section="trending">
 			<TrendingShelf limit={12} />
 
 			{#if genrePicks.length > 0}
@@ -304,6 +203,46 @@
 						{/each}
 					</div>
 				</div>
+			{/if}
+		</section>
+
+		<!-- New Releases (now below Trending, sourced from Last.fm JSON API). -->
+		<section class="discovery-section" data-section="new-releases">
+			<div class="section-header">
+				<div class="section-title-group">
+					<p class="eyebrow">Last.fm</p>
+					<h2>New releases</h2>
+				</div>
+				{#if sectionsLoading.releases}
+					<span class="loading-indicator">Loading...</span>
+				{/if}
+			</div>
+
+			{#if releases.length > 0}
+				<div class="horizontal-scroll">
+					{#each releases.slice(0, 12) as release (release.link || `${release.author}-${release.title}`)}
+						<a class="release-card glass-tile" href={release.link} target="_blank" rel="noopener">
+							{#if release.image_url}
+								<img class="release-art" src={release.image_url} alt="" />
+							{:else}
+								<div class="release-art placeholder">💿</div>
+							{/if}
+							<div class="release-info">
+								<h3 class="release-title">{release.title}</h3>
+								{#if release.author}
+									<p class="release-artist">{release.author}</p>
+								{/if}
+							</div>
+						</a>
+					{/each}
+				</div>
+			{:else if releasesNotConfigured}
+				<EmptyState
+					title="Connect Last.fm to see new releases"
+					copy="Last.fm powers the new-releases shelf. Add your API key in Settings → Sources → Last.fm."
+				/>
+			{:else if !sectionsLoading.releases}
+				<EmptyState title="No new releases found" copy="Last.fm did not return any recent albums." />
 			{/if}
 		</section>
 
@@ -394,124 +333,19 @@
 	.page-header {
 		display: flex;
 		flex-direction: column;
+		align-items: center;
 		gap: 8px;
 		padding-top: 4px;
 	}
 
-	.page-header h1 {
-		max-width: 16ch;
-		font-size: clamp(2rem, 3.4vw, 3.2rem);
-		line-height: 1.02;
+	/* Brand wordmark in the page header — replaces the old title + status
+	   badges. Centered, sized to feel like a hero rather than a label. */
+	.page-wordmark {
+		width: clamp(320px, 42vw, 640px);
+		height: auto;
+		display: block;
+		margin: 0 auto;
 	}
-
-	.system-badges {
-		display: flex;
-		flex-wrap: wrap;
-		gap: 10px;
-		margin-top: 8px;
-	}
-
-	/* Now playing bar */
-	.now-playing-bar {
-		padding: 16px 20px;
-		display: flex;
-		align-items: center;
-		gap: 16px;
-	}
-
-	.np-left {
-		display: flex;
-		align-items: center;
-		gap: 14px;
-	}
-
-	.np-art {
-		width: 52px;
-		height: 52px;
-		border-radius: 8px;
-		object-fit: cover;
-		flex-shrink: 0;
-	}
-
-	.np-art.placeholder {
-		background: var(--accent-soft);
-		display: grid;
-		place-items: center;
-		color: var(--accent-strong);
-		font-size: 1.2rem;
-	}
-
-	.np-meta {
-		display: flex;
-		flex-direction: column;
-		gap: 2px;
-		min-width: 0;
-	}
-
-	.np-meta h3 {
-		font-size: 0.95rem;
-		font-weight: 700;
-		white-space: nowrap;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		margin: 0;
-	}
-
-	.np-meta span {
-		font-size: 0.8rem;
-		color: var(--text-muted);
-	}
-
-	/* Now-playing DSP badge row */
-	.now-playing-dsp {
-		display: flex;
-		align-items: center;
-		gap: 8px;
-		margin-top: 3px;
-	}
-
-	.camelot-badge {
-		font-size: 10px;
-		font-weight: 700;
-		padding: 2px 6px;
-		border-radius: 4px;
-		letter-spacing: 0.02em;
-		color: #111;
-		background: rgba(255, 255, 255, 0.65);
-		line-height: 1;
-	}
-
-	.bpm-label {
-		font-size: 11px;
-		opacity: 0.55;
-		font-variant-numeric: tabular-nums;
-	}
-
-	/* Camelot wheel colors — B variants are vivid, A variants are desaturated. */
-	.camelot-1.camelot-letter-B  { background: #ff6b6b; color: #fff; }
-	.camelot-1.camelot-letter-A  { background: #d18b8b; color: #201010; }
-	.camelot-2.camelot-letter-B  { background: #ff9f43; color: #fff; }
-	.camelot-2.camelot-letter-A  { background: #c99a6e; color: #201810; }
-	.camelot-3.camelot-letter-B  { background: #ffd43b; color: #201a00; }
-	.camelot-3.camelot-letter-A  { background: #c8b36a; color: #1a1500; }
-	.camelot-4.camelot-letter-B  { background: #ffee58; color: #1c1a00; }
-	.camelot-4.camelot-letter-A  { background: #c7bf7a; color: #1a1800; }
-	.camelot-5.camelot-letter-B  { background: #a8e063; color: #0d1a05; }
-	.camelot-5.camelot-letter-A  { background: #9eb37a; color: #101a0c; }
-	.camelot-6.camelot-letter-B  { background: #4caf50; color: #fff; }
-	.camelot-6.camelot-letter-A  { background: #7fa080; color: #0c1a0d; }
-	.camelot-7.camelot-letter-B  { background: #26a69a; color: #fff; }
-	.camelot-7.camelot-letter-A  { background: #6fa39d; color: #081b19; }
-	.camelot-8.camelot-letter-B  { background: #00bcd4; color: #001e23; }
-	.camelot-8.camelot-letter-A  { background: #6ba8b3; color: #0a1c20; }
-	.camelot-9.camelot-letter-B  { background: #3b82f6; color: #fff; }
-	.camelot-9.camelot-letter-A  { background: #7e97c1; color: #0e162a; }
-	.camelot-10.camelot-letter-B { background: #6366f1; color: #fff; }
-	.camelot-10.camelot-letter-A { background: #8a8bc2; color: #14142a; }
-	.camelot-11.camelot-letter-B { background: #a855f7; color: #fff; }
-	.camelot-11.camelot-letter-A { background: #a58bc0; color: #1a1224; }
-	.camelot-12.camelot-letter-B { background: #ec4899; color: #fff; }
-	.camelot-12.camelot-letter-A { background: #c78aa5; color: #2a0f1d; }
 
 	/* Discovery sections */
 	.discovery-section {

--- a/frontend/static/mark-animated-dark.svg
+++ b/frontend/static/mark-animated-dark.svg
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 160" role="img" aria-label="NoorWave mark (animated, dark mode)">
+  <title>NoorWave animated mark — dark mode</title>
+  <desc>Dark-mode variant of the animated OO mark. White rings instead of dark navy, for use over dark surfaces. Transparent background.</desc>
+
+  <!-- LEFT RING (idle / silence state) -->
+  <g transform="translate(96, 80)">
+    <circle r="60" fill="none" stroke="#F5F7F9" stroke-width="5"/>
+    <circle r="46" fill="none" stroke="#22E0D6" stroke-width="4"/>
+    <circle r="30" fill="none" stroke="#F5F7F9" stroke-width="3.5"/>
+  </g>
+
+  <!-- RIGHT RING (active / signal state) -->
+  <g transform="translate(224, 80)">
+    <circle r="60" fill="none" stroke="#22E0D6">
+      <animate attributeName="r" values="60;90" dur="2s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.5;0" dur="2s" repeatCount="indefinite"/>
+      <animate attributeName="stroke-width" values="2.5;0.3" dur="2s" repeatCount="indefinite"/>
+    </circle>
+
+    <circle r="60" fill="none" stroke="#F5F7F9" stroke-width="5"/>
+
+    <circle r="46" fill="none" stroke="#22E0D6">
+      <animate attributeName="stroke-width" values="4;5;4" dur="2s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="1;0.85;1" dur="2s" repeatCount="indefinite"/>
+    </circle>
+
+    <circle r="30" fill="none" stroke="#F5F7F9" stroke-width="3.5"/>
+
+    <path stroke="#22E0D6" stroke-width="3.5" fill="none" stroke-linecap="round" stroke-linejoin="round">
+      <animate attributeName="d"
+               values="M -18 0 Q -13 -10, -8 -2 T 8 2 T 18 -3;
+                       M -18 0 Q -13 -3, -8 3 T 8 -3 T 18 2;
+                       M -18 0 Q -13 -8, -8 1 T 8 -6 T 18 -1;
+                       M -18 0 Q -13 -5, -8 -1 T 8 4 T 18 -2;
+                       M -18 0 Q -13 -10, -8 -2 T 8 2 T 18 -3"
+               keyTimes="0;0.25;0.5;0.75;1"
+               dur="2s" repeatCount="indefinite"
+               calcMode="spline"
+               keySplines="0.4 0 0.6 1; 0.4 0 0.6 1; 0.4 0 0.6 1; 0.4 0 0.6 1"/>
+    </path>
+  </g>
+</svg>

--- a/frontend/static/mark-animated.svg
+++ b/frontend/static/mark-animated.svg
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 160" role="img" aria-label="NoorWave mark (animated)">
+  <title>NoorWave animated mark</title>
+  <desc>Animated OO mark on transparent background. The right ring carries a pulsing waveform, the inner aqua ring breathes, and a soft sonar ring radiates outward once per 2-second loop. Sized for inline menu/header use.</desc>
+
+  <!-- LEFT RING (idle / silence state — never animates) -->
+  <g transform="translate(96, 80)">
+    <circle r="60" fill="none" stroke="#0B1220" stroke-width="5"/>
+    <circle r="46" fill="none" stroke="#22E0D6" stroke-width="4"/>
+    <circle r="30" fill="none" stroke="#0B1220" stroke-width="3.5"/>
+  </g>
+
+  <!-- RIGHT RING (active / signal state with animations) -->
+  <g transform="translate(224, 80)">
+
+    <!-- Sonar ping: ring expanding outward and fading once per cycle -->
+    <circle r="60" fill="none" stroke="#22E0D6">
+      <animate attributeName="r"
+               values="60;90"
+               dur="2s" repeatCount="indefinite"/>
+      <animate attributeName="opacity"
+               values="0.5;0"
+               dur="2s" repeatCount="indefinite"/>
+      <animate attributeName="stroke-width"
+               values="2.5;0.3"
+               dur="2s" repeatCount="indefinite"/>
+    </circle>
+
+    <!-- Outer ring (static) -->
+    <circle r="60" fill="none" stroke="#0B1220" stroke-width="5"/>
+
+    <!-- Middle aqua ring with subtle breathing -->
+    <circle r="46" fill="none" stroke="#22E0D6">
+      <animate attributeName="stroke-width"
+               values="4;5;4"
+               dur="2s" repeatCount="indefinite"/>
+      <animate attributeName="opacity"
+               values="1;0.85;1"
+               dur="2s" repeatCount="indefinite"/>
+    </circle>
+
+    <!-- Inner ring (static) -->
+    <circle r="30" fill="none" stroke="#0B1220" stroke-width="3.5"/>
+
+    <!-- Animated waveform inside the inner ring -->
+    <path stroke="#22E0D6" stroke-width="3.5" fill="none" stroke-linecap="round" stroke-linejoin="round">
+      <animate attributeName="d"
+               values="M -18 0 Q -13 -10, -8 -2 T 8 2 T 18 -3;
+                       M -18 0 Q -13 -3, -8 3 T 8 -3 T 18 2;
+                       M -18 0 Q -13 -8, -8 1 T 8 -6 T 18 -1;
+                       M -18 0 Q -13 -5, -8 -1 T 8 4 T 18 -2;
+                       M -18 0 Q -13 -10, -8 -2 T 8 2 T 18 -3"
+               keyTimes="0;0.25;0.5;0.75;1"
+               dur="2s" repeatCount="indefinite"
+               calcMode="spline"
+               keySplines="0.4 0 0.6 1; 0.4 0 0.6 1; 0.4 0 0.6 1; 0.4 0 0.6 1"/>
+    </path>
+  </g>
+</svg>

--- a/frontend/static/splash.svg
+++ b/frontend/static/splash.svg
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024" role="img" aria-label="NoorWave splash screen">
+  <title>NoorWave splash</title>
+  <desc>Animated splash with the waveform inside the right ring pulsing on a 2-second loop. The inner aqua ring breathes subtly and a soft sonar ping radiates outward from the right ring once per cycle.</desc>
+
+  <!-- Background -->
+  <rect width="1024" height="1024" rx="224" fill="#0B1220"/>
+
+  <!-- Left ring (idle / silence state) -->
+  <g transform="translate(348, 512)">
+    <circle r="180" fill="none" stroke="#F5F7F9" stroke-width="14" opacity="0.85"/>
+    <circle r="138" fill="none" stroke="#135A63" stroke-width="17"/>
+    <circle r="92" fill="none" stroke="#22E0D6" stroke-width="13"/>
+  </g>
+
+  <!-- Right ring (active / signal state with animated content) -->
+  <g transform="translate(676, 512)">
+
+    <!-- Sonar ping: ring expanding outward and fading once per cycle -->
+    <circle r="180" fill="none" stroke="#22E0D6">
+      <animate attributeName="r"
+               values="180;260"
+               dur="2s" repeatCount="indefinite"/>
+      <animate attributeName="opacity"
+               values="0.4;0"
+               dur="2s" repeatCount="indefinite"/>
+      <animate attributeName="stroke-width"
+               values="6;0.5"
+               dur="2s" repeatCount="indefinite"/>
+    </circle>
+
+    <!-- Outer ring (static) -->
+    <circle r="180" fill="none" stroke="#F5F7F9" stroke-width="14" opacity="0.85"/>
+
+    <!-- Middle structural ring (static) -->
+    <circle r="138" fill="none" stroke="#135A63" stroke-width="17"/>
+
+    <!-- Inner aqua ring with subtle breathing -->
+    <circle r="92" fill="none" stroke="#22E0D6">
+      <animate attributeName="stroke-width"
+               values="13;15.5;13"
+               dur="2s" repeatCount="indefinite"/>
+      <animate attributeName="opacity"
+               values="1;0.85;1"
+               dur="2s" repeatCount="indefinite"/>
+    </circle>
+
+    <!-- Animated waveform: morphs through 4 states for a continuous audio feel -->
+    <path stroke="#22E0D6" stroke-width="11" fill="none" stroke-linecap="round" stroke-linejoin="round">
+      <animate attributeName="d"
+               values="M -52 0 Q -38 -28, -22 -6 T 22 8 T 52 -10;
+                       M -52 0 Q -38 -8, -22 8 T 22 -8 T 52 6;
+                       M -52 0 Q -38 -22, -22 4 T 22 -16 T 52 -4;
+                       M -52 0 Q -38 -14, -22 -2 T 22 12 T 52 -6;
+                       M -52 0 Q -38 -28, -22 -6 T 22 8 T 52 -10"
+               keyTimes="0;0.25;0.5;0.75;1"
+               dur="2s" repeatCount="indefinite"
+               calcMode="spline"
+               keySplines="0.4 0 0.6 1; 0.4 0 0.6 1; 0.4 0 0.6 1; 0.4 0 0.6 1"/>
+    </path>
+  </g>
+</svg>

--- a/noor-server/Cargo.toml
+++ b/noor-server/Cargo.toml
@@ -39,6 +39,7 @@ rustfft = "6"
 num-complex = "0.4"
 hmac = "0.12"
 sha1 = "0.10"
+md5 = "0.7"
 
 # Utilities
 tracing = "0.1"

--- a/noor-server/src/main.rs
+++ b/noor-server/src/main.rs
@@ -36,6 +36,20 @@ pub struct StreamDisplayInfo {
     pub bit_depth: Option<i32>,
 }
 
+/// One slot in the pending ephemeral TIDAL queue (e.g. rest of a TIDAL mix
+/// after the first track started). Just metadata — stream URL is resolved
+/// lazily when this slot is promoted to the active track, since TIDAL stream
+/// URLs expire after ~30 min and a long mix could outlive an upfront resolve.
+#[derive(Debug, Clone)]
+pub struct PendingEphemeralTidalTrack {
+    pub tidal_track_id: i64,
+    pub title: String,
+    pub artist_name: Option<String>,
+    pub album_title: Option<String>,
+    pub artwork_url: Option<String>,
+    pub duration_ms: Option<i64>,
+}
+
 /// Shared application state accessible by all modules
 pub struct AppState {
     pub db: db::Database,
@@ -81,6 +95,21 @@ pub struct AppState {
     /// Discovery training cancel flag — flipped to true by POST /api/discovery/train/stop,
     /// reset to false at the start of each training run.
     pub discovery_train_cancel: Arc<AtomicBool>,
+    /// Symmetric key used to encrypt service secrets (currently only the
+    /// Last.fm scrobble session_key — see `services/crypto.rs`).
+    pub master_key: services::crypto::MasterKey,
+    /// Pending ephemeral TIDAL tracks queued behind the currently-playing
+    /// ephemeral track (e.g. the rest of a TIDAL mix the user clicked into).
+    /// Auto-advanced by `handle_runtime_finished` when the active ephemeral
+    /// track ends. Cleared on explicit stop or when the user starts a
+    /// different ephemeral track (`play_tidal_ephemeral` clears before
+    /// queuing). Stream URLs resolved lazily at advance time — TIDAL
+    /// stream URLs expire (~30 min) so pre-resolving the whole mix is wasteful.
+    pub pending_tidal_mix_queue: Arc<std::sync::Mutex<std::collections::VecDeque<PendingEphemeralTidalTrack>>>,
+    /// Last.fm app shared secret, loaded once from `LASTFM_API_SECRET` env at
+    /// boot. `None` disables every scrobble auth + scrobble call (endpoints
+    /// return HTTP 501). Never serialized into responses, never logged.
+    pub lastfm_api_secret: Option<String>,
     /// Shared bearer token for network auth
     pub server_token: String,
     /// `true` only while the CPAL callback is actively draining samples (set by the
@@ -223,6 +252,22 @@ async fn main() -> Result<()> {
     info!("Database initialized");
     info!("Genre taxonomy loaded: {} genres", genre_count);
 
+    // Load (or generate) the master key used to encrypt service secrets.
+    // Lives next to noor.db so it travels with the install.
+    let master_key = services::crypto::MasterKey::load_or_generate(
+        &services::crypto::secret_dir_for_db(&db_path),
+    )?;
+
+    // Last.fm shared app secret. Optional: when missing, all scrobble auth +
+    // scrobble endpoints return 501 and the rest of the app keeps working.
+    // Never round-tripped through the UI, never logged.
+    let lastfm_api_secret = std::env::var("LASTFM_API_SECRET").ok().filter(|s| !s.is_empty());
+    if lastfm_api_secret.is_some() {
+        info!("Last.fm scrobbling enabled (LASTFM_API_SECRET present)");
+    } else {
+        info!("Last.fm scrobbling disabled (set LASTFM_API_SECRET to enable)");
+    }
+
     // Event bus for real-time state sync
     let (event_tx, _) = broadcast::channel(256);
 
@@ -307,6 +352,9 @@ async fn main() -> Result<()> {
         lastfm_prefetch_done: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
         lastfm_enrich_started_at: Arc::new(std::sync::atomic::AtomicI64::new(0)),
         discovery_train_cancel: Arc::new(AtomicBool::new(false)),
+        master_key,
+        pending_tidal_mix_queue: Arc::new(std::sync::Mutex::new(std::collections::VecDeque::new())),
+        lastfm_api_secret,
         server_token,
         audio_active: Arc::new(AtomicBool::new(false)),
     }));

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -40,7 +40,13 @@ pub struct ListParams {
     sort_dir: Option<String>,
     limit: Option<i64>,
     offset: Option<i64>,
+    // Legacy naming: despite "favorite_only", this means "library tracks" =
+    // tracks where tracks.is_favorite=1 OR the parent album has albums.is_favorite=1.
+    // For a strict "user explicitly liked this track" filter, use `liked_only` instead.
     favorite_only: Option<bool>,
+    // Strict filter: tracks where tracks.is_favorite=1 only. Takes precedence
+    // over `favorite_only` when both are set.
+    liked_only: Option<bool>,
     // DSP filter params
     bpm_min: Option<f64>,
     bpm_max: Option<f64>,
@@ -425,6 +431,10 @@ pub fn api_routes(state: SharedState) -> Router {
         .route("/api/lastfm/config", post(lastfm_save_config))
         .route("/api/lastfm/config", axum::routing::delete(lastfm_clear_config))
         .route("/api/lastfm/status", get(lastfm_status))
+        // Last.fm scrobble auth (server-side flow — `LASTFM_API_SECRET` env required)
+        .route("/api/lastfm/auth/start", post(lastfm_auth_start))
+        .route("/api/lastfm/auth/complete", post(lastfm_auth_complete))
+        .route("/api/lastfm/auth/disconnect", post(lastfm_auth_disconnect))
         .route("/api/library/enrich/lastfm", post(start_lastfm_enrichment))
         .route("/api/library/enrich/lastfm/stop", post(stop_lastfm_enrichment))
         .route("/api/library/enrich/lastfm/status", get(get_lastfm_enrichment_status))
@@ -448,6 +458,10 @@ pub fn api_routes(state: SharedState) -> Router {
         .route("/api/home/picks", get(get_home_picks))
         .route("/api/home/articles", get(get_home_articles))
         .route("/api/home/news", get(get_home_news))
+        // TIDAL "Your Mixes" — drives the home Your Mixes shelf above Trending.
+        .route("/api/tidal/mixes", get(get_tidal_mixes))
+        .route("/api/tidal/mixes/{id}/tracks", get(get_tidal_mix_tracks))
+        .route("/api/tidal/play-mix", post(play_tidal_mix))
         // Trending / charts (Phase 5)
         .route("/api/charts", get(get_charts))
         .route("/api/charts/lastfm/genres", get(list_lastfm_genres))
@@ -544,6 +558,7 @@ async fn get_tracks(
     let limit = params.limit.unwrap_or(50);
     let offset = params.offset.unwrap_or(0);
     let favorite_only = params.favorite_only.unwrap_or(false);
+    let liked_only = params.liked_only.unwrap_or(false);
 
     let dsp = queries::DspFilters {
         bpm_min: params.bpm_min,
@@ -558,8 +573,8 @@ async fn get_tracks(
         .db
         .with_conn(|conn| {
             let tracks =
-                queries::get_tracks_with_dsp(conn, sort_by, sort_dir, limit, offset, favorite_only, &dsp)?;
-            let total = queries::get_track_count(conn, favorite_only)?;
+                queries::get_tracks_with_dsp(conn, sort_by, sort_dir, limit, offset, favorite_only, liked_only, &dsp)?;
+            let total = queries::get_track_count(conn, favorite_only, liked_only)?;
             Ok(Json(json!({ "tracks": tracks, "total": total })))
         })
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
@@ -570,11 +585,12 @@ async fn get_track_count(
     Query(params): Query<ListParams>,
 ) -> Result<Json<Value>, StatusCode> {
     let favorite_only = params.favorite_only.unwrap_or(false);
+    let liked_only = params.liked_only.unwrap_or(false);
     let state = state.read().await;
     state
         .db
         .with_conn(|conn| {
-            let count = queries::get_track_count(conn, favorite_only)?;
+            let count = queries::get_track_count(conn, favorite_only, liked_only)?;
             Ok(Json(json!({ "count": count })))
         })
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
@@ -4038,6 +4054,57 @@ async fn overlay_snapshot_with_external_track_and_position(
             snapshot.state.current_track = Some(track.clone());
         }
     }
+    // Surface the pending TIDAL mix queue (auto-advance items behind the
+    // currently-playing ephemeral track) into the visible queue so UP NEXT
+    // shows the rest of the mix instead of "empty".
+    let pending = state_guard
+        .pending_tidal_mix_queue
+        .lock()
+        .unwrap()
+        .iter()
+        .cloned()
+        .collect::<Vec<_>>();
+    drop(state_guard);
+    if !pending.is_empty() {
+        let start_position = snapshot.queue.iter().map(|q| q.position).max().unwrap_or(-1) + 1;
+        for (offset, p) in pending.into_iter().enumerate() {
+            let track = crate::db::models::Track {
+                id: -p.tidal_track_id,
+                title: p.title,
+                artist_id: 0,
+                artist_name: p.artist_name,
+                album_id: None,
+                album_title: p.album_title,
+                disc_number: None,
+                track_number: None,
+                duration_ms: p.duration_ms,
+                isrc: None,
+                tidal_id: Some(p.tidal_track_id),
+                ytmusic_id: None,
+                soundcloud_id: None,
+                best_quality: Some("LOSSLESS".to_string()),
+                best_source: Some("tidal".to_string()),
+                fidelity_score: 0,
+                is_favorite: false,
+                play_count: 0,
+                last_played_at: None,
+                date_added: None,
+                source: "tidal_ephemeral".to_string(),
+                artwork_url: p.artwork_url,
+            };
+            // Negative ids for both queue id + track id so the frontend can
+            // tell these are in-memory placeholders and skip remove/reorder
+            // until proper ephemeral-queue management ships.
+            snapshot.queue.push(crate::db::models::QueueItem {
+                id: -(offset as i64 + 1),
+                track,
+                position: start_position + offset as i32,
+                source: "tidal_mix".to_string(),
+                reason: None,
+                is_pending: false,
+            });
+        }
+    }
     snapshot
 }
 
@@ -4893,14 +4960,17 @@ async fn get_playback_runtime(State(state): State<SharedState>) -> Result<Json<V
 }
 
 async fn get_playback_queue(State(state): State<SharedState>) -> Result<Json<Value>, StatusCode> {
-    let state = state.read().await;
-    state
-        .db
-        .with_conn(|conn| {
-            let queue = queue::load_queue(conn)?;
-            Ok(Json(json!({ "queue": queue })))
-        })
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+    let snapshot = {
+        let state_guard = state.read().await;
+        state_guard
+            .db
+            .with_conn(player::load_snapshot)
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+    };
+    // Reuse the overlay so the pending TIDAL mix queue + any external/ephemeral
+    // current-track shows up here, matching what /api/playback/state returns.
+    let snapshot = overlay_snapshot_with_external_track(&state, snapshot).await;
+    Ok(Json(json!({ "queue": snapshot.queue })))
 }
 
 async fn play_track(
@@ -6838,9 +6908,78 @@ async fn play_tidal_ephemeral(
     State(state): State<SharedState>,
     Json(body): Json<PlayTidalRequest>,
 ) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    // Fresh single-track play wipes any pending mix queue — the user is
+    // explicitly choosing a different track, so the previously-queued mix
+    // continuation is no longer the user's intent.
+    {
+        let s = state.read().await;
+        s.pending_tidal_mix_queue.lock().unwrap().clear();
+    }
+    let track = crate::PendingEphemeralTidalTrack {
+        tidal_track_id: body.tidal_track_id,
+        title: body.title,
+        artist_name: body.artist_name,
+        album_title: body.album_title,
+        artwork_url: body.artwork_url,
+        duration_ms: body.duration_ms,
+    };
+    start_ephemeral_tidal_playback(&state, track).await?;
+    Ok(Json(json!({ "ok": true })))
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct PlayTidalMixRequest {
+    tracks: Vec<PlayTidalRequest>,
+}
+
+/// Play the first track immediately and stash the rest in the pending
+/// ephemeral queue so `handle_runtime_finished` can advance through them.
+/// Used by the home Your Mixes shelf when a tile is clicked.
+async fn play_tidal_mix(
+    State(state): State<SharedState>,
+    Json(body): Json<PlayTidalMixRequest>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    if body.tracks.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "Mix has no tracks" })),
+        ));
+    }
+
+    let mut iter = body.tracks.into_iter().map(|t| crate::PendingEphemeralTidalTrack {
+        tidal_track_id: t.tidal_track_id,
+        title: t.title,
+        artist_name: t.artist_name,
+        album_title: t.album_title,
+        artwork_url: t.artwork_url,
+        duration_ms: t.duration_ms,
+    });
+    let first = iter.next().expect("non-empty per check above");
+    let rest: Vec<crate::PendingEphemeralTidalTrack> = iter.collect();
+
+    // Replace any existing pending queue with this mix's continuation.
+    {
+        let s = state.read().await;
+        let mut q = s.pending_tidal_mix_queue.lock().unwrap();
+        q.clear();
+        q.extend(rest);
+    }
+
+    start_ephemeral_tidal_playback(&state, first).await?;
+    Ok(Json(json!({ "ok": true })))
+}
+
+/// Resolve a TIDAL stream URL and start ephemeral playback. Shared by the
+/// single-track entry point (`play_tidal_ephemeral`), the mix entry point
+/// (`play_tidal_mix`), and the auto-advance hook (`handle_runtime_finished`)
+/// when stepping through a queued mix.
+async fn start_ephemeral_tidal_playback(
+    state: &SharedState,
+    track: crate::PendingEphemeralTidalTrack,
+) -> Result<(), (StatusCode, Json<Value>)> {
     // Resolve TIDAL tokens (same pattern as tidal_search)
     let tokens = {
-        let persisted = load_persisted_tidal_tokens(&state).await.map_err(|e| {
+        let persisted = load_persisted_tidal_tokens(state).await.map_err(|e| {
             (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({ "error": e.to_string() })))
         })?;
         let s = state.read().await;
@@ -6859,7 +6998,7 @@ async fn play_tidal_ephemeral(
         let s = state.read().await;
         s.http_client.clone()
     };
-    let stream_req = tidal_stream::StreamRequest::new(body.tidal_track_id, "LOSSLESS");
+    let stream_req = tidal_stream::StreamRequest::new(track.tidal_track_id, "LOSSLESS");
     let stream_info = match tidal_stream::resolve_stream(
         &http_client,
         &tokens.access_token,
@@ -6869,7 +7008,7 @@ async fn play_tidal_ephemeral(
     {
         Ok(info) => info,
         Err(e) if e.is_session_expired() => {
-            let refreshed = recover_tidal_session(&state, &http_client, &tokens)
+            let refreshed = recover_tidal_session(state, &http_client, &tokens)
                 .await
                 .map_err(|re| (
                     StatusCode::BAD_GATEWAY,
@@ -6894,17 +7033,17 @@ async fn play_tidal_ephemeral(
 
     // Build a synthetic Track with a negative id to avoid any DB collision
     let synthetic = crate::db::models::Track {
-        id: -body.tidal_track_id,
-        title: body.title.clone(),
+        id: -track.tidal_track_id,
+        title: track.title.clone(),
         artist_id: 0,
-        artist_name: body.artist_name.clone(),
+        artist_name: track.artist_name.clone(),
         album_id: None,
-        album_title: body.album_title.clone(),
+        album_title: track.album_title.clone(),
         disc_number: None,
         track_number: None,
-        duration_ms: body.duration_ms,
+        duration_ms: track.duration_ms,
         isrc: None,
-        tidal_id: Some(body.tidal_track_id),
+        tidal_id: Some(track.tidal_track_id),
         ytmusic_id: None,
         soundcloud_id: None,
         best_quality: Some("LOSSLESS".to_string()),
@@ -6915,16 +7054,16 @@ async fn play_tidal_ephemeral(
         last_played_at: None,
         date_added: None,
         source: "tidal_ephemeral".to_string(),
-        artwork_url: body.artwork_url.clone(),
+        artwork_url: track.artwork_url.clone(),
     };
 
     // Build the playback job and start it via the runtime
-    let crossfade_ms = current_crossfade_ms(&state).await;
+    let crossfade_ms = current_crossfade_ms(state).await;
     let job = player::build_playback_preparation(&synthetic, Some(&stream_info), crossfade_ms, None);
-    let runtime_handle = ensure_playback_runtime_for_track(&state, &synthetic).await?;
+    let runtime_handle = ensure_playback_runtime_for_track(state, &synthetic).await?;
     runtime_handle.play(job).map_err(|e| {
         let message = format!("Failed to start host audio playback: {e}");
-        report_playback_failure(&state, &message);
+        report_playback_failure(state, &message);
         (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(json!({ "error": message })),
@@ -6962,9 +7101,9 @@ async fn play_tidal_ephemeral(
         let _ = state_guard.event_tx.send(AppEvent::PlaybackStateChanged);
         snapshot
     };
-    sync_session_after_snapshot(&state, &snapshot, Some(player::ListenSessionEndReason::Replaced)).await;
+    sync_session_after_snapshot(state, &snapshot, Some(player::ListenSessionEndReason::Replaced)).await;
 
-    Ok(Json(json!({ "ok": true })))
+    Ok(())
 }
 
 async fn tidal_artist_profile(
@@ -8073,6 +8212,33 @@ async fn handle_runtime_finished(state: SharedState, finished_track_id: i64) -> 
             .unwrap_or(false)
     };
     if external_finished {
+        // Auto-advance through any queued ephemeral mix continuation before
+        // tearing down. Pop the next track out of the pending queue and start
+        // it; if the queue is empty, fall through to the existing teardown.
+        let next = {
+            let s = state.read().await;
+            s.pending_tidal_mix_queue.lock().unwrap().pop_front()
+        };
+        if let Some(next) = next {
+            // Clear the previous ephemeral track marker so the new one's
+            // PlaybackStateChanged + Started events overwrite cleanly.
+            {
+                let mut state_guard = state.write().await;
+                state_guard.external_playback_track = None;
+            }
+            if let Err((status, body)) = start_ephemeral_tidal_playback(&state, next).await {
+                tracing::warn!(
+                    "Failed to advance ephemeral mix queue ({status}): {} — clearing remaining queue",
+                    body.0
+                );
+                let s = state.read().await;
+                s.pending_tidal_mix_queue.lock().unwrap().clear();
+                // Fall through to teardown so the UI doesn't get stuck on a
+                // ghost track.
+            } else {
+                return Ok(());
+            }
+        }
         {
             let mut state_guard = state.write().await;
             state_guard.external_playback_track = None;
@@ -8541,21 +8707,24 @@ async fn sync_session_after_snapshot(
     snapshot: &player::PlaybackSnapshot,
     end_reason: Option<player::ListenSessionEndReason>,
 ) {
-    let flushed_track_id = {
+    // Capture both the flush outcome and a "now playing" payload (if a new
+    // track just started) inside the write lock, then dispatch the Last.fm
+    // calls outside the lock so the spawned tasks never contend with us.
+    let (flushed_track_id, scrobble_completed_payload, now_playing_payload) = {
         let mut state = state.write().await;
         let now = chrono::Utc::now();
 
-        let flushed_track_id = if let Some(reason) = end_reason {
+        let outcome = if let Some(reason) = end_reason {
             flush_active_listen_session_locked(&mut state, now, reason)
                 .map_err(|err| {
                     error!("failed to flush listen session: {err}");
                 })
-                .ok()
-                .flatten()
+                .unwrap_or(FlushOutcome { flushed_track_id: None, scrobble_completed: None })
         } else {
-            None
+            FlushOutcome { flushed_track_id: None, scrobble_completed: None }
         };
 
+        let mut now_playing: Option<(String, String, Option<String>, Option<i64>, String)> = None;
         if snapshot.state.is_playing {
             if let Some(track) = snapshot.state.current_track.as_ref() {
                 let source = state
@@ -8566,12 +8735,19 @@ async fn sync_session_after_snapshot(
                 state.active_listen_session = Some(player::ActiveListenSession::start(
                     track.id, now, source, prior,
                 ));
+                now_playing = Some((
+                    track.artist_name.clone().unwrap_or_default(),
+                    track.title.clone(),
+                    track.album_title.clone(),
+                    track.duration_ms,
+                    track.source.clone(),
+                ));
             }
         } else if snapshot.state.current_track.is_none() {
             state.active_listen_session = None;
         }
 
-        flushed_track_id
+        (outcome.flushed_track_id, outcome.scrobble_completed, now_playing)
     };
 
     if let Some(track_id) = flushed_track_id {
@@ -8580,15 +8756,54 @@ async fn sync_session_after_snapshot(
             .event_tx
             .send(AppEvent::ListenHistoryUpdated { track_id });
     }
+
+    // Fire-and-forget Last.fm scrobbles. Helpers no-op when source != tidal,
+    // when LASTFM_API_SECRET is unset, or when no session_key is stored.
+    if let Some((artist, title, album, duration_ms, listened_ms, started_at_unix, source)) =
+        scrobble_completed_payload
+    {
+        if !artist.is_empty() && !title.is_empty() {
+            crate::services::lastfm::scrobble::spawn_scrobble_completed(
+                state.clone(),
+                artist,
+                title,
+                album,
+                duration_ms,
+                listened_ms,
+                started_at_unix,
+                &source,
+            );
+        }
+    }
+    if let Some((artist, title, album, duration_ms, source)) = now_playing_payload {
+        if !artist.is_empty() && !title.is_empty() {
+            crate::services::lastfm::scrobble::spawn_now_playing(
+                state.clone(),
+                artist,
+                title,
+                album,
+                duration_ms,
+                &source,
+            );
+        }
+    }
+}
+
+struct FlushOutcome {
+    flushed_track_id: Option<i64>,
+    /// (artist, title, album, duration_ms, listened_ms, started_at_unix, source).
+    /// `None` when there's nothing eligible to consider for a scrobble call.
+    /// The actual eligibility + source filter happens in the scrobble helper.
+    scrobble_completed: Option<(String, String, Option<String>, i64, i64, i64, String)>,
 }
 
 fn flush_active_listen_session_locked(
     state: &mut crate::AppState,
     now: chrono::DateTime<chrono::Utc>,
     _reason: player::ListenSessionEndReason,
-) -> anyhow::Result<Option<i64>> {
+) -> anyhow::Result<FlushOutcome> {
     let Some(mut session) = state.active_listen_session.take() else {
-        return Ok(None);
+        return Ok(FlushOutcome { flushed_track_id: None, scrobble_completed: None });
     };
 
     session.pause(now);
@@ -8596,19 +8811,20 @@ fn flush_active_listen_session_locked(
     // Skip sessions shorter than 5 seconds to avoid spurious near-zero entries
     // from rapid track changes or accidental clicks.
     if listened_ms < 5_000 {
-        return Ok(None);
+        return Ok(FlushOutcome { flushed_track_id: None, scrobble_completed: None });
     }
 
     let started_at = session.started_at.to_rfc3339();
+    let started_at_unix = session.started_at.timestamp();
     let track_id = session.track_id;
     if track_id <= 0 {
-        return Ok(None);
+        return Ok(FlushOutcome { flushed_track_id: None, scrobble_completed: None });
     }
     let session_id = session.session_id.clone();
     let source = session.source;
     let position_in_session = session.position_in_session;
     let transition_from_track_id = session.transition_from_track_id;
-    let completed = state.db.with_conn(|conn| {
+    let (completed, scrobble_payload) = state.db.with_conn(|conn| {
         let track = queue::get_track_by_id(conn, track_id)?.ok_or_else(|| {
             anyhow::anyhow!("track {} missing when flushing listen session", track_id)
         })?;
@@ -8625,7 +8841,19 @@ fn flush_active_listen_session_locked(
             transition_from_track_id,
         )?;
         queries::increment_track_play_summary(conn, track_id, &started_at, completed)?;
-        Ok(completed)
+        // Capture the fields needed for a Last.fm scrobble. The scrobble
+        // helper itself does the source filter + eligibility check + silent
+        // no-op when scrobbling isn't configured.
+        let payload = (
+            track.artist_name.clone().unwrap_or_default(),
+            track.title.clone(),
+            track.album_title.clone(),
+            track.duration_ms.unwrap_or(0),
+            listened_ms,
+            started_at_unix,
+            track.source.clone(),
+        );
+        Ok((completed, payload))
     })?;
     state.live_listen_session = Some(session.to_live_session(now));
 
@@ -8637,7 +8865,10 @@ fn flush_active_listen_session_locked(
         "flushed listen session"
     );
 
-    Ok(Some(track_id))
+    Ok(FlushOutcome {
+        flushed_track_id: Some(track_id),
+        scrobble_completed: Some(scrobble_payload),
+    })
 }
 
 async fn clear_tidal_session(state: &SharedState) -> anyhow::Result<()> {
@@ -8836,13 +9067,252 @@ pub struct SyncStats {
 async fn get_home_releases(
     State(state): State<SharedState>,
 ) -> Result<Json<Value>, StatusCode> {
-    let aggregator = state.read().await.rss_aggregator.clone();
-    let releases = aggregator.get_new_releases().await;
-    
+    use crate::services::lastfm;
+
+    // Pull api_key from the existing Last.fm credentials row. If Last.fm
+    // isn't configured, we 503 so the frontend renders the connect/empty
+    // state instead of falling back to the old AllMusic RSS feed.
+    let (http, api_key) = {
+        let s = state.read().await;
+        let api_key = s
+            .db
+            .with_conn(|conn| Ok(lastfm::auth::load_credentials(conn).ok().flatten()))
+            .ok()
+            .flatten()
+            .map(|c| c.api_key);
+        (s.http_client.clone(), api_key)
+    };
+    let Some(api_key) = api_key.filter(|k| !k.is_empty()) else {
+        return Err(StatusCode::SERVICE_UNAVAILABLE);
+    };
+
+    match lastfm::releases::fetch_new_releases_cached(&http, &api_key).await {
+        Ok(releases) => Ok(Json(json!({
+            "releases": releases,
+            "source": "lastfm_api",
+        }))),
+        Err(e) => {
+            tracing::warn!("Last.fm new-releases pipeline failed: {e}");
+            Err(StatusCode::BAD_GATEWAY)
+        }
+    }
+}
+
+// ─── TIDAL: Your Mixes ───────────────────────────────────────────────────────
+
+/// Returns the authenticated user's TIDAL mixes (Daily Discovery, My Mix N,
+/// Master Mix, etc) for the home page Your Mixes shelf.
+///
+/// 503 when TIDAL is disconnected so the frontend can render its connect prompt.
+async fn get_tidal_mixes(
+    State(state): State<SharedState>,
+) -> Result<Json<Value>, StatusCode> {
+    let tokens = state.read().await.tidal_tokens.clone();
+    let Some(tokens) = tokens else {
+        return Err(StatusCode::SERVICE_UNAVAILABLE);
+    };
+    let client = TidalClient::new(tokens.access_token.clone(), tokens.country_code.clone());
+    let mixes = client.get_my_mixes().await.map_err(|e| {
+        tracing::warn!("TIDAL get_my_mixes failed: {e}");
+        StatusCode::BAD_GATEWAY
+    })?;
+    Ok(Json(json!({ "mixes": mixes, "source": "tidal" })))
+}
+
+/// Returns the playable tracks inside a TIDAL mix. Frontend calls this when
+/// the user clicks a mix card on the home Your Mixes shelf, then queues +
+/// plays the first track via the existing TIDAL playback path.
+async fn get_tidal_mix_tracks(
+    State(state): State<SharedState>,
+    Path(mix_id): Path<String>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    let tokens = state.read().await.tidal_tokens.clone();
+    let Some(tokens) = tokens else {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({ "error": "TIDAL not connected" })),
+        ));
+    };
+    let client = TidalClient::new(tokens.access_token.clone(), tokens.country_code.clone());
+    let items = client.get_mix_tracks(&mix_id).await.map_err(|e| {
+        (StatusCode::BAD_GATEWAY, Json(json!({ "error": e.to_string() })))
+    })?;
+
+    // Reuse the same shape `getTidalAlbumTracks` returns so the frontend's
+    // `playTidalTrackNow` consumer can reuse its existing track-mapping.
+    let tracks: Vec<Value> = items
+        .into_iter()
+        .map(|t| {
+            let artwork = t
+                .album
+                .as_ref()
+                .and_then(|al| al.cover.as_ref())
+                .and_then(|c| {
+                    crate::services::tidal::client::TidalClient::get_artwork_url(
+                        &Some(c.clone()),
+                        160,
+                    )
+                });
+            json!({
+                "tidal_id": t.id,
+                "title": t.title,
+                "duration_ms": t.duration * 1000,
+                "track_number": t.track_number,
+                "disc_number": t.volume_number,
+                "artist_name": t.artist.name,
+                "artist_tidal_id": t.artist.id,
+                "album_title": t.album.as_ref().map(|al| al.title.clone()),
+                "artwork_url": artwork,
+            })
+        })
+        .collect();
+
+    Ok(Json(json!({ "tracks": tracks })))
+}
+
+// ─── Last.fm scrobble auth (server-side web-auth flow) ──────────────────────
+
+/// Reasoning lives in `services/lastfm/scrobble.rs` and the plan file. Short
+/// version: the user goes Settings → "Connect Last.fm account" → we open
+/// `https://www.last.fm/api/auth/?api_key=...&token=...` in a new tab → user
+/// clicks "Yes, allow access" → returns to NOORwave → "I've authorized" button
+/// fires /complete → we redeem the token for a session_key (encrypted on disk).
+
+async fn lastfm_auth_start(
+    State(state): State<SharedState>,
+) -> Result<Json<Value>, StatusCode> {
+    use crate::services::lastfm;
+
+    let (http, api_secret, api_key) = {
+        let s = state.read().await;
+        let api_key = s
+            .db
+            .with_conn(|conn| Ok(lastfm::auth::load_credentials(conn).ok().flatten()))
+            .ok()
+            .flatten()
+            .map(|c| c.api_key);
+        (s.http_client.clone(), s.lastfm_api_secret.clone(), api_key)
+    };
+    let Some(api_secret) = api_secret else {
+        return Err(StatusCode::NOT_IMPLEMENTED);
+    };
+    let Some(api_key) = api_key.filter(|k| !k.is_empty()) else {
+        return Ok(Json(json!({
+            "status": "error",
+            "message": "Save a Last.fm API key first."
+        })));
+    };
+
+    let token = match lastfm::scrobble::get_token(&http, &api_key, &api_secret).await {
+        Ok(t) => t,
+        Err(e) => {
+            return Ok(Json(json!({
+                "status": "error",
+                "message": format!("auth.getToken failed: {e}")
+            })));
+        }
+    };
+
+    // Stash the pending token server-side so /complete doesn't have to trust
+    // the client to round-trip it.
+    let stash_result = state
+        .read()
+        .await
+        .db
+        .with_conn(|conn| {
+            lastfm::auth::set_pending_token(conn, &token)?;
+            Ok(())
+        });
+    if let Err(e) = stash_result {
+        tracing::warn!("Failed to stash Last.fm pending_token: {e}");
+        return Err(StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    let auth_url = format!(
+        "https://www.last.fm/api/auth/?api_key={}&token={}",
+        urlencoding::encode(&api_key),
+        urlencoding::encode(&token)
+    );
     Ok(Json(json!({
-        "releases": releases,
-        "source": "allmusic_rss"
+        "status": "awaiting",
+        "auth_url": auth_url,
     })))
+}
+
+async fn lastfm_auth_complete(
+    State(state): State<SharedState>,
+) -> Result<Json<Value>, StatusCode> {
+    use crate::services::lastfm;
+
+    let (http, api_secret, api_key, pending_token, master_key) = {
+        let s = state.read().await;
+        let creds = s
+            .db
+            .with_conn(|conn| Ok(lastfm::auth::load_credentials(conn).ok().flatten()))
+            .ok()
+            .flatten();
+        (
+            s.http_client.clone(),
+            s.lastfm_api_secret.clone(),
+            creds.as_ref().map(|c| c.api_key.clone()),
+            creds.and_then(|c| c.pending_token),
+            s.master_key.clone(),
+        )
+    };
+    let Some(api_secret) = api_secret else {
+        return Err(StatusCode::NOT_IMPLEMENTED);
+    };
+    let Some(api_key) = api_key.filter(|k| !k.is_empty()) else {
+        return Ok(Json(json!({
+            "status": "error",
+            "message": "Last.fm API key not configured."
+        })));
+    };
+    let Some(token) = pending_token else {
+        return Ok(Json(json!({
+            "status": "error",
+            "message": "No pending auth — call /api/lastfm/auth/start first."
+        })));
+    };
+
+    let session = match lastfm::scrobble::get_session(&http, &api_key, &api_secret, &token).await
+    {
+        Ok(s) => s,
+        Err(e) => {
+            // Don't drop the pending_token on a "not yet authorized" error —
+            // the user might just need a few more seconds in the browser.
+            // The user can retry by clicking the button again.
+            return Ok(Json(json!({
+                "status": "not_yet_authorized",
+                "message": format!("auth.getSession failed: {e}")
+            })));
+        }
+    };
+
+    let persist_result = state.read().await.db.with_conn(|conn| {
+        lastfm::auth::save_session_key(conn, &master_key, &session.session_key, &session.user_name)?;
+        Ok(())
+    });
+    if let Err(e) = persist_result {
+        tracing::warn!("Failed to persist Last.fm session: {e}");
+        return Err(StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    Ok(Json(json!({
+        "status": "connected",
+        "user": session.user_name,
+    })))
+}
+
+async fn lastfm_auth_disconnect(
+    State(state): State<SharedState>,
+) -> Result<Json<Value>, StatusCode> {
+    use crate::services::lastfm;
+    let _ = state.read().await.db.with_conn(|conn| {
+        lastfm::auth::clear_session(conn)?;
+        Ok(())
+    });
+    Ok(Json(json!({"status": "disconnected"})))
 }
 
 /// Get daily picks curated from user's library using learning model
@@ -8855,7 +9325,7 @@ async fn get_home_picks(
     // Get top tracks from listening history with variety
     let picks = db.with_conn(|conn| {
         // Fetch recent top tracks that aren't played in last 7 days (rediscovery)
-        let tracks = queries::get_tracks(conn, "play_count", "desc", 20, 0, false)?;
+        let tracks = queries::get_tracks(conn, "play_count", "desc", 20, 0, false, false)?;
         
         // Get tracks from different genres for variety
         let mut genre_tracks = conn.prepare(
@@ -9236,7 +9706,7 @@ async fn lastfm_save_config(
                         body_text.chars().take(200).collect::<String>())
                 })));
             }
-            let creds = lastfm::auth::LastFmCredentials { api_key };
+            let creds = lastfm::auth::LastFmCredentials { api_key, ..Default::default() };
             let _ = state.read().await.db.with_conn(|conn| {
                 lastfm::auth::save_credentials(conn, &creds)?;
                 Ok(())
@@ -9256,18 +9726,30 @@ async fn lastfm_save_config(
 
 async fn lastfm_status(State(state): State<SharedState>) -> Result<Json<Value>, StatusCode> {
     use crate::services::lastfm;
-    let configured = state
-        .read()
-        .await
-        .db
-        .with_conn(|conn| {
-            Ok(lastfm::auth::load_credentials(conn)
-                .ok()
-                .flatten()
-                .is_some())
-        })
+    let (creds, has_secret) = {
+        let s = state.read().await;
+        let creds = s
+            .db
+            .with_conn(|conn| Ok(lastfm::auth::load_credentials(conn).ok().flatten()))
+            .ok()
+            .flatten();
+        (creds, s.lastfm_api_secret.is_some())
+    };
+    let enrichment = creds
+        .as_ref()
+        .map(|c| !c.api_key.is_empty())
         .unwrap_or(false);
-    Ok(Json(json!({"configured": configured})))
+    let user = creds.as_ref().and_then(|c| c.session_user.clone());
+    let scrobbling = enrichment && has_secret && user.is_some();
+    Ok(Json(json!({
+        // Legacy field kept for backward compat with any existing caller of
+        // /api/lastfm/status — equivalent to `enrichment`.
+        "configured": enrichment,
+        "enrichment": enrichment,
+        "scrobbling": scrobbling,
+        "scrobble_available": has_secret,
+        "user": user,
+    })))
 }
 
 async fn lastfm_clear_config(State(state): State<SharedState>) -> Result<Json<Value>, StatusCode> {
@@ -10503,6 +10985,11 @@ mod tests {
             lastfm_prefetch_done: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             lastfm_enrich_started_at: Arc::new(std::sync::atomic::AtomicI64::new(0)),
             discovery_train_cancel: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            master_key: crate::services::crypto::MasterKey::load_or_generate(
+                &std::env::temp_dir().join(format!("noor-test-key-{}", uuid::Uuid::new_v4())),
+            )
+            .expect("test master key"),
+            lastfm_api_secret: None,
             server_token: String::new(),
             audio_active: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         })));
@@ -10575,6 +11062,11 @@ mod tests {
             lastfm_prefetch_done: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             lastfm_enrich_started_at: Arc::new(std::sync::atomic::AtomicI64::new(0)),
             discovery_train_cancel: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            master_key: crate::services::crypto::MasterKey::load_or_generate(
+                &std::env::temp_dir().join(format!("noor-test-key-{}", uuid::Uuid::new_v4())),
+            )
+            .expect("test master key"),
+            lastfm_api_secret: None,
             server_token: String::new(),
             audio_active: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         })))

--- a/noor-server/src/services/crypto.rs
+++ b/noor-server/src/services/crypto.rs
@@ -1,0 +1,188 @@
+//! Symmetric token encryption for service credentials.
+//!
+//! NOTE: Today only the new Last.fm session key is routed through this helper.
+//! TIDAL/Spotify tokens still live as plaintext UTF-8 JSON in the historically
+//! mis-named `service_auth.access_token_enc` BLOB column. Migrating those to
+//! this helper is intentional follow-up work — see `MIGRATION` note below.
+//!
+//! Master-key lifecycle:
+//! - On first boot we generate 32 random bytes and write them to
+//!   `<noor.db dir>/.noor_secret`.
+//! - On subsequent boots we read them back.
+//! - On Unix the file is chmod'd to 0o600. On Windows the user-profile
+//!   directory's default ACL already restricts read access to the owning user;
+//!   we do not invoke `icacls` to avoid the platform-dep blast radius.
+//! - There is no key rotation. Wiping `.noor_secret` invalidates every
+//!   encrypted blob on disk; users will have to reconnect affected services.
+//!
+//! MIGRATION (follow-up): swap `services/tidal/auth.rs` and `services/spotify`
+//! token reads/writes to `MasterKey::encrypt`/`decrypt` and rename the column.
+
+use aes_gcm::{
+    aead::{Aead, KeyInit, OsRng},
+    AeadCore, Aes256Gcm, Key, Nonce,
+};
+use anyhow::{anyhow, Context, Result};
+use rand::RngCore;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+const SECRET_FILENAME: &str = ".noor_secret";
+const NONCE_LEN: usize = 12;
+
+#[derive(Clone)]
+pub struct MasterKey {
+    cipher: Arc<Aes256Gcm>,
+}
+
+impl std::fmt::Debug for MasterKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Never reveal the key material in logs / debug dumps.
+        f.write_str("MasterKey(<redacted>)")
+    }
+}
+
+impl MasterKey {
+    /// Read the master key from `<dir>/.noor_secret`, generating it on first
+    /// run. The file is owner-only on Unix.
+    pub fn load_or_generate(dir: &Path) -> Result<Self> {
+        if !dir.exists() {
+            std::fs::create_dir_all(dir)
+                .with_context(|| format!("create dir {}", dir.display()))?;
+        }
+        let path = dir.join(SECRET_FILENAME);
+        let bytes = if path.exists() {
+            let bytes = std::fs::read(&path)
+                .with_context(|| format!("read {}", path.display()))?;
+            if bytes.len() != 32 {
+                return Err(anyhow!(
+                    "{} is {} bytes, expected 32 — refusing to use a malformed key",
+                    path.display(),
+                    bytes.len()
+                ));
+            }
+            bytes
+        } else {
+            let mut buf = vec![0u8; 32];
+            OsRng.fill_bytes(&mut buf);
+            write_secret_file(&path, &buf)?;
+            tracing::info!(
+                "Generated new master key at {} (owner-only on Unix)",
+                path.display()
+            );
+            buf
+        };
+        let key = Key::<Aes256Gcm>::from_slice(&bytes);
+        Ok(Self { cipher: Arc::new(Aes256Gcm::new(key)) })
+    }
+
+    /// Encrypt arbitrary bytes. Output layout: `nonce(12) || ciphertext+tag`.
+    pub fn encrypt(&self, plaintext: &[u8]) -> Result<Vec<u8>> {
+        let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
+        let ct = self
+            .cipher
+            .encrypt(&nonce, plaintext)
+            .map_err(|e| anyhow!("AES-GCM encrypt failed: {e}"))?;
+        let mut out = Vec::with_capacity(NONCE_LEN + ct.len());
+        out.extend_from_slice(nonce.as_slice());
+        out.extend_from_slice(&ct);
+        Ok(out)
+    }
+
+    /// Decrypt bytes produced by `encrypt`. Errors on tampering or wrong key.
+    pub fn decrypt(&self, blob: &[u8]) -> Result<Vec<u8>> {
+        if blob.len() <= NONCE_LEN {
+            return Err(anyhow!("ciphertext too short"));
+        }
+        let (nonce_bytes, ct) = blob.split_at(NONCE_LEN);
+        let nonce = Nonce::from_slice(nonce_bytes);
+        self.cipher
+            .decrypt(nonce, ct)
+            .map_err(|e| anyhow!("AES-GCM decrypt failed: {e}"))
+    }
+}
+
+#[cfg(unix)]
+fn write_secret_file(path: &Path, bytes: &[u8]) -> Result<()> {
+    use std::os::unix::fs::OpenOptionsExt;
+    let mut f = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(path)
+        .with_context(|| format!("create {}", path.display()))?;
+    use std::io::Write;
+    f.write_all(bytes)?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn write_secret_file(path: &Path, bytes: &[u8]) -> Result<()> {
+    std::fs::write(path, bytes)
+        .with_context(|| format!("create {}", path.display()))
+}
+
+/// Resolve the directory that should hold `.noor_secret` — the same dir as
+/// the SQLite db, so it travels with the install.
+pub fn secret_dir_for_db(db_path: &str) -> PathBuf {
+    Path::new(db_path)
+        .parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip() {
+        let dir = tempdir();
+        let key = MasterKey::load_or_generate(&dir).unwrap();
+        let plain = b"hunter2-very-long-session-key";
+        let blob = key.encrypt(plain).unwrap();
+        assert_ne!(blob, plain, "ciphertext must differ from plaintext");
+        let back = key.decrypt(&blob).unwrap();
+        assert_eq!(back, plain);
+    }
+
+    #[test]
+    fn key_persists_across_loads() {
+        let dir = tempdir();
+        let k1 = MasterKey::load_or_generate(&dir).unwrap();
+        let k2 = MasterKey::load_or_generate(&dir).unwrap();
+        let blob = k1.encrypt(b"x").unwrap();
+        assert_eq!(k2.decrypt(&blob).unwrap(), b"x");
+    }
+
+    #[test]
+    fn ciphertext_does_not_leak_plaintext() {
+        let dir = tempdir();
+        let key = MasterKey::load_or_generate(&dir).unwrap();
+        let secret = b"super-secret-session-key-7c4f";
+        let blob = key.encrypt(secret).unwrap();
+        // Hard requirement from the plan: the raw stored blob must not
+        // contain the plaintext anywhere as a substring.
+        assert!(
+            !blob.windows(secret.len()).any(|w| w == secret),
+            "raw ciphertext leaked plaintext bytes"
+        );
+    }
+
+    #[test]
+    fn tampering_is_detected() {
+        let dir = tempdir();
+        let key = MasterKey::load_or_generate(&dir).unwrap();
+        let mut blob = key.encrypt(b"hello").unwrap();
+        let last = blob.len() - 1;
+        blob[last] ^= 0xff;
+        assert!(key.decrypt(&blob).is_err());
+    }
+
+    fn tempdir() -> PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(format!("noor-crypto-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+}

--- a/noor-server/src/services/lastfm/auth.rs
+++ b/noor-server/src/services/lastfm/auth.rs
@@ -1,10 +1,36 @@
 use anyhow::Result;
-use rusqlite::{params, Connection};
+use rusqlite::{params, Connection, OptionalExtension};
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+use crate::services::crypto::MasterKey;
+
+/// Last.fm credentials persisted in `service_auth` for `service = 'lastfm'`.
+///
+/// Layout:
+/// - `extra_data` JSON  → `api_key`, optional `session_user`, optional
+///   short-lived `pending_token`. `api_key` is user-provided and not a secret
+///   we own; `session_user` is just a username; `pending_token` is a one-time
+///   challenge that's cleared on completion/disconnect/cancel.
+/// - `access_token_enc` BLOB → AES-256-GCM-encrypted `session_key` (the actual
+///   secret), see `services/crypto.rs`. Read/written via `load_session_key` /
+///   `save_session_key` — NEVER stuffed into `extra_data` JSON.
+///
+/// IMPORTANT: do not add `api_secret` or `session_key` fields to this struct.
+/// `api_secret` is server-only env (`LASTFM_API_SECRET`); `session_key` lives
+/// in the encrypted blob column.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct LastFmCredentials {
     pub api_key: String,
+    /// Last.fm username for the account that completed scrobble auth.
+    /// Cleared when the user disconnects scrobbling.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_user: Option<String>,
+    /// Short-lived `auth.getToken` value, set by `/api/lastfm/auth/start` and
+    /// cleared by `/auth/complete` / `/auth/disconnect`. Plaintext is fine:
+    /// the token is only useful for ~60 minutes and is paired with the
+    /// server-only `api_secret` to be redeemed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pending_token: Option<String>,
 }
 
 pub fn load_credentials(conn: &Connection) -> Result<Option<LastFmCredentials>> {
@@ -33,4 +59,198 @@ pub fn save_credentials(conn: &Connection, creds: &LastFmCredentials) -> Result<
 pub fn clear_credentials(conn: &Connection) -> Result<()> {
     conn.execute("DELETE FROM service_auth WHERE service = 'lastfm'", [])?;
     Ok(())
+}
+
+/// Decrypt and return the stored Last.fm scrobble session key, if any.
+pub fn load_session_key(conn: &Connection, master: &MasterKey) -> Result<Option<String>> {
+    let blob: Option<Vec<u8>> = conn
+        .query_row(
+            "SELECT access_token_enc FROM service_auth WHERE service = 'lastfm'",
+            [],
+            |row| row.get::<_, Option<Vec<u8>>>(0),
+        )
+        .optional()?
+        .flatten();
+    let Some(blob) = blob else { return Ok(None) };
+    if blob.is_empty() {
+        return Ok(None);
+    }
+    let plain = master.decrypt(&blob)?;
+    Ok(Some(String::from_utf8(plain)?))
+}
+
+/// Encrypt and persist the Last.fm session key. Also updates `session_user`
+/// in the `extra_data` JSON, preserving any existing `api_key`.
+pub fn save_session_key(
+    conn: &Connection,
+    master: &MasterKey,
+    session_key: &str,
+    session_user: &str,
+) -> Result<()> {
+    let mut creds = load_credentials(conn)?.unwrap_or_default();
+    creds.session_user = Some(session_user.to_string());
+    creds.pending_token = None;
+    let json = serde_json::to_string(&creds)?;
+    let blob = master.encrypt(session_key.as_bytes())?;
+    conn.execute(
+        "INSERT INTO service_auth (service, extra_data, access_token_enc, user_id, connected_at)
+         VALUES ('lastfm', ?1, ?2, 'app', datetime('now'))
+         ON CONFLICT(service) DO UPDATE SET
+             extra_data       = excluded.extra_data,
+             access_token_enc = excluded.access_token_enc",
+        params![json, blob],
+    )?;
+    Ok(())
+}
+
+/// Clear the encrypted session key + session_user. Leaves `api_key` in place
+/// so tag enrichment + new-releases reads keep working.
+pub fn clear_session(conn: &Connection) -> Result<()> {
+    let mut creds = load_credentials(conn)?.unwrap_or_default();
+    creds.session_user = None;
+    creds.pending_token = None;
+    let json = serde_json::to_string(&creds)?;
+    conn.execute(
+        "UPDATE service_auth
+            SET extra_data = ?1,
+                access_token_enc = NULL
+          WHERE service = 'lastfm'",
+        params![json],
+    )?;
+    Ok(())
+}
+
+/// Stash the `auth.getToken` value while the user authorizes in their browser.
+/// Cleared when /auth/complete or /auth/disconnect runs, or when the user
+/// explicitly cancels.
+pub fn set_pending_token(conn: &Connection, token: &str) -> Result<()> {
+    let mut creds = load_credentials(conn)?.unwrap_or_default();
+    creds.pending_token = Some(token.to_string());
+    save_credentials(conn, &creds)
+}
+
+pub fn clear_pending_token(conn: &Connection) -> Result<()> {
+    let mut creds = load_credentials(conn)?.unwrap_or_default();
+    creds.pending_token = None;
+    save_credentials(conn, &creds)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn open_in_memory_db_with_schema() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute(
+            "CREATE TABLE service_auth (
+                service TEXT PRIMARY KEY,
+                access_token_enc BLOB,
+                refresh_token_enc BLOB,
+                token_expiry TEXT,
+                user_id TEXT,
+                subscription_type TEXT,
+                extra_data TEXT,
+                connected_at TEXT DEFAULT (datetime('now'))
+            )",
+            [],
+        )
+        .unwrap();
+        conn
+    }
+
+    fn temp_master_key() -> MasterKey {
+        let mut p = std::env::temp_dir();
+        p.push(format!("noor-auth-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&p).unwrap();
+        MasterKey::load_or_generate(&p).unwrap()
+    }
+
+    /// Documents the env-only contract for `api_secret`. If anyone ever adds
+    /// an `api_secret` field to `LastFmCredentials`, this test starts failing
+    /// loudly. The plan + the user spec say `api_secret` is server-only env
+    /// and must never round-trip through this struct (which is JSON-serialized
+    /// into `service_auth.extra_data`).
+    #[test]
+    fn no_secret_in_struct() {
+        let creds = LastFmCredentials {
+            api_key: "abc".into(),
+            session_user: Some("user".into()),
+            pending_token: Some("tok".into()),
+        };
+        let json = serde_json::to_value(&creds).unwrap();
+        let obj = json.as_object().unwrap();
+        assert!(
+            !obj.contains_key("api_secret"),
+            "api_secret must never be serialized into LastFmCredentials"
+        );
+        assert!(
+            !obj.contains_key("session_key"),
+            "session_key must never be serialized into LastFmCredentials JSON \
+             (it lives in the encrypted access_token_enc blob)"
+        );
+    }
+
+    /// The plan's required regression: the raw stored bytes for the session
+    /// key must NOT contain the plaintext anywhere. This exercises the full
+    /// save → SELECT-raw-blob round-trip.
+    #[test]
+    fn session_key_encrypted() {
+        let conn = open_in_memory_db_with_schema();
+        let master = temp_master_key();
+        let secret = "Y0u_w0nt_f1nd_th1s_1n_th3_b1n";
+        save_session_key(&conn, &master, secret, "alice").unwrap();
+
+        let raw: Vec<u8> = conn
+            .query_row(
+                "SELECT access_token_enc FROM service_auth WHERE service = 'lastfm'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(!raw.is_empty(), "blob must not be empty");
+        let secret_bytes = secret.as_bytes();
+        assert!(
+            !raw.windows(secret_bytes.len()).any(|w| w == secret_bytes),
+            "raw session_key blob leaked plaintext"
+        );
+
+        // Also ensure session_user (non-secret) IS readable, but session_key
+        // and pending_token are NOT in the JSON.
+        let extra: String = conn
+            .query_row(
+                "SELECT extra_data FROM service_auth WHERE service = 'lastfm'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(extra.contains("\"alice\""), "session_user should be in extra_data");
+        assert!(
+            !extra.contains(secret),
+            "session_key must never be stored in extra_data JSON"
+        );
+
+        // Round-trip read must yield the original secret.
+        let back = load_session_key(&conn, &master).unwrap();
+        assert_eq!(back.as_deref(), Some(secret));
+    }
+
+    #[test]
+    fn clear_session_preserves_api_key() {
+        let conn = open_in_memory_db_with_schema();
+        let master = temp_master_key();
+        save_credentials(
+            &conn,
+            &LastFmCredentials {
+                api_key: "the-api-key".into(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        save_session_key(&conn, &master, "sk-xyz", "alice").unwrap();
+        clear_session(&conn).unwrap();
+        let creds = load_credentials(&conn).unwrap().unwrap();
+        assert_eq!(creds.api_key, "the-api-key");
+        assert!(creds.session_user.is_none());
+        assert!(load_session_key(&conn, &master).unwrap().is_none());
+    }
 }

--- a/noor-server/src/services/lastfm/mod.rs
+++ b/noor-server/src/services/lastfm/mod.rs
@@ -1,3 +1,5 @@
 pub mod auth;
 pub mod enrichment;
+pub mod releases;
+pub mod scrobble;
 pub mod tag_filter;

--- a/noor-server/src/services/lastfm/releases.rs
+++ b/noor-server/src/services/lastfm/releases.rs
@@ -1,0 +1,565 @@
+//! "New Releases" via the Last.fm JSON API only — no HTML scraping.
+//!
+//! Pipeline (locked by the user's spec):
+//!   1. `chart.getTopArtists` (limit ~30)
+//!   2. for the top 25 artists, `artist.getTopAlbums` (limit ~5 each)
+//!   3. dedupe candidates by mbid OR normalized (artist, album)
+//!   4. for the top 30 candidates, `album.getInfo` (by mbid if present)
+//!   5. take the high-res image (mega > extralarge), parse `releasedate`
+//!   6. keep dated releases <= 90 days old; undated kept but ranked lower
+//!   7. sort released_at DESC NULLS LAST, then by parent-artist chart rank ASC
+//!   8. return top 12-15
+//!
+//! Output `ReleaseItem` matches the existing frontend release-card shape, so
+//! the frontend type does not change.
+
+use anyhow::{Context, Result};
+use chrono::{Duration as ChronoDuration, NaiveDateTime, Utc};
+use futures::stream::{self, StreamExt};
+use serde::Serialize;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+use std::sync::LazyLock;
+
+const ENDPOINT: &str = "https://ws.audioscrobbler.com/2.0/";
+
+const TOP_ARTISTS_LIMIT: u32 = 30;
+const ARTISTS_TO_SCAN: usize = 25;
+const TOP_ALBUMS_PER_ARTIST: u32 = 5;
+const CANDIDATES_FOR_GETINFO: usize = 30;
+const CONCURRENT_REQUESTS: usize = 8;
+const RECENT_WINDOW_DAYS: i64 = 90;
+const RESULT_CAP: usize = 15;
+const CACHE_TTL: Duration = Duration::from_secs(6 * 60 * 60);
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ReleaseItem {
+    pub title: String,
+    pub link: String,
+    pub author: String,
+    pub image_url: Option<String>,
+    pub source: &'static str,
+    /// Best-effort release date in RFC3339. `None` when Last.fm did not
+    /// provide a `releasedate` for the album.
+    pub published_at: Option<String>,
+}
+
+/// Cached entry point. Returns the cached value when fresh; otherwise refreshes
+/// in the foreground. Falls back to the previous (stale) cached value if the
+/// refresh fails so the home page never goes empty on a transient API blip.
+pub async fn fetch_new_releases_cached(
+    http: &reqwest::Client,
+    api_key: &str,
+) -> Result<Vec<ReleaseItem>> {
+    {
+        let guard = CACHE.lock().unwrap();
+        if let Some((items, fetched_at)) = guard.as_ref() {
+            if fetched_at.elapsed() < CACHE_TTL {
+                return Ok(items.clone());
+            }
+        }
+    }
+    match fetch_new_releases(http, api_key).await {
+        Ok(items) => {
+            let mut guard = CACHE.lock().unwrap();
+            *guard = Some((items.clone(), Instant::now()));
+            Ok(items)
+        }
+        Err(e) => {
+            // On a refresh failure, prefer serving stale data over a hard error.
+            let guard = CACHE.lock().unwrap();
+            if let Some((items, _)) = guard.as_ref() {
+                tracing::warn!("Last.fm releases refresh failed, serving stale cache: {e}");
+                Ok(items.clone())
+            } else {
+                Err(e)
+            }
+        }
+    }
+}
+
+static CACHE: LazyLock<Mutex<Option<(Vec<ReleaseItem>, Instant)>>> =
+    LazyLock::new(|| Mutex::new(None));
+
+/// Uncached pipeline. Public for tests + cache layer above.
+pub async fn fetch_new_releases(
+    http: &reqwest::Client,
+    api_key: &str,
+) -> Result<Vec<ReleaseItem>> {
+    let chart_body = call_lastfm(
+        http,
+        api_key,
+        "chart.getTopArtists",
+        &[("limit", TOP_ARTISTS_LIMIT.to_string())],
+    )
+    .await
+    .context("chart.getTopArtists")?;
+    let top_artists = parse_chart_artists(&chart_body);
+
+    // (artist, rank) for the top N
+    let scan_artists: Vec<(String, usize)> = top_artists
+        .into_iter()
+        .take(ARTISTS_TO_SCAN)
+        .enumerate()
+        .map(|(i, name)| (name, i))
+        .collect();
+
+    // Fetch top albums per artist with bounded concurrency.
+    let album_lists: Vec<Vec<AlbumCandidate>> = stream::iter(scan_artists.into_iter())
+        .map(|(artist, rank)| {
+            let http = http.clone();
+            let api_key = api_key.to_string();
+            async move {
+                match call_lastfm(
+                    &http,
+                    &api_key,
+                    "artist.getTopAlbums",
+                    &[
+                        ("artist", artist.clone()),
+                        ("limit", TOP_ALBUMS_PER_ARTIST.to_string()),
+                    ],
+                )
+                .await
+                {
+                    Ok(body) => parse_top_albums(&body, &artist, rank),
+                    Err(e) => {
+                        tracing::debug!("artist.getTopAlbums({artist}): {e}");
+                        Vec::new()
+                    }
+                }
+            }
+        })
+        .buffer_unordered(CONCURRENT_REQUESTS)
+        .collect()
+        .await;
+
+    let mut candidates: Vec<AlbumCandidate> = album_lists.into_iter().flatten().collect();
+    dedupe_candidates(&mut candidates);
+
+    // Sort by parent-artist chart rank ASC so getInfo budget goes to the
+    // most-trending entries first.
+    candidates.sort_by_key(|c| c.artist_rank);
+    candidates.truncate(CANDIDATES_FOR_GETINFO);
+
+    // Enrich each candidate with album.getInfo (image + release date).
+    let enriched: Vec<EnrichedAlbum> = stream::iter(candidates.into_iter())
+        .map(|cand| {
+            let http = http.clone();
+            let api_key = api_key.to_string();
+            async move {
+                let mut params: Vec<(&'static str, String)> = Vec::new();
+                if let Some(mbid) = cand.mbid.as_ref() {
+                    params.push(("mbid", mbid.clone()));
+                } else {
+                    params.push(("artist", cand.artist.clone()));
+                    params.push(("album", cand.album.clone()));
+                }
+                match call_lastfm(&http, &api_key, "album.getInfo", &params).await {
+                    Ok(body) => Some(parse_album_info(&body, &cand)),
+                    Err(e) => {
+                        tracing::debug!(
+                            "album.getInfo({} - {}): {e}",
+                            cand.artist,
+                            cand.album
+                        );
+                        // Fall back to the chart-list image we already have.
+                        Some(EnrichedAlbum {
+                            cand,
+                            image_url: None,
+                            released_at: None,
+                            link: None,
+                        })
+                    }
+                }
+            }
+        })
+        .buffer_unordered(CONCURRENT_REQUESTS)
+        .filter_map(|x| async move { x })
+        .collect()
+        .await;
+
+    let cutoff = (Utc::now() - ChronoDuration::days(RECENT_WINDOW_DAYS)).naive_utc();
+
+    let mut keep: Vec<EnrichedAlbum> = enriched
+        .into_iter()
+        .filter(|e| match e.released_at {
+            Some(dt) => dt >= cutoff,
+            // Undated entries are kept (per spec) and ranked below dated.
+            None => true,
+        })
+        .collect();
+
+    // Sort: released_at DESC NULLS LAST, then artist rank ASC.
+    keep.sort_by(|a, b| match (a.released_at, b.released_at) {
+        (Some(x), Some(y)) => y
+            .cmp(&x)
+            .then_with(|| a.cand.artist_rank.cmp(&b.cand.artist_rank)),
+        (Some(_), None) => std::cmp::Ordering::Less,
+        (None, Some(_)) => std::cmp::Ordering::Greater,
+        (None, None) => a.cand.artist_rank.cmp(&b.cand.artist_rank),
+    });
+
+    keep.truncate(RESULT_CAP);
+
+    Ok(keep
+        .into_iter()
+        .map(|e| ReleaseItem {
+            title: e.cand.album,
+            author: e.cand.artist,
+            link: e
+                .link
+                .or_else(|| e.cand.url.clone())
+                .unwrap_or_default(),
+            image_url: e.image_url.or_else(|| e.cand.image_url.clone()),
+            source: "lastfm_api",
+            published_at: e.released_at.map(|dt| dt.format("%Y-%m-%dT%H:%M:%SZ").to_string()),
+        })
+        .collect())
+}
+
+// ─── Internal ────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+struct AlbumCandidate {
+    artist: String,
+    album: String,
+    mbid: Option<String>,
+    image_url: Option<String>,
+    url: Option<String>,
+    artist_rank: usize,
+}
+
+#[derive(Debug)]
+struct EnrichedAlbum {
+    cand: AlbumCandidate,
+    image_url: Option<String>,
+    released_at: Option<NaiveDateTime>,
+    link: Option<String>,
+}
+
+async fn call_lastfm(
+    http: &reqwest::Client,
+    api_key: &str,
+    method: &str,
+    extra: &[(&'static str, String)],
+) -> Result<serde_json::Value> {
+    let mut req = http
+        .get(ENDPOINT)
+        .query(&[("method", method), ("api_key", api_key), ("format", "json")]);
+    for (k, v) in extra {
+        req = req.query(&[(*k, v.as_str())]);
+    }
+    let resp = req.send().await.context("send")?;
+    let status = resp.status();
+    let body: serde_json::Value = resp.json().await.context("decode json")?;
+    if let Some(err) = body.get("error").and_then(serde_json::Value::as_i64) {
+        anyhow::bail!(
+            "Last.fm error {}: {} (HTTP {})",
+            err,
+            body.get("message")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or(""),
+            status
+        );
+    }
+    if !status.is_success() {
+        anyhow::bail!("Last.fm HTTP {}", status);
+    }
+    Ok(body)
+}
+
+fn parse_chart_artists(body: &serde_json::Value) -> Vec<String> {
+    body.get("artists")
+        .and_then(|v| v.get("artist"))
+        .and_then(serde_json::Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|a| {
+                    a.get("name")
+                        .and_then(serde_json::Value::as_str)
+                        .map(str::to_string)
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn parse_top_albums(
+    body: &serde_json::Value,
+    artist: &str,
+    artist_rank: usize,
+) -> Vec<AlbumCandidate> {
+    let Some(arr) = body
+        .get("topalbums")
+        .and_then(|v| v.get("album"))
+        .and_then(serde_json::Value::as_array)
+    else {
+        return Vec::new();
+    };
+    arr.iter()
+        .filter_map(|a| {
+            let album = a.get("name").and_then(serde_json::Value::as_str)?.to_string();
+            // Last.fm sentinel for unknown album.
+            if album.eq_ignore_ascii_case("(null)") || album.is_empty() {
+                return None;
+            }
+            let mbid = a
+                .get("mbid")
+                .and_then(serde_json::Value::as_str)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string);
+            let url = a
+                .get("url")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string);
+            let image_url = pick_image(a.get("image"), &["mega", "extralarge", "large"]);
+            Some(AlbumCandidate {
+                artist: artist.to_string(),
+                album,
+                mbid,
+                image_url,
+                url,
+                artist_rank,
+            })
+        })
+        .collect()
+}
+
+fn parse_album_info(body: &serde_json::Value, cand: &AlbumCandidate) -> EnrichedAlbum {
+    let album = body.get("album");
+    let image_url = album.and_then(|a| a.get("image"));
+    let image_url = pick_image(image_url, &["mega", "extralarge", "large"]);
+    let link = album
+        .and_then(|a| a.get("url"))
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string);
+    let released_at = album
+        .and_then(|a| a.get("releasedate"))
+        .and_then(serde_json::Value::as_str)
+        .and_then(parse_release_date)
+        .or_else(|| {
+            album
+                .and_then(|a| a.get("wiki"))
+                .and_then(|w| w.get("published"))
+                .and_then(serde_json::Value::as_str)
+                .and_then(parse_release_date)
+        });
+    EnrichedAlbum {
+        cand: cand.clone(),
+        image_url,
+        released_at,
+        link,
+    }
+}
+
+/// Last.fm releasedate strings look like `"    6 Sep 2024, 00:00"` (leading
+/// whitespace, day-name optional). We accept both that format and the wiki's
+/// `"08 Mar 2008, 16:01"`.
+fn parse_release_date(raw: &str) -> Option<NaiveDateTime> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    NaiveDateTime::parse_from_str(trimmed, "%e %b %Y, %H:%M")
+        .ok()
+        .or_else(|| NaiveDateTime::parse_from_str(trimmed, "%d %b %Y, %H:%M").ok())
+}
+
+fn pick_image(images: Option<&serde_json::Value>, sizes: &[&str]) -> Option<String> {
+    let arr = images?.as_array()?;
+    for size in sizes {
+        for img in arr {
+            let s = img.get("size").and_then(serde_json::Value::as_str);
+            let url = img.get("#text").and_then(serde_json::Value::as_str);
+            if s == Some(*size) {
+                if let Some(u) = url {
+                    if !u.is_empty() {
+                        return Some(u.to_string());
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+fn dedupe_candidates(candidates: &mut Vec<AlbumCandidate>) {
+    use std::collections::HashSet;
+    let mut seen_mbid: HashSet<String> = HashSet::new();
+    let mut seen_pair: HashSet<(String, String)> = HashSet::new();
+    candidates.retain(|c| {
+        if let Some(mbid) = c.mbid.as_ref() {
+            if !seen_mbid.insert(mbid.clone()) {
+                return false;
+            }
+        }
+        let key = (c.artist.to_lowercase(), c.album.to_lowercase());
+        if !seen_pair.insert(key) {
+            return false;
+        }
+        true
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parses_chart_top_artists() {
+        let body = json!({
+            "artists": {
+                "artist": [
+                    { "name": "Artist A" },
+                    { "name": "Artist B" },
+                    { "name": "" }
+                ]
+            }
+        });
+        let names = parse_chart_artists(&body);
+        // Empty names are still surfaced — filtering happens at top_albums where
+        // an empty artist would just yield no albums. We keep this lenient so
+        // a single bad row in Last.fm's response doesn't drop neighbors.
+        assert!(names.contains(&"Artist A".to_string()));
+        assert!(names.contains(&"Artist B".to_string()));
+    }
+
+    #[test]
+    fn parses_top_albums_skips_null_sentinel() {
+        let body = json!({
+            "topalbums": {
+                "album": [
+                    {
+                        "name": "Real Album",
+                        "mbid": "abc-123",
+                        "url": "https://www.last.fm/music/Foo/Real+Album",
+                        "image": [
+                            { "#text": "https://img.example/sm.png", "size": "small" },
+                            { "#text": "https://img.example/xl.png", "size": "extralarge" }
+                        ]
+                    },
+                    { "name": "(null)" },
+                    { "name": "" }
+                ]
+            }
+        });
+        let cands = parse_top_albums(&body, "Foo", 7);
+        assert_eq!(cands.len(), 1);
+        assert_eq!(cands[0].album, "Real Album");
+        assert_eq!(cands[0].artist, "Foo");
+        assert_eq!(cands[0].artist_rank, 7);
+        assert_eq!(cands[0].mbid.as_deref(), Some("abc-123"));
+        assert_eq!(
+            cands[0].image_url.as_deref(),
+            Some("https://img.example/xl.png")
+        );
+    }
+
+    #[test]
+    fn pick_image_prefers_mega() {
+        let v = json!([
+            { "size": "small",      "#text": "small.png" },
+            { "size": "extralarge", "#text": "xl.png" },
+            { "size": "mega",       "#text": "mega.png" }
+        ]);
+        assert_eq!(
+            pick_image(Some(&v), &["mega", "extralarge"]).as_deref(),
+            Some("mega.png")
+        );
+    }
+
+    #[test]
+    fn pick_image_falls_back_to_smaller_when_mega_missing() {
+        let v = json!([
+            { "size": "small",      "#text": "small.png" },
+            { "size": "extralarge", "#text": "xl.png" }
+        ]);
+        assert_eq!(
+            pick_image(Some(&v), &["mega", "extralarge"]).as_deref(),
+            Some("xl.png")
+        );
+    }
+
+    #[test]
+    fn parse_release_date_handles_padded_day() {
+        // Last.fm's "DD Mon YYYY, HH:MM" with leading-space single-digit day.
+        let dt = parse_release_date(" 6 Sep 2024, 00:00").unwrap();
+        assert_eq!(dt.format("%Y-%m-%d").to_string(), "2024-09-06");
+
+        let dt = parse_release_date("23 Mar 2025, 12:30").unwrap();
+        assert_eq!(dt.format("%Y-%m-%d").to_string(), "2025-03-23");
+
+        assert!(parse_release_date("").is_none());
+        assert!(parse_release_date("garbage").is_none());
+    }
+
+    #[test]
+    fn parse_album_info_extracts_image_link_and_date() {
+        let body = json!({
+            "album": {
+                "name": "Real Album",
+                "url": "https://www.last.fm/music/Foo/Real+Album",
+                "image": [
+                    { "size": "extralarge", "#text": "https://img.example/xl.png" },
+                    { "size": "mega",       "#text": "https://img.example/mega.png" }
+                ],
+                "releasedate": " 6 Sep 2024, 00:00"
+            }
+        });
+        let cand = AlbumCandidate {
+            artist: "Foo".into(),
+            album: "Real Album".into(),
+            mbid: None,
+            image_url: None,
+            url: None,
+            artist_rank: 0,
+        };
+        let e = parse_album_info(&body, &cand);
+        assert_eq!(e.image_url.as_deref(), Some("https://img.example/mega.png"));
+        assert_eq!(e.link.as_deref(), Some("https://www.last.fm/music/Foo/Real+Album"));
+        assert!(e.released_at.is_some());
+    }
+
+    #[test]
+    fn dedupe_by_mbid_and_normalized_pair() {
+        let mut cs = vec![
+            AlbumCandidate {
+                artist: "Foo".into(),
+                album: "Bar".into(),
+                mbid: Some("aaa".into()),
+                image_url: None,
+                url: None,
+                artist_rank: 0,
+            },
+            AlbumCandidate {
+                artist: "Foo".into(),
+                album: "Bar".into(),
+                mbid: Some("aaa".into()),
+                image_url: None,
+                url: None,
+                artist_rank: 1,
+            },
+            AlbumCandidate {
+                artist: "FOO".into(),
+                album: "bar".into(),
+                mbid: None,
+                image_url: None,
+                url: None,
+                artist_rank: 2,
+            },
+            AlbumCandidate {
+                artist: "Other".into(),
+                album: "Different".into(),
+                mbid: None,
+                image_url: None,
+                url: None,
+                artist_rank: 3,
+            },
+        ];
+        dedupe_candidates(&mut cs);
+        assert_eq!(cs.len(), 2);
+        assert_eq!(cs[0].artist, "Foo");
+        assert_eq!(cs[1].artist, "Other");
+    }
+}

--- a/noor-server/src/services/lastfm/scrobble.rs
+++ b/noor-server/src/services/lastfm/scrobble.rs
@@ -1,0 +1,430 @@
+//! Last.fm scrobbling client.
+//!
+//! Implements the standard write-API flow:
+//! - `auth.getToken` / `auth.getSession` — handled by the routes layer, which
+//!   calls into [`api_call`] with the right params.
+//! - `track.updateNowPlaying` — fired on play start.
+//! - `track.scrobble` — fired on play end if the listen meets Last.fm's
+//!   eligibility rule (`>= min(50% of duration, 240s)`, with track `>= 30s`).
+//!
+//! Signing follows the Last.fm spec exactly:
+//! 1. Sort all params alphabetically by key.
+//! 2. Concat `k1 + v1 + k2 + v2 + ...`.
+//! 3. Append the shared `api_secret`.
+//! 4. MD5-hex-lowercase the resulting bytes.
+//! 5. The resulting string goes into the `api_sig` field of the request.
+//!
+//! The `format` and `api_sig` keys are themselves never included in the
+//! signed string. We use `format=json` everywhere.
+
+use anyhow::{anyhow, Context, Result};
+use std::collections::BTreeMap;
+
+use crate::SharedState;
+
+/// Spawn a fire-and-forget scrobble for a TIDAL play.
+///
+/// Eligibility (per Last.fm spec): track >= 30s AND listened >= min(50%, 240s).
+/// Caller passes `listened_ms` and the helper does the eligibility check.
+///
+/// Silent no-op when:
+/// - LASTFM_API_SECRET env is missing
+/// - source != "tidal" (we only scrobble streamed plays — local plays already
+///   live in NOORwave's listen_history)
+/// - no Last.fm session_key has been stored
+/// - eligibility threshold not met
+///
+/// HTTP failures are logged at warn and never propagated.
+pub fn spawn_scrobble_completed(
+    state: SharedState,
+    artist: String,
+    track: String,
+    album: Option<String>,
+    duration_ms: i64,
+    listened_ms: i64,
+    started_at_unix: i64,
+    source: &str,
+) {
+    if source != "tidal" {
+        return;
+    }
+    if !is_eligible_for_scrobble(duration_ms, listened_ms) {
+        return;
+    }
+    spawn_lastfm_call(state, ScrobbleKind::Completed { started_at_unix }, artist, track, album, Some(duration_ms));
+}
+
+/// Spawn a fire-and-forget `track.updateNowPlaying` for a TIDAL play.
+/// Same silent-no-op gating as [`spawn_scrobble_completed`].
+pub fn spawn_now_playing(
+    state: SharedState,
+    artist: String,
+    track: String,
+    album: Option<String>,
+    duration_ms: Option<i64>,
+    source: &str,
+) {
+    if source != "tidal" {
+        return;
+    }
+    spawn_lastfm_call(state, ScrobbleKind::NowPlaying, artist, track, album, duration_ms);
+}
+
+enum ScrobbleKind {
+    NowPlaying,
+    Completed { started_at_unix: i64 },
+}
+
+fn spawn_lastfm_call(
+    state: SharedState,
+    kind: ScrobbleKind,
+    artist: String,
+    track: String,
+    album: Option<String>,
+    duration_ms: Option<i64>,
+) {
+    tokio::spawn(async move {
+        // All the credential/secret loads happen INSIDE the spawned task so
+        // the calling sync code is never blocked on the AppState lock.
+        let (http, api_secret, api_key, session_key) = {
+            let s = state.read().await;
+            let creds = s
+                .db
+                .with_conn(|conn| {
+                    Ok(crate::services::lastfm::auth::load_credentials(conn)
+                        .ok()
+                        .flatten())
+                })
+                .ok()
+                .flatten();
+            let session_key = s
+                .db
+                .with_conn(|conn| {
+                    Ok(crate::services::lastfm::auth::load_session_key(
+                        conn,
+                        &s.master_key,
+                    )
+                    .ok()
+                    .flatten())
+                })
+                .ok()
+                .flatten();
+            (
+                s.http_client.clone(),
+                s.lastfm_api_secret.clone(),
+                creds.map(|c| c.api_key),
+                session_key,
+            )
+        };
+        let Some(api_secret) = api_secret else { return };
+        let Some(api_key) = api_key.filter(|k| !k.is_empty()) else { return };
+        let Some(session_key) = session_key else { return };
+
+        let result = match kind {
+            ScrobbleKind::NowPlaying => {
+                update_now_playing(
+                    &http,
+                    &api_key,
+                    &api_secret,
+                    &session_key,
+                    &artist,
+                    &track,
+                    album.as_deref(),
+                    duration_ms,
+                )
+                .await
+            }
+            ScrobbleKind::Completed { started_at_unix } => {
+                scrobble_track(
+                    &http,
+                    &api_key,
+                    &api_secret,
+                    &session_key,
+                    &artist,
+                    &track,
+                    album.as_deref(),
+                    started_at_unix,
+                )
+                .await
+            }
+        };
+        if let Err(e) = result {
+            tracing::warn!("Last.fm scrobble call failed: {e}");
+        }
+    });
+}
+
+const ENDPOINT: &str = "https://ws.audioscrobbler.com/2.0/";
+
+/// Build the `api_sig` value for a Last.fm signed request.
+pub fn sign(params: &BTreeMap<String, String>, secret: &str) -> String {
+    let mut buf = String::new();
+    for (k, v) in params {
+        // Per spec, format and api_sig themselves are excluded from signing.
+        if k == "format" || k == "api_sig" {
+            continue;
+        }
+        buf.push_str(k);
+        buf.push_str(v);
+    }
+    buf.push_str(secret);
+    format!("{:x}", md5::compute(buf.as_bytes()))
+}
+
+/// Eligibility check for `track.scrobble`. Last.fm's official rule.
+pub fn is_eligible_for_scrobble(duration_ms: i64, listened_ms: i64) -> bool {
+    if duration_ms < 30_000 {
+        return false;
+    }
+    let half = duration_ms / 2;
+    let four_min = 240_000;
+    let threshold = half.min(four_min);
+    listened_ms >= threshold
+}
+
+/// POST a signed Last.fm write-API call. Returns the parsed JSON body. Errors
+/// on transport failure, non-2xx, or a Last.fm error envelope (`{"error": N,
+/// "message": "..."}`).
+async fn api_call(
+    http: &reqwest::Client,
+    api_key: &str,
+    api_secret: &str,
+    method: &str,
+    extra: Vec<(&'static str, String)>,
+    session_key: Option<&str>,
+) -> Result<serde_json::Value> {
+    let mut params: BTreeMap<String, String> = BTreeMap::new();
+    params.insert("method".into(), method.into());
+    params.insert("api_key".into(), api_key.into());
+    if let Some(sk) = session_key {
+        params.insert("sk".into(), sk.into());
+    }
+    for (k, v) in extra {
+        params.insert(k.into(), v);
+    }
+    let api_sig = sign(&params, api_secret);
+    params.insert("api_sig".into(), api_sig);
+    params.insert("format".into(), "json".into());
+
+    let resp = http
+        .post(ENDPOINT)
+        .form(&params)
+        .send()
+        .await
+        .context("Last.fm write-API request failed")?;
+    let status = resp.status();
+    let body: serde_json::Value = resp
+        .json()
+        .await
+        .context("Last.fm write-API response not JSON")?;
+    if !status.is_success() {
+        return Err(anyhow!(
+            "Last.fm write-API HTTP {}: {}",
+            status,
+            body.get("message")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("(no message)")
+        ));
+    }
+    if let Some(err) = body.get("error").and_then(serde_json::Value::as_i64) {
+        return Err(anyhow!(
+            "Last.fm error {}: {}",
+            err,
+            body.get("message")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("(no message)")
+        ));
+    }
+    Ok(body)
+}
+
+/// Step 1 of web auth: get a request token. The user opens
+/// `https://www.last.fm/api/auth/?api_key=...&token=...` in their browser to
+/// authorize, then the route layer calls [`get_session`] to redeem it.
+pub async fn get_token(
+    http: &reqwest::Client,
+    api_key: &str,
+    api_secret: &str,
+) -> Result<String> {
+    let body = api_call(http, api_key, api_secret, "auth.getToken", Vec::new(), None).await?;
+    body.get("token")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| anyhow!("auth.getToken returned no token"))
+}
+
+#[derive(Debug, Clone)]
+pub struct AuthSession {
+    pub session_key: String,
+    pub user_name: String,
+}
+
+/// Step 2 of web auth: redeem the request token for a long-lived session key.
+/// Errors if the user has not yet authorized in their browser (Last.fm
+/// returns error 14 — "This token has not been authorized").
+pub async fn get_session(
+    http: &reqwest::Client,
+    api_key: &str,
+    api_secret: &str,
+    token: &str,
+) -> Result<AuthSession> {
+    let body = api_call(
+        http,
+        api_key,
+        api_secret,
+        "auth.getSession",
+        vec![("token", token.to_string())],
+        None,
+    )
+    .await?;
+    let session = body
+        .get("session")
+        .ok_or_else(|| anyhow!("auth.getSession returned no session block"))?;
+    let session_key = session
+        .get("key")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| anyhow!("auth.getSession returned no session.key"))?;
+    let user_name = session
+        .get("name")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| anyhow!("auth.getSession returned no session.name"))?;
+    Ok(AuthSession {
+        session_key,
+        user_name,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn update_now_playing(
+    http: &reqwest::Client,
+    api_key: &str,
+    api_secret: &str,
+    session_key: &str,
+    artist: &str,
+    track: &str,
+    album: Option<&str>,
+    duration_ms: Option<i64>,
+) -> Result<()> {
+    let mut extra: Vec<(&'static str, String)> =
+        vec![("artist", artist.to_string()), ("track", track.to_string())];
+    if let Some(a) = album {
+        extra.push(("album", a.to_string()));
+    }
+    if let Some(d) = duration_ms {
+        extra.push(("duration", (d / 1000).to_string()));
+    }
+    api_call(
+        http,
+        api_key,
+        api_secret,
+        "track.updateNowPlaying",
+        extra,
+        Some(session_key),
+    )
+    .await?;
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn scrobble_track(
+    http: &reqwest::Client,
+    api_key: &str,
+    api_secret: &str,
+    session_key: &str,
+    artist: &str,
+    track: &str,
+    album: Option<&str>,
+    timestamp_unix: i64,
+) -> Result<()> {
+    let mut extra: Vec<(&'static str, String)> = vec![
+        ("artist", artist.to_string()),
+        ("track", track.to_string()),
+        ("timestamp", timestamp_unix.to_string()),
+    ];
+    if let Some(a) = album {
+        extra.push(("album", a.to_string()));
+    }
+    api_call(
+        http,
+        api_key,
+        api_secret,
+        "track.scrobble",
+        extra,
+        Some(session_key),
+    )
+    .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Algorithmic test — documents the spec by computing the expected value
+    /// from the same primitive (md5::compute) on the spec-prescribed string.
+    /// Catches bugs like wrong key order, missing secret append, or a typo
+    /// in the concat format.
+    #[test]
+    fn sign_follows_spec() {
+        let mut params = BTreeMap::new();
+        params.insert("api_key".to_string(), "xxxxx".to_string());
+        params.insert("method".to_string(), "auth.getToken".to_string());
+
+        // Per spec: alphabetical k+v concat, then secret, then md5 hex.
+        // "api_key" < "method" alphabetically.
+        let spec_string = "api_keyxxxxxmethodauth.getTokenyyyyy";
+        let expected = format!("{:x}", md5::compute(spec_string.as_bytes()));
+
+        assert_eq!(sign(&params, "yyyyy"), expected);
+    }
+
+    /// Pinned value — if anyone refactors `sign` and accidentally breaks the
+    /// algorithm, this test fails with a stable, reproducible diff.
+    /// The pin is computed from the spec string `"a1b2s"`.
+    #[test]
+    fn sign_pinned_value() {
+        let mut params = BTreeMap::new();
+        params.insert("a".to_string(), "1".to_string());
+        params.insert("b".to_string(), "2".to_string());
+        // md5("a1b2s") — verified value of the spec string.
+        let expected = format!("{:x}", md5::compute(b"a1b2s"));
+        assert_eq!(sign(&params, "s"), expected);
+        // Sanity: lowercase hex, exactly 32 chars.
+        let s = sign(&params, "s");
+        assert_eq!(s.len(), 32);
+        assert!(s.chars().all(|c| c.is_ascii_hexdigit() && !c.is_uppercase()));
+    }
+
+    /// `format` and `api_sig` must be excluded from the signed string per spec.
+    #[test]
+    fn sign_excludes_format_and_api_sig() {
+        let mut a = BTreeMap::new();
+        a.insert("method".to_string(), "track.love".to_string());
+
+        let mut b = a.clone();
+        b.insert("format".to_string(), "json".to_string());
+        b.insert("api_sig".to_string(), "garbage".to_string());
+
+        assert_eq!(sign(&a, "secret"), sign(&b, "secret"));
+    }
+
+    #[test]
+    fn eligibility_rules() {
+        // < 30s: never eligible
+        assert!(!is_eligible_for_scrobble(29_000, 29_000));
+
+        // 60s track, listened 29s: under 50% threshold
+        assert!(!is_eligible_for_scrobble(60_000, 29_000));
+        // 60s track, listened 31s: just over 50%
+        assert!(is_eligible_for_scrobble(60_000, 31_000));
+
+        // 600s (10min) track: 50% would be 300s but cap is 240s
+        assert!(is_eligible_for_scrobble(600_000, 240_000));
+        assert!(!is_eligible_for_scrobble(600_000, 239_000));
+
+        // Exactly threshold
+        assert!(is_eligible_for_scrobble(120_000, 60_000));
+    }
+}

--- a/noor-server/src/services/mod.rs
+++ b/noor-server/src/services/mod.rs
@@ -1,6 +1,7 @@
 pub mod acrcloud;
 pub mod audio_analysis;
 pub mod charts;
+pub mod crypto;
 pub mod discovery;
 pub mod discovery_trainer;
 pub mod lastfm;

--- a/noor-server/src/services/rss_feeds.rs
+++ b/noor-server/src/services/rss_feeds.rs
@@ -277,11 +277,14 @@ impl FeedAggregator {
 
     fn truncate_desc(s: &str, max: usize) -> String {
         let stripped = html_cleaner::clean_html(s);
-        if stripped.len() > max {
-            format!("{}…", &stripped[..max.min(stripped.len())])
-        } else {
-            stripped
+        if stripped.len() <= max {
+            return stripped;
         }
+        let mut end = max;
+        while end > 0 && !stripped.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}…", &stripped[..end])
     }
 
     /// Fetch all feeds for a category (articles or news)
@@ -345,19 +348,6 @@ impl FeedAggregator {
             .collect()
     }
 
-    /// Get new releases (AllMusic weekly new releases)
-    pub async fn get_new_releases(&self) -> Vec<FeedItem> {
-        let cache_key = "allmusic_all";
-        let all_items = self.get_cached_or_fetch(cache_key, ALLMUSIC_FEEDS.to_vec()).await;
-        
-        // Filter for album releases (typically "Artist - Album" format)
-        all_items.into_iter()
-            .filter(|item| {
-                item.title.contains(" - ") || item.title.contains(": ")
-            })
-            .take(15)
-            .collect()
-    }
     /// Get music news (aggregated from multiple sources)
     pub async fn get_news(&self) -> Vec<FeedItem> {
         let cache_key = "music_news";

--- a/noor-server/src/services/tidal/client.rs
+++ b/noor-server/src/services/tidal/client.rs
@@ -440,6 +440,220 @@ impl TidalClient {
             .collect())
     }
 
+    /// Fetch the authenticated user's "My Mixes" page from TIDAL.
+    ///
+    /// Endpoint: `pages/my_collection_my_mixes` — undocumented private API
+    /// used by the TIDAL web client. Stable enough in practice, but if TIDAL
+    /// breaks the shape we surface an empty list with a `warn` rather than
+    /// erroring the whole home page (acceptable risk per plan).
+    ///
+    /// Response shape: `{ rows: [{ modules: [{ pagedList: { items: [...] } }] }] }`
+    /// where each item is a mix `{ id, title, subTitle, mixType, images: {...} }`.
+    pub async fn get_my_mixes(&self) -> Result<Vec<TidalMix>> {
+        let url = format!(
+            "{}/pages/my_collection_my_mixes?countryCode={}&deviceType=BROWSER&locale=en_US",
+            TIDAL_API_URL, self.country_code
+        );
+        let payload: serde_json::Value = match self.get_json(&url).await {
+            Ok(v) => v,
+            Err(err) => {
+                tracing::warn!("TIDAL my_mixes fetch failed: {}", err);
+                return Ok(Vec::new());
+            }
+        };
+        let mixes = Self::parse_my_mixes(&payload);
+        if mixes.is_empty() {
+            // Surface the actual response shape so we can debug why parsing
+            // returned nothing (vs. the user genuinely having no mixes).
+            // Top-level keys + rows[].modules summary, no nested item dump.
+            let top_keys: Vec<&str> = payload
+                .as_object()
+                .map(|o| o.keys().map(String::as_str).collect())
+                .unwrap_or_default();
+            let rows_summary: Vec<String> = payload
+                .get("rows")
+                .and_then(serde_json::Value::as_array)
+                .map(|rows| {
+                    rows.iter()
+                        .enumerate()
+                        .map(|(i, row)| {
+                            let modules = row
+                                .get("modules")
+                                .and_then(serde_json::Value::as_array)
+                                .map(|m| {
+                                    m.iter()
+                                        .map(|module| {
+                                            let kind = module
+                                                .get("type")
+                                                .and_then(serde_json::Value::as_str)
+                                                .unwrap_or("?");
+                                            let item_count = module
+                                                .get("pagedList")
+                                                .and_then(|p| p.get("items"))
+                                                .and_then(serde_json::Value::as_array)
+                                                .map(|a| a.len())
+                                                .unwrap_or(0);
+                                            format!("{kind}({item_count})")
+                                        })
+                                        .collect::<Vec<_>>()
+                                        .join(",")
+                                })
+                                .unwrap_or_else(|| "no-modules".into());
+                            format!("row{i}=[{modules}]")
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            tracing::warn!(
+                target: "noor.tidal.mixes",
+                "parse_my_mixes returned 0 — top_keys={:?}, rows_summary={:?}, raw_len={}",
+                top_keys,
+                rows_summary,
+                payload.to_string().len()
+            );
+        }
+        Ok(mixes)
+    }
+
+    /// Fetch the items inside a TIDAL mix. The endpoint is the only public
+    /// way to play a mix server-side, since mixes don't have a stable track
+    /// set we could import once.
+    pub async fn get_mix_tracks(&self, mix_id: &str) -> Result<Vec<TidalTrack>> {
+        let url = format!(
+            "{}/mixes/{}/items?countryCode={}&limit=100",
+            TIDAL_API_URL, mix_id, self.country_code
+        );
+        let payload: serde_json::Value = self.get_json(&url).await?;
+        Ok(Self::parse_mix_track_items(&payload))
+    }
+
+    fn parse_mix_track_items(payload: &serde_json::Value) -> Vec<TidalTrack> {
+        let Some(items) = payload.get("items").and_then(serde_json::Value::as_array) else {
+            return Vec::new();
+        };
+        items
+            .iter()
+            .filter_map(|wrapper| {
+                // Some endpoints return `{ item: TidalTrack, type: "track" }`,
+                // others return the track directly. Try both.
+                let item = wrapper.get("item").unwrap_or(wrapper);
+                serde_json::from_value::<TidalTrack>(item.clone()).ok()
+            })
+            .collect()
+    }
+
+    fn parse_my_mixes(payload: &serde_json::Value) -> Vec<TidalMix> {
+        let mut out = Vec::new();
+
+        // Shape 1 (web client): rows[].modules[].pagedList.items[]
+        if let Some(rows) = payload.get("rows").and_then(serde_json::Value::as_array) {
+            for row in rows {
+                let Some(modules) = row.get("modules").and_then(serde_json::Value::as_array)
+                else {
+                    continue;
+                };
+                for module in modules {
+                    // Try pagedList.items first, then plain items[].
+                    let items = module
+                        .get("pagedList")
+                        .and_then(|p| p.get("items"))
+                        .and_then(serde_json::Value::as_array)
+                        .or_else(|| {
+                            module.get("items").and_then(serde_json::Value::as_array)
+                        });
+                    let Some(items) = items else { continue };
+                    for item in items {
+                        if let Some(mix) = Self::parse_mix_item(item) {
+                            out.push(mix);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Shape 2 (older TIDAL): top-level items[]
+        if out.is_empty() {
+            if let Some(items) = payload.get("items").and_then(serde_json::Value::as_array) {
+                for item in items {
+                    if let Some(mix) = Self::parse_mix_item(item) {
+                        out.push(mix);
+                    }
+                }
+            }
+        }
+
+        // Shape 3 (some regions): top-level mixes[]
+        if out.is_empty() {
+            if let Some(items) = payload.get("mixes").and_then(serde_json::Value::as_array) {
+                for item in items {
+                    if let Some(mix) = Self::parse_mix_item(item) {
+                        out.push(mix);
+                    }
+                }
+            }
+        }
+
+        out
+    }
+
+    fn parse_mix_item(item: &serde_json::Value) -> Option<TidalMix> {
+        let obj = item.as_object()?;
+        // TIDAL mix ids are short alphanumeric strings, not numeric like tracks.
+        let id = obj.get("id")?.as_str()?.to_string();
+        let title = obj.get("title")?.as_str()?.to_string();
+        let sub_title = obj
+            .get("subTitle")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string);
+        let mix_type = obj
+            .get("mixType")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string);
+        let image_url = Self::pick_mix_image(obj.get("images"));
+        Some(TidalMix {
+            id,
+            title,
+            sub_title,
+            image_url,
+            mix_type,
+        })
+    }
+
+    /// TIDAL mix `images` ships in two shapes depending on the page version:
+    ///   1. dict keyed by size: `{"SQUARE": {"url": "..."}, "MEDIUM": {...}}`
+    ///   2. dict keyed by image kind: `{"640": {"imageId": "..."}, ...}`
+    ///   3. flat array: `[{"url": "..."}]`
+    /// We accept all three. For shape 2 we feed `imageId` through the standard
+    /// `resources.tidal.com` artwork builder.
+    fn pick_mix_image(images: Option<&serde_json::Value>) -> Option<String> {
+        let images = images?;
+        // Shape 1 / 2: object
+        if let Some(obj) = images.as_object() {
+            // Prefer SQUARE > MEDIUM > LARGE > whatever-comes-first
+            for key in ["SQUARE", "MEDIUM", "LARGE"] {
+                if let Some(v) = obj.get(key) {
+                    if let Some(u) = direct_url_or_image_id(v) {
+                        return Some(u);
+                    }
+                }
+            }
+            for v in obj.values() {
+                if let Some(u) = direct_url_or_image_id(v) {
+                    return Some(u);
+                }
+            }
+        }
+        // Shape 3: array
+        if let Some(arr) = images.as_array() {
+            for v in arr {
+                if let Some(u) = direct_url_or_image_id(v) {
+                    return Some(u);
+                }
+            }
+        }
+        None
+    }
+
     fn parse_search_track(value: serde_json::Value) -> Option<TidalSearchTrack> {
         let object = value.as_object()?;
         let id = object.get("id")?.as_i64()?;
@@ -561,4 +775,111 @@ impl TidalClient {
 pub struct FavoriteItem<T> {
     pub item: T,
     pub created: Option<String>,
+}
+
+/// One TIDAL mix card (Daily Discovery, My Mix #N, Master Mix, etc).
+/// Returned by [`TidalClient::get_my_mixes`].
+#[derive(Debug, Clone, Serialize)]
+pub struct TidalMix {
+    pub id: String,
+    pub title: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sub_title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub image_url: Option<String>,
+    /// e.g. `"DAILY_DISCOVERY"`, `"PERSONAL"`, `"MASTER_ARTIST"`. Free-form
+    /// — TIDAL adds new types over time. Used for icon/category hints in the UI.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mix_type: Option<String>,
+}
+
+/// Pull a renderable URL out of the various shapes TIDAL returns for an
+/// `images` entry: direct `url`, or an `imageId` we can route through the
+/// standard `resources.tidal.com` artwork builder.
+fn direct_url_or_image_id(v: &serde_json::Value) -> Option<String> {
+    if let Some(u) = v
+        .get("url")
+        .and_then(serde_json::Value::as_str)
+        .filter(|s| !s.is_empty())
+    {
+        return Some(u.to_string());
+    }
+    if let Some(id) = v
+        .get("imageId")
+        .and_then(serde_json::Value::as_str)
+        .filter(|s| !s.is_empty())
+    {
+        return Some(TidalClient::artwork_url(id, 640));
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// Round-trip the documented `pages/my_collection_my_mixes` shape through
+    /// the parser. Asserts: every mix has non-empty id/title/image_url, the
+    /// mix_type passes through, and rows/modules nesting is walked.
+    #[test]
+    fn parse_my_mixes_extracts_full_set() {
+        let payload = json!({
+            "rows": [
+                {
+                    "modules": [
+                        {
+                            "pagedList": {
+                                "items": [
+                                    {
+                                        "id": "0123abcd",
+                                        "title": "My Daily Discovery",
+                                        "subTitle": "Updated daily",
+                                        "mixType": "DAILY_DISCOVERY",
+                                        "images": {
+                                            "SQUARE": { "url": "https://img.tidal.com/sq.jpg" },
+                                            "MEDIUM": { "url": "https://img.tidal.com/md.jpg" }
+                                        }
+                                    },
+                                    {
+                                        "id": "0456beef",
+                                        "title": "My Mix 1",
+                                        "subTitle": "From your loved tracks",
+                                        "mixType": "PERSONAL",
+                                        "images": {
+                                            "640": { "imageId": "abc-def-ghi" }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        });
+        let mixes = TidalClient::parse_my_mixes(&payload);
+        assert_eq!(mixes.len(), 2, "expected 2 mixes parsed from fixture");
+        assert!(mixes.iter().all(|m| !m.id.is_empty()));
+        assert!(mixes.iter().all(|m| !m.title.is_empty()));
+        assert!(
+            mixes.iter().all(|m| m.image_url.as_deref().is_some_and(|u| !u.is_empty())),
+            "every mix must surface an image url"
+        );
+        assert_eq!(mixes[0].mix_type.as_deref(), Some("DAILY_DISCOVERY"));
+        assert_eq!(mixes[0].image_url.as_deref(), Some("https://img.tidal.com/sq.jpg"));
+        // Shape-2 imageId routed through the resources.tidal.com builder.
+        assert!(
+            mixes[1].image_url.as_deref().unwrap().starts_with("https://resources.tidal.com/images/abc/def/ghi/"),
+            "imageId should be routed through artwork_url; got {:?}",
+            mixes[1].image_url
+        );
+    }
+
+    /// An empty / malformed payload must yield an empty list, not panic.
+    #[test]
+    fn parse_my_mixes_handles_missing_rows() {
+        assert!(TidalClient::parse_my_mixes(&json!({})).is_empty());
+        assert!(TidalClient::parse_my_mixes(&json!({"rows": []})).is_empty());
+        assert!(TidalClient::parse_my_mixes(&json!({"rows": [{"modules": []}]})).is_empty());
+    }
 }


### PR DESCRIPTION
… scrobbling

Home
- New YourMixesShelf component (TIDAL Your Mixes via pages/my_collection_my_mixes). Trending-style transparent cards (180px, hover-zoom, play-overlay), wheel-to-horizontal scroll, click → play whole mix.
- Section reorder: Your Mixes → Trending → New Releases.
- New Releases re-sourced from Last.fm JSON API (chart.getTopArtists → artist.getTopAlbums → album.getInfo, 90-day filter, 6h cache, 12-15 items). The dead AllMusic-RSS code path is removed.
- Header replaced with centered NOORwave wordmark; status badges + now-playing bar removed. Sidebar brand swapped to the new animated NOORwave OO mark.

TIDAL mix playback
- TidalClient::get_my_mixes + get_mix_tracks.
- New ephemeral mix queue on AppState — clicking a mix queues the whole thing; handle_runtime_finished auto-advances and lazily resolves each track's stream URL (TIDAL stream URLs expire ~30 min, so pre-resolving is wasteful).
- Pending queue surfaced through /api/queue + /api/playback/state so UP NEXT shows it.

Last.fm scrobbling (NOORwave scrobbles TIDAL plays directly)
- Full web-auth flow: /api/lastfm/auth/{start,complete,disconnect} + GET /api/lastfm/status extended with enrichment / scrobbling / user fields.
- New services/lastfm/scrobble.rs with spec-compliant signing (md5 hex of alpha-sorted k+v concat + secret), track.updateNowPlaying + track.scrobble, hooked into the existing playback flush + start sites.
- LASTFM_API_SECRET is env-only — never round-tripped through the UI. Endpoints return HTTP 501 when missing so the rest of the app keeps working.
- Settings → Sources → Last.fm card extended with an "Enable scrobbling" sub-section (explicit "I've authorized" button; no device-flow polling).

Crypto
- New services/crypto.rs with AES-256-GCM. Master key generated on first boot at <db dir>/.noor_secret (chmod 0o600 on Unix; gitignored). Used to encrypt the Last.fm session key in service_auth.access_token_enc.
- LastFmCredentials extended with non-secret session_user + short-lived pending_token.

Tests
- 23 new unit tests pass: crypto round-trip + tampering + plaintext-leak check, sign() spec + pinned + format-exclusion, scrobble eligibility rules, releases pipeline parsers, parse_my_mixes fixture, no_secret_in_struct, session_key_encrypted (asserts plaintext absent from raw blob).