### PR TITLE
feat(sportify): anonymous Spotify discovery layer, search grid views,…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2710,7 +2710,7 @@ dependencies = [
 
 [[package]]
 name = "noor-server"
-version = "0.1.12"
+version = "0.1.16"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/frontend/src/lib/actions/wheel-to-horizontal.ts
+++ b/frontend/src/lib/actions/wheel-to-horizontal.ts
@@ -1,6 +1,10 @@
 export function wheelToHorizontal(node: HTMLElement) {
   const onWheel = (e: WheelEvent) => {
     if (Math.abs(e.deltaY) <= Math.abs(e.deltaX)) return
+    // No horizontal overflow → let the page scroll vertically. Without this,
+    // grid-mode containers (no x-overflow) silently swallow every wheel event
+    // mouse-over them and the page appears frozen.
+    if (node.scrollWidth <= node.clientWidth) return
     e.preventDefault()
     node.scrollLeft += e.deltaY
   }

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -146,6 +146,211 @@ export interface TidalSearchResults {
 	artists: TidalSearchArtist[];
 }
 
+/**
+ * Compact Spotify-playlist search result. Powers the Spotify section of
+ * /search and Ctrl+K. Click navigates to the ephemeral /spotify-playlist/{id}
+ * view, which fetches the full track listing and bulk-resolves to TIDAL.
+ */
+export interface SpotifyPlaylistSearchItem {
+	spotifyId: string;
+	title: string | null;
+	description: string | null;
+	thumbnail: string | null;
+	owner: string | null;
+	followers: number | null;
+	totalTracks: number | null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+	return value && typeof value === 'object' && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: null;
+}
+
+function pickString(obj: Record<string, unknown>, keys: string[]): string | null {
+	for (const key of keys) {
+		const value = obj[key];
+		if (typeof value === 'string' && value.trim()) return value;
+	}
+	return null;
+}
+
+function pickNumber(obj: Record<string, unknown>, keys: string[]): number | null {
+	for (const key of keys) {
+		const value = obj[key];
+		if (typeof value === 'number' && Number.isFinite(value)) return value;
+		if (typeof value === 'string') {
+			const parsed = Number(value);
+			if (Number.isFinite(parsed)) return parsed;
+		}
+	}
+	return null;
+}
+
+function pickBoolean(obj: Record<string, unknown>, keys: string[]): boolean | null {
+	for (const key of keys) {
+		const value = obj[key];
+		if (typeof value === 'boolean') return value;
+	}
+	return null;
+}
+
+function pickArray(obj: Record<string, unknown>, keys: string[]): unknown[] {
+	for (const key of keys) {
+		const value = obj[key];
+		if (Array.isArray(value)) return value;
+		const nested = asRecord(value);
+		if (nested && Array.isArray(nested.items)) return nested.items;
+	}
+	return [];
+}
+
+function playlistOwnerName(value: unknown): string | null {
+	if (typeof value === 'string' && value.trim()) return value;
+	const owner = asRecord(value);
+	return owner ? pickString(owner, ['display_name', 'displayName', 'name']) : null;
+}
+
+function normalizeSpotifyPlaylistSearchItem(raw: unknown): SpotifyPlaylistSearchItem | null {
+	const item = asRecord(raw);
+	if (!item) return null;
+	const spotifyId = pickString(item, ['spotifyId', 'spotify_id', 'id']);
+	if (!spotifyId) return null;
+	return {
+		spotifyId,
+		title: pickString(item, ['title', 'name']),
+		description: pickString(item, ['description']),
+		thumbnail: pickString(item, ['thumbnail', 'image_url', 'imageUrl', 'artwork_url', 'artworkUrl', 'cover']),
+		owner: playlistOwnerName(item.owner),
+		followers: pickNumber(item, ['followers', 'follower_count', 'followerCount']),
+		totalTracks: pickNumber(item, ['totalTracks', 'total_tracks', 'track_count', 'trackCount']),
+	};
+}
+
+function normalizeSpotifyTidalState(raw: unknown): SpotifyTidalState {
+	const item = asRecord(raw) ?? {};
+	const status = pickString(item, ['status']);
+	const allowed = ['pending', 'resolved', 'low_confidence', 'unresolved', 'error'] as const;
+	const normalizedStatus = allowed.includes(status as (typeof allowed)[number])
+		? (status as SpotifyTidalState['status'])
+		: 'pending';
+	return {
+		status: normalizedStatus,
+		id: pickNumber(item, ['id', 'tidal_id', 'tidalId']),
+		confidence: pickNumber(item, ['confidence']) ?? 0,
+		matchReason: pickString(item, ['matchReason', 'match_reason']),
+		fromCache: pickBoolean(item, ['fromCache', 'from_cache']) ?? false,
+	};
+}
+
+function normalizeArtistRefs(raw: unknown): { id: string | null; name: string | null }[] {
+	return Array.isArray(raw)
+		? raw
+				.map(asRecord)
+				.filter((artist): artist is Record<string, unknown> => artist !== null)
+				.map((artist) => ({
+					id: pickString(artist, ['id', 'spotifyId', 'spotify_id']),
+					name: pickString(artist, ['name']),
+				}))
+		: [];
+}
+
+function normalizeSpotifyPlaylistTrack(raw: unknown): SpotifyPlaylistTrack | null {
+	const item = asRecord(raw);
+	if (!item) return null;
+	return {
+		source: 'spotify',
+		spotifyId: pickString(item, ['spotifyId', 'spotify_id', 'id']),
+		type: 'track',
+		title: pickString(item, ['title', 'name']),
+		primaryArtist: pickString(item, ['primaryArtist', 'primary_artist', 'artist']),
+		artists: normalizeArtistRefs(item.artists),
+		album: pickString(item, ['album', 'album_title', 'albumTitle']),
+		albumId: pickString(item, ['albumId', 'album_id']),
+		thumbnail: pickString(item, ['thumbnail', 'image_url', 'imageUrl', 'artwork_url', 'artworkUrl', 'cover']),
+		durationMs: pickNumber(item, ['durationMs', 'duration_ms']),
+		releaseDate: pickString(item, ['releaseDate', 'release_date']),
+		explicit: pickBoolean(item, ['explicit']),
+		trackNumber: pickNumber(item, ['trackNumber', 'track_number']),
+		discNumber: pickNumber(item, ['discNumber', 'disc_number']),
+		spotifyUrl: pickString(item, ['spotifyUrl', 'spotify_url', 'url']),
+		previewUrl: pickString(item, ['previewUrl', 'preview_url']),
+		playcount: pickNumber(item, ['playcount', 'play_count', 'playCount']),
+		popularity: pickNumber(item, ['popularity']),
+		isrc: pickString(item, ['isrc']),
+		tidal: normalizeSpotifyTidalState(item.tidal),
+	};
+}
+
+function normalizeSpotifyPlaylistDetail(raw: unknown): SpotifyPlaylistDetail {
+	const item = asRecord(raw) ?? {};
+	return {
+		source: 'spotify',
+		spotifyId: pickString(item, ['spotifyId', 'spotify_id', 'id']),
+		type: 'playlist',
+		title: pickString(item, ['title', 'name']),
+		description: pickString(item, ['description']),
+		thumbnail: pickString(item, ['thumbnail', 'image_url', 'imageUrl', 'artwork_url', 'artworkUrl', 'cover']),
+		owner: playlistOwnerName(item.owner),
+		followers: pickNumber(item, ['followers', 'follower_count', 'followerCount']),
+		totalTracks: pickNumber(item, ['totalTracks', 'total_tracks', 'track_count', 'trackCount']),
+		snapshotId: pickString(item, ['snapshotId', 'snapshot_id']),
+		tracks: pickArray(item, ['tracks', 'items'])
+			.map(normalizeSpotifyPlaylistTrack)
+			.filter((track): track is SpotifyPlaylistTrack => track !== null),
+	};
+}
+
+export interface SpotifyTidalState {
+	status: 'pending' | 'resolved' | 'low_confidence' | 'unresolved' | 'error';
+	id: number | null;
+	confidence: number;
+	matchReason: string | null;
+	fromCache: boolean;
+}
+
+export interface SpotifyPlaylistTrack {
+	source: 'spotify';
+	spotifyId: string | null;
+	type: 'track';
+	title: string | null;
+	primaryArtist: string | null;
+	artists: { id: string | null; name: string | null }[];
+	album: string | null;
+	albumId: string | null;
+	thumbnail: string | null;
+	durationMs: number | null;
+	releaseDate: string | null;
+	explicit: boolean | null;
+	trackNumber: number | null;
+	discNumber: number | null;
+	spotifyUrl: string | null;
+	previewUrl: string | null;
+	playcount: number | null;
+	popularity: number | null;
+	isrc: string | null;
+	tidal: SpotifyTidalState;
+}
+
+export interface SpotifyPlaylistDetail {
+	source: 'spotify';
+	spotifyId: string | null;
+	type: 'playlist';
+	title: string | null;
+	description: string | null;
+	thumbnail: string | null;
+	owner: string | null;
+	followers: number | null;
+	totalTracks: number | null;
+	snapshotId: string | null;
+	tracks: SpotifyPlaylistTrack[];
+}
+
+export interface ResolveStatusEntry {
+	spotifyId: string;
+	tidal: SpotifyTidalState;
+}
+
 export interface TidalArtistProfile {
 	artist_name: string | null;
 	top_tracks: TidalDiscographyTrack[];
@@ -1123,12 +1328,106 @@ export const api = {
 		});
 	},
 
-	searchTidalPlaylists(q: string, signal?: AbortSignal) {
+	searchTidalPlaylists(q: string, signal?: AbortSignal, opts?: { limit?: number; offset?: number }) {
+		const limit = opts?.limit ?? 20;
+		const offset = opts?.offset ?? 0;
 		return fetchApi<{ playlists: TidalSearchPlaylist[] }>(
-			`/api/tidal/playlists/search?q=${encodeURIComponent(q)}`,
+			`/api/tidal/playlists/search?q=${encodeURIComponent(q)}&limit=${limit}&offset=${offset}`,
 			undefined,
 			{ signal },
 		);
+	},
+
+	/**
+	 * Search Spotify (via the Sportify proxy) for playlists. Best-effort —
+	 * the caller should swallow errors so a Sportify outage never breaks
+	 * /search or Ctrl+K rendering.
+	 */
+	/**
+	 * Fetch a Spotify-sourced playlist's full metadata + track list, with
+	 * each track stamped with its current TIDAL resolution state.
+	 */
+	getSpotifyPlaylist(
+		spotifyId: string,
+		signal?: AbortSignal,
+	): Promise<{ playlist: SpotifyPlaylistDetail; pendingSpotifyIds: string[] }> {
+		return fetchApi<{ playlist?: unknown; pendingSpotifyIds?: unknown; pending_spotify_ids?: unknown }>(
+			`/api/discovery/sportify/playlist/${encodeURIComponent(spotifyId)}`,
+			undefined,
+			{ signal },
+		).then((res) => ({
+			playlist: normalizeSpotifyPlaylistDetail(res.playlist),
+			pendingSpotifyIds: [
+				...(Array.isArray(res.pendingSpotifyIds) ? res.pendingSpotifyIds : []),
+				...(Array.isArray(res.pending_spotify_ids) ? res.pending_spotify_ids : []),
+			].filter((id): id is string => typeof id === 'string' && id.length > 0),
+		}));
+	},
+
+	/**
+	 * Cache-only resolution status poll. Used by the ephemeral playlist view
+	 * to fill in lazy-tail tracks as the background resolver finishes them.
+	 */
+	getResolveTidalStatus(
+		spotifyIds: string[],
+		signal?: AbortSignal,
+	): Promise<{ entries: ResolveStatusEntry[] }> {
+		return fetchApi<{ entries: ResolveStatusEntry[] }>(
+			`/api/resolve/tidal/status`,
+			{ spotify_ids: spotifyIds.join(',') },
+			{ signal },
+		);
+	},
+
+	/**
+	 * Save the ephemeral Spotify playlist into the user's library. Imports
+	 * each resolved TIDAL track and creates a noor playlist; unresolved
+	 * rows are skipped (counts come back in the response).
+	 */
+	saveSpotifyPlaylist(spotifyId: string, name?: string) {
+		return fetchApi<{
+			playlist: Playlist;
+			added: number;
+			totalTracks: number;
+			resolvedCount: number;
+			unresolvedCount: number;
+			importFailures: number;
+		}>(`/api/spotify-playlist/save`, undefined, {
+			method: 'POST',
+			body: JSON.stringify({ spotify_id: spotifyId, name }),
+		});
+	},
+
+	async searchSpotifyPlaylists(
+		q: string,
+		limit = 12,
+		signal?: AbortSignal,
+		offset = 0,
+	): Promise<SpotifyPlaylistSearchItem[]> {
+		type Resp = { playlists?: unknown[]; spotify_playlists?: unknown[] };
+		const fromResponse = (res: Resp) =>
+			[...(res.playlists ?? []), ...(res.spotify_playlists ?? [])]
+				.map(normalizeSpotifyPlaylistSearchItem)
+				.filter((item): item is SpotifyPlaylistSearchItem => item !== null);
+
+		try {
+			const res = await fetchApi<Resp>(
+				`/api/discovery/sportify/search`,
+				{ q, type: 'playlist', limit: String(limit), offset: String(offset) },
+				{ signal },
+			);
+			const playlists = fromResponse(res);
+			if (playlists.length > 0 || offset > 0) return playlists;
+		} catch (error) {
+			if (signal?.aborted) throw error;
+		}
+
+		const fallback = await fetchApi<Resp>(
+			'/api/search',
+			{ q, limit: String(limit) },
+			{ signal },
+		);
+		return fromResponse(fallback);
 	},
 
 	getTidalPlaylistTracks(tidalUuid: string) {
@@ -1544,10 +1843,24 @@ export const api = {
 		});
 	},
 
+	queuePlayNextMany(items: QueueExternalRequest[]) {
+		return fetchApi<{ queue: QueueItem[] }>('/api/queue/play_next_many', undefined, {
+			method: 'POST',
+			body: JSON.stringify({ items }),
+		});
+	},
+
 	queueAppend(req: QueueExternalRequest) {
 		return fetchApi<{ queue: QueueItem[] }>('/api/queue/append', undefined, {
 			method: 'POST',
 			body: JSON.stringify(req),
+		});
+	},
+
+	queueAppendMany(items: QueueExternalRequest[]) {
+		return fetchApi<{ queue: QueueItem[] }>('/api/queue/append_many', undefined, {
+			method: 'POST',
+			body: JSON.stringify({ items }),
 		});
 	},
 
@@ -1775,8 +2088,12 @@ export const api = {
 		});
 	},
 
-	searchTidal(q: string, limit = 20, signal?: AbortSignal): Promise<TidalSearchResults> {
-		return fetchApi<TidalSearchResults>('/api/tidal/search', { q, limit: String(limit) }, { signal });
+	searchTidal(q: string, limit = 20, signal?: AbortSignal, offset = 0): Promise<TidalSearchResults> {
+		return fetchApi<TidalSearchResults>(
+			'/api/tidal/search',
+			{ q, limit: String(limit), offset: String(offset) },
+			{ signal },
+		);
 	},
 
 	playTidalTrack(track: TidalPlayable): Promise<void> {

--- a/frontend/src/lib/components/CommandPalette.svelte
+++ b/frontend/src/lib/components/CommandPalette.svelte
@@ -3,7 +3,13 @@
 	import { quintOut } from 'svelte/easing';
 	import { goto } from '$app/navigation';
 	import { get } from 'svelte/store';
-	import { api, type TidalSearchTrack, type TidalSearchAlbum, type TidalSearchArtist } from '$lib/api/client';
+	import {
+		api,
+		type TidalSearchTrack,
+		type TidalSearchAlbum,
+		type TidalSearchArtist,
+		type SpotifyPlaylistSearchItem,
+	} from '$lib/api/client';
 	import { commandPaletteOpen } from '$lib/stores/command_palette';
 	import {
 		playTidalTrackNow,
@@ -23,6 +29,7 @@
 	let tracks = $state<TidalSearchTrack[]>([]);
 	let albums = $state<TidalSearchAlbum[]>([]);
 	let artists = $state<TidalSearchArtist[]>([]);
+	let spotifyPlaylists = $state<SpotifyPlaylistSearchItem[]>([]);
 	let cursor = $state(0);
 	let debounceTimer: ReturnType<typeof setTimeout>;
 	let rowEls: (HTMLElement | null)[] = $state([]);
@@ -32,7 +39,9 @@
 
 	// Total navigable items count (for cursor wrapping)
 	const totalItems = $derived(
-		isSlashMode ? slashMatches.length : tracks.length + albums.length + artists.length
+		isSlashMode
+			? slashMatches.length
+			: tracks.length + albums.length + artists.length + spotifyPlaylists.length
 	);
 
 	$effect(() => {
@@ -43,6 +52,7 @@
 			tracks = [];
 			albums = [];
 			artists = [];
+			spotifyPlaylists = [];
 			cursor = 0;
 		}
 	});
@@ -58,19 +68,29 @@
 			tracks = [];
 			albums = [];
 			artists = [];
+			spotifyPlaylists = [];
 			loading = false;
 			return;
 		}
 		loading = true;
 		debounceTimer = setTimeout(async () => {
-			try {
-				const res = await api.searchTidal(query.trim());
-				tracks = res.tracks.slice(0, 5);
-				albums = res.albums.slice(0, 3);
-				artists = res.artists.slice(0, 3);
-			} catch { /* silent */ } finally {
-				loading = false;
+			// TIDAL + Spotify playlist searches in parallel. A Sportify outage
+			// must never block TIDAL results from rendering.
+			const [tidalRes, spotifyRes] = await Promise.allSettled([
+				api.searchTidal(query.trim()),
+				api.searchSpotifyPlaylists(query.trim(), 6),
+			]);
+			if (tidalRes.status === 'fulfilled') {
+				tracks = tidalRes.value.tracks.slice(0, 5);
+				albums = tidalRes.value.albums.slice(0, 3);
+				artists = tidalRes.value.artists.slice(0, 3);
+			} else {
+				tracks = [];
+				albums = [];
+				artists = [];
 			}
+			spotifyPlaylists = spotifyRes.status === 'fulfilled' ? spotifyRes.value.slice(0, 4) : [];
+			loading = false;
 		}, 220);
 	}
 
@@ -87,6 +107,11 @@
 	function selectArtist(artist: TidalSearchArtist) {
 		close();
 		goto(artist.local_id ? `/artists/${artist.local_id}` : `/tidal/artists/${artist.tidal_id}`);
+	}
+
+	function selectSpotifyPlaylist(playlist: SpotifyPlaylistSearchItem) {
+		close();
+		goto(`/spotify-playlist/${playlist.spotifyId}`);
 	}
 
 	// Wrap menu items so they always close the palette after firing.
@@ -253,12 +278,18 @@
 				return;
 			}
 			// Normal search mode: activate cursor item
-			const allItems = [...artists, ...albums, ...tracks];
-			const item = allItems[cursor];
-			if (!item) return;
-			if ('name' in item) selectArtist(item as TidalSearchArtist);
-			else if (!('duration_ms' in item)) selectAlbum(item as TidalSearchAlbum);
-			else void selectTrack(item as TidalSearchTrack);
+			const idx = cursor;
+			if (idx < artists.length) {
+				selectArtist(artists[idx]);
+			} else if (idx < artists.length + albums.length) {
+				selectAlbum(albums[idx - artists.length]);
+			} else if (idx < artists.length + albums.length + tracks.length) {
+				void selectTrack(tracks[idx - artists.length - albums.length]);
+			} else if (idx < artists.length + albums.length + tracks.length + spotifyPlaylists.length) {
+				selectSpotifyPlaylist(
+					spotifyPlaylists[idx - artists.length - albums.length - tracks.length],
+				);
+			}
 		}
 	}
 </script>
@@ -306,7 +337,7 @@
 					</li>
 				{/each}
 			</ul>
-		{:else if !isSlashMode && (tracks.length > 0 || albums.length > 0 || artists.length > 0)}
+		{:else if !isSlashMode && (tracks.length > 0 || albums.length > 0 || artists.length > 0 || spotifyPlaylists.length > 0)}
 			<ul class="palette-list">
 				{#each artists as artist, i (artist.tidal_id)}
 					{@const idx = i}
@@ -384,6 +415,26 @@
 							onclick={(e) => handleMoreClick(e, idx)}
 							onkeydown={(e) => handleMoreKeydown(e, idx)}
 						>⋯</button>
+					</li>
+				{/each}
+				{#each spotifyPlaylists as playlist, i (playlist.spotifyId)}
+					{@const idx = artists.length + albums.length + tracks.length + i}
+					<li class="palette-row-wrap" class:palette-row-wrap--active={cursor === idx} bind:this={rowEls[idx]}>
+						<button
+							class="palette-row"
+							onclick={() => selectSpotifyPlaylist(playlist)}
+						>
+							{#if playlist.thumbnail}
+								<div class="row-art" style="background-image:url('{playlist.thumbnail}')"></div>
+							{:else}
+								<div class="row-art row-art--fallback">♫</div>
+							{/if}
+							<div class="row-meta">
+								<span class="row-title">{playlist.title ?? 'Untitled playlist'}</span>
+								{#if playlist.owner}<span class="row-sub">{playlist.owner}{playlist.totalTracks ? ` · ${playlist.totalTracks} tracks` : ''}</span>{/if}
+							</div>
+							<span class="row-kind row-kind--spotify">Spotify</span>
+						</button>
 					</li>
 				{/each}
 			</ul>
@@ -520,6 +571,7 @@
 	.row-title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; min-width: 0; }
 	.row-sub { font-size: 11px; color: var(--text-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 	.row-kind { font-size: 10px; color: var(--text-muted); margin-left: auto; flex-shrink: 0; }
+	.row-kind--spotify { color: #1ed760; font-weight: 600; }
 	.row-lib { font-size: 10px; color: var(--accent); flex-shrink: 0; }
 	.cmd-prefix { font-weight: 600; color: var(--accent); font-family: monospace; flex-shrink: 0; }
 	.cmd-args { font-size: 11px; color: var(--text-muted); font-family: monospace; flex-shrink: 0; }

--- a/frontend/src/lib/components/now-playing/NowPlayingTransport.svelte
+++ b/frontend/src/lib/components/now-playing/NowPlayingTransport.svelte
@@ -48,7 +48,11 @@
 		shuffleMode: string;
 		repeatMode: string;
 		favoritePending?: boolean;
-		onToggleFavorite: () => void;
+		/** Optional. When omitted, the inline favorite button is hidden — the
+		 * desktop now-playing surface mounts a separate favorite overlay on
+		 * the artwork, so the transport bar stays uncluttered. QuietMode
+		 * still uses the inline button. */
+		onToggleFavorite?: () => void;
 		onCycleShuffle: () => void;
 		onPrev: () => void;
 		onPlayPause: () => void;
@@ -71,22 +75,25 @@
 
 <div class="transport" aria-label="Playback controls">
 	<div class="transport-group transport-group-secondary" role="group" aria-label="Track and shuffle controls">
-		<button
-			class:active={track?.is_favorite}
-			class="tp-btn tp-like-btn"
-			title={track?.is_favorite ? 'Remove from favorites' : 'Add to favorites'}
-			aria-label={track?.is_favorite ? 'Remove from favorites' : 'Add to favorites'}
-			onclick={onToggleFavorite}
-			disabled={favoritePending || !track}
-		>
-			{track?.is_favorite ? '♥' : '♡'}
-		</button>
+		{#if onToggleFavorite}
+			<button
+				class:active={track?.is_favorite}
+				class="tp-btn tp-like-btn"
+				title={track?.is_favorite ? 'Remove from favorites' : 'Add to favorites'}
+				aria-label={track?.is_favorite ? 'Remove from favorites' : 'Add to favorites'}
+				onclick={onToggleFavorite}
+				disabled={favoritePending || !track}
+			>
+				{track?.is_favorite ? '♥' : '♡'}
+			</button>
+		{/if}
 		<button
 			class:active={shuffleMode !== 'off'}
 			class="tp-btn tp-mode-btn"
 			title={SHUFFLE_LABELS[shuffleMode]}
 			aria-label={SHUFFLE_LABELS[shuffleMode]}
 			onclick={onCycleShuffle}
+			disabled={!track}
 		>
 			{SHUFFLE_ICONS[shuffleMode]}
 		</button>
@@ -122,17 +129,25 @@
 
 <style>
 	.transport {
-		display: flex;
+		display: grid;
+		grid-template-columns: 1fr auto 1fr;
 		align-items: center;
-		justify-content: center;
-		gap: 12px;
+		column-gap: 10px;
 	}
 
 	.transport-group {
 		position: relative;
 		display: flex;
 		align-items: center;
-		gap: 8px;
+		gap: 6px;
+	}
+
+	.transport > .transport-group-secondary:first-child {
+		justify-self: end;
+	}
+
+	.transport > .transport-group-secondary:last-child {
+		justify-self: start;
 	}
 
 	.transport-group + .transport-group::before {
@@ -144,13 +159,13 @@
 	}
 
 	.transport-group-playback {
-		gap: 10px;
+		gap: 8px;
 	}
 
 	.tp-btn,
 	.tp-play {
-		width: 36px;
-		height: 36px;
+		width: 32px;
+		height: 32px;
 		border-radius: 50%;
 		display: grid;
 		place-items: center;
@@ -180,39 +195,16 @@
 		position: relative;
 	}
 
-	.tp-like-btn {
-		font-size: 18px;
-		color: var(--text-secondary);
-		transition:
-			transform var(--motion-fast),
-			background var(--motion-fast),
-			border-color var(--motion-fast),
-			color var(--motion-fast),
-			box-shadow var(--motion-fast);
-	}
-
-	.tp-like-btn:active {
-		transform: scale(0.92);
-	}
-
-	.tp-like-btn:disabled,
 	.tp-btn:disabled {
 		opacity: 0.5;
 		cursor: not-allowed;
 	}
 
-	.tp-like-btn.active {
-		color: #ff4d6d;
-		background: color-mix(in srgb, #ff4d6d 15%, transparent);
-		border-color: color-mix(in srgb, #ff4d6d 40%, transparent);
-		box-shadow: 0 0 12px color-mix(in srgb, #ff4d6d 30%, transparent);
-	}
-
 	.tp-play {
 		background: var(--accent);
 		color: #fff;
-		width: 42px;
-		height: 42px;
+		width: 38px;
+		height: 38px;
 		box-shadow: 0 10px 26px var(--accent-glow);
 	}
 

--- a/frontend/src/lib/stores/player.ts
+++ b/frontend/src/lib/stores/player.ts
@@ -930,6 +930,33 @@ function tidalQueueRequest(track: TidalPlayable) {
 	};
 }
 
+function setOptimisticTidalTrack(track: TidalPlayable) {
+	currentTrack.set({
+		id: -track.tidal_id,
+		title: track.title,
+		artist_id: -1,
+		artist_name: track.artist_name,
+		artist_tidal_id: track.artist_tidal_id ?? null,
+		album_id: null,
+		album_title: track.album_title,
+		disc_number: null,
+		track_number: null,
+		duration_ms: track.duration_ms,
+		isrc: null,
+		tidal_id: track.tidal_id,
+		best_quality: 'LOSSLESS',
+		best_source: 'tidal',
+		fidelity_score: 0,
+		is_favorite: false,
+		play_count: 0,
+		last_played_at: null,
+		date_added: null,
+		source: 'tidal_ephemeral',
+		artwork_url: track.artwork_url,
+	});
+	isPlaying.set(true);
+}
+
 export async function playTidalTrackNext(track: TidalPlayable): Promise<void> {
 	playerError.set(null);
 	try {
@@ -942,6 +969,47 @@ export async function playTidalTrackNext(track: TidalPlayable): Promise<void> {
 	}
 }
 
+export async function playTidalTracksNow(tracks: TidalPlayable[], label = 'playlist'): Promise<void> {
+	if (!assertOnline()) return;
+	const playable = tracks.filter((track) => track.tidal_id > 0);
+	if (!playable.length) {
+		showToast('No playable tracks ready yet', 'info');
+		return;
+	}
+	playerError.set(null);
+	try {
+		setOptimisticTidalTrack(playable[0]);
+		await api.playTidalMix(playable);
+		noteSuccess();
+		showToast(`Playing ${label} (${playable.length} tracks)`, 'success');
+	} catch (error) {
+		setError('play those Tidal tracks', error, () => playTidalTracksNow(tracks, label));
+		showToast('Playback failed', 'error');
+	}
+}
+
+export async function shuffleTidalTracksNow(tracks: TidalPlayable[], label = 'playlist'): Promise<void> {
+	const shuffled = shuffleArray(tracks);
+	await playTidalTracksNow(shuffled, label);
+}
+
+export async function playTidalTracksNext(tracks: TidalPlayable[]): Promise<void> {
+	const playable = tracks.filter((track) => track.tidal_id > 0);
+	if (!playable.length) {
+		showToast('No playable tracks ready yet', 'info');
+		return;
+	}
+	playerError.set(null);
+	try {
+		const result = await api.queuePlayNextMany(playable.map(tidalQueueRequest));
+		playbackQueue.set(result.queue);
+		noteSuccess();
+		showToast(`Queued next: ${playable.length} tracks`, 'success');
+	} catch (error) {
+		setError('queue those Tidal tracks next', error, () => playTidalTracksNext(tracks));
+	}
+}
+
 export async function addTidalTrackToQueue(track: TidalPlayable): Promise<void> {
 	playerError.set(null);
 	try {
@@ -951,6 +1019,23 @@ export async function addTidalTrackToQueue(track: TidalPlayable): Promise<void> 
 		showToast(`Added to queue: ${trackLabel(track)}`, 'success');
 	} catch (error) {
 		setError('add that Tidal track to queue', error, () => addTidalTrackToQueue(track));
+	}
+}
+
+export async function addTidalTracksToQueue(tracks: TidalPlayable[]): Promise<void> {
+	const playable = tracks.filter((track) => track.tidal_id > 0);
+	if (!playable.length) {
+		showToast('No playable tracks ready yet', 'info');
+		return;
+	}
+	playerError.set(null);
+	try {
+		const result = await api.queueAppendMany(playable.map(tidalQueueRequest));
+		playbackQueue.set(result.queue);
+		noteSuccess();
+		showToast(`Added to queue: ${playable.length} tracks`, 'success');
+	} catch (error) {
+		setError('add those Tidal tracks to queue', error, () => addTidalTracksToQueue(tracks));
 	}
 }
 

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1039,6 +1039,15 @@
 						title="Quiet mode"
 						onclick={openQuietMode}
 					>⛶</button>
+					<button
+						class="np-art-fav"
+						class:active={$currentTrack?.is_favorite}
+						aria-label={$currentTrack?.is_favorite ? 'Remove from favorites' : 'Add to favorites'}
+						title={$currentTrack?.is_favorite ? 'Remove from favorites' : 'Add to favorites'}
+						aria-pressed={$currentTrack?.is_favorite}
+						disabled={desktopFavoritePending}
+						onclick={() => void handleDesktopFavoriteToggle()}
+					>{$currentTrack?.is_favorite ? '♥' : '♡'}</button>
 				{/if}
 			</div>
 
@@ -1063,8 +1072,6 @@
 				isPlaying={$isPlaying}
 				shuffleMode={$shuffleMode}
 				repeatMode={$repeatMode}
-				favoritePending={desktopFavoritePending}
-				onToggleFavorite={() => void handleDesktopFavoriteToggle()}
 				onCycleShuffle={() => void cyclePlayerShuffleMode()}
 				onPrev={() => void playPreviousTrack()}
 				onPlayPause={() => void togglePlayback()}
@@ -2021,6 +2028,51 @@
 
 	.np-fullscreen-btn:hover {
 		background: rgba(0, 0, 0, 0.65);
+	}
+
+	.np-art-fav {
+		position: absolute;
+		bottom: 10px;
+		right: 10px;
+		width: 36px;
+		height: 36px;
+		border-radius: 50%;
+		display: grid;
+		place-items: center;
+		font-size: 18px;
+		line-height: 1;
+		color: rgba(255, 255, 255, 0.92);
+		background: rgba(0, 0, 0, 0.45);
+		border: 1px solid rgba(255, 255, 255, 0.18);
+		backdrop-filter: blur(8px);
+		cursor: pointer;
+		transition:
+			transform 160ms ease,
+			background 160ms ease,
+			color 160ms ease,
+			border-color 160ms ease,
+			box-shadow 160ms ease;
+	}
+
+	.np-art-fav:hover {
+		background: rgba(0, 0, 0, 0.65);
+		transform: translateY(-1px);
+	}
+
+	.np-art-fav:active {
+		transform: scale(0.92);
+	}
+
+	.np-art-fav:disabled {
+		opacity: 0.55;
+		cursor: not-allowed;
+	}
+
+	.np-art-fav.active {
+		color: #ff4d6d;
+		background: color-mix(in srgb, #ff4d6d 24%, rgba(0, 0, 0, 0.55));
+		border-color: color-mix(in srgb, #ff4d6d 60%, transparent);
+		box-shadow: 0 0 14px color-mix(in srgb, #ff4d6d 40%, transparent);
 	}
 
 	.np-artwork {

--- a/frontend/src/routes/search/+page.svelte
+++ b/frontend/src/routes/search/+page.svelte
@@ -2,7 +2,7 @@
   import { onMount } from 'svelte'
   import { goto, beforeNavigate } from '$app/navigation'
   import type { Snapshot } from './$types'
-  import { api, type TidalSearchResults, type TidalSearchAlbum, type TidalSearchArtist, type TidalSearchTrack, type AudioSearchResult, type AudioSearchParams, type Genre, type VibeTrack, type BasicTrack, type Playlist, type TidalSearchPlaylist } from '$lib/api/client'
+  import { api, type TidalSearchResults, type TidalSearchAlbum, type TidalSearchArtist, type TidalSearchTrack, type AudioSearchResult, type AudioSearchParams, type Genre, type VibeTrack, type BasicTrack, type Playlist, type TidalSearchPlaylist, type SpotifyPlaylistSearchItem } from '$lib/api/client'
   import TrendingShelf from '$lib/components/charts/TrendingShelf.svelte'
   import { buildTidalTrackMenu, buildTrackMenu } from '$lib/player/track_menu'
   import { buildAlbumMenu } from '$lib/player/album_menu'
@@ -19,6 +19,9 @@
 
   const RECENT_KEY = 'noor_recent_searches'
   const RECENT_MAX = 8
+  // Backend caps `limit` at 50 (see tidal_search route). Use the cap as the
+  // page size so each round-trip pulls the maximum the upstream allows.
+  const SEARCH_PAGE_SIZE = 50
 
   function loadRecent(): string[] {
     if (typeof localStorage === 'undefined') return []
@@ -78,9 +81,23 @@
 
   let localPlaylists = $state<Playlist[]>([])
   let tidalPlaylistResults = $state<TidalSearchPlaylist[]>([])
+  let spotifyPlaylistResults = $state<SpotifyPlaylistSearchItem[]>([])
 
   type FilterMode = 'all' | 'artists' | 'albums' | 'tracks' | 'library' | 'playlists'
   let filterMode = $state<FilterMode>('all')
+
+  // Infinite-scroll state. The combined Tidal endpoint shares one offset for
+  // tracks/albums/artists; playlists are paged separately because they hit a
+  // different endpoint. `lastQuery` lets `loadMore` re-query the same string
+  // without depending on the live `query` input (which may be mid-edit).
+  let tidalOffset = $state(0)
+  let tidalPlaylistOffset = $state(0)
+  let spotifyPlaylistOffset = $state(0)
+  let hasMoreTidal = $state(true)
+  let hasMoreTidalPlaylists = $state(true)
+  let hasMoreSpotifyPlaylists = $state(true)
+  let loadingMore = $state(false)
+  let lastQuery = $state('')
 
   // Trending shelf is encapsulated in <TrendingShelf /> below; shown only when
   // the query is empty (inside the existing {#if !query.trim()} branch).
@@ -134,6 +151,7 @@
       results = null
       audioResults = null
       tidalPlaylistResults = []
+      spotifyPlaylistResults = []
       loading = false
       error = null
       return
@@ -180,24 +198,53 @@
           audioResults = res.tracks
           results = null
           tidalPlaylistResults = []
+          spotifyPlaylistResults = []
         } else {
           audioResults = null
+          // Reset paging — every fresh query starts at offset 0.
+          tidalOffset = 0
+          tidalPlaylistOffset = 0
+          spotifyPlaylistOffset = 0
+          hasMoreTidal = true
+          hasMoreTidalPlaylists = true
+          hasMoreSpotifyPlaylists = true
+          lastQuery = q
           const cacheKey = q.toLowerCase()
           const cached = resultCache.get(cacheKey)
           if (cached) {
             results = cached
+            tidalOffset = SEARCH_PAGE_SIZE
+            // Cached page may already cap a category — assume more exists; the
+            // next load-more attempt will discover the truth and flip the flag.
           } else {
-            const fresh = await api.searchTidal(q, 20, signal)
+            const fresh = await api.searchTidal(q, SEARCH_PAGE_SIZE, signal, 0)
             results = fresh
             resultCache.set(cacheKey, fresh)
             if (resultCache.size > 5) resultCache.delete(resultCache.keys().next().value!)
+            tidalOffset = SEARCH_PAGE_SIZE
+            // If the initial page came back short for ALL three categories,
+            // there's nothing left to load.
+            if (
+              fresh.tracks.length < SEARCH_PAGE_SIZE &&
+              fresh.albums.length < SEARCH_PAGE_SIZE &&
+              fresh.artists.length < SEARCH_PAGE_SIZE
+            ) {
+              hasMoreTidal = false
+            }
           }
-          try {
-            const { playlists } = await api.searchTidalPlaylists(q, signal)
-            tidalPlaylistResults = playlists
-          } catch {
-            tidalPlaylistResults = []
-          }
+          // TIDAL + Spotify playlist searches run in parallel. Either one
+          // failing leaves the other intact — Sportify is upstream and may
+          // break, but that should never block local + TIDAL results.
+          const [tidalRes, spotifyRes] = await Promise.allSettled([
+            api.searchTidalPlaylists(q, signal, { limit: SEARCH_PAGE_SIZE, offset: 0 }),
+            api.searchSpotifyPlaylists(q, SEARCH_PAGE_SIZE, signal, 0),
+          ])
+          tidalPlaylistResults = tidalRes.status === 'fulfilled' ? tidalRes.value.playlists : []
+          spotifyPlaylistResults = spotifyRes.status === 'fulfilled' ? spotifyRes.value : []
+          tidalPlaylistOffset = tidalPlaylistResults.length
+          spotifyPlaylistOffset = spotifyPlaylistResults.length
+          if (tidalPlaylistResults.length < SEARCH_PAGE_SIZE) hasMoreTidalPlaylists = false
+          if (spotifyPlaylistResults.length < SEARCH_PAGE_SIZE) hasMoreSpotifyPlaylists = false
         }
         error = null
         pushRecent(q)
@@ -217,6 +264,98 @@
     onInput()
     inputEl?.focus()
   }
+
+  // Load the next page for whichever single-category pill is active. The
+  // combined Tidal endpoint covers tracks/albums/artists with a shared offset,
+  // so loading once advances all three; the Playlists pill triggers two
+  // independent fetches (TIDAL + Spotify) since they live on separate endpoints.
+  async function loadMore() {
+    if (loadingMore) return
+    if (!lastQuery.trim()) return
+    if (filterMode === 'all' || filterMode === 'library') return
+    if (audioResults !== null) return
+    const needsTidal =
+      (filterMode === 'tracks' || filterMode === 'albums' || filterMode === 'artists') &&
+      hasMoreTidal &&
+      results !== null
+    const needsPlaylists =
+      filterMode === 'playlists' && (hasMoreTidalPlaylists || hasMoreSpotifyPlaylists)
+    if (!needsTidal && !needsPlaylists) return
+
+    loadingMore = true
+    try {
+      if (needsTidal && results) {
+        const next = await api.searchTidal(lastQuery, SEARCH_PAGE_SIZE, undefined, tidalOffset)
+        tidalOffset += SEARCH_PAGE_SIZE
+        // De-dupe by id — Tidal occasionally returns overlapping pages.
+        const seenTracks = new Set(results.tracks.map((t) => t.tidal_id))
+        const seenAlbums = new Set(results.albums.map((a) => a.tidal_id))
+        const seenArtists = new Set(results.artists.map((a) => a.tidal_id))
+        const newTracks = next.tracks.filter((t) => !seenTracks.has(t.tidal_id))
+        const newAlbums = next.albums.filter((a) => !seenAlbums.has(a.tidal_id))
+        const newArtists = next.artists.filter((a) => !seenArtists.has(a.tidal_id))
+        results = {
+          tracks: [...results.tracks, ...newTracks],
+          albums: [...results.albums, ...newAlbums],
+          artists: [...results.artists, ...newArtists],
+        }
+        if (
+          next.tracks.length < SEARCH_PAGE_SIZE &&
+          next.albums.length < SEARCH_PAGE_SIZE &&
+          next.artists.length < SEARCH_PAGE_SIZE
+        ) {
+          hasMoreTidal = false
+        }
+      }
+      if (needsPlaylists) {
+        const tasks: Promise<unknown>[] = []
+        if (hasMoreTidalPlaylists) {
+          tasks.push(
+            api
+              .searchTidalPlaylists(lastQuery, undefined, { limit: SEARCH_PAGE_SIZE, offset: tidalPlaylistOffset })
+              .then((r) => {
+                const seen = new Set(tidalPlaylistResults.map((p) => p.uuid))
+                const fresh = r.playlists.filter((p) => !seen.has(p.uuid))
+                tidalPlaylistResults = [...tidalPlaylistResults, ...fresh]
+                tidalPlaylistOffset += SEARCH_PAGE_SIZE
+                if (r.playlists.length < SEARCH_PAGE_SIZE) hasMoreTidalPlaylists = false
+              })
+              .catch(() => { hasMoreTidalPlaylists = false }),
+          )
+        }
+        if (hasMoreSpotifyPlaylists) {
+          tasks.push(
+            api
+              .searchSpotifyPlaylists(lastQuery, SEARCH_PAGE_SIZE, undefined, spotifyPlaylistOffset)
+              .then((items) => {
+                const seen = new Set(spotifyPlaylistResults.map((p) => p.spotifyId))
+                const fresh = items.filter((p) => !seen.has(p.spotifyId))
+                spotifyPlaylistResults = [...spotifyPlaylistResults, ...fresh]
+                spotifyPlaylistOffset += SEARCH_PAGE_SIZE
+                if (items.length < SEARCH_PAGE_SIZE) hasMoreSpotifyPlaylists = false
+              })
+              .catch(() => { hasMoreSpotifyPlaylists = false }),
+          )
+        }
+        await Promise.allSettled(tasks)
+      }
+    } finally {
+      loadingMore = false
+    }
+  }
+
+  // IntersectionObserver on a sentinel below the result list. Fires loadMore
+  // whenever the sentinel scrolls into view — only if a single-category pill
+  // is active, which is the only mode where pagination is meaningful.
+  let infiniteSentinel = $state<HTMLDivElement | null>(null)
+  $effect(() => {
+    if (!infiniteSentinel) return
+    const observer = new IntersectionObserver((entries) => {
+      if (entries.some((e) => e.isIntersecting)) void loadMore()
+    }, { rootMargin: '400px 0px' })
+    observer.observe(infiniteSentinel)
+    return () => observer.disconnect()
+  })
 
   const isEmpty = $derived(
     results !== null &&
@@ -263,12 +402,20 @@
   const showPlaylists = $derived(filterMode === 'all' || filterMode === 'playlists')
 
   const filteredPlaylists = $derived.by(() => {
-    if (!query.trim()) return { local: [] as Playlist[], tidal: [] as TidalSearchPlaylist[] }
+    if (!query.trim())
+      return {
+        local: [] as Playlist[],
+        tidal: [] as TidalSearchPlaylist[],
+        spotify: [] as SpotifyPlaylistSearchItem[],
+      }
     const q = query.trim().toLowerCase()
     const matched = localPlaylists.filter(p => p.name.toLowerCase().includes(q))
     const localNames = new Set(matched.map(p => p.name.toLowerCase()))
     const tidalOnly = tidalPlaylistResults.filter(tp => !localNames.has(tp.title.toLowerCase()))
-    return { local: matched, tidal: tidalOnly }
+    // Keep Spotify visible even when a TIDAL/local playlist has the same
+    // title. The source chip is the useful distinction on mixed-service search.
+    const spotifyOnly = spotifyPlaylistResults.filter(sp => sp.spotifyId)
+    return { local: matched, tidal: tidalOnly, spotify: spotifyOnly }
   })
 
   const isFilteredEmpty = $derived(
@@ -277,7 +424,7 @@
     sortedTracks.length === 0 &&
     sortedAlbums.length === 0 &&
     sortedArtists.length === 0 &&
-    !(showPlaylists && (filteredPlaylists.local.length > 0 || filteredPlaylists.tidal.length > 0))
+    !(showPlaylists && (filteredPlaylists.local.length > 0 || filteredPlaylists.tidal.length > 0 || filteredPlaylists.spotify.length > 0))
   )
 
   type TopResult =
@@ -372,6 +519,24 @@
       },
       { isLocal: artist.in_library && artist.local_id != null }
     )
+  }
+
+  function localPlaylistMenuItems(_playlist: Playlist): MenuItem[] {
+    return [
+      { label: 'Open playlist', icon: '↗', onSelect: () => void goto('/playlists') },
+    ]
+  }
+
+  function tidalPlaylistMenuItems(playlist: TidalSearchPlaylist): MenuItem[] {
+    return [
+      { label: 'Play', icon: '▶', onSelect: () => void playTidalPlaylist(playlist.uuid) },
+    ]
+  }
+
+  function spotifyPlaylistMenuItems(playlist: SpotifyPlaylistSearchItem): MenuItem[] {
+    return [
+      { label: 'Open', icon: '↗', onSelect: () => void goto(`/spotify-playlist/${playlist.spotifyId}`) },
+    ]
   }
 
   function trackContextMenu(track: TidalSearchTrack): MenuItem[] {
@@ -817,7 +982,11 @@
     {#if sortedArtists.length > 0}
       <section class="results-section">
         <h3 class="section-label">Artists</h3>
-        <div class="artists-row" use:wheelToHorizontal>
+        <div
+          class="artists-row"
+          class:section-grid-artists={filterMode === 'artists'}
+          use:wheelToHorizontal
+        >
           {#each sortedArtists as artist (artist.tidal_id)}
             <a
               class="artist-card"
@@ -854,7 +1023,11 @@
     {#if sortedAlbums.length > 0}
       <section class="results-section">
         <h3 class="section-label">Albums</h3>
-        <div class="albums-row" use:wheelToHorizontal>
+        <div
+          class="albums-row"
+          class:section-grid-albums={filterMode === 'albums'}
+          use:wheelToHorizontal
+        >
           {#each sortedAlbums as album (album.tidal_id)}
             <a
               class="album-card"
@@ -891,15 +1064,20 @@
       </section>
     {/if}
 
-    {#if showPlaylists && (filteredPlaylists.local.length > 0 || filteredPlaylists.tidal.length > 0)}
+    {#if showPlaylists && (filteredPlaylists.local.length > 0 || filteredPlaylists.tidal.length > 0 || filteredPlaylists.spotify.length > 0)}
       <section class="results-section">
         <h3 class="section-label">Playlists</h3>
-        <div class="albums-row" use:wheelToHorizontal>
+        <div
+          class="albums-row"
+          class:section-grid-albums={filterMode === 'playlists'}
+          use:wheelToHorizontal
+        >
 
           {#each filteredPlaylists.local as playlist (playlist.id)}
             <a
               class="album-card in-library"
               href="/playlists"
+              oncontextmenu={(e) => { e.preventDefault(); openContextMenu(e, localPlaylistMenuItems(playlist), playlist.name) }}
             >
               <div class="art-wrap">
                 <div class="album-art fallback" style="background: {letterColor(playlist.name)}">
@@ -919,6 +1097,7 @@
               tabindex="0"
               onclick={() => void playTidalPlaylist(playlist.uuid)}
               onkeydown={(e) => e.key === 'Enter' && void playTidalPlaylist(playlist.uuid)}
+              oncontextmenu={(e) => { e.preventDefault(); openContextMenu(e, tidalPlaylistMenuItems(playlist), playlist.title) }}
             >
               <div class="art-wrap">
                 {#if playlist.square_image}
@@ -942,6 +1121,32 @@
             </div>
           {/each}
 
+          {#each filteredPlaylists.spotify as playlist (playlist.spotifyId)}
+            <a
+              class="album-card spotify-card"
+              href="/spotify-playlist/{playlist.spotifyId}"
+              oncontextmenu={(e) => { e.preventDefault(); openContextMenu(e, spotifyPlaylistMenuItems(playlist), playlist.title ?? 'Spotify playlist') }}
+            >
+              <div class="art-wrap">
+                {#if playlist.thumbnail}
+                  <div
+                    class="album-art"
+                    style="background-image: url('{playlist.thumbnail}')"
+                  ></div>
+                {:else}
+                  <div class="album-art fallback" style="background: {letterColor(playlist.title ?? 'playlist')}">
+                    <span>♫</span>
+                  </div>
+                {/if}
+                <span class="source-chip" aria-label="Spotify">Spotify</span>
+              </div>
+              <p class="album-title">{playlist.title ?? 'Untitled playlist'}</p>
+              <p class="album-artist">
+                {#if playlist.owner}{playlist.owner} · {/if}{playlist.totalTracks ?? '?'} tracks
+              </p>
+            </a>
+          {/each}
+
         </div>
       </section>
     {/if}
@@ -949,6 +1154,112 @@
     {#if sortedTracks.length > 0}
       <section class="results-section">
         <h3 class="section-label">Tracks</h3>
+        {#if filterMode === 'tracks'}
+          <div class="search-track-table" role="list">
+            <div class="search-track-header">
+              <span class="col-num">#</span>
+              <span class="col-title">Title</span>
+              <span class="col-artist">Artist</span>
+              <span class="col-album">Album</span>
+              <span class="col-quality">Quality</span>
+              <span class="col-duration">Duration</span>
+              <span class="col-actions"></span>
+            </div>
+            {#each sortedTracks as track, idx (track.tidal_id)}
+              <!-- svelte-ignore a11y_no_noninteractive_element_to_interactive_role -->
+              <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+              <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+              <div
+                class="search-track-row"
+                class:cursor={cursor === idx}
+                class:disabled={!canPlaySearchTrack(track)}
+                class:in-library={track.in_library}
+                data-cursor-idx={idx}
+                role="button"
+                tabindex={canPlaySearchTrack(track) ? 0 : -1}
+                aria-disabled={!canPlaySearchTrack(track)}
+                onclick={() => canPlaySearchTrack(track) && void playTidalTrackNow(toPlayable(track))}
+                onmouseenter={() => { cursor = idx }}
+                onkeydown={(e) => (e.key === 'Enter' || e.key === ' ') && (e.preventDefault(), canPlaySearchTrack(track) && void playTidalTrackNow(toPlayable(track)))}
+                oncontextmenu={(e) => { e.preventDefault(); openContextMenu(e, trackContextMenu(track)) }}
+              >
+                <span class="col-num">
+                  <span class="track-num-label">{idx + 1}</span>
+                  <button
+                    class="track-num-play"
+                    disabled={!canPlaySearchTrack(track)}
+                    onclick={(e) => { e.stopPropagation(); canPlaySearchTrack(track) && void playTidalTrackNow(toPlayable(track)) }}
+                    aria-label="Play {track.title}"
+                  >▶</button>
+                </span>
+                <span class="col-title">
+                  {#if track.artwork_url}
+                    <span class="row-art" style={`background-image: url('${track.artwork_url}')`}></span>
+                  {:else}
+                    <span class="row-art fallback" style={`background: ${letterColor(track.title)}`}>♫</span>
+                  {/if}
+                  <span class="row-title-text">{track.title}</span>
+                  {#if track.in_library}<span class="lib-dot" aria-label="In your library"></span>{/if}
+                </span>
+                <span class="col-artist">
+                  {#if track.artist_name && track.artist_id != null}
+                    <a
+                      href={`/tidal/artists/${track.artist_id}`}
+                      class="subtitle-link"
+                      onclick={(e) => e.stopPropagation()}
+                    >{track.artist_name}</a>
+                  {:else if track.artist_name}
+                    {track.artist_name}
+                  {:else}
+                    —
+                  {/if}
+                </span>
+                <span class="col-album">
+                  {#if track.album_title && track.album_tidal_id != null}
+                    <a
+                      href={`/tidal/albums/${track.album_tidal_id}`}
+                      class="subtitle-link"
+                      onclick={(e) => e.stopPropagation()}
+                    >{track.album_title}</a>
+                  {:else if track.album_title}
+                    {track.album_title}
+                  {:else}
+                    —
+                  {/if}
+                </span>
+                <span class="col-quality">
+                  {#if track.audio_quality}
+                    <span class="quality-badge">{track.audio_quality.replace(/_/g, ' ')}</span>
+                  {:else}
+                    —
+                  {/if}
+                </span>
+                <span class="col-duration">{formatDuration(track.duration_ms)}</span>
+                <span class="col-actions">
+                  <button
+                    class="row-btn"
+                    disabled={!canPlaySearchTrack(track)}
+                    onclick={(e) => { e.stopPropagation(); canPlaySearchTrack(track) && void addTidalTrackToQueue(toPlayable(track)) }}
+                    title={canPlaySearchTrack(track) ? 'Add to queue' : playableSearchLabel(track)}
+                    aria-label="Queue {track.title}"
+                  >＋</button>
+                  <button
+                    class="row-btn"
+                    onclick={(e) => { e.stopPropagation(); void startTidalSongRadio(track) }}
+                    title="Song radio"
+                    aria-label="Start radio from {track.title}"
+                  >◎</button>
+                  <button
+                    class="row-btn"
+                    onclick={(e) => { e.stopPropagation(); openContextMenu(e, trackContextMenu(track)) }}
+                    title="More options"
+                    aria-label="More options"
+                  >⋯</button>
+                </span>
+              </div>
+            {/each}
+          </div>
+        {:else}
         <ul class="tracks-list">
           {#each sortedTracks as track, idx (track.tidal_id)}
             <!-- svelte-ignore a11y_no_noninteractive_element_to_interactive_role -->
@@ -1037,6 +1348,7 @@
             </li>
           {/each}
         </ul>
+        {/if}
       </section>
     {/if}
 
@@ -1102,6 +1414,18 @@
           {/each}
         </ul>
       </section>
+    {/if}
+
+    {#if filterMode !== 'all' && filterMode !== 'library' && audioResults === null}
+      <div bind:this={infiniteSentinel} class="infinite-sentinel" aria-hidden="true">
+        {#if loadingMore}
+          <span class="infinite-spinner">Loading more…</span>
+        {:else if (
+          (filterMode === 'tracks' || filterMode === 'albums' || filterMode === 'artists') && !hasMoreTidal
+        ) || (filterMode === 'playlists' && !hasMoreTidalPlaylists && !hasMoreSpotifyPlaylists)}
+          <span class="infinite-end">— end of results —</span>
+        {/if}
+      </div>
     {/if}
 
   {/if}
@@ -1452,6 +1776,21 @@
     background: var(--accent);
     border: 2px solid var(--bg-base);
   }
+  .source-chip {
+    position: absolute;
+    bottom: 6px;
+    left: 6px;
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: #1ed760;
+    background: rgba(0, 0, 0, 0.65);
+    backdrop-filter: blur(4px);
+  }
+  .spotify-card { text-decoration: none; }
   .lib-dot {
     display: inline-block;
     width: 6px;
@@ -1686,4 +2025,158 @@
     width: 100px;
     height: 100px;
   }
+
+  /* Single-category grids — Trending/Library style. Override the carousel's
+     horizontal-scroll layout when the matching pill is active. */
+  .section-grid-albums {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+    gap: 14px;
+    overflow: visible;
+    padding-bottom: 0;
+  }
+  .section-grid-albums .album-card { width: 100%; }
+  .section-grid-albums .art-wrap { width: 100%; aspect-ratio: 1 / 1; }
+  .section-grid-albums .album-art {
+    width: 100%;
+    height: 100%;
+    aspect-ratio: 1 / 1;
+  }
+
+  .section-grid-artists {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
+    gap: 14px;
+    overflow: visible;
+    justify-items: center;
+    padding-bottom: 0;
+  }
+
+  /* Library-style track table for the Tracks pill. Mirrors the visual rhythm
+     of the library tracks tab: compact header row, fixed-grid columns,
+     hoverable rows with inline play / queue / radio / menu actions. */
+  .search-track-table {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+  }
+  .search-track-header,
+  .search-track-row {
+    display: grid;
+    grid-template-columns: 44px minmax(0, 2.2fr) minmax(0, 1.4fr) minmax(0, 1.4fr) 96px 64px 132px;
+    align-items: center;
+    gap: 12px;
+    padding: 6px 10px;
+    border-radius: 4px;
+  }
+  .search-track-header {
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 1.4px;
+    color: var(--text-muted);
+    border-bottom: 1px solid var(--border-subtle);
+    padding-bottom: 8px;
+    margin-bottom: 4px;
+  }
+  .search-track-header .col-num { text-align: center; }
+  .search-track-row {
+    font-size: 13px;
+    color: var(--text-primary);
+    cursor: pointer;
+    transition: background 0.12s;
+  }
+  .search-track-row:hover { background: var(--bg-hover); }
+  .search-track-row.cursor { background: var(--bg-hover); box-shadow: inset 2px 0 0 var(--accent); }
+  .search-track-row.disabled { cursor: default; opacity: 0.62; }
+  .search-track-row .col-num {
+    position: relative;
+    text-align: center;
+    color: var(--text-muted);
+    font-size: 12px;
+    font-variant-numeric: tabular-nums;
+  }
+  .search-track-row .track-num-label { display: inline; }
+  .search-track-row .track-num-play {
+    display: none;
+    background: none;
+    border: none;
+    color: var(--text-primary);
+    font-size: 14px;
+    cursor: pointer;
+    padding: 0;
+  }
+  .search-track-row:hover .track-num-label { display: none; }
+  .search-track-row:hover .track-num-play { display: inline; }
+  .search-track-row .track-num-play:disabled { opacity: 0.4; cursor: not-allowed; }
+  .search-track-row .col-title {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-width: 0;
+  }
+  .search-track-row .row-art {
+    width: 32px;
+    height: 32px;
+    border-radius: 3px;
+    background-size: cover;
+    background-position: center;
+    background-color: var(--bg-raised);
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 14px;
+    color: rgba(255,255,255,0.5);
+  }
+  .search-track-row .row-title-text {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .search-track-row.in-library .row-title-text { color: var(--text-primary); font-weight: 600; }
+  .search-track-row .col-artist,
+  .search-track-row .col-album {
+    color: var(--text-secondary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .search-track-row .col-quality .quality-badge {
+    display: inline-block;
+    padding: 2px 7px;
+    border-radius: 99px;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    background: rgba(125, 200, 175, 0.10);
+    color: var(--accent, #7dc8af);
+  }
+  .search-track-row .col-duration {
+    color: var(--text-muted);
+    font-size: 12px;
+    font-variant-numeric: tabular-nums;
+    text-align: right;
+  }
+  .search-track-row .col-actions {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 2px;
+  }
+  .search-track-row .col-actions .row-btn { opacity: 0; }
+  .search-track-row:hover .col-actions .row-btn { opacity: 1; }
+
+  .infinite-sentinel {
+    min-height: 60px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-muted);
+    font-size: 12px;
+    padding: 16px 0;
+  }
+  .infinite-spinner { font-style: italic; }
+  .infinite-end { letter-spacing: 0.04em; }
 </style>

--- a/frontend/src/routes/spotify-playlist/[id]/+page.svelte
+++ b/frontend/src/routes/spotify-playlist/[id]/+page.svelte
@@ -1,0 +1,661 @@
+<script lang="ts">
+  import { page } from '$app/stores';
+  import { onMount, onDestroy } from 'svelte';
+  import { goto } from '$app/navigation';
+  import {
+    api,
+    type SpotifyPlaylistDetail,
+    type SpotifyPlaylistTrack,
+    type SpotifyTidalState,
+    type TidalPlayable,
+  } from '$lib/api/client';
+  import { openContextMenu, openMenuAtElement, type MenuItem } from '$lib/stores/context_menu';
+  import {
+    addTidalTrackToQueue,
+    addTidalTracksToQueue,
+    playTidalTrackNext,
+    playTidalTrackNow,
+    playTidalTracksNext,
+    playTidalTracksNow,
+    shuffleTidalTracksNow,
+    startTidalSongRadio,
+  } from '$lib/stores/player';
+  import { tidalStatus } from '$lib/stores/tidal';
+  import { showToast } from '$lib/stores/toast';
+
+  // Ephemeral Spotify playlist view. The playlist is NOT in the user's
+  // library — clicking Save promotes it. Until then, navigation away loses
+  // any state held only in this component.
+
+  const spotifyId = $derived($page.params.id ?? '');
+
+  let detail = $state<SpotifyPlaylistDetail | null>(null);
+  let pendingIds = $state<string[]>([]);
+  let loading = $state(true);
+  let error = $state<string | null>(null);
+  let saving = $state(false);
+  let saveResult = $state<string | null>(null);
+  let saveErr = $state<string | null>(null);
+
+  // Lazy-tail status polling. Stops on full resolution, on hard timeout, or
+  // when the user navigates away.
+  const POLL_INTERVAL_MS = 1500;
+  const POLL_DEADLINE_MS = 30_000;
+  let pollTimer: ReturnType<typeof setTimeout> | null = null;
+  let pollDeadline = 0;
+
+  function clearPoll() {
+    if (pollTimer) {
+      clearTimeout(pollTimer);
+      pollTimer = null;
+    }
+  }
+
+  async function pollResolution() {
+    if (!detail || pendingIds.length === 0 || Date.now() > pollDeadline) {
+      clearPoll();
+      return;
+    }
+    try {
+      const { entries } = await api.getResolveTidalStatus(pendingIds);
+      const byId = new Map(entries.map((e) => [e.spotifyId, e.tidal]));
+      // Merge new states into the playlist tracks. Pending entries stay in
+      // the watch list; non-pending ones are removed.
+      const stillPending: string[] = [];
+      detail = {
+        ...detail,
+        tracks: detail.tracks.map((t) => {
+          if (!t.spotifyId) return t;
+          const next = byId.get(t.spotifyId);
+          if (!next) return t;
+          if (next.status === 'pending') stillPending.push(t.spotifyId);
+          return { ...t, tidal: next };
+        }),
+      };
+      pendingIds = stillPending;
+      if (pendingIds.length > 0) {
+        pollTimer = setTimeout(pollResolution, POLL_INTERVAL_MS);
+      } else {
+        clearPoll();
+      }
+    } catch (e) {
+      // One bad poll round shouldn't kill the loop — back off and retry.
+      console.warn('resolve status poll failed', e);
+      pollTimer = setTimeout(pollResolution, POLL_INTERVAL_MS * 2);
+    }
+  }
+
+  async function load(id: string) {
+    if (!id.trim()) {
+      error = 'Missing Spotify playlist ID';
+      loading = false;
+      return;
+    }
+    loading = true;
+    error = null;
+    detail = null;
+    pendingIds = [];
+    saveResult = null;
+    saveErr = null;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 15_000);
+    try {
+      const res = await api.getSpotifyPlaylist(id, controller.signal);
+      detail = res.playlist;
+      pendingIds = res.pendingSpotifyIds ?? [];
+      pollDeadline = Date.now() + POLL_DEADLINE_MS;
+      if (pendingIds.length > 0) {
+        pollTimer = setTimeout(pollResolution, POLL_INTERVAL_MS);
+      }
+    } catch (e) {
+      error =
+        (e as Error).name === 'AbortError'
+          ? 'Timed out loading playlist metadata'
+          : ((e as Error).message ?? 'Failed to load playlist');
+    } finally {
+      clearTimeout(timeout);
+      loading = false;
+    }
+  }
+
+  onMount(() => {
+    void load(spotifyId);
+  });
+
+  $effect(() => {
+    // Reload if the user navigates between two Spotify playlists.
+    if (detail && detail.spotifyId !== spotifyId) {
+      clearPoll();
+      void load(spotifyId);
+    }
+  });
+
+  onDestroy(() => {
+    clearPoll();
+  });
+
+  function statusLabel(t: SpotifyTidalState): string {
+    if ($tidalStatus !== 'connected') return 'Connect TIDAL to play this track';
+    switch (t.status) {
+      case 'resolved':
+        return 'Play on TIDAL';
+      case 'low_confidence':
+        return 'Play (low-confidence match)';
+      case 'pending':
+        return 'Resolving on TIDAL…';
+      case 'unresolved':
+        return "Couldn't find on TIDAL";
+      case 'error':
+        return 'Resolution error';
+    }
+  }
+
+  function isPlayable(t: SpotifyPlaylistTrack): boolean {
+    return (
+      (t.tidal.status === 'resolved' || t.tidal.status === 'low_confidence') &&
+      t.tidal.id !== null &&
+      $tidalStatus === 'connected'
+    );
+  }
+
+  function asTidalPlayable(t: SpotifyPlaylistTrack): TidalPlayable | null {
+    if (!isPlayable(t) || !t.tidal.id) return null;
+    return {
+      tidal_id: t.tidal.id,
+      title: t.title ?? '',
+      artist_name: t.primaryArtist ?? null,
+      artist_tidal_id: null,
+      album_title: t.album ?? null,
+      album_tidal_id: null,
+      artwork_url: t.thumbnail ?? null,
+      duration_ms: t.durationMs ?? null,
+    };
+  }
+
+  function playableSpotifyTracks(): SpotifyPlaylistTrack[] {
+    return detail?.tracks.filter(isPlayable) ?? [];
+  }
+
+  function playableTidalTracks(): TidalPlayable[] {
+    return playableSpotifyTracks()
+      .map(asTidalPlayable)
+      .filter((track): track is TidalPlayable => track !== null);
+  }
+
+  async function play(t: SpotifyPlaylistTrack) {
+    const track = asTidalPlayable(t);
+    if (!track) return;
+    await playTidalTrackNow(track);
+  }
+
+  async function playAll() {
+    await playTidalTracksNow(playableTidalTracks(), detail?.title ?? 'Spotify playlist');
+  }
+
+  async function shuffleAll() {
+    await shuffleTidalTracksNow(playableTidalTracks(), detail?.title ?? 'Spotify playlist');
+  }
+
+  async function playAllNext() {
+    await playTidalTracksNext(playableTidalTracks());
+  }
+
+  async function addAllToQueue() {
+    await addTidalTracksToQueue(playableTidalTracks());
+  }
+
+  async function startPlaylistRadio() {
+    const seed = playableSpotifyTracks()
+      .slice()
+      .sort((a, b) => (b.playcount ?? 0) - (a.playcount ?? 0))[0];
+    const track = seed ? asTidalPlayable(seed) : null;
+    if (!track) {
+      showToast('No playable tracks ready yet', 'info');
+      return;
+    }
+    await startTidalSongRadio(track);
+  }
+
+  function buildRowMenu(t: SpotifyPlaylistTrack): MenuItem[] {
+    const track = asTidalPlayable(t);
+    const disabled = track === null;
+    const hint = disabled ? statusLabel(t.tidal) : undefined;
+    return [
+      {
+        label: 'Play now',
+        icon: 'Play',
+        disabled,
+        hint,
+        onSelect: () => {
+          if (track) void playTidalTrackNow(track);
+        },
+      },
+      {
+        label: 'Play next',
+        icon: 'Next',
+        disabled,
+        hint,
+        onSelect: () => {
+          if (track) void playTidalTrackNext(track);
+        },
+      },
+      {
+        label: 'Add to queue',
+        icon: '+',
+        disabled,
+        hint,
+        onSelect: () => {
+          if (track) void addTidalTrackToQueue(track);
+        },
+      },
+      { separator: true, label: '' },
+      {
+        label: 'Song radio',
+        icon: 'Radio',
+        disabled,
+        hint,
+        onSelect: () => {
+          if (track) void startTidalSongRadio(track);
+        },
+      },
+    ];
+  }
+
+  function handleRowContextMenu(e: MouseEvent, t: SpotifyPlaylistTrack) {
+    openContextMenu(e, buildRowMenu(t), t.title ?? 'Spotify track');
+  }
+
+  function handleMoreClick(e: MouseEvent, t: SpotifyPlaylistTrack) {
+    e.stopPropagation();
+    openMenuAtElement(e.currentTarget as HTMLElement, buildRowMenu(t), t.title ?? 'Spotify track');
+  }
+
+  async function save() {
+    if (!detail || saving) return;
+    saving = true;
+    saveErr = null;
+    try {
+      const res = await api.saveSpotifyPlaylist(spotifyId);
+      const skipped = res.unresolvedCount + (res.importFailures ?? 0);
+      saveResult =
+        skipped > 0
+          ? `Saved ${res.added} tracks. ${skipped} unavailable on TIDAL were skipped.`
+          : `Saved ${res.added} tracks.`;
+      // Navigate to the new playlist after a beat so the user sees the toast.
+      setTimeout(() => goto(`/playlists`), 1200);
+    } catch (e) {
+      saveErr = (e as Error).message ?? 'Save failed';
+    } finally {
+      saving = false;
+    }
+  }
+
+  function formatDuration(ms: number | null): string {
+    if (!ms || ms <= 0) return '—';
+    const total = Math.floor(ms / 1000);
+    const m = Math.floor(total / 60);
+    const s = total % 60;
+    return `${m}:${s.toString().padStart(2, '0')}`;
+  }
+
+  function formatNumber(n: number | null): string {
+    if (n === null || n === undefined) return '';
+    if (n < 1_000) return n.toString();
+    if (n < 1_000_000) return `${(n / 1_000).toFixed(1)}K`;
+    if (n < 1_000_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+    return `${(n / 1_000_000_000).toFixed(1)}B`;
+  }
+
+  const resolvedCount = $derived(
+    detail?.tracks.filter(
+      (t) => t.tidal.status === 'resolved' || t.tidal.status === 'low_confidence',
+    ).length ?? 0,
+  );
+  const playableCount = $derived(detail?.tracks.filter(isPlayable).length ?? 0);
+  const totalCount = $derived(detail?.tracks.length ?? 0);
+</script>
+
+<svelte:head>
+  <title>{detail?.title ?? 'Spotify playlist'} · NOOR</title>
+</svelte:head>
+
+<div class="page">
+  {#if loading}
+    <div class="state">Loading playlist…</div>
+  {:else if error}
+    <div class="state error">Couldn't load this playlist: {error}</div>
+  {:else if detail}
+    <header class="header">
+      {#if detail.thumbnail}
+        <div class="cover" style="background-image:url('{detail.thumbnail}')"></div>
+      {:else}
+        <div class="cover fallback">♫</div>
+      {/if}
+      <div class="meta">
+        <span class="kicker">Spotify playlist · ephemeral</span>
+        <h1 class="title">{detail.title ?? 'Untitled playlist'}</h1>
+        {#if detail.description}
+          <p class="description">{detail.description}</p>
+        {/if}
+        <div class="stats">
+          {#if detail.owner}
+            <span>By {detail.owner}</span>
+          {/if}
+          {#if detail.followers !== null}
+            <span>· {formatNumber(detail.followers)} followers</span>
+          {/if}
+          <span>· {totalCount} tracks</span>
+          <span class="resolved-count">· {resolvedCount} playable on TIDAL</span>
+        </div>
+        <div class="actions">
+          <button class="btn-primary" disabled={playableCount === 0} onclick={playAll}>Play all</button>
+          <button class="btn-secondary" disabled={playableCount === 0} onclick={shuffleAll}>Shuffle</button>
+          <button class="btn-secondary" disabled={playableCount === 0} onclick={playAllNext}>Play next</button>
+          <button class="btn-secondary" disabled={playableCount === 0} onclick={addAllToQueue}>Add to queue</button>
+          <button class="btn-secondary" disabled={playableCount === 0} onclick={startPlaylistRadio}>Song radio</button>
+          <button
+            class="btn-secondary"
+            disabled={saving || resolvedCount === 0}
+            onclick={save}
+          >
+            {saving ? 'Saving…' : 'Save to library'}
+          </button>
+          {#if pendingIds.length > 0}
+            <span class="resolving-badge">Resolving {pendingIds.length} more…</span>
+          {/if}
+        </div>
+        {#if saveResult}
+          <p class="toast success">{saveResult}</p>
+        {/if}
+        {#if saveErr}
+          <p class="toast error">Save failed: {saveErr}</p>
+        {/if}
+      </div>
+    </header>
+
+    <ol class="tracks">
+      {#each detail.tracks as t, i (t.spotifyId ?? `idx:${i}`)}
+        {@const playable = isPlayable(t)}
+        <!-- svelte-ignore a11y_no_noninteractive_element_to_interactive_role -->
+        <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+        <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+        <li
+          class="row"
+          class:disabled={!playable}
+          class:pending={t.tidal.status === 'pending'}
+          class:unresolved={t.tidal.status === 'unresolved' || t.tidal.status === 'error'}
+          class:low-confidence={t.tidal.status === 'low_confidence'}
+          role="button"
+          tabindex={playable ? 0 : -1}
+          aria-disabled={!playable}
+          title={statusLabel(t.tidal)}
+          onclick={() => void play(t)}
+          onkeydown={(e) => (e.key === 'Enter' || e.key === ' ') && (e.preventDefault(), void play(t))}
+          oncontextmenu={(e) => handleRowContextMenu(e, t)}
+        >
+          <span class="rank">{i + 1}</span>
+          {#if t.thumbnail}
+            <div class="thumb" style="background-image:url('{t.thumbnail}')"></div>
+          {:else}
+            <div class="thumb fallback">♫</div>
+          {/if}
+          <div class="row-meta">
+            <span class="row-title">{t.title ?? '—'}</span>
+            <span class="row-artist">{t.primaryArtist ?? ''}</span>
+          </div>
+          {#if t.playcount !== null}
+            <span class="playcount">{formatNumber(t.playcount)} plays</span>
+          {/if}
+          <span class="status status--{t.tidal.status}">
+            {t.tidal.status === 'resolved'
+              ? 'TIDAL'
+              : t.tidal.status === 'low_confidence'
+                ? 'Match?'
+                : t.tidal.status === 'pending'
+                  ? 'Resolving…'
+                  : 'N/A'}
+          </span>
+          <span class="dur">{formatDuration(t.durationMs)}</span>
+          <div class="row-actions">
+            <button
+              class="row-btn"
+              disabled={!playable}
+              title={playable ? `Play ${t.title ?? 'track'}` : statusLabel(t.tidal)}
+              aria-label="Play {t.title ?? 'track'}"
+              onclick={(e) => {
+                e.stopPropagation();
+                void play(t);
+              }}
+            >Play</button>
+            <button
+              class="row-btn"
+              disabled={!playable}
+              title={playable ? 'Add to queue' : statusLabel(t.tidal)}
+              aria-label="Add to queue"
+              onclick={(e) => {
+                e.stopPropagation();
+                const track = asTidalPlayable(t);
+                if (track) void addTidalTrackToQueue(track);
+              }}
+            >+</button>
+            <button
+              class="row-btn"
+              title="More actions"
+              aria-label="More actions"
+              onclick={(e) => handleMoreClick(e, t)}
+            >More</button>
+          </div>
+        </li>
+      {/each}
+    </ol>
+  {/if}
+</div>
+
+<style>
+  .page { max-width: 1080px; margin: 0 auto; padding: 32px 28px 96px; }
+  .state { padding: 80px 0; text-align: center; color: var(--text-muted); }
+  .state.error { color: #ef4444; }
+
+  .header {
+    display: grid;
+    grid-template-columns: 220px 1fr;
+    gap: 28px;
+    align-items: end;
+    margin-bottom: 32px;
+  }
+  .cover {
+    width: 220px;
+    height: 220px;
+    border-radius: 14px;
+    background-size: cover;
+    background-position: center;
+    box-shadow: 0 18px 36px -16px rgba(0, 0, 0, 0.6);
+  }
+  .cover.fallback {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: linear-gradient(135deg, #1ed760, #1aa34a);
+    font-size: 56px;
+    color: #fff;
+  }
+  .meta { display: flex; flex-direction: column; gap: 10px; min-width: 0; }
+  .kicker {
+    font-size: 11px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #1ed760;
+    font-weight: 700;
+  }
+  .title {
+    margin: 0;
+    font-size: 38px;
+    font-weight: 800;
+    line-height: 1.1;
+    color: var(--text-primary);
+  }
+  .description {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: 13px;
+    max-width: 60ch;
+  }
+  .stats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    color: var(--text-muted);
+    font-size: 12px;
+  }
+  .stats .resolved-count { color: var(--accent); font-weight: 600; }
+  .actions { display: flex; align-items: center; flex-wrap: wrap; gap: 8px; margin-top: 8px; }
+  .btn-primary,
+  .btn-secondary {
+    background: var(--accent);
+    color: var(--bg-base);
+    border: none;
+    padding: 9px 14px;
+    border-radius: 999px;
+    font-weight: 700;
+    cursor: pointer;
+    font-size: 13px;
+  }
+  .btn-secondary {
+    background: rgba(255, 255, 255, 0.07);
+    color: var(--text-primary);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+  }
+  .btn-primary:disabled,
+  .btn-secondary:disabled { opacity: 0.5; cursor: not-allowed; }
+  .resolving-badge {
+    font-size: 11px;
+    color: var(--text-muted);
+    font-style: italic;
+  }
+  .toast {
+    margin: 8px 0 0;
+    font-size: 12px;
+    padding: 8px 12px;
+    border-radius: 8px;
+    width: fit-content;
+  }
+  .toast.success { background: rgba(125, 200, 175, 0.12); color: var(--accent); }
+  .toast.error { background: rgba(239, 68, 68, 0.12); color: #ef4444; }
+
+  .tracks { list-style: none; margin: 0; padding: 0; }
+  .row {
+    display: grid;
+    grid-template-columns: 36px 44px minmax(0, 1fr) auto auto auto auto;
+    gap: 14px;
+    align-items: center;
+    padding: 8px 12px;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: background 100ms ease;
+  }
+  .row:hover { background: rgba(255, 255, 255, 0.04); }
+  .row.disabled { cursor: default; opacity: 0.55; }
+  .row.disabled:hover { background: none; }
+  .row.disabled .row-actions { opacity: 1; }
+  .rank { color: var(--text-muted); text-align: center; font-variant-numeric: tabular-nums; }
+  .thumb {
+    width: 44px;
+    height: 44px;
+    border-radius: 4px;
+    background-size: cover;
+    background-position: center;
+    background-color: var(--bg-raised);
+  }
+  .thumb.fallback {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-muted);
+  }
+  .row-meta { display: flex; flex-direction: column; min-width: 0; }
+  .row-title {
+    color: var(--text-primary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-size: 14px;
+    font-weight: 500;
+  }
+  .row-artist {
+    color: var(--text-secondary);
+    font-size: 12px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .playcount {
+    color: var(--text-muted);
+    font-size: 11px;
+    font-variant-numeric: tabular-nums;
+  }
+  .status {
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    padding: 2px 8px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.05);
+    color: var(--text-muted);
+  }
+  .status--resolved { background: rgba(125, 200, 175, 0.16); color: var(--accent); }
+  .status--low_confidence { background: rgba(245, 200, 70, 0.14); color: #f5c846; }
+  .status--pending { background: rgba(255, 255, 255, 0.06); color: var(--text-muted); font-style: italic; }
+  .status--unresolved, .status--error { background: rgba(239, 68, 68, 0.10); color: #ef4444; }
+  .dur {
+    color: var(--text-muted);
+    font-size: 12px;
+    font-variant-numeric: tabular-nums;
+    min-width: 36px;
+    text-align: right;
+  }
+  .row-actions {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 4px;
+    opacity: 0;
+    transition: opacity 100ms ease;
+  }
+  .row:hover .row-actions,
+  .row:focus-within .row-actions { opacity: 1; }
+  .row-btn {
+    border: none;
+    min-width: 30px;
+    height: 30px;
+    padding: 0 8px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.06);
+    color: var(--text-secondary);
+    cursor: pointer;
+    font-size: 11px;
+    font-weight: 700;
+  }
+  .row-btn:hover {
+    background: rgba(255, 255, 255, 0.12);
+    color: var(--text-primary);
+  }
+  .row-btn:disabled {
+    cursor: not-allowed;
+    opacity: 0.45;
+  }
+  @media (max-width: 760px) {
+    .page { padding: 24px 16px 88px; }
+    .header { grid-template-columns: 96px 1fr; gap: 16px; align-items: start; }
+    .cover { width: 96px; height: 96px; border-radius: 10px; }
+    .title { font-size: 26px; }
+    .row {
+      grid-template-columns: 28px 40px minmax(0, 1fr) auto;
+      gap: 10px;
+    }
+    .playcount,
+    .status,
+    .dur { display: none; }
+    .row-actions { opacity: 1; }
+  }
+</style>

--- a/noor-server/src/db/schema.rs
+++ b/noor-server/src/db/schema.rs
@@ -32,6 +32,8 @@ const MIGRATIONS: &[&str] = &[
     MIGRATION_028,
     MIGRATION_029,
     MIGRATION_030,
+    MIGRATION_031,
+    MIGRATION_032,
 ];
 
 const MIGRATION_001: &str = r#"
@@ -816,6 +818,97 @@ CREATE TABLE IF NOT EXISTS spotify_null_cache (
 // Existing rows have NULL; resolver falls back to artist+title search.
 const MIGRATION_030: &str = r#"
 ALTER TABLE queue ADD COLUMN tidal_id_hint INTEGER;
+"#;
+
+// Sportify (anonymous Spotify metadata proxy) discovery layer.
+// Four metadata caches keyed on Spotify IDs, plus the Spotify->TIDAL
+// resolution map and its negative-cache twin, plus a search-result cache.
+// World playcounts and monthly listeners go into the existing
+// spotify_track_stats / spotify_artist_stats tables (MIGRATION_029) — no
+// parallel sportify_*_stats tables, so the legacy artist page benefits too.
+const MIGRATION_031: &str = r#"
+CREATE TABLE IF NOT EXISTS sportify_track_meta (
+    spotify_track_id TEXT PRIMARY KEY,
+    payload          TEXT NOT NULL,
+    fetched_at       INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_sportify_track_meta_fetched_at
+    ON sportify_track_meta(fetched_at);
+
+CREATE TABLE IF NOT EXISTS sportify_album_meta (
+    spotify_album_id TEXT PRIMARY KEY,
+    payload          TEXT NOT NULL,
+    fetched_at       INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_sportify_album_meta_fetched_at
+    ON sportify_album_meta(fetched_at);
+
+CREATE TABLE IF NOT EXISTS sportify_artist_meta (
+    spotify_artist_id TEXT PRIMARY KEY,
+    payload           TEXT NOT NULL,
+    fetched_at        INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_sportify_artist_meta_fetched_at
+    ON sportify_artist_meta(fetched_at);
+
+CREATE TABLE IF NOT EXISTS sportify_playlist_meta (
+    spotify_playlist_id TEXT PRIMARY KEY,
+    payload             TEXT NOT NULL,
+    snapshot_id         TEXT,
+    fetched_at          INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_sportify_playlist_meta_fetched_at
+    ON sportify_playlist_meta(fetched_at);
+
+CREATE TABLE IF NOT EXISTS sportify_track_map (
+    spotify_track_id TEXT PRIMARY KEY,
+    tidal_track_id   INTEGER NOT NULL,
+    confidence       REAL NOT NULL,
+    match_reason     TEXT,
+    resolved_at      INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_sportify_track_map_tidal
+    ON sportify_track_map(tidal_track_id);
+
+CREATE TABLE IF NOT EXISTS sportify_unresolved (
+    spotify_track_id TEXT PRIMARY KEY,
+    last_attempt_at  INTEGER NOT NULL,
+    attempts         INTEGER NOT NULL DEFAULT 1,
+    reason           TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_sportify_unresolved_last_attempt
+    ON sportify_unresolved(last_attempt_at);
+
+CREATE TABLE IF NOT EXISTS sportify_search_cache (
+    query_hash TEXT PRIMARY KEY,
+    kind       TEXT NOT NULL,
+    payload    TEXT NOT NULL,
+    fetched_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_sportify_search_cache_fetched_at
+    ON sportify_search_cache(fetched_at);
+"#;
+
+// Clear Sportify metadata + search caches. Initial release shipped with a
+// model that mismatched the upstream Sportify shape (track `title`/`artist`,
+// playlist `owner` string, flat `results` array). All four meta tables and
+// the search cache may hold rows that deserialized into all-None defaults.
+// Wipe them once so live re-fetches populate with the corrected models.
+// Resolution map (`sportify_track_map`) is preserved — those rows are TIDAL
+// ids and aren't affected by Sportify shape changes.
+const MIGRATION_032: &str = r#"
+DELETE FROM sportify_track_meta;
+DELETE FROM sportify_album_meta;
+DELETE FROM sportify_artist_meta;
+DELETE FROM sportify_playlist_meta;
+DELETE FROM sportify_search_cache;
 "#;
 
 pub fn run_migrations(conn: &Connection) -> Result<()> {

--- a/noor-server/src/main.rs
+++ b/noor-server/src/main.rs
@@ -146,6 +146,13 @@ pub struct AppState {
     /// the `spotify-public` cargo feature; without it the env var is ignored
     /// and we log one warning at startup.
     pub spotify_public_stats_enabled: bool,
+    /// Sportify (anonymous Spotify metadata proxy) client used by the
+    /// `/api/discovery/sportify/*` discovery routes. Constructed once at boot.
+    pub sportify_client: Option<Arc<services::sportify::SportifyClient>>,
+    /// Cache TTL config for Sportify metadata + TIDAL resolution maps.
+    pub sportify_cache_config: services::sportify::cache::SportifyCacheConfig,
+    /// Eager-first-N + lazy-rest tunables for discovery list endpoints.
+    pub sportify_resolve_config: services::sportify::cache::SportifyResolveConfig,
 }
 
 /// Events broadcast across the application
@@ -208,6 +215,24 @@ pub enum AppEvent {
 }
 
 pub type SharedState = Arc<RwLock<AppState>>;
+
+/// Read an env var holding a number of days; fall back to `default` on
+/// missing or unparseable input. Returns the value in whole days as `i64`.
+fn parse_days_env(var: &str, default: i64) -> i64 {
+    std::env::var(var)
+        .ok()
+        .and_then(|s| s.trim().parse::<i64>().ok())
+        .filter(|d| *d > 0)
+        .unwrap_or(default)
+}
+
+fn parse_usize_env(var: &str, default: usize) -> usize {
+    std::env::var(var)
+        .ok()
+        .and_then(|s| s.trim().parse::<usize>().ok())
+        .filter(|v| *v > 0)
+        .unwrap_or(default)
+}
 
 fn resolve_bind_addr(db: &db::Database) -> String {
     // NOOR_ADDR env var always wins (power-user override)
@@ -352,6 +377,46 @@ async fn main() -> Result<()> {
         info!("Last.fm scrobbling disabled (set LASTFM_API_SECRET to enable)");
     }
 
+    // Sportify (anonymous Spotify metadata proxy) — powers /discover. Default
+    // base URL ships in code; env var lets ops point at a self-hosted mirror.
+    let sportify_base_url = std::env::var("SPORTIFY_API_BASE_URL")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| "https://sportify.xcasper.space".to_string());
+    let sportify_client = match services::sportify::SportifyClient::new(
+        services::sportify::SportifyClientConfig {
+            base_url: sportify_base_url.clone(),
+            user_agent: format!(
+                "noor-server/{} (sportify discovery)",
+                env!("CARGO_PKG_VERSION")
+            ),
+        },
+    ) {
+        Ok(client) => {
+            info!("Sportify discovery client ready ({})", sportify_base_url);
+            Some(Arc::new(client))
+        }
+        Err(e) => {
+            tracing::warn!("Failed to construct Sportify client: {}; /discover will be degraded", e);
+            None
+        }
+    };
+    let sportify_cache_config = services::sportify::cache::SportifyCacheConfig {
+        meta_ttl_secs: parse_days_env("DISCOVERY_CACHE_TTL_DAYS", 30) * 86_400,
+        resolve_ttl_secs: parse_days_env("RESOLVE_CACHE_TTL_DAYS", 30) * 86_400,
+        unresolved_retry_after_secs: parse_days_env("RESOLVE_RETRY_AFTER_DAYS", 7) * 86_400,
+    };
+    let sportify_resolve_config = services::sportify::cache::SportifyResolveConfig {
+        eager_n: parse_usize_env(
+            "RESOLVE_EAGER_N",
+            services::sportify::cache::DEFAULT_EAGER_N,
+        ),
+        bulk_concurrency: parse_usize_env(
+            "RESOLVE_BULK_CONCURRENCY",
+            services::sportify::cache::DEFAULT_BULK_CONCURRENCY,
+        ),
+    };
+
     // Event bus for real-time state sync
     let (event_tx, _) = broadcast::channel(256);
 
@@ -446,6 +511,9 @@ async fn main() -> Result<()> {
         audio_active: Arc::new(AtomicBool::new(false)),
         user_cleared_at: Arc::new(std::sync::atomic::AtomicI64::new(0)),
         spotify_public_stats_enabled,
+        sportify_client,
+        sportify_cache_config,
+        sportify_resolve_config,
     }));
 
     // Check for auto-sync daily services and trigger sync if needed

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -193,6 +193,11 @@ pub struct QueueExternalRequest {
 }
 
 #[derive(Debug, Deserialize)]
+pub struct QueueExternalManyRequest {
+    items: Vec<QueueExternalRequest>,
+}
+
+#[derive(Debug, Deserialize)]
 pub struct PlaylistFromQueueRequest {
     name: String,
     #[serde(default)]
@@ -305,7 +310,10 @@ pub fn api_routes(state: SharedState) -> Router {
         .route("/api/artists", get(get_artists))
         .route("/api/artists/{id}/tracks", get(get_artist_tracks))
         .route("/api/artists/{id}/discography", get(get_artist_discography))
-        .route("/api/artists/{id}/spotify-stats", get(get_artist_spotify_stats))
+        .route(
+            "/api/artists/{id}/spotify-stats",
+            get(get_artist_spotify_stats),
+        )
         .route("/api/tidal/albums/{id}/tracks", get(get_tidal_album_tracks))
         .route("/api/tidal/albums/{id}/import", post(import_tidal_album))
         .route(
@@ -369,6 +377,56 @@ pub fn api_routes(state: SharedState) -> Router {
         )
         // Discovery Sound Space
         .route("/api/discovery/space", post(get_discovery_space))
+        // Sportify-based discovery resolver — single, bulk, and cache-only status poll.
+        .route("/api/resolve/tidal/track", get(resolve_tidal_track))
+        .route("/api/resolve/tidal/bulk", post(resolve_tidal_bulk))
+        .route("/api/resolve/tidal/status", get(resolve_tidal_status))
+        // Sportify (anonymous Spotify metadata proxy) discovery surface.
+        // Sportify is upstream and subject to breakage — every handler is
+        // cache-first, every failure surfaces as JSON error or empty list,
+        // and nothing here writes to library tables. Worst case for an
+        // outage is a degraded /discover; existing library data is never
+        // affected.
+        .route(
+            "/api/discovery/sportify/search",
+            get(sportify_discovery_search),
+        )
+        .route(
+            "/api/discovery/sportify/track/{spotify_id}",
+            get(sportify_discovery_track),
+        )
+        .route(
+            "/api/discovery/sportify/album/{spotify_id}",
+            get(sportify_discovery_album),
+        )
+        .route(
+            "/api/discovery/sportify/playlist/{spotify_id}",
+            get(sportify_discovery_playlist),
+        )
+        .route(
+            "/api/discovery/sportify/artist/{spotify_id}",
+            get(sportify_discovery_artist),
+        )
+        .route(
+            "/api/discovery/sportify/artist/{spotify_id}/top-tracks",
+            get(sportify_discovery_artist_top_tracks),
+        )
+        .route(
+            "/api/discovery/sportify/artist/{spotify_id}/related",
+            get(sportify_discovery_artist_related),
+        )
+        .route(
+            "/api/discovery/sportify/album/{spotify_id}/related",
+            get(sportify_discovery_album_related),
+        )
+        .route(
+            "/api/discovery/sportify/track/{spotify_id}/related",
+            get(sportify_discovery_track_related),
+        )
+        // Save an ephemeral Spotify-sourced playlist into the user's library.
+        // Imports each resolved TIDAL track + creates a noor playlist; rows
+        // without a TIDAL match are skipped (counted in the response).
+        .route("/api/spotify-playlist/save", post(save_spotify_playlist))
         .route("/api/radio/song", post(radio_song))
         .route("/api/radio/album", post(radio_album))
         .route("/api/radio/artist", post(radio_artist))
@@ -435,7 +493,9 @@ pub fn api_routes(state: SharedState) -> Router {
         .route("/api/playback/queue/move", post(move_queue_track))
         .route("/api/playback/queue/clear", post(clear_queue_route))
         .route("/api/queue/play_next", post(queue_play_next))
+        .route("/api/queue/play_next_many", post(queue_play_next_many))
         .route("/api/queue/append", post(queue_append))
+        .route("/api/queue/append_many", post(queue_append_many))
         .route(
             "/api/playlists/from-queue",
             post(create_playlist_from_queue),
@@ -922,43 +982,35 @@ async fn get_artist_spotify_stats(
         if !enabled {
             return Json(json!({ "monthly_listeners": null, "tracks": [] }));
         }
-        let pairs = s
-            .db
-            .with_conn(|conn| queries::get_artist_tracks(conn, id))
-            .map(|tracks| {
-                let mut sorted = tracks
-                    .into_iter()
-                    .filter(|t| t.isrc.as_deref().is_some_and(|s| !s.is_empty()))
-                    .collect::<Vec<_>>();
-                sorted.sort_by(|a, b| b.play_count.cmp(&a.play_count));
-                sorted.truncate(10);
-                sorted
-                    .into_iter()
-                    .map(|t| (t.isrc.unwrap_or_default(), t.title))
-                    .collect::<Vec<(String, String)>>()
-            })
-            .unwrap_or_default();
-        let artist_name = pairs
-            .first()
-            .map(|_| String::new())
-            .unwrap_or_default();
+        let pairs =
+            s.db.with_conn(|conn| queries::get_artist_tracks(conn, id))
+                .map(|tracks| {
+                    let mut sorted = tracks
+                        .into_iter()
+                        .filter(|t| t.isrc.as_deref().is_some_and(|s| !s.is_empty()))
+                        .collect::<Vec<_>>();
+                    sorted.sort_by(|a, b| b.play_count.cmp(&a.play_count));
+                    sorted.truncate(10);
+                    sorted
+                        .into_iter()
+                        .map(|t| (t.isrc.unwrap_or_default(), t.title))
+                        .collect::<Vec<(String, String)>>()
+                })
+                .unwrap_or_default();
+        let artist_name = pairs.first().map(|_| String::new()).unwrap_or_default();
         // Re-look up the artist's display name (any track's artist_name works
         // — they all share artist_id=id by construction).
-        let name = s
-            .db
-            .with_conn(|conn| queries::get_artist_tracks(conn, id))
-            .ok()
-            .and_then(|ts| ts.first().and_then(|t| t.artist_name.clone()))
-            .unwrap_or(artist_name);
+        let name =
+            s.db.with_conn(|conn| queries::get_artist_tracks(conn, id))
+                .ok()
+                .and_then(|ts| ts.first().and_then(|t| t.artist_name.clone()))
+                .unwrap_or(artist_name);
         (enabled, name, pairs)
     };
 
-    let result = crate::services::spotify_public::fetch_artist_stats(
-        enabled,
-        &artist_name,
-        &isrc_pairs,
-    )
-    .await;
+    let result =
+        crate::services::spotify_public::fetch_artist_stats(enabled, &artist_name, &isrc_pairs)
+            .await;
 
     Json(json!({
         "monthly_listeners": result.monthly_listeners,
@@ -2522,6 +2574,1464 @@ struct DiscoverySpaceRequest {
     limit: Option<i64>,
 }
 
+#[derive(Debug, Deserialize)]
+struct ResolveTidalTrackQuery {
+    spotify_id: String,
+    /// When true, ignore any cached resolution and re-run the matcher.
+    #[serde(default)]
+    refresh: bool,
+}
+
+/// Resolve one Spotify (Sportify) track to TIDAL for playback. Reads the
+/// Spotify→TIDAL map cache first; on miss, fetches Sportify metadata and
+/// runs the title/artist/duration matcher against TIDAL search.
+///
+/// Response shape mirrors the `tidal: {...}` block on the normalized
+/// DiscoveryTrack so the frontend can drop it straight in.
+async fn resolve_tidal_track(
+    State(state): State<SharedState>,
+    Query(params): Query<ResolveTidalTrackQuery>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    use crate::services::sportify::{cache as sp_cache, resolver};
+
+    let spotify_id = params.spotify_id.trim();
+    if spotify_id.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "spotify_id required" })),
+        ));
+    }
+
+    let (sportify_client, cache_cfg, db) = {
+        let s = state.read().await;
+        (
+            s.sportify_client.clone(),
+            s.sportify_cache_config,
+            s.db.clone(),
+        )
+    };
+
+    let Some(sportify_client) = sportify_client else {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({ "error": "sportify_unavailable" })),
+        ));
+    };
+
+    if !params.refresh {
+        let cached = db
+            .with_conn(|conn| sp_cache::get_tidal_resolution(conn, &cache_cfg, spotify_id))
+            .map_err(internal)?;
+        if let Some(hit) = cached {
+            return Ok(Json(json!({
+                "spotify_id": spotify_id,
+                "tidal": {
+                    "status": resolver::classify(hit.confidence).as_str(),
+                    "id": hit.tidal_track_id,
+                    "confidence": hit.confidence,
+                    "match_reason": hit.match_reason,
+                    "resolved_at": hit.resolved_at,
+                    "from_cache": true,
+                }
+            })));
+        }
+        let unresolved = db
+            .with_conn(|conn| sp_cache::get_unresolved(conn, spotify_id))
+            .map_err(internal)?;
+        if let Some(record) = unresolved.as_ref() {
+            if sp_cache::unresolved_is_cold(record, &cache_cfg) {
+                return Ok(Json(json!({
+                    "spotify_id": spotify_id,
+                    "tidal": {
+                        "status": "unresolved",
+                        "id": null,
+                        "confidence": 0.0,
+                        "match_reason": record.reason,
+                        "last_attempt_at": record.last_attempt_at,
+                        "attempts": record.attempts,
+                        "from_cache": true,
+                    }
+                })));
+            }
+        }
+    }
+
+    let sportify_track = match db
+        .with_conn(|conn| sp_cache::get_track_meta(conn, &cache_cfg, spotify_id))
+        .map_err(internal)?
+    {
+        Some(t) => t,
+        None => {
+            let fetched = sportify_client.track(spotify_id).await.map_err(|e| {
+                (
+                    StatusCode::BAD_GATEWAY,
+                    Json(json!({ "error": format!("sportify_track_fetch: {e}") })),
+                )
+            })?;
+            db.with_conn(|conn| {
+                sp_cache::put_track_meta(conn, spotify_id, &fetched)?;
+                crate::services::sportify::stats::write_track_playcount(conn, &fetched);
+                Ok::<_, anyhow::Error>(())
+            })
+            .map_err(internal)?;
+            fetched
+        }
+    };
+
+    let tokens = {
+        let persisted = load_persisted_tidal_tokens(&state)
+            .await
+            .map_err(internal)?;
+        let s = state.read().await;
+        s.tidal_tokens.clone().or(persisted)
+    };
+    let Some(tokens) = tokens else {
+        return Ok(Json(json!({
+            "spotify_id": spotify_id,
+            "tidal": {
+                "status": "error",
+                "id": null,
+                "confidence": 0.0,
+                "match_reason": "tidal_not_connected",
+            }
+        })));
+    };
+
+    let tidal_client = TidalClient::new(tokens.access_token.clone(), tokens.country_code.clone());
+    let outcome = resolver::resolve_track(&tidal_client, &sportify_track)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::BAD_GATEWAY,
+                Json(json!({ "error": format!("resolve: {e}") })),
+            )
+        })?;
+
+    match outcome.status {
+        resolver::ResolutionStatus::Resolved | resolver::ResolutionStatus::LowConfidence => {
+            if let Some(tidal_id) = outcome.tidal_track_id {
+                let reason = outcome.reason.clone();
+                db.with_conn(|conn| {
+                    sp_cache::put_tidal_resolution(
+                        conn,
+                        spotify_id,
+                        tidal_id,
+                        outcome.confidence,
+                        Some(&reason),
+                    )
+                })
+                .map_err(internal)?;
+            }
+        }
+        resolver::ResolutionStatus::Unresolved => {
+            let reason = outcome.reason.clone();
+            db.with_conn(|conn| sp_cache::put_unresolved(conn, spotify_id, Some(&reason)))
+                .map_err(internal)?;
+        }
+    }
+
+    Ok(Json(json!({
+        "spotify_id": spotify_id,
+        "tidal": {
+            "status": outcome.status.as_str(),
+            "id": outcome.tidal_track_id,
+            "confidence": outcome.confidence,
+            "match_reason": outcome.reason,
+            "from_cache": false,
+        }
+    })))
+}
+
+// ─── Sportify bulk + status resolution endpoints ────────────
+
+#[derive(Debug, Deserialize)]
+struct ResolveTidalBulkBody {
+    spotify_ids: Vec<String>,
+    /// When true, ignore any cached resolution for the given ids.
+    #[serde(default)]
+    refresh: bool,
+}
+
+/// Resolve a batch of Spotify ids in one request. Returns the cached state
+/// for any ids that already had resolutions, plus fresh resolutions for the
+/// rest. Caller may use this for a "resolve everything before opening" flow
+/// or to force a refresh after a TIDAL session change.
+async fn resolve_tidal_bulk(
+    State(state): State<SharedState>,
+    Json(body): Json<ResolveTidalBulkBody>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    use crate::services::sportify::{cache as sp_cache, resolver};
+
+    let ids: Vec<String> = body
+        .spotify_ids
+        .into_iter()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+    if ids.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "spotify_ids required" })),
+        ));
+    }
+
+    let (sportify_client, cache_cfg, resolve_cfg, db, tokens_in_state) = {
+        let s = state.read().await;
+        (
+            s.sportify_client.clone(),
+            s.sportify_cache_config,
+            s.sportify_resolve_config,
+            s.db.clone(),
+            s.tidal_tokens.clone(),
+        )
+    };
+    let Some(sportify_client) = sportify_client else {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({ "error": "sportify_unavailable" })),
+        ));
+    };
+
+    // Partition: which ids do we need to actually resolve vs. read from cache.
+    let mut resolved: Vec<Value> = Vec::new();
+    let mut unresolved_payload: Vec<Value> = Vec::new();
+    let mut needs_fetch: Vec<String> = Vec::new();
+    db.with_conn(|conn| {
+        for id in &ids {
+            if !body.refresh {
+                if let Some(hit) = sp_cache::get_tidal_resolution(conn, &cache_cfg, id)? {
+                    resolved.push(json!({
+                        "spotifyId": id,
+                        "tidal": {
+                            "status": resolver::classify(hit.confidence).as_str(),
+                            "id": hit.tidal_track_id,
+                            "confidence": hit.confidence,
+                            "matchReason": hit.match_reason,
+                            "fromCache": true,
+                        }
+                    }));
+                    continue;
+                }
+                if let Some(record) = sp_cache::get_unresolved(conn, id)? {
+                    if sp_cache::unresolved_is_cold(&record, &cache_cfg) {
+                        unresolved_payload.push(json!({
+                            "spotifyId": id,
+                            "tidal": {
+                                "status": "unresolved",
+                                "id": null,
+                                "confidence": 0.0,
+                                "matchReason": record.reason,
+                                "attempts": record.attempts,
+                                "fromCache": true,
+                            }
+                        }));
+                        continue;
+                    }
+                }
+            }
+            needs_fetch.push(id.clone());
+        }
+        Ok::<_, anyhow::Error>(())
+    })
+    .map_err(internal)?;
+
+    if needs_fetch.is_empty() {
+        return Ok(Json(json!({
+            "resolved": resolved,
+            "unresolved": unresolved_payload,
+        })));
+    }
+
+    // Fetch Sportify metadata for everything we need to resolve. Cache miss
+    // → upstream call; failures fall through as `unresolved` rather than
+    // failing the whole batch.
+    let mut to_resolve: Vec<(String, crate::services::sportify::models::SportifyTrack)> =
+        Vec::with_capacity(needs_fetch.len());
+    for id in &needs_fetch {
+        let cached = db
+            .with_conn(|conn| sp_cache::get_track_meta(conn, &cache_cfg, id))
+            .map_err(internal)?;
+        let track = match cached {
+            Some(t) => t,
+            None => match sportify_client.track(id).await {
+                Ok(t) => {
+                    let _ = db.with_conn(|conn| {
+                        sp_cache::put_track_meta(conn, id, &t)?;
+                        crate::services::sportify::stats::write_track_playcount(conn, &t);
+                        Ok::<_, anyhow::Error>(())
+                    });
+                    t
+                }
+                Err(e) => {
+                    unresolved_payload.push(json!({
+                        "spotifyId": id,
+                        "tidal": {
+                            "status": "error",
+                            "id": null,
+                            "confidence": 0.0,
+                            "matchReason": format!("sportify_fetch:{e}"),
+                            "fromCache": false,
+                        }
+                    }));
+                    continue;
+                }
+            },
+        };
+        to_resolve.push((id.clone(), track));
+    }
+
+    let tokens = match tokens_in_state {
+        Some(t) => Some(t),
+        None => load_persisted_tidal_tokens(&state)
+            .await
+            .map_err(internal)?,
+    };
+    let Some(tokens) = tokens else {
+        for (id, _) in to_resolve {
+            unresolved_payload.push(json!({
+                "spotifyId": id,
+                "tidal": {
+                    "status": "error",
+                    "id": null,
+                    "confidence": 0.0,
+                    "matchReason": "tidal_not_connected",
+                    "fromCache": false,
+                }
+            }));
+        }
+        return Ok(Json(json!({
+            "resolved": resolved,
+            "unresolved": unresolved_payload,
+        })));
+    };
+
+    let client = TidalClient::new(tokens.access_token.clone(), tokens.country_code.clone());
+    let outcomes = resolver::resolve_many(&client, &to_resolve, resolve_cfg.bulk_concurrency).await;
+
+    db.with_conn(|conn| {
+        for (id, outcome) in &outcomes {
+            persist_outcome(conn, id, outcome);
+        }
+        Ok::<_, anyhow::Error>(())
+    })
+    .map_err(internal)?;
+
+    for (id, outcome) in outcomes {
+        let row = json!({
+            "spotifyId": id,
+            "tidal": {
+                "status": outcome.status.as_str(),
+                "id": outcome.tidal_track_id,
+                "confidence": outcome.confidence,
+                "matchReason": outcome.reason,
+                "fromCache": false,
+            }
+        });
+        match outcome.status {
+            resolver::ResolutionStatus::Resolved | resolver::ResolutionStatus::LowConfidence => {
+                resolved.push(row);
+            }
+            resolver::ResolutionStatus::Unresolved => unresolved_payload.push(row),
+        }
+    }
+
+    Ok(Json(json!({
+        "resolved": resolved,
+        "unresolved": unresolved_payload,
+    })))
+}
+
+#[derive(Debug, Deserialize)]
+struct ResolveTidalStatusQuery {
+    /// Comma-separated list of Spotify track ids.
+    spotify_ids: String,
+}
+
+/// Cheap polling endpoint: reads the cache only, never hits TIDAL or
+/// Sportify. The frontend's lazy-tail poller calls this every ~1.5s after
+/// opening a list endpoint until everything is non-pending or it times out.
+async fn resolve_tidal_status(
+    State(state): State<SharedState>,
+    Query(params): Query<ResolveTidalStatusQuery>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    use crate::services::sportify::{cache as sp_cache, resolver};
+
+    let ids: Vec<String> = params
+        .spotify_ids
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+    if ids.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "spotify_ids required" })),
+        ));
+    }
+
+    let (cache_cfg, db) = {
+        let s = state.read().await;
+        (s.sportify_cache_config, s.db.clone())
+    };
+
+    let entries = db
+        .with_conn(|conn| {
+            let mut out: Vec<Value> = Vec::with_capacity(ids.len());
+            for id in &ids {
+                if let Some(hit) = sp_cache::get_tidal_resolution(conn, &cache_cfg, id)? {
+                    out.push(json!({
+                        "spotifyId": id,
+                        "tidal": {
+                            "status": resolver::classify(hit.confidence).as_str(),
+                            "id": hit.tidal_track_id,
+                            "confidence": hit.confidence,
+                            "matchReason": hit.match_reason,
+                            "fromCache": true,
+                        }
+                    }));
+                    continue;
+                }
+                if let Some(record) = sp_cache::get_unresolved(conn, id)? {
+                    if sp_cache::unresolved_is_cold(&record, &cache_cfg) {
+                        out.push(json!({
+                            "spotifyId": id,
+                            "tidal": {
+                                "status": "unresolved",
+                                "id": null,
+                                "confidence": 0.0,
+                                "matchReason": record.reason,
+                                "fromCache": true,
+                            }
+                        }));
+                        continue;
+                    }
+                }
+                out.push(json!({
+                    "spotifyId": id,
+                    "tidal": {
+                        "status": "pending",
+                        "id": null,
+                        "confidence": 0.0,
+                        "fromCache": false,
+                    }
+                }));
+            }
+            Ok::<_, anyhow::Error>(out)
+        })
+        .map_err(internal)?;
+
+    Ok(Json(json!({ "entries": entries })))
+}
+
+// ─── Sportify discovery read endpoints ──────────────────────
+
+/// Resolve the first `eager_n` Spotify tracks against TIDAL inline (so the
+/// top of the response is instantly playable) and spawn a background task
+/// for the remainder. Both paths persist into `sportify_track_map` /
+/// `sportify_unresolved`, so a follow-up `enrich_tracks_with_tidal_cache`
+/// call reflects the inline resolutions in the response.
+///
+/// Returns the list of spotify_ids spawned for lazy resolution — surfaced in
+/// the response so the frontend's status poller knows what to watch.
+async fn eager_and_lazy_resolve_for_list(
+    state: &SharedState,
+    sportify_tracks: &[crate::services::sportify::models::SportifyTrack],
+) -> Vec<String> {
+    use crate::services::sportify::{cache as sp_cache, resolver};
+
+    let (cache_cfg, resolve_cfg, db, tidal_tokens_in_state) = {
+        let s = state.read().await;
+        (
+            s.sportify_cache_config,
+            s.sportify_resolve_config,
+            s.db.clone(),
+            s.tidal_tokens.clone(),
+        )
+    };
+
+    // Filter to entries that need resolution: they have a spotify_id, no
+    // cached resolution, and aren't sitting in a fresh negative-cache row.
+    let needs_resolve: Vec<(String, crate::services::sportify::models::SportifyTrack)> = {
+        let pairs: Vec<(String, crate::services::sportify::models::SportifyTrack)> =
+            sportify_tracks
+                .iter()
+                .filter_map(|t| t.id.clone().map(|id| (id, t.clone())))
+                .collect();
+        let cache_check = db.with_conn(|conn| {
+            let mut keep = Vec::with_capacity(pairs.len());
+            for (id, track) in pairs.iter() {
+                if sp_cache::get_tidal_resolution(conn, &cache_cfg, id)?.is_some() {
+                    continue;
+                }
+                if let Some(record) = sp_cache::get_unresolved(conn, id)? {
+                    if sp_cache::unresolved_is_cold(&record, &cache_cfg) {
+                        continue;
+                    }
+                }
+                keep.push((id.clone(), track.clone()));
+            }
+            Ok::<_, anyhow::Error>(keep)
+        });
+        match cache_check {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!("eager_and_lazy_resolve cache check failed: {}", e);
+                return Vec::new();
+            }
+        }
+    };
+
+    if needs_resolve.is_empty() {
+        return Vec::new();
+    }
+
+    // Without TIDAL credentials we can't resolve anything. Leave rows pending
+    // so the UI shows them as such — better than persisting bogus failures.
+    let tokens = match tidal_tokens_in_state {
+        Some(t) => Some(t),
+        None => match load_persisted_tidal_tokens(state).await {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::warn!("eager_and_lazy_resolve token load failed: {}", e);
+                None
+            }
+        },
+    };
+    let Some(tokens) = tokens else {
+        return Vec::new();
+    };
+    let client = TidalClient::new(tokens.access_token.clone(), tokens.country_code.clone());
+
+    let eager_count = needs_resolve.len().min(resolve_cfg.eager_n);
+    let (eager, lazy) = needs_resolve.split_at(eager_count);
+
+    // Eager pass: resolve inline and persist before returning.
+    if !eager.is_empty() {
+        let outcomes = resolver::resolve_many(&client, eager, resolve_cfg.bulk_concurrency).await;
+        let _ = db.with_conn(|conn| {
+            for (id, outcome) in &outcomes {
+                persist_outcome(conn, id, outcome);
+            }
+            Ok::<_, anyhow::Error>(())
+        });
+    }
+
+    // Lazy pass: spawn detached task. The cache writes show up in the next
+    // status-poll round trip from the frontend.
+    let lazy_ids: Vec<String> = lazy.iter().map(|(id, _)| id.clone()).collect();
+    if !lazy.is_empty() {
+        let lazy_owned = lazy.to_vec();
+        let db_lazy = db.clone();
+        let concurrency = resolve_cfg.bulk_concurrency;
+        tokio::spawn(async move {
+            let outcomes = resolver::resolve_many(&client, &lazy_owned, concurrency).await;
+            let _ = db_lazy.with_conn(|conn| {
+                for (id, outcome) in &outcomes {
+                    persist_outcome(conn, id, outcome);
+                }
+                Ok::<_, anyhow::Error>(())
+            });
+        });
+    }
+
+    lazy_ids
+}
+
+/// Playlist pages need a fast first paint: return cache-only rows immediately
+/// and resolve every remaining Spotify track in the background.
+async fn spawn_background_resolve_for_list(
+    state: &SharedState,
+    sportify_tracks: &[crate::services::sportify::models::SportifyTrack],
+) -> Vec<String> {
+    use crate::services::sportify::{cache as sp_cache, resolver};
+
+    let (cache_cfg, resolve_cfg, db, tidal_tokens_in_state) = {
+        let s = state.read().await;
+        (
+            s.sportify_cache_config,
+            s.sportify_resolve_config,
+            s.db.clone(),
+            s.tidal_tokens.clone(),
+        )
+    };
+
+    let needs_resolve: Vec<(String, crate::services::sportify::models::SportifyTrack)> = {
+        let pairs: Vec<(String, crate::services::sportify::models::SportifyTrack)> =
+            sportify_tracks
+                .iter()
+                .filter_map(|t| t.id.clone().map(|id| (id, t.clone())))
+                .collect();
+        match db.with_conn(|conn| {
+            let mut keep = Vec::with_capacity(pairs.len());
+            for (id, track) in pairs.iter() {
+                if sp_cache::get_tidal_resolution(conn, &cache_cfg, id)?.is_some() {
+                    continue;
+                }
+                if let Some(record) = sp_cache::get_unresolved(conn, id)? {
+                    if sp_cache::unresolved_is_cold(&record, &cache_cfg) {
+                        continue;
+                    }
+                }
+                keep.push((id.clone(), track.clone()));
+            }
+            Ok::<_, anyhow::Error>(keep)
+        }) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!("background Sportify resolve cache check failed: {}", e);
+                return Vec::new();
+            }
+        }
+    };
+
+    if needs_resolve.is_empty() {
+        return Vec::new();
+    }
+
+    let pending_ids: Vec<String> = needs_resolve.iter().map(|(id, _)| id.clone()).collect();
+    let tokens = match tidal_tokens_in_state {
+        Some(t) => Some(t),
+        None => match load_persisted_tidal_tokens(state).await {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::warn!("background Sportify resolve token load failed: {}", e);
+                None
+            }
+        },
+    };
+    let Some(tokens) = tokens else {
+        return Vec::new();
+    };
+
+    tokio::spawn(async move {
+        let client = TidalClient::new(tokens.access_token.clone(), tokens.country_code.clone());
+        let outcomes =
+            resolver::resolve_many(&client, &needs_resolve, resolve_cfg.bulk_concurrency).await;
+        let _ = db.with_conn(|conn| {
+            for (id, outcome) in &outcomes {
+                persist_outcome(conn, id, outcome);
+            }
+            Ok::<_, anyhow::Error>(())
+        });
+    });
+
+    pending_ids
+}
+
+fn persist_outcome(
+    conn: &rusqlite::Connection,
+    spotify_id: &str,
+    outcome: &crate::services::sportify::resolver::ResolutionOutcome,
+) {
+    use crate::services::sportify::{cache as sp_cache, resolver::ResolutionStatus};
+    match outcome.status {
+        ResolutionStatus::Resolved | ResolutionStatus::LowConfidence => {
+            if let Some(tidal_id) = outcome.tidal_track_id {
+                let _ = sp_cache::put_tidal_resolution(
+                    conn,
+                    spotify_id,
+                    tidal_id,
+                    outcome.confidence,
+                    Some(&outcome.reason),
+                );
+            }
+        }
+        ResolutionStatus::Unresolved => {
+            let _ = sp_cache::put_unresolved(conn, spotify_id, Some(&outcome.reason));
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct SportifySearchQuery {
+    q: String,
+    #[serde(default)]
+    r#type: Option<String>,
+    #[serde(default)]
+    limit: Option<u32>,
+    #[serde(default)]
+    offset: Option<u32>,
+}
+
+fn parse_search_kind(s: Option<&str>) -> crate::services::sportify::client::SportifySearchKind {
+    use crate::services::sportify::client::SportifySearchKind;
+    match s.map(str::to_ascii_lowercase).as_deref() {
+        Some("album") => SportifySearchKind::Album,
+        Some("artist") => SportifySearchKind::Artist,
+        Some("playlist") => SportifySearchKind::Playlist,
+        // Default to track when missing or unknown — matches Sportify's own
+        // most-common usage.
+        _ => SportifySearchKind::Track,
+    }
+}
+
+async fn sportify_discovery_search(
+    State(state): State<SharedState>,
+    Query(params): Query<SportifySearchQuery>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    use crate::services::sportify::{cache as sp_cache, normalize};
+
+    let q = params.q.trim();
+    if q.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "q required" })),
+        ));
+    }
+
+    let kind = parse_search_kind(params.r#type.as_deref());
+    let limit = params.limit.unwrap_or(20).clamp(1, 50);
+    let offset = params.offset.unwrap_or(0);
+
+    let (sportify_client, cache_cfg, db) = {
+        let s = state.read().await;
+        (
+            s.sportify_client.clone(),
+            s.sportify_cache_config,
+            s.db.clone(),
+        )
+    };
+    let Some(sportify_client) = sportify_client else {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({ "error": "sportify_unavailable" })),
+        ));
+    };
+
+    let cached = db
+        .with_conn(|conn| sp_cache::get_search(conn, &cache_cfg, q, kind, limit, offset))
+        .map_err(internal)?;
+
+    let payload = match cached {
+        Some(p) => p,
+        None => {
+            let fetched = sportify_client
+                .search(q, kind, limit, offset)
+                .await
+                .map_err(|e| {
+                    (
+                        StatusCode::BAD_GATEWAY,
+                        Json(json!({ "error": format!("sportify_search: {e}") })),
+                    )
+                })?;
+            db.with_conn(|conn| sp_cache::put_search(conn, q, kind, limit, offset, &fetched))
+                .map_err(internal)?;
+            fetched
+        }
+    };
+
+    let mut normalized = normalize::search_from_sportify(&payload, "sportify_search");
+    db.with_conn(|conn| {
+        normalize::enrich_tracks_with_tidal_cache(conn, &cache_cfg, &mut normalized.tracks)?;
+        for album in normalized.albums.iter_mut() {
+            normalize::enrich_tracks_with_tidal_cache(conn, &cache_cfg, &mut album.tracks)?;
+        }
+        for playlist in normalized.playlists.iter_mut() {
+            normalize::enrich_tracks_with_tidal_cache(conn, &cache_cfg, &mut playlist.tracks)?;
+        }
+        Ok(())
+    })
+    .map_err(internal)?;
+
+    Ok(Json(serde_json::to_value(normalized).unwrap_or(json!({}))))
+}
+
+async fn sportify_discovery_track(
+    State(state): State<SharedState>,
+    Path(spotify_id): Path<String>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    use crate::services::sportify::{cache as sp_cache, normalize};
+
+    let id = spotify_id.trim();
+    if id.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "spotify_id required" })),
+        ));
+    }
+
+    let (sportify_client, cache_cfg, db) = {
+        let s = state.read().await;
+        (
+            s.sportify_client.clone(),
+            s.sportify_cache_config,
+            s.db.clone(),
+        )
+    };
+    let Some(sportify_client) = sportify_client else {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({ "error": "sportify_unavailable" })),
+        ));
+    };
+
+    let track = match db
+        .with_conn(|conn| sp_cache::get_track_meta(conn, &cache_cfg, id))
+        .map_err(internal)?
+    {
+        Some(t) => t,
+        None => {
+            let fetched = sportify_client.track(id).await.map_err(|e| {
+                (
+                    StatusCode::BAD_GATEWAY,
+                    Json(json!({ "error": format!("sportify_track_fetch: {e}") })),
+                )
+            })?;
+            db.with_conn(|conn| {
+                sp_cache::put_track_meta(conn, id, &fetched)?;
+                crate::services::sportify::stats::write_track_playcount(conn, &fetched);
+                Ok::<_, anyhow::Error>(())
+            })
+            .map_err(internal)?;
+            fetched
+        }
+    };
+
+    let mut row = normalize::track_from_sportify(&track, "sportify_track");
+    db.with_conn(|conn| {
+        normalize::enrich_tracks_with_tidal_cache(conn, &cache_cfg, std::slice::from_mut(&mut row))
+    })
+    .map_err(internal)?;
+
+    Ok(Json(serde_json::to_value(row).unwrap_or(json!({}))))
+}
+
+async fn sportify_discovery_album(
+    State(state): State<SharedState>,
+    Path(spotify_id): Path<String>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    use crate::services::sportify::{cache as sp_cache, normalize};
+
+    let id = spotify_id.trim();
+    if id.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "spotify_id required" })),
+        ));
+    }
+
+    let (sportify_client, cache_cfg, db) = {
+        let s = state.read().await;
+        (
+            s.sportify_client.clone(),
+            s.sportify_cache_config,
+            s.db.clone(),
+        )
+    };
+    let Some(sportify_client) = sportify_client else {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({ "error": "sportify_unavailable" })),
+        ));
+    };
+
+    let album = match db
+        .with_conn(|conn| sp_cache::get_album_meta(conn, &cache_cfg, id))
+        .map_err(internal)?
+    {
+        Some(a) => a,
+        None => {
+            let fetched = sportify_client.album(id).await.map_err(|e| {
+                (
+                    StatusCode::BAD_GATEWAY,
+                    Json(json!({ "error": format!("sportify_album_fetch: {e}") })),
+                )
+            })?;
+            db.with_conn(|conn| {
+                sp_cache::put_album_meta(conn, id, &fetched)?;
+                crate::services::sportify::stats::write_track_playcounts(conn, &fetched.tracks);
+                Ok::<_, anyhow::Error>(())
+            })
+            .map_err(internal)?;
+            fetched
+        }
+    };
+
+    let mut row = normalize::album_from_sportify(&album, "sportify_album");
+    let pending_ids = eager_and_lazy_resolve_for_list(&state, &album.tracks).await;
+    db.with_conn(|conn| {
+        normalize::enrich_tracks_with_tidal_cache(conn, &cache_cfg, &mut row.tracks)
+    })
+    .map_err(internal)?;
+
+    Ok(Json(json!({
+        "album": serde_json::to_value(row).unwrap_or(json!({})),
+        "pendingSpotifyIds": pending_ids,
+    })))
+}
+
+async fn sportify_discovery_playlist(
+    State(state): State<SharedState>,
+    Path(spotify_id): Path<String>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    use crate::services::sportify::{cache as sp_cache, normalize};
+
+    let id = spotify_id.trim();
+    if id.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "spotify_id required" })),
+        ));
+    }
+
+    let (sportify_client, cache_cfg, db) = {
+        let s = state.read().await;
+        (
+            s.sportify_client.clone(),
+            s.sportify_cache_config,
+            s.db.clone(),
+        )
+    };
+    let Some(sportify_client) = sportify_client else {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({ "error": "sportify_unavailable" })),
+        ));
+    };
+
+    let playlist = match db
+        .with_conn(|conn| sp_cache::get_playlist_meta(conn, &cache_cfg, id))
+        .map_err(internal)?
+    {
+        Some(p) => p,
+        None => {
+            let fetched = sportify_client.playlist(id).await.map_err(|e| {
+                (
+                    StatusCode::BAD_GATEWAY,
+                    Json(json!({ "error": format!("sportify_playlist_fetch: {e}") })),
+                )
+            })?;
+            db.with_conn(|conn| {
+                sp_cache::put_playlist_meta(conn, id, &fetched)?;
+                crate::services::sportify::stats::write_track_playcounts(conn, &fetched.tracks);
+                Ok::<_, anyhow::Error>(())
+            })
+            .map_err(internal)?;
+            fetched
+        }
+    };
+
+    let mut row = normalize::playlist_from_sportify(&playlist, "sportify_playlist");
+    db.with_conn(|conn| {
+        normalize::enrich_tracks_with_tidal_cache(conn, &cache_cfg, &mut row.tracks)
+    })
+    .map_err(internal)?;
+    let pending_ids = spawn_background_resolve_for_list(&state, &playlist.tracks).await;
+
+    Ok(Json(json!({
+        "playlist": serde_json::to_value(row).unwrap_or(json!({})),
+        "pendingSpotifyIds": pending_ids,
+    })))
+}
+
+async fn sportify_discovery_artist(
+    State(state): State<SharedState>,
+    Path(spotify_id): Path<String>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    use crate::services::sportify::{cache as sp_cache, normalize};
+
+    let id = spotify_id.trim();
+    if id.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "spotify_id required" })),
+        ));
+    }
+
+    let (sportify_client, cache_cfg, db) = {
+        let s = state.read().await;
+        (
+            s.sportify_client.clone(),
+            s.sportify_cache_config,
+            s.db.clone(),
+        )
+    };
+    let Some(sportify_client) = sportify_client else {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({ "error": "sportify_unavailable" })),
+        ));
+    };
+
+    let artist = match db
+        .with_conn(|conn| sp_cache::get_artist_meta(conn, &cache_cfg, id))
+        .map_err(internal)?
+    {
+        Some(a) => a,
+        None => {
+            let fetched = sportify_client.artist(id).await.map_err(|e| {
+                (
+                    StatusCode::BAD_GATEWAY,
+                    Json(json!({ "error": format!("sportify_artist_fetch: {e}") })),
+                )
+            })?;
+            db.with_conn(|conn| {
+                sp_cache::put_artist_meta(conn, id, &fetched)?;
+                crate::services::sportify::stats::write_artist_monthly_listeners(conn, &fetched);
+                Ok::<_, anyhow::Error>(())
+            })
+            .map_err(internal)?;
+            fetched
+        }
+    };
+
+    let row = normalize::artist_from_sportify(&artist);
+    Ok(Json(serde_json::to_value(row).unwrap_or(json!({}))))
+}
+
+async fn sportify_discovery_artist_top_tracks(
+    State(state): State<SharedState>,
+    Path(spotify_id): Path<String>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    use crate::services::sportify::{cache as sp_cache, normalize};
+
+    let id = spotify_id.trim();
+    if id.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "spotify_id required" })),
+        ));
+    }
+
+    let (sportify_client, cache_cfg, db) = {
+        let s = state.read().await;
+        (
+            s.sportify_client.clone(),
+            s.sportify_cache_config,
+            s.db.clone(),
+        )
+    };
+    let Some(sportify_client) = sportify_client else {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({ "error": "sportify_unavailable" })),
+        ));
+    };
+
+    // Top tracks aren't cached as a unit (they're a derived list); rely on
+    // the per-track meta cache to absorb repeat hits.
+    let tracks = sportify_client.artist_top_tracks(id).await.map_err(|e| {
+        (
+            StatusCode::BAD_GATEWAY,
+            Json(json!({ "error": format!("sportify_top_tracks_fetch: {e}") })),
+        )
+    })?;
+
+    db.with_conn(|conn| {
+        for t in &tracks {
+            if let Some(track_id) = t.id.as_deref() {
+                let _ = sp_cache::put_track_meta(conn, track_id, t);
+            }
+        }
+        crate::services::sportify::stats::write_track_playcounts(conn, &tracks);
+        Ok::<_, anyhow::Error>(())
+    })
+    .map_err(internal)?;
+
+    let mut rows: Vec<_> = tracks
+        .iter()
+        .map(|t| normalize::track_from_sportify(t, "sportify_artist_top_tracks"))
+        .collect();
+    let pending_ids = eager_and_lazy_resolve_for_list(&state, &tracks).await;
+    db.with_conn(|conn| normalize::enrich_tracks_with_tidal_cache(conn, &cache_cfg, &mut rows))
+        .map_err(internal)?;
+
+    Ok(Json(json!({
+        "spotifyId": id,
+        "tracks": rows,
+        "pendingSpotifyIds": pending_ids,
+    })))
+}
+
+async fn sportify_discovery_artist_related(
+    State(state): State<SharedState>,
+    Path(spotify_id): Path<String>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    use crate::services::sportify::{normalize, recommend};
+
+    let id = spotify_id.trim();
+    if id.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "spotify_id required" })),
+        ));
+    }
+
+    let (sportify_client, cache_cfg, db) = {
+        let s = state.read().await;
+        (
+            s.sportify_client.clone(),
+            s.sportify_cache_config,
+            s.db.clone(),
+        )
+    };
+    let Some(sportify_client) = sportify_client else {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({ "error": "sportify_unavailable" })),
+        ));
+    };
+
+    let related = recommend::artist_related(&sportify_client, &db, &cache_cfg, id)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::BAD_GATEWAY,
+                Json(json!({ "error": format!("sportify_related: {e}") })),
+            )
+        })?;
+
+    // Track lists go through eager+lazy resolution; albums/artists carry no
+    // tidal state since they're just navigation cards.
+    let mut top_rows: Vec<_> = related
+        .top_tracks
+        .iter()
+        .map(|t| normalize::track_from_sportify(t, "sportify_artist_related_top"))
+        .collect();
+    let mut deep_rows: Vec<_> = related
+        .deep_cuts
+        .iter()
+        .map(|t| normalize::track_from_sportify(t, "sportify_artist_related_deep"))
+        .collect();
+
+    let mut pending = Vec::new();
+    pending.extend(eager_and_lazy_resolve_for_list(&state, &related.top_tracks).await);
+    pending.extend(eager_and_lazy_resolve_for_list(&state, &related.deep_cuts).await);
+
+    db.with_conn(|conn| {
+        normalize::enrich_tracks_with_tidal_cache(conn, &cache_cfg, &mut top_rows)?;
+        normalize::enrich_tracks_with_tidal_cache(conn, &cache_cfg, &mut deep_rows)?;
+        Ok::<_, anyhow::Error>(())
+    })
+    .map_err(internal)?;
+
+    let recent_releases: Vec<_> = related
+        .recent_releases
+        .iter()
+        .map(|a| normalize::album_from_sportify(a, "sportify_artist_related_recent"))
+        .collect();
+    let similar_artists: Vec<_> = related
+        .similar_artists
+        .iter()
+        .map(normalize::artist_from_sportify)
+        .collect();
+
+    Ok(Json(json!({
+        "spotifyId": id,
+        "topTracks": top_rows,
+        "deepCuts": deep_rows,
+        "recentReleases": recent_releases,
+        "similarArtists": similar_artists,
+        "pendingSpotifyIds": pending,
+    })))
+}
+
+async fn sportify_discovery_album_related(
+    State(state): State<SharedState>,
+    Path(spotify_id): Path<String>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    use crate::services::sportify::{normalize, recommend};
+
+    let id = spotify_id.trim();
+    if id.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "spotify_id required" })),
+        ));
+    }
+
+    let (sportify_client, cache_cfg, db) = {
+        let s = state.read().await;
+        (
+            s.sportify_client.clone(),
+            s.sportify_cache_config,
+            s.db.clone(),
+        )
+    };
+    let Some(sportify_client) = sportify_client else {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({ "error": "sportify_unavailable" })),
+        ));
+    };
+
+    let related = recommend::album_related(&sportify_client, &db, &cache_cfg, id)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::BAD_GATEWAY,
+                Json(json!({ "error": format!("sportify_related: {e}") })),
+            )
+        })?;
+
+    let mut more_from_artist: Vec<_> = related
+        .more_from_artist
+        .iter()
+        .map(|t| normalize::track_from_sportify(t, "sportify_album_related"))
+        .collect();
+    let pending = eager_and_lazy_resolve_for_list(&state, &related.more_from_artist).await;
+
+    db.with_conn(|conn| {
+        normalize::enrich_tracks_with_tidal_cache(conn, &cache_cfg, &mut more_from_artist)
+    })
+    .map_err(internal)?;
+
+    let more_albums_by_artist: Vec<_> = related
+        .more_albums_by_artist
+        .iter()
+        .map(|a| normalize::album_from_sportify(a, "sportify_album_related_albums"))
+        .collect();
+
+    Ok(Json(json!({
+        "spotifyId": id,
+        "moreFromArtist": more_from_artist,
+        "moreAlbumsByArtist": more_albums_by_artist,
+        "pendingSpotifyIds": pending,
+    })))
+}
+
+async fn sportify_discovery_track_related(
+    State(state): State<SharedState>,
+    Path(spotify_id): Path<String>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    use crate::services::sportify::{normalize, recommend};
+
+    let id = spotify_id.trim();
+    if id.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "spotify_id required" })),
+        ));
+    }
+
+    let (sportify_client, cache_cfg, db) = {
+        let s = state.read().await;
+        (
+            s.sportify_client.clone(),
+            s.sportify_cache_config,
+            s.db.clone(),
+        )
+    };
+    let Some(sportify_client) = sportify_client else {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({ "error": "sportify_unavailable" })),
+        ));
+    };
+
+    let related = recommend::track_related(&sportify_client, &db, &cache_cfg, id)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::BAD_GATEWAY,
+                Json(json!({ "error": format!("sportify_related: {e}") })),
+            )
+        })?;
+
+    let mut more_from_album: Vec<_> = related
+        .more_from_album
+        .iter()
+        .map(|t| normalize::track_from_sportify(t, "sportify_track_related_album"))
+        .collect();
+    let mut more_from_artist: Vec<_> = related
+        .more_from_artist
+        .iter()
+        .map(|t| normalize::track_from_sportify(t, "sportify_track_related_artist"))
+        .collect();
+
+    let mut pending = Vec::new();
+    pending.extend(eager_and_lazy_resolve_for_list(&state, &related.more_from_album).await);
+    pending.extend(eager_and_lazy_resolve_for_list(&state, &related.more_from_artist).await);
+
+    db.with_conn(|conn| {
+        normalize::enrich_tracks_with_tidal_cache(conn, &cache_cfg, &mut more_from_album)?;
+        normalize::enrich_tracks_with_tidal_cache(conn, &cache_cfg, &mut more_from_artist)?;
+        Ok::<_, anyhow::Error>(())
+    })
+    .map_err(internal)?;
+
+    Ok(Json(json!({
+        "spotifyId": id,
+        "moreFromAlbum": more_from_album,
+        "moreFromArtist": more_from_artist,
+        "pendingSpotifyIds": pending,
+    })))
+}
+
+#[derive(Debug, Deserialize)]
+struct SaveSpotifyPlaylistBody {
+    spotify_id: String,
+    /// Override for the noor playlist name. Defaults to the Sportify
+    /// playlist title.
+    #[serde(default)]
+    name: Option<String>,
+}
+
+/// Save an ephemeral Spotify-sourced playlist into the user's library.
+///
+/// Pre-condition: the playlist's tracks have been bulk-resolved against
+/// TIDAL (the ephemeral view does this on open). Tracks without a cached
+/// resolution are skipped — we never invent a placeholder TIDAL id.
+async fn save_spotify_playlist(
+    State(state): State<SharedState>,
+    Json(body): Json<SaveSpotifyPlaylistBody>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    use crate::services::sportify::{cache as sp_cache, recommend};
+
+    let id = body.spotify_id.trim();
+    if id.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "spotify_id required" })),
+        ));
+    }
+
+    let (sportify_client, cache_cfg, db) = {
+        let s = state.read().await;
+        (
+            s.sportify_client.clone(),
+            s.sportify_cache_config,
+            s.db.clone(),
+        )
+    };
+    let Some(sportify_client) = sportify_client else {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({ "error": "sportify_unavailable" })),
+        ));
+    };
+
+    let playlist = recommend::cached_playlist(&sportify_client, &db, &cache_cfg, id)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::BAD_GATEWAY,
+                Json(json!({ "error": format!("sportify_playlist_fetch: {e}") })),
+            )
+        })?;
+
+    let playlist_name = body
+        .name
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .or_else(|| playlist.name.clone())
+        .unwrap_or_else(|| "Spotify playlist".to_string());
+
+    // Pull cached TIDAL resolutions for the playlist's tracks. Tracks without
+    // a cached hit are skipped here — the frontend should bulk-resolve before
+    // calling Save.
+    let resolutions: Vec<(crate::services::sportify::models::SportifyTrack, i64)> = db
+        .with_conn(|conn| {
+            let mut out = Vec::new();
+            for t in &playlist.tracks {
+                let Some(spotify_track_id) = t.id.as_deref() else {
+                    continue;
+                };
+                if let Some(hit) =
+                    sp_cache::get_tidal_resolution(conn, &cache_cfg, spotify_track_id)?
+                {
+                    out.push((t.clone(), hit.tidal_track_id));
+                }
+            }
+            Ok::<_, anyhow::Error>(out)
+        })
+        .map_err(internal)?;
+
+    let total_tracks = playlist.tracks.len();
+    let resolved_count = resolutions.len();
+    let unresolved_count = total_tracks.saturating_sub(resolved_count);
+
+    if resolutions.is_empty() {
+        return Err((
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(json!({
+                "error": "no_resolved_tracks",
+                "totalTracks": total_tracks,
+                "resolvedCount": 0,
+                "unresolvedCount": unresolved_count,
+            })),
+        ));
+    }
+
+    // Import each resolved TIDAL track into the local library so it has a
+    // local_id for the playlist join. Failures are skipped, not fatal.
+    let mut local_ids: Vec<i64> = Vec::with_capacity(resolutions.len());
+    let mut import_failures: usize = 0;
+    for (sp_track, tidal_id) in &resolutions {
+        let metadata = tidal_import::ImportTrackMetadata {
+            tidal_id: *tidal_id,
+            title: sp_track.name.clone().unwrap_or_default(),
+            artist_name: sp_track
+                .primary_artist()
+                .map(str::to_string)
+                .unwrap_or_default(),
+            artist_tidal_id: None,
+            artist_picture: None,
+            album_title: sp_track.album.as_ref().and_then(|a| a.name.clone()),
+            album_tidal_id: None,
+            album_artwork_url: sp_track.best_thumbnail(),
+            duration_ms: sp_track.duration_ms,
+        };
+        match tidal_import::import_track_from_metadata(&db, metadata).await {
+            Ok(imported) => local_ids.push(imported.local_id),
+            Err(e) => {
+                tracing::warn!(
+                    "save_spotify_playlist: import failed for tidal_id {}: {}",
+                    tidal_id,
+                    e
+                );
+                import_failures += 1;
+            }
+        }
+    }
+
+    if local_ids.is_empty() {
+        return Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({
+                "error": "all_imports_failed",
+                "totalTracks": total_tracks,
+                "resolvedCount": resolved_count,
+                "importFailures": import_failures,
+            })),
+        ));
+    }
+
+    // Create the playlist row and bulk-add tracks in a single transaction.
+    let result = db
+        .with_conn(|conn| {
+            conn.execute(
+                "INSERT INTO playlists (name, description, is_smart, is_synced, track_count)
+                 VALUES (?1, ?2, 0, 0, 0)",
+                params![playlist_name, playlist.description],
+            )?;
+            let playlist_id = conn.last_insert_rowid();
+            let added = queries::add_tracks_to_playlist(conn, playlist_id, &local_ids)?;
+            let row = queries::get_playlist(conn, playlist_id)?
+                .ok_or_else(|| anyhow::anyhow!("playlist not found after insert"))?;
+            Ok::<_, anyhow::Error>((row, added))
+        })
+        .map_err(internal)?;
+
+    Ok(Json(json!({
+        "playlist": result.0,
+        "added": result.1,
+        "totalTracks": total_tracks,
+        "resolvedCount": resolved_count,
+        "unresolvedCount": unresolved_count,
+        "importFailures": import_failures,
+    })))
+}
+
+fn internal<E: std::fmt::Display>(e: E) -> (StatusCode, Json<Value>) {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(json!({ "error": e.to_string() })),
+    )
+}
+
 async fn get_discovery_space(
     State(state): State<SharedState>,
     Json(payload): Json<DiscoverySpaceRequest>,
@@ -3773,11 +5283,13 @@ async fn radio_start(
     // Build queue atomically and collect pending row IDs for background tasks.
     let build = db
         .with_conn(move |conn| {
-            Ok(crate::server::radio_pipeline::build_radio_queue_from_candidates(
-                conn,
-                payload.seed_track_id,
-                radio_queue.tracks,
-            )?)
+            Ok(
+                crate::server::radio_pipeline::build_radio_queue_from_candidates(
+                    conn,
+                    payload.seed_track_id,
+                    radio_queue.tracks,
+                )?,
+            )
         })
         .map_err(|e| {
             tracing::error!("radio_start: queue build failed: {e}");
@@ -5503,16 +7015,109 @@ async fn search(
     State(state): State<SharedState>,
     Query(params): Query<SearchParams>,
 ) -> Result<Json<Value>, StatusCode> {
-    let state = state.read().await;
     let limit = params.limit.unwrap_or(20);
 
-    state
-        .db
-        .with_conn(|conn| {
-            let results = queries::search(conn, &params.q, limit)?;
-            Ok(Json(json!(results)))
+    // Snapshot what each side needs without holding the read lock across the
+    // Sportify HTTP call.
+    let (db, sportify_client, cache_cfg) = {
+        let s = state.read().await;
+        (
+            s.db.clone(),
+            s.sportify_client.clone(),
+            s.sportify_cache_config,
+        )
+    };
+
+    // Local DB search — must succeed; this is the existing contract.
+    let local = db
+        .with_conn(|conn| queries::search(conn, &params.q, limit))
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    // Sportify playlist results — best-effort, never fails the request.
+    // Sportify is upstream and subject to breakage; we'd rather show local
+    // results with no Spotify bucket than 500 the search.
+    let spotify_playlists = match sportify_client {
+        Some(client) => fetch_spotify_playlist_search_compact(
+            &client,
+            &db,
+            &cache_cfg,
+            &params.q,
+            limit.min(20).max(1) as u32,
+        )
+        .await
+        .unwrap_or_else(|e| {
+            tracing::warn!("sportify playlist search failed: {}", e);
+            Vec::new()
+        }),
+        None => Vec::new(),
+    };
+
+    Ok(Json(json!({
+        "tracks": local.tracks,
+        "albums": local.albums,
+        "artists": local.artists,
+        "spotify_playlists": spotify_playlists,
+    })))
+}
+
+/// Compact playlist-search result tailored for inline rendering in /search
+/// and Ctrl+K. Drops the heavyweight track-list payload — the ephemeral
+/// view fetches that on click.
+#[derive(Debug, Serialize)]
+struct SpotifyPlaylistSearchItem {
+    spotify_id: String,
+    name: String,
+    description: Option<String>,
+    image_url: Option<String>,
+    owner: Option<String>,
+    follower_count: Option<i64>,
+    total_tracks: Option<i32>,
+}
+
+async fn fetch_spotify_playlist_search_compact(
+    client: &crate::services::sportify::SportifyClient,
+    db: &crate::db::Database,
+    cfg: &crate::services::sportify::cache::SportifyCacheConfig,
+    query: &str,
+    limit: u32,
+) -> anyhow::Result<Vec<SpotifyPlaylistSearchItem>> {
+    use crate::services::sportify::client::SportifySearchKind;
+    use crate::services::sportify::recommend::cached_search;
+
+    if query.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let results = cached_search(
+        client,
+        db,
+        cfg,
+        query,
+        SportifySearchKind::Playlist,
+        limit,
+        0,
+    )
+    .await?;
+
+    Ok(results
+        .playlists
+        .into_iter()
+        .filter_map(|p| {
+            let id = p.spotify_id()?;
+            Some(SpotifyPlaylistSearchItem {
+                spotify_id: id,
+                name: p.title().unwrap_or_default(),
+                description: p.description.clone(),
+                image_url: p.best_thumbnail(),
+                owner: p
+                    .owner
+                    .as_ref()
+                    .and_then(|o| o.display_name().map(str::to_string)),
+                follower_count: p.follower_count(),
+                total_tracks: p.total_track_count(),
+            })
         })
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+        .collect())
 }
 
 #[derive(Debug, Deserialize)]
@@ -6348,17 +7953,21 @@ async fn resolve_pending_row(
     };
 
     let client = TidalClient::new(tokens.access_token.clone(), tokens.country_code.clone());
-    let resolved =
-        match find_pending_tidal_match(&client, &pending_artist, &pending_title, tidal_id_hint)
-            .await
-        {
-            Ok(r) => r,
-            Err(e) => {
-                tracing::warn!(queue_item_id, error = %e, "background resolver: Tidal resolve failed");
-                release(&db, queue_item_id);
-                return;
-            }
-        };
+    let resolved = match find_pending_tidal_match(
+        &client,
+        &pending_artist,
+        &pending_title,
+        tidal_id_hint,
+    )
+    .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!(queue_item_id, error = %e, "background resolver: Tidal resolve failed");
+            release(&db, queue_item_id);
+            return;
+        }
+    };
 
     let (score, metadata) = match resolved {
         Some(p) => p,
@@ -6509,8 +8118,7 @@ async fn resolve_pending_current_queue_item(
         let s = state.read().await;
         s.event_tx.clone()
     };
-    let promoted =
-        promote_pending_row_emit(&db, &event_tx, queue_item_id, local_id, score_stored);
+    let promoted = promote_pending_row_emit(&db, &event_tx, queue_item_id, local_id, score_stored);
 
     if !promoted {
         return None;
@@ -6524,9 +8132,7 @@ async fn resolve_pending_current_queue_item(
         )
         .map_err(anyhow::Error::from)
     });
-    let _ = event_tx.send(AppEvent::TrackChanged {
-        track_id: local_id,
-    });
+    let _ = event_tx.send(AppEvent::TrackChanged { track_id: local_id });
     let _ = event_tx.send(AppEvent::PlaybackStateChanged);
 
     db.with_conn(move |conn| queue::get_track_by_id(conn, local_id))
@@ -7087,12 +8693,8 @@ async fn queue_append(
     State(state): State<SharedState>,
     Json(payload): Json<QueueExternalRequest>,
 ) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
-    let insert = queue_external_insert(&payload, "user_queue").map_err(|message| {
-        (
-            StatusCode::BAD_REQUEST,
-            Json(json!({ "error": message })),
-        )
-    })?;
+    let insert = queue_external_insert(&payload, "user_queue")
+        .map_err(|message| (StatusCode::BAD_REQUEST, Json(json!({ "error": message }))))?;
 
     let (queue, inserted) = {
         let state_guard = state.read().await;
@@ -7123,16 +8725,57 @@ async fn queue_append(
     Ok(Json(json!({ "queue": queue })))
 }
 
+async fn queue_append_many(
+    State(state): State<SharedState>,
+    Json(payload): Json<QueueExternalManyRequest>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    let inserts: Vec<_> = payload
+        .items
+        .iter()
+        .map(|item| queue_external_insert(item, "user_queue"))
+        .collect::<Result<_, _>>()
+        .map_err(|message| (StatusCode::BAD_REQUEST, Json(json!({ "error": message }))))?;
+
+    let (queue, inserted) = {
+        let state_guard = state.read().await;
+        state_guard
+            .user_cleared_at
+            .store(0, std::sync::atomic::Ordering::Relaxed);
+        let event_tx = state_guard.event_tx.clone();
+        state_guard
+            .db
+            .with_conn(|conn| {
+                let mut inserted = Vec::with_capacity(inserts.len());
+                for insert in &inserts {
+                    inserted.push(queue::append_external_track(conn, insert)?);
+                }
+                let queue = queue::load_queue(conn)?;
+                let _ = event_tx.send(AppEvent::QueueUpdated);
+                Ok((queue, inserted))
+            })
+            .map_err(|_| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({ "error": "failed to append queue items" })),
+                )
+            })?
+    };
+
+    for item in inserted {
+        if let queue::InsertResult::Pending { queue_id } = item {
+            spawn_pending_queue_resolver(&state, queue_id).await;
+        }
+    }
+
+    Ok(Json(json!({ "queue": queue })))
+}
+
 async fn queue_play_next(
     State(state): State<SharedState>,
     Json(payload): Json<QueueExternalRequest>,
 ) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
-    let insert = queue_external_insert(&payload, "user_play_next").map_err(|message| {
-        (
-            StatusCode::BAD_REQUEST,
-            Json(json!({ "error": message })),
-        )
-    })?;
+    let insert = queue_external_insert(&payload, "user_play_next")
+        .map_err(|message| (StatusCode::BAD_REQUEST, Json(json!({ "error": message }))))?;
 
     let (queue, inserted) = {
         let state_guard = state.read().await;
@@ -7161,6 +8804,63 @@ async fn queue_play_next(
 
     if let queue::InsertResult::Pending { queue_id } = inserted {
         spawn_pending_queue_resolver(&state, queue_id).await;
+    }
+
+    Ok(Json(json!({ "queue": queue })))
+}
+
+async fn queue_play_next_many(
+    State(state): State<SharedState>,
+    Json(payload): Json<QueueExternalManyRequest>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    let inserts: Vec<_> = payload
+        .items
+        .iter()
+        .map(|item| queue_external_insert(item, "user_play_next"))
+        .collect::<Result<_, _>>()
+        .map_err(|message| (StatusCode::BAD_REQUEST, Json(json!({ "error": message }))))?;
+
+    let (queue, inserted) = {
+        let state_guard = state.read().await;
+        state_guard
+            .user_cleared_at
+            .store(0, std::sync::atomic::Ordering::Relaxed);
+        let event_tx = state_guard.event_tx.clone();
+        state_guard
+            .db
+            .with_conn(|conn| {
+                let mut inserted = Vec::with_capacity(inserts.len());
+                match current_queue_position(conn)? {
+                    Some(position) => {
+                        // Insert in reverse so repeated "after current" inserts preserve
+                        // the caller's original order in the queue.
+                        for insert in inserts.iter().rev() {
+                            inserted
+                                .push(queue::insert_external_track_after(conn, insert, position)?);
+                        }
+                    }
+                    None => {
+                        for insert in &inserts {
+                            inserted.push(queue::append_external_track(conn, insert)?);
+                        }
+                    }
+                }
+                let queue = queue::load_queue(conn)?;
+                let _ = event_tx.send(AppEvent::QueueUpdated);
+                Ok((queue, inserted))
+            })
+            .map_err(|_| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({ "error": "failed to insert queue items" })),
+                )
+            })?
+    };
+
+    for item in inserted {
+        if let queue::InsertResult::Pending { queue_id } = item {
+            spawn_pending_queue_resolver(&state, queue_id).await;
+        }
     }
 
     Ok(Json(json!({ "queue": queue })))
@@ -7619,6 +9319,7 @@ async fn tidal_logout(State(state): State<SharedState>) -> Json<Value> {
 struct TidalSearchParams {
     q: String,
     limit: Option<i32>,
+    offset: Option<i32>,
 }
 
 #[derive(Serialize)]
@@ -7679,10 +9380,11 @@ async fn tidal_search(
     };
 
     let limit = params.limit.unwrap_or(20).min(50);
+    let offset = params.offset.unwrap_or(0).max(0);
     let http_client = state.read().await.http_client.clone();
 
     let client = TidalClient::new(tokens.access_token.clone(), tokens.country_code.clone());
-    let results = match client.search_catalog(&params.q, limit).await {
+    let results = match client.search_catalog(&params.q, limit, offset).await {
         Ok(r) => r,
         Err(e) if error_looks_like_auth(&e) => {
             let refreshed = recover_tidal_session(&state, &http_client, &tokens)
@@ -7698,7 +9400,7 @@ async fn tidal_search(
                 refreshed.country_code.clone(),
             );
             retry_client
-                .search_catalog(&params.q, limit)
+                .search_catalog(&params.q, limit, offset)
                 .await
                 .map_err(|e2| {
                     (
@@ -7794,6 +9496,8 @@ struct TidalPlaylistSearchParams {
     q: String,
     #[serde(default)]
     limit: Option<i32>,
+    #[serde(default)]
+    offset: Option<i32>,
 }
 
 async fn tidal_playlist_search(
@@ -7818,9 +9522,10 @@ async fn tidal_playlist_search(
     };
 
     let limit = params.limit.unwrap_or(20).min(50);
+    let offset = params.offset.unwrap_or(0).max(0);
     let http_client = state.read().await.http_client.clone();
     let client = TidalClient::new(tokens.access_token.clone(), tokens.country_code.clone());
-    let playlists = match client.search_playlists(&params.q, limit).await {
+    let playlists = match client.search_playlists(&params.q, limit, offset).await {
         Ok(r) => r,
         Err(e) if error_looks_like_auth(&e) => {
             let refreshed = recover_tidal_session(&state, &http_client, &tokens)
@@ -7836,7 +9541,7 @@ async fn tidal_playlist_search(
                 refreshed.country_code.clone(),
             );
             retry_client
-                .search_playlists(&params.q, limit)
+                .search_playlists(&params.q, limit, offset)
                 .await
                 .map_err(|e2| {
                     (
@@ -12200,6 +13905,10 @@ mod tests {
             audio_active: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             user_cleared_at: Arc::new(std::sync::atomic::AtomicI64::new(0)),
             spotify_public_stats_enabled: false,
+            sportify_client: None,
+            sportify_cache_config: crate::services::sportify::cache::SportifyCacheConfig::default(),
+            sportify_resolve_config:
+                crate::services::sportify::cache::SportifyResolveConfig::default(),
         }
     }
 
@@ -12224,7 +13933,10 @@ mod tests {
 
     fn seed_basic_tracks(db: &Database) {
         db.with_conn(|conn| {
-            conn.execute("INSERT INTO artists (id, name) VALUES (1, 'Seed Artist')", [])?;
+            conn.execute(
+                "INSERT INTO artists (id, name) VALUES (1, 'Seed Artist')",
+                [],
+            )?;
             conn.execute(
                 "INSERT INTO tracks (
                     id, title, artist_id, duration_ms, source, fidelity_score
@@ -12347,9 +14059,11 @@ mod tests {
 
         let source: String = db
             .with_conn(|conn| {
-                Ok(conn.query_row("SELECT source FROM queue WHERE track_id = 1", [], |row| {
-                    row.get(0)
-                })?)
+                Ok(
+                    conn.query_row("SELECT source FROM queue WHERE track_id = 1", [], |row| {
+                        row.get(0)
+                    })?,
+                )
             })
             .unwrap();
         assert_eq!(source, "user_queue");
@@ -12429,18 +14143,107 @@ mod tests {
                 )?)
             })
             .unwrap();
-        assert_eq!(pending, (1, "user_play_next".into(), "External Artist".into(), "External Title".into(), Some(777)));
+        assert_eq!(
+            pending,
+            (
+                1,
+                "user_play_next".into(),
+                "External Artist".into(),
+                "External Title".into(),
+                Some(777)
+            )
+        );
 
         let shifted_pos: i32 = db
             .with_conn(|conn| {
-                Ok(conn.query_row(
-                    "SELECT position FROM queue WHERE track_id = 2",
-                    [],
-                    |row| row.get(0),
-                )?)
+                Ok(
+                    conn.query_row("SELECT position FROM queue WHERE track_id = 2", [], |row| {
+                        row.get(0)
+                    })?,
+                )
             })
             .unwrap();
         assert_eq!(shifted_pos, 2);
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[tokio::test]
+    async fn queue_play_next_many_preserves_requested_order() {
+        let (db, db_path) = fresh_migrated_db();
+        seed_basic_tracks(&db);
+        db.with_conn(|conn| {
+            conn.execute(
+                "INSERT INTO queue (track_id, position, source) VALUES (1, 0, 'user')",
+                [],
+            )?;
+            let qid = conn.last_insert_rowid();
+            conn.execute(
+                "INSERT INTO queue (track_id, position, source) VALUES (2, 1, 'user')",
+                [],
+            )?;
+            conn.execute(
+                "UPDATE playback_state
+                 SET current_track_id = 1, current_queue_item_id = ?1, is_playing = 1
+                 WHERE id = 1",
+                rusqlite::params![qid],
+            )?;
+            Ok(())
+        })
+        .unwrap();
+
+        let app = api_routes(Arc::new(tokio::sync::RwLock::new(fresh_test_state(
+            db.clone(),
+        ))));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/queue/play_next_many")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"items":[
+                            {"kind":"tidal","tidal_id":101,"artist":"A","title":"First external"},
+                            {"kind":"tidal","tidal_id":102,"artist":"B","title":"Second external"}
+                        ]}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: Value = serde_json::from_slice(
+            &axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(body["queue"].as_array().unwrap().len(), 4);
+        assert_eq!(body["queue"][1]["track"]["title"], "First external");
+        assert_eq!(body["queue"][2]["track"]["title"], "Second external");
+        assert_eq!(body["queue"][3]["track"]["id"], 2);
+
+        let rows: Vec<(i32, String, Option<i64>)> = db
+            .with_conn(|conn| {
+                let mut stmt = conn.prepare(
+                    "SELECT position, pending_title, tidal_id_hint
+                     FROM queue
+                     WHERE track_id IS NULL
+                     ORDER BY position ASC",
+                )?;
+                Ok(stmt
+                    .query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))?
+                    .collect::<rusqlite::Result<Vec<_>>>()?)
+            })
+            .unwrap();
+        assert_eq!(
+            rows,
+            vec![
+                (1, "First external".to_string(), Some(101)),
+                (2, "Second external".to_string(), Some(102)),
+            ]
+        );
 
         let _ = std::fs::remove_file(db_path);
     }
@@ -12524,11 +14327,11 @@ mod tests {
 
         let queue_item_id: i64 = db
             .with_conn(|conn| {
-                Ok(conn.query_row(
-                    "SELECT id FROM queue WHERE track_id IS NULL",
-                    [],
-                    |row| row.get(0),
-                )?)
+                Ok(
+                    conn.query_row("SELECT id FROM queue WHERE track_id IS NULL", [], |row| {
+                        row.get(0)
+                    })?,
+                )
             })
             .unwrap();
 
@@ -12559,7 +14362,10 @@ mod tests {
         let again = promote_pending_row_emit(&db, &event_tx, queue_item_id, 1, 950);
         assert!(!again);
         let no_more = tokio::time::timeout(std::time::Duration::from_millis(100), rx.recv()).await;
-        assert!(no_more.is_err(), "no second event should fire on idempotent retry");
+        assert!(
+            no_more.is_err(),
+            "no second event should fire on idempotent retry"
+        );
 
         let _ = std::fs::remove_file(db_path);
     }

--- a/noor-server/src/services/discovery.rs
+++ b/noor-server/src/services/discovery.rs
@@ -217,7 +217,7 @@ impl DiscoveryProvider for TidalDiscoveryProvider {
         for query in queries {
             let catalog = self
                 .client
-                .search_catalog(query, limit_per_query as i32)
+                .search_catalog(query, limit_per_query as i32, 0)
                 .await?;
             tracks.extend(
                 self.collect_catalog_tracks(query, catalog, limit_per_query)
@@ -241,7 +241,7 @@ impl DiscoveryProvider for TidalDiscoveryProvider {
                 seed.artist_name.as_deref().unwrap_or_default(),
                 album_title
             );
-            let catalog = self.client.search_catalog(&album_query, 4).await?;
+            let catalog = self.client.search_catalog(&album_query, 4, 0).await?;
             tracks.extend(
                 self.collect_catalog_tracks(&album_query, catalog, limit_per_query)
                     .await?
@@ -257,7 +257,7 @@ impl DiscoveryProvider for TidalDiscoveryProvider {
         for query in queries {
             let catalog = self
                 .client
-                .search_catalog(query, limit_per_query as i32)
+                .search_catalog(query, limit_per_query as i32, 0)
                 .await?;
             tracks.extend(
                 self.collect_catalog_tracks(query, catalog, limit_per_query)

--- a/noor-server/src/services/mod.rs
+++ b/noor-server/src/services/mod.rs
@@ -15,4 +15,5 @@ pub mod radio_config;
 pub mod rss_feeds;
 pub mod spotify;
 pub mod spotify_public;
+pub mod sportify;
 pub mod tidal;

--- a/noor-server/src/services/sportify/cache.rs
+++ b/noor-server/src/services/sportify/cache.rs
@@ -1,0 +1,530 @@
+// Phase 1 scaffolding: every cache fn here is wired up by phases 2-4
+// (resolver, route handlers, bulk resolve). The dead-code allow comes off
+// once those land.
+#![allow(dead_code)]
+
+//! SQLite-backed cache for Sportify metadata + Spotify→TIDAL resolutions.
+//!
+//! Tables created by `MIGRATION_031`:
+//!   sportify_track_meta, sportify_album_meta,
+//!   sportify_artist_meta, sportify_playlist_meta — entity caches
+//!   sportify_track_map     — successful Spotify→TIDAL mappings
+//!   sportify_unresolved    — negative cache (gives up to N attempts)
+//!   sportify_search_cache  — search-result cache keyed by query hash
+
+use anyhow::{Context, Result};
+use rusqlite::{Connection, OptionalExtension, params};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use super::client::SportifySearchKind;
+use super::models::{
+    SportifyAlbum, SportifyArtist, SportifyPlaylist, SportifySearchResults, SportifyTrack,
+};
+
+const DEFAULT_TTL_SECS: i64 = 30 * 24 * 60 * 60; // 30 days
+const DEFAULT_RESOLVE_TTL_SECS: i64 = 30 * 24 * 60 * 60;
+const DEFAULT_RETRY_AFTER_SECS: i64 = 7 * 24 * 60 * 60;
+pub const DEFAULT_EAGER_N: usize = 10;
+pub const DEFAULT_BULK_CONCURRENCY: usize = 6;
+
+/// Eager-first-N + lazy-rest tunables for the discovery list endpoints.
+#[derive(Debug, Clone, Copy)]
+pub struct SportifyResolveConfig {
+    /// How many pending tracks the request resolves synchronously before
+    /// responding. The rest are spawned into a background task.
+    pub eager_n: usize,
+    /// Max concurrent TIDAL searches when resolving a batch.
+    pub bulk_concurrency: usize,
+}
+
+impl Default for SportifyResolveConfig {
+    fn default() -> Self {
+        Self {
+            eager_n: DEFAULT_EAGER_N,
+            bulk_concurrency: DEFAULT_BULK_CONCURRENCY,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct SportifyCacheConfig {
+    pub meta_ttl_secs: i64,
+    pub resolve_ttl_secs: i64,
+    pub unresolved_retry_after_secs: i64,
+}
+
+impl Default for SportifyCacheConfig {
+    fn default() -> Self {
+        Self {
+            meta_ttl_secs: DEFAULT_TTL_SECS,
+            resolve_ttl_secs: DEFAULT_RESOLVE_TTL_SECS,
+            unresolved_retry_after_secs: DEFAULT_RETRY_AFTER_SECS,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CachedTidalResolution {
+    pub spotify_track_id: String,
+    pub tidal_track_id: i64,
+    pub confidence: f64,
+    pub match_reason: Option<String>,
+    pub resolved_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UnresolvedRecord {
+    pub spotify_track_id: String,
+    pub last_attempt_at: i64,
+    pub attempts: i64,
+    pub reason: Option<String>,
+}
+
+fn now_secs() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+fn fresh(fetched_at: i64, ttl: i64) -> bool {
+    now_secs().saturating_sub(fetched_at) < ttl
+}
+
+fn hash_query(query: &str, kind: SportifySearchKind, limit: u32, offset: u32) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(kind.as_str().as_bytes());
+    hasher.update(b"\0");
+    hasher.update(query.trim().to_lowercase().as_bytes());
+    hasher.update(format!("|{}|{}", limit, offset).as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+// `hex` is not in the existing dep tree; we encode by hand to avoid a new dep.
+mod hex {
+    pub fn encode(bytes: impl AsRef<[u8]>) -> String {
+        const HEX: &[u8; 16] = b"0123456789abcdef";
+        let bytes = bytes.as_ref();
+        let mut out = String::with_capacity(bytes.len() * 2);
+        for b in bytes {
+            out.push(HEX[(b >> 4) as usize] as char);
+            out.push(HEX[(b & 0x0f) as usize] as char);
+        }
+        out
+    }
+}
+
+fn read_meta<T: DeserializeOwned>(
+    conn: &Connection,
+    table: &str,
+    id_column: &str,
+    id: &str,
+    ttl: i64,
+) -> Result<Option<T>> {
+    let sql = format!(
+        "SELECT payload, fetched_at FROM {} WHERE {} = ?1",
+        table, id_column
+    );
+    let row: Option<(String, i64)> = conn
+        .query_row(&sql, params![id], |row| Ok((row.get(0)?, row.get(1)?)))
+        .optional()
+        .with_context(|| format!("read {}", table))?;
+
+    match row {
+        Some((json, fetched_at)) if fresh(fetched_at, ttl) => {
+            let parsed = serde_json::from_str(&json)
+                .with_context(|| format!("decode cached {} payload", table))?;
+            Ok(Some(parsed))
+        }
+        _ => Ok(None),
+    }
+}
+
+fn write_meta<T: Serialize>(
+    conn: &Connection,
+    table: &str,
+    id_column: &str,
+    id: &str,
+    payload: &T,
+) -> Result<()> {
+    let json = serde_json::to_string(payload)
+        .with_context(|| format!("serialize {} payload", table))?;
+    let sql = format!(
+        "INSERT INTO {tbl} ({col}, payload, fetched_at) VALUES (?1, ?2, ?3)
+         ON CONFLICT({col}) DO UPDATE SET payload = excluded.payload, fetched_at = excluded.fetched_at",
+        tbl = table,
+        col = id_column,
+    );
+    conn.execute(&sql, params![id, json, now_secs()])
+        .with_context(|| format!("write {}", table))?;
+    Ok(())
+}
+
+pub fn get_track_meta(
+    conn: &Connection,
+    cfg: &SportifyCacheConfig,
+    spotify_id: &str,
+) -> Result<Option<SportifyTrack>> {
+    read_meta(
+        conn,
+        "sportify_track_meta",
+        "spotify_track_id",
+        spotify_id,
+        cfg.meta_ttl_secs,
+    )
+}
+
+pub fn put_track_meta(conn: &Connection, spotify_id: &str, payload: &SportifyTrack) -> Result<()> {
+    write_meta(conn, "sportify_track_meta", "spotify_track_id", spotify_id, payload)
+}
+
+pub fn get_album_meta(
+    conn: &Connection,
+    cfg: &SportifyCacheConfig,
+    spotify_id: &str,
+) -> Result<Option<SportifyAlbum>> {
+    read_meta(
+        conn,
+        "sportify_album_meta",
+        "spotify_album_id",
+        spotify_id,
+        cfg.meta_ttl_secs,
+    )
+}
+
+pub fn put_album_meta(conn: &Connection, spotify_id: &str, payload: &SportifyAlbum) -> Result<()> {
+    write_meta(conn, "sportify_album_meta", "spotify_album_id", spotify_id, payload)
+}
+
+pub fn get_artist_meta(
+    conn: &Connection,
+    cfg: &SportifyCacheConfig,
+    spotify_id: &str,
+) -> Result<Option<SportifyArtist>> {
+    read_meta(
+        conn,
+        "sportify_artist_meta",
+        "spotify_artist_id",
+        spotify_id,
+        cfg.meta_ttl_secs,
+    )
+}
+
+pub fn put_artist_meta(conn: &Connection, spotify_id: &str, payload: &SportifyArtist) -> Result<()> {
+    write_meta(conn, "sportify_artist_meta", "spotify_artist_id", spotify_id, payload)
+}
+
+pub fn get_playlist_meta(
+    conn: &Connection,
+    cfg: &SportifyCacheConfig,
+    spotify_id: &str,
+) -> Result<Option<SportifyPlaylist>> {
+    let row: Option<(String, i64)> = conn
+        .query_row(
+            "SELECT payload, fetched_at FROM sportify_playlist_meta
+             WHERE spotify_playlist_id = ?1",
+            params![spotify_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .optional()
+        .context("read sportify_playlist_meta")?;
+
+    match row {
+        Some((json, fetched_at)) if fresh(fetched_at, cfg.meta_ttl_secs) => {
+            let parsed: SportifyPlaylist =
+                serde_json::from_str(&json).context("decode cached playlist payload")?;
+            Ok(Some(parsed))
+        }
+        _ => Ok(None),
+    }
+}
+
+pub fn put_playlist_meta(
+    conn: &Connection,
+    spotify_id: &str,
+    payload: &SportifyPlaylist,
+) -> Result<()> {
+    let json = serde_json::to_string(payload).context("serialize playlist")?;
+    let snapshot = payload.snapshot_id.clone();
+    conn.execute(
+        "INSERT INTO sportify_playlist_meta
+            (spotify_playlist_id, payload, snapshot_id, fetched_at)
+         VALUES (?1, ?2, ?3, ?4)
+         ON CONFLICT(spotify_playlist_id) DO UPDATE SET
+            payload = excluded.payload,
+            snapshot_id = excluded.snapshot_id,
+            fetched_at = excluded.fetched_at",
+        params![spotify_id, json, snapshot, now_secs()],
+    )
+    .context("write sportify_playlist_meta")?;
+    Ok(())
+}
+
+pub fn get_search(
+    conn: &Connection,
+    cfg: &SportifyCacheConfig,
+    query: &str,
+    kind: SportifySearchKind,
+    limit: u32,
+    offset: u32,
+) -> Result<Option<SportifySearchResults>> {
+    let key = hash_query(query, kind, limit, offset);
+    let row: Option<(String, i64)> = conn
+        .query_row(
+            "SELECT payload, fetched_at FROM sportify_search_cache WHERE query_hash = ?1",
+            params![key],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .optional()
+        .context("read sportify_search_cache")?;
+
+    match row {
+        Some((json, fetched_at)) if fresh(fetched_at, cfg.meta_ttl_secs) => {
+            let parsed: SportifySearchResults =
+                serde_json::from_str(&json).context("decode cached search payload")?;
+            // A previous playlist parser could cache an empty first page even
+            // though Sportify returned rows in an unhandled shape. Treat that
+            // specific cache entry as stale so search can recover immediately
+            // after parser fixes, while preserving empty later pages.
+            if matches!(kind, SportifySearchKind::Playlist)
+                && offset == 0
+                && parsed.playlists.is_empty()
+            {
+                Ok(None)
+            } else {
+                Ok(Some(parsed))
+            }
+        }
+        _ => Ok(None),
+    }
+}
+
+pub fn put_search(
+    conn: &Connection,
+    query: &str,
+    kind: SportifySearchKind,
+    limit: u32,
+    offset: u32,
+    payload: &SportifySearchResults,
+) -> Result<()> {
+    let key = hash_query(query, kind, limit, offset);
+    let json = serde_json::to_string(payload).context("serialize search results")?;
+    conn.execute(
+        "INSERT INTO sportify_search_cache (query_hash, kind, payload, fetched_at)
+         VALUES (?1, ?2, ?3, ?4)
+         ON CONFLICT(query_hash) DO UPDATE SET
+            kind = excluded.kind,
+            payload = excluded.payload,
+            fetched_at = excluded.fetched_at",
+        params![key, kind.as_str(), json, now_secs()],
+    )
+    .context("write sportify_search_cache")?;
+    Ok(())
+}
+
+// ─── Resolution map ──────────────────────────────────────────
+
+pub fn get_tidal_resolution(
+    conn: &Connection,
+    cfg: &SportifyCacheConfig,
+    spotify_track_id: &str,
+) -> Result<Option<CachedTidalResolution>> {
+    let row: Option<(String, i64, f64, Option<String>, i64)> = conn
+        .query_row(
+            "SELECT spotify_track_id, tidal_track_id, confidence, match_reason, resolved_at
+             FROM sportify_track_map WHERE spotify_track_id = ?1",
+            params![spotify_track_id],
+            |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                ))
+            },
+        )
+        .optional()
+        .context("read sportify_track_map")?;
+
+    match row {
+        Some((id, tidal, conf, reason, at)) if fresh(at, cfg.resolve_ttl_secs) => {
+            Ok(Some(CachedTidalResolution {
+                spotify_track_id: id,
+                tidal_track_id: tidal,
+                confidence: conf,
+                match_reason: reason,
+                resolved_at: at,
+            }))
+        }
+        _ => Ok(None),
+    }
+}
+
+pub fn put_tidal_resolution(
+    conn: &Connection,
+    spotify_track_id: &str,
+    tidal_track_id: i64,
+    confidence: f64,
+    match_reason: Option<&str>,
+) -> Result<()> {
+    conn.execute(
+        "INSERT INTO sportify_track_map
+            (spotify_track_id, tidal_track_id, confidence, match_reason, resolved_at)
+         VALUES (?1, ?2, ?3, ?4, ?5)
+         ON CONFLICT(spotify_track_id) DO UPDATE SET
+            tidal_track_id = excluded.tidal_track_id,
+            confidence = excluded.confidence,
+            match_reason = excluded.match_reason,
+            resolved_at = excluded.resolved_at",
+        params![
+            spotify_track_id,
+            tidal_track_id,
+            confidence,
+            match_reason,
+            now_secs()
+        ],
+    )
+    .context("write sportify_track_map")?;
+    // A successful resolution invalidates any prior unresolved record.
+    conn.execute(
+        "DELETE FROM sportify_unresolved WHERE spotify_track_id = ?1",
+        params![spotify_track_id],
+    )
+    .ok();
+    Ok(())
+}
+
+pub fn get_unresolved(
+    conn: &Connection,
+    spotify_track_id: &str,
+) -> Result<Option<UnresolvedRecord>> {
+    let row: Option<(String, i64, i64, Option<String>)> = conn
+        .query_row(
+            "SELECT spotify_track_id, last_attempt_at, attempts, reason
+             FROM sportify_unresolved WHERE spotify_track_id = ?1",
+            params![spotify_track_id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .optional()
+        .context("read sportify_unresolved")?;
+
+    Ok(row.map(|(id, at, attempts, reason)| UnresolvedRecord {
+        spotify_track_id: id,
+        last_attempt_at: at,
+        attempts,
+        reason,
+    }))
+}
+
+/// True if we should skip a fresh attempt (the row was tried recently).
+pub fn unresolved_is_cold(record: &UnresolvedRecord, cfg: &SportifyCacheConfig) -> bool {
+    now_secs().saturating_sub(record.last_attempt_at) < cfg.unresolved_retry_after_secs
+}
+
+pub fn put_unresolved(
+    conn: &Connection,
+    spotify_track_id: &str,
+    reason: Option<&str>,
+) -> Result<()> {
+    conn.execute(
+        "INSERT INTO sportify_unresolved
+            (spotify_track_id, last_attempt_at, attempts, reason)
+         VALUES (?1, ?2, 1, ?3)
+         ON CONFLICT(spotify_track_id) DO UPDATE SET
+            last_attempt_at = excluded.last_attempt_at,
+            attempts = sportify_unresolved.attempts + 1,
+            reason = excluded.reason",
+        params![spotify_track_id, now_secs(), reason],
+    )
+    .context("write sportify_unresolved")?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::schema::run_migrations;
+
+    fn open_test_db() -> Connection {
+        let conn = Connection::open_in_memory().expect("open memory db");
+        run_migrations(&conn).expect("apply migrations");
+        conn
+    }
+
+    #[test]
+    fn track_meta_round_trip() {
+        let conn = open_test_db();
+        let cfg = SportifyCacheConfig::default();
+        let track = SportifyTrack {
+            id: Some("abc".into()),
+            name: Some("Test".into()),
+            ..Default::default()
+        };
+        put_track_meta(&conn, "abc", &track).unwrap();
+        let got = get_track_meta(&conn, &cfg, "abc").unwrap().unwrap();
+        assert_eq!(got.id.as_deref(), Some("abc"));
+        assert_eq!(got.name.as_deref(), Some("Test"));
+    }
+
+    #[test]
+    fn track_meta_expires() {
+        let conn = open_test_db();
+        let cfg = SportifyCacheConfig {
+            meta_ttl_secs: 0,
+            ..Default::default()
+        };
+        let track = SportifyTrack {
+            id: Some("abc".into()),
+            ..Default::default()
+        };
+        put_track_meta(&conn, "abc", &track).unwrap();
+        assert!(get_track_meta(&conn, &cfg, "abc").unwrap().is_none());
+    }
+
+    #[test]
+    fn resolution_round_trip_clears_unresolved() {
+        let conn = open_test_db();
+        let cfg = SportifyCacheConfig::default();
+        put_unresolved(&conn, "abc", Some("first try")).unwrap();
+        assert!(get_unresolved(&conn, "abc").unwrap().is_some());
+
+        put_tidal_resolution(&conn, "abc", 12345, 0.95, Some("title+artist")).unwrap();
+        let got = get_tidal_resolution(&conn, &cfg, "abc").unwrap().unwrap();
+        assert_eq!(got.tidal_track_id, 12345);
+        assert!((got.confidence - 0.95).abs() < 1e-9);
+        assert!(get_unresolved(&conn, "abc").unwrap().is_none());
+    }
+
+    #[test]
+    fn unresolved_increments_attempts() {
+        let conn = open_test_db();
+        put_unresolved(&conn, "abc", Some("a")).unwrap();
+        put_unresolved(&conn, "abc", Some("b")).unwrap();
+        let rec = get_unresolved(&conn, "abc").unwrap().unwrap();
+        assert_eq!(rec.attempts, 2);
+        assert_eq!(rec.reason.as_deref(), Some("b"));
+    }
+
+    #[test]
+    fn search_cache_round_trip() {
+        let conn = open_test_db();
+        let cfg = SportifyCacheConfig::default();
+        let payload = SportifySearchResults::default();
+        put_search(&conn, "daft punk", SportifySearchKind::Track, 10, 0, &payload).unwrap();
+        assert!(
+            get_search(&conn, &cfg, "daft punk", SportifySearchKind::Track, 10, 0)
+                .unwrap()
+                .is_some()
+        );
+        // Casing/trim-insensitive.
+        assert!(
+            get_search(&conn, &cfg, " Daft Punk ", SportifySearchKind::Track, 10, 0)
+                .unwrap()
+                .is_some()
+        );
+    }
+}

--- a/noor-server/src/services/sportify/client.rs
+++ b/noor-server/src/services/sportify/client.rs
@@ -1,0 +1,300 @@
+//! Thin reqwest wrapper over the 8 Sportify endpoints.
+//!
+//! Sportify exposes:
+//!   GET /api/health
+//!   GET /api/token              (we don't expose; Sportify manages it)
+//!   GET /api/search?q=&type=&limit=&offset=
+//!   GET /api/track/:id
+//!   GET /api/album/:id
+//!   GET /api/playlist/:id
+//!   GET /api/artist/:id
+//!   GET /api/artist/:id/top-tracks
+//!
+//! No auth required. Standard envelope: `{ success, error?, ...payload }`.
+
+use anyhow::{Context, Result, anyhow};
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+
+use super::models::{
+    SportifyAlbum, SportifyArtist, SportifyPlaylist, SportifySearchResults, SportifyTrack,
+};
+
+#[derive(Debug, Clone)]
+pub struct SportifyClientConfig {
+    pub base_url: String,
+    pub user_agent: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn extracts_flat_search_results_array() {
+        let value = json!({
+            "success": true,
+            "results": [{ "id": "spotify-playlist-1", "name": "Lofi" }]
+        });
+
+        let items = extract_search_items(&value, SportifySearchKind::Playlist);
+        assert_eq!(items.as_array().unwrap().len(), 1);
+        assert_eq!(items[0]["id"], "spotify-playlist-1");
+    }
+
+    #[test]
+    fn extracts_nested_search_results_items() {
+        let value = json!({
+            "success": true,
+            "results": {
+                "items": [{ "id": "spotify-playlist-2", "name": "Vietnamese Classics" }]
+            }
+        });
+
+        let items = extract_search_items(&value, SportifySearchKind::Playlist);
+        assert_eq!(items.as_array().unwrap().len(), 1);
+        assert_eq!(items[0]["id"], "spotify-playlist-2");
+    }
+
+    #[test]
+    fn extracts_typed_playlist_bucket() {
+        let value = json!({
+            "success": true,
+            "playlists": {
+                "items": [{ "id": "spotify-playlist-3", "name": "Deep Focus" }]
+            }
+        });
+
+        let items = extract_search_items(&value, SportifySearchKind::Playlist);
+        assert_eq!(items.as_array().unwrap().len(), 1);
+        assert_eq!(items[0]["id"], "spotify-playlist-3");
+    }
+}
+
+impl Default for SportifyClientConfig {
+    fn default() -> Self {
+        Self {
+            base_url: "https://sportify.xcasper.space".to_string(),
+            user_agent: "noor-server/sportify".to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum SportifySearchKind {
+    Track,
+    Album,
+    Artist,
+    Playlist,
+}
+
+impl SportifySearchKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Track => "track",
+            Self::Album => "album",
+            Self::Artist => "artist",
+            Self::Playlist => "playlist",
+        }
+    }
+
+    fn plural_str(&self) -> &'static str {
+        match self {
+            Self::Track => "tracks",
+            Self::Album => "albums",
+            Self::Artist => "artists",
+            Self::Playlist => "playlists",
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct SportifyClient {
+    http: reqwest::Client,
+    base_url: String,
+}
+
+impl SportifyClient {
+    pub fn new(config: SportifyClientConfig) -> Result<Self> {
+        let http = reqwest::Client::builder()
+            .user_agent(config.user_agent)
+            .build()
+            .context("build sportify reqwest client")?;
+        Ok(Self {
+            http,
+            base_url: config.base_url.trim_end_matches('/').to_string(),
+        })
+    }
+
+    /// Issue a GET, validate the standard envelope, and return the raw body
+    /// JSON (envelope fields included). Callers extract the resource field.
+    async fn fetch_raw(&self, path: &str, query: &[(&str, String)]) -> Result<Value> {
+        let url = format!("{}{}", self.base_url, path);
+        let resp = self
+            .http
+            .get(&url)
+            .query(query)
+            .send()
+            .await
+            .with_context(|| format!("sportify request failed: {}", path))?;
+
+        let status = resp.status();
+        let body = resp.text().await.context("read sportify body")?;
+        if !status.is_success() {
+            return Err(anyhow!(
+                "sportify {} returned HTTP {}: {}",
+                path,
+                status,
+                truncate_for_log(&body)
+            ));
+        }
+
+        let value: Value = serde_json::from_str(&body)
+            .with_context(|| format!("parse sportify json: {}", path))?;
+
+        let success = value
+            .get("success")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        if !success {
+            let err = value
+                .get("error")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown");
+            return Err(anyhow!("sportify {} unsuccessful: {}", path, err));
+        }
+
+        Ok(value)
+    }
+
+    /// Resource endpoints wrap the entity in a field named after the
+    /// resource (e.g. `{ "success": true, "track": {...} }`). Try that field
+    /// first; fall back to root for older response shapes.
+    fn extract_field<T: DeserializeOwned>(value: Value, field: &str) -> Result<T> {
+        if let Some(inner) = value.get(field).cloned() {
+            serde_json::from_value(inner)
+                .with_context(|| format!("parse sportify {} payload", field))
+        } else {
+            serde_json::from_value(value)
+                .with_context(|| format!("parse sportify {} (root)", field))
+        }
+    }
+
+    pub async fn search(
+        &self,
+        query: &str,
+        kind: SportifySearchKind,
+        limit: u32,
+        offset: u32,
+    ) -> Result<SportifySearchResults> {
+        let limit = limit.clamp(1, 50);
+        let value = self
+            .fetch_raw(
+                "/api/search",
+                &[
+                    ("q", query.to_string()),
+                    ("type", kind.as_str().to_string()),
+                    ("limit", limit.to_string()),
+                    ("offset", offset.to_string()),
+                ],
+            )
+            .await?;
+
+        // Sportify search usually returns `{ results: [...] }`, but has also
+        // shipped nested `{ results: { items: [...] } }` and typed buckets.
+        // Normalize all of those into the requested result bucket.
+        let mut out = SportifySearchResults::default();
+        let array = extract_search_items(&value, kind);
+
+        match kind {
+            SportifySearchKind::Track => {
+                out.tracks = serde_json::from_value(array).unwrap_or_default();
+            }
+            SportifySearchKind::Album => {
+                out.albums = serde_json::from_value(array).unwrap_or_default();
+            }
+            SportifySearchKind::Artist => {
+                out.artists = serde_json::from_value(array).unwrap_or_default();
+            }
+            SportifySearchKind::Playlist => {
+                out.playlists = serde_json::from_value(array).unwrap_or_default();
+            }
+        }
+        Ok(out)
+    }
+
+    pub async fn track(&self, spotify_id: &str) -> Result<SportifyTrack> {
+        let value = self
+            .fetch_raw(&format!("/api/track/{}", spotify_id), &[])
+            .await?;
+        Self::extract_field(value, "track")
+    }
+
+    pub async fn album(&self, spotify_id: &str) -> Result<SportifyAlbum> {
+        let value = self
+            .fetch_raw(&format!("/api/album/{}", spotify_id), &[])
+            .await?;
+        Self::extract_field(value, "album")
+    }
+
+    pub async fn playlist(&self, spotify_id: &str) -> Result<SportifyPlaylist> {
+        let value = self
+            .fetch_raw(&format!("/api/playlist/{}", spotify_id), &[])
+            .await?;
+        Self::extract_field(value, "playlist")
+    }
+
+    pub async fn artist(&self, spotify_id: &str) -> Result<SportifyArtist> {
+        let value = self
+            .fetch_raw(&format!("/api/artist/{}", spotify_id), &[])
+            .await?;
+        Self::extract_field(value, "artist")
+    }
+
+    pub async fn artist_top_tracks(&self, spotify_id: &str) -> Result<Vec<SportifyTrack>> {
+        let value = self
+            .fetch_raw(&format!("/api/artist/{}/top-tracks", spotify_id), &[])
+            .await?;
+        if let Some(inner) = value.get("tracks").cloned() {
+            return serde_json::from_value(inner).context("parse sportify top-tracks `tracks`");
+        }
+        if let Some(inner) = value.get("items").cloned() {
+            return serde_json::from_value(inner).context("parse sportify top-tracks `items`");
+        }
+        Ok(Vec::new())
+    }
+}
+
+fn extract_search_items(value: &Value, kind: SportifySearchKind) -> Value {
+    fn unwrap_items(value: &Value, kind: SportifySearchKind) -> Option<Value> {
+        if value.is_array() {
+            return Some(value.clone());
+        }
+        value
+            .get("items")
+            .cloned()
+            .or_else(|| value.get(kind.as_str()).cloned())
+            .or_else(|| value.get(kind.plural_str()).cloned())
+            .and_then(|v| unwrap_items(&v, kind).or(Some(v)))
+    }
+
+    value
+        .get("results")
+        .and_then(|v| unwrap_items(v, kind))
+        .or_else(|| value.get(kind.as_str()).and_then(|v| unwrap_items(v, kind)))
+        .or_else(|| {
+            value
+                .get(kind.plural_str())
+                .and_then(|v| unwrap_items(v, kind))
+        })
+        .unwrap_or_else(|| Value::Array(Vec::new()))
+}
+
+fn truncate_for_log(s: &str) -> String {
+    if s.len() > 256 {
+        format!("{}…", &s[..256])
+    } else {
+        s.to_string()
+    }
+}

--- a/noor-server/src/services/sportify/mod.rs
+++ b/noor-server/src/services/sportify/mod.rs
@@ -1,0 +1,24 @@
+//! Sportify (anonymous Spotify metadata proxy) discovery layer.
+//!
+//! Sportify is the discovery brain — search, browse, playlist/album/artist
+//! detail pages, top tracks, relationships. TIDAL remains the speakers:
+//! every playable item is resolved against the existing TIDAL client and
+//! actual audio comes from `services::tidal`.
+//!
+//! Phase 1 (this commit): client + meta cache + DB plumbing. No HTTP routes
+//! yet — those land in phase 3.
+//!
+//! World playcounts and monthly listeners extracted from Sportify responses
+//! are written into the existing `spotify_track_stats` /
+//! `spotify_artist_stats` tables (MIGRATION_029) so the legacy artist page
+//! benefits without parallel state.
+
+pub mod cache;
+pub mod client;
+pub mod models;
+pub mod normalize;
+pub mod recommend;
+pub mod resolver;
+pub mod stats;
+
+pub use client::{SportifyClient, SportifyClientConfig};

--- a/noor-server/src/services/sportify/models.rs
+++ b/noor-server/src/services/sportify/models.rs
@@ -1,0 +1,408 @@
+//! Sportify response DTOs.
+//!
+//! Sportify's underlying data sources (Spotify embed scraping + Spotify
+//! partner GraphQL + MusicBrainz fallback) mean fields can be sparse. We
+//! deserialize permissively: every nested struct uses `#[serde(default)]`
+//! and unknown fields are kept in `extra` for forward compatibility.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct SportifyImage {
+    #[serde(default)]
+    pub url: Option<String>,
+    #[serde(default)]
+    pub width: Option<i32>,
+    #[serde(default)]
+    pub height: Option<i32>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct SportifyArtistRef {
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default, rename = "uri")]
+    pub uri: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct SportifyAlbumRef {
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub images: Vec<SportifyImage>,
+    #[serde(default, rename = "release_date")]
+    pub release_date: Option<String>,
+    #[serde(default, rename = "total_tracks")]
+    pub total_tracks: Option<i32>,
+}
+
+/// External IDs block (Spotify exposes `isrc`, `ean`, `upc`).
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct SportifyExternalIds {
+    #[serde(default)]
+    pub isrc: Option<String>,
+    #[serde(default)]
+    pub ean: Option<String>,
+    #[serde(default)]
+    pub upc: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct SportifyTrack {
+    #[serde(default)]
+    pub id: Option<String>,
+    /// Sportify uses `title` for the track name; some shapes use `name`.
+    /// Alias picks up either form into one field.
+    #[serde(default, alias = "title")]
+    pub name: Option<String>,
+    /// Some endpoints (track detail) ship a structured `artists` array.
+    #[serde(default)]
+    pub artists: Vec<SportifyArtistRef>,
+    /// Other endpoints (playlist body, search results) ship a flat `artist`
+    /// string only. Consumers go through [`SportifyTrack::primary_artist`].
+    #[serde(default)]
+    pub artist: Option<String>,
+    #[serde(default)]
+    pub album: Option<SportifyAlbumRef>,
+    /// Top-level thumbnail URL (track detail + playlist track shape). Album
+    /// artwork lives here when there's no nested `album.images`.
+    #[serde(default)]
+    pub thumbnail: Option<String>,
+    #[serde(default, rename = "duration_ms")]
+    pub duration_ms: Option<i64>,
+    #[serde(default)]
+    pub explicit: Option<bool>,
+    #[serde(default, rename = "track_number")]
+    pub track_number: Option<i32>,
+    #[serde(default, rename = "disc_number")]
+    pub disc_number: Option<i32>,
+    #[serde(default, rename = "preview_url")]
+    pub preview_url: Option<String>,
+    #[serde(default)]
+    pub popularity: Option<i32>,
+    #[serde(default, rename = "playcount")]
+    pub playcount: Option<i64>,
+    #[serde(default, rename = "external_ids")]
+    pub external_ids: Option<SportifyExternalIds>,
+    #[serde(default, rename = "external_urls")]
+    pub external_urls: HashMap<String, String>,
+    /// Spotify-facing URL on the track body (search/playlist shape).
+    #[serde(default)]
+    pub url: Option<String>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+impl SportifyTrack {
+    /// Primary artist name. Prefers the structured `artists` array; falls
+    /// back to the flat `artist` string.
+    pub fn primary_artist(&self) -> Option<&str> {
+        self.artists
+            .first()
+            .and_then(|a| a.name.as_deref())
+            .or(self.artist.as_deref())
+    }
+
+    /// Best-available artwork URL for this track. Tries top-level
+    /// `thumbnail`, then nested album image, then nothing.
+    pub fn best_thumbnail(&self) -> Option<String> {
+        if let Some(t) = self.thumbnail.as_deref() {
+            return Some(t.to_string());
+        }
+        self.album
+            .as_ref()
+            .and_then(|a| a.images.iter().max_by_key(|i| i.width.unwrap_or(0)))
+            .and_then(|i| i.url.clone())
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct SportifyAlbum {
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub artists: Vec<SportifyArtistRef>,
+    #[serde(default)]
+    pub images: Vec<SportifyImage>,
+    #[serde(default, rename = "release_date")]
+    pub release_date: Option<String>,
+    #[serde(default, rename = "release_date_precision")]
+    pub release_date_precision: Option<String>,
+    #[serde(default, rename = "total_tracks")]
+    pub total_tracks: Option<i32>,
+    #[serde(default, rename = "album_type")]
+    pub album_type: Option<String>,
+    #[serde(default)]
+    pub label: Option<String>,
+    #[serde(default)]
+    pub genres: Vec<String>,
+    #[serde(default)]
+    pub tracks: Vec<SportifyTrack>,
+    #[serde(default, rename = "external_ids")]
+    pub external_ids: Option<SportifyExternalIds>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct SportifyArtist {
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub genres: Vec<String>,
+    #[serde(default)]
+    pub images: Vec<SportifyImage>,
+    #[serde(default)]
+    pub popularity: Option<i32>,
+    #[serde(default, rename = "monthly_listeners")]
+    pub monthly_listeners: Option<i64>,
+    #[serde(default)]
+    pub followers: Option<i64>,
+    #[serde(default, rename = "world_rank")]
+    pub world_rank: Option<i64>,
+    #[serde(default)]
+    pub biography: Option<String>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+/// Owner can come back as either a flat string ("Lofi Girl") or a nested
+/// object ({ id, display_name }). Untagged so serde tries each in turn —
+/// upstream shape changes don't break the whole deserialization.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum SportifyPlaylistOwner {
+    Name(String),
+    Object {
+        #[serde(default)]
+        id: Option<String>,
+        #[serde(default, alias = "display_name")]
+        name: Option<String>,
+    },
+}
+
+impl SportifyPlaylistOwner {
+    pub fn display_name(&self) -> Option<&str> {
+        match self {
+            Self::Name(s) => Some(s.as_str()),
+            Self::Object { name, .. } => name.as_deref(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct SportifyPlaylist {
+    #[serde(default, alias = "spotify_id", alias = "spotifyId")]
+    pub id: Option<String>,
+    #[serde(default, alias = "title")]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub description: Option<String>,
+    /// Flat thumbnail URL the search/playlist endpoints actually return.
+    #[serde(
+        default,
+        alias = "image_url",
+        alias = "imageUrl",
+        alias = "artwork_url",
+        alias = "artworkUrl",
+        alias = "cover"
+    )]
+    pub thumbnail: Option<String>,
+    /// Some endpoints return an `images` array instead. Pick whichever is
+    /// present in [`crate::services::sportify::normalize`].
+    #[serde(default)]
+    pub images: Vec<SportifyImage>,
+    #[serde(default)]
+    pub owner: Option<SportifyPlaylistOwner>,
+    #[serde(default, alias = "follower_count", alias = "followerCount")]
+    pub followers: Option<i64>,
+    #[serde(default, rename = "snapshot_id", alias = "snapshotId")]
+    pub snapshot_id: Option<String>,
+    #[serde(
+        default,
+        rename = "total_tracks",
+        alias = "totalTracks",
+        alias = "track_count",
+        alias = "trackCount"
+    )]
+    pub total_tracks: Option<i32>,
+    /// Spotify-facing URL on the playlist body (search shape).
+    #[serde(default)]
+    pub url: Option<String>,
+    #[serde(default)]
+    pub tracks: Vec<SportifyTrack>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+impl SportifyPlaylist {
+    pub fn spotify_id(&self) -> Option<String> {
+        self.id
+            .clone()
+            .or_else(|| extra_string(&self.extra, "spotify_id"))
+            .or_else(|| extra_string(&self.extra, "spotifyId"))
+            .or_else(|| extra_string(&self.extra, "id"))
+    }
+
+    pub fn title(&self) -> Option<String> {
+        self.name
+            .clone()
+            .or_else(|| extra_string(&self.extra, "title"))
+            .or_else(|| extra_string(&self.extra, "name"))
+    }
+
+    pub fn best_thumbnail(&self) -> Option<String> {
+        self.images
+            .iter()
+            .max_by_key(|i| i.width.unwrap_or(0))
+            .and_then(|i| i.url.clone())
+            .or_else(|| self.thumbnail.clone())
+            .or_else(|| extra_string(&self.extra, "image_url"))
+            .or_else(|| extra_string(&self.extra, "imageUrl"))
+            .or_else(|| extra_string(&self.extra, "artwork_url"))
+            .or_else(|| extra_string(&self.extra, "artworkUrl"))
+            .or_else(|| extra_string(&self.extra, "cover"))
+    }
+
+    pub fn follower_count(&self) -> Option<i64> {
+        self.followers
+            .or_else(|| extra_i64(&self.extra, "follower_count"))
+            .or_else(|| extra_i64(&self.extra, "followerCount"))
+            .or_else(|| extra_i64(&self.extra, "followers"))
+    }
+
+    pub fn total_track_count(&self) -> Option<i32> {
+        self.total_tracks
+            .or_else(|| extra_i64(&self.extra, "total_tracks").and_then(i64_to_i32))
+            .or_else(|| extra_i64(&self.extra, "totalTracks").and_then(i64_to_i32))
+            .or_else(|| extra_i64(&self.extra, "track_count").and_then(i64_to_i32))
+            .or_else(|| extra_i64(&self.extra, "trackCount").and_then(i64_to_i32))
+    }
+}
+
+fn extra_string(extra: &HashMap<String, serde_json::Value>, key: &str) -> Option<String> {
+    extra.get(key).and_then(|v| v.as_str()).map(str::to_string)
+}
+
+fn extra_i64(extra: &HashMap<String, serde_json::Value>, key: &str) -> Option<i64> {
+    extra.get(key).and_then(|v| v.as_i64())
+}
+
+fn i64_to_i32(value: i64) -> Option<i32> {
+    i32::try_from(value).ok()
+}
+
+/// Search response. Fields are individually optional because Sportify only
+/// returns the bucket matching the requested `type`.
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct SportifySearchResults {
+    #[serde(default)]
+    pub tracks: Vec<SportifyTrack>,
+    #[serde(default)]
+    pub albums: Vec<SportifyAlbum>,
+    #[serde(default)]
+    pub artists: Vec<SportifyArtist>,
+    #[serde(default)]
+    pub playlists: Vec<SportifyPlaylist>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression: playlist-body track shape uses `title` + flat `artist`
+    /// + top-level `thumbnail`. The first ship missed this and every track
+    /// deserialized into all-None defaults.
+    #[test]
+    fn deserializes_playlist_track_shape() {
+        let json = r#"{
+            "id": "6bp0DUXnsAdLbueBfFTPFn",
+            "title": "The Descent",
+            "artist": "Blue Wednesday",
+            "thumbnail": "https://example.com/thumb.jpg",
+            "duration": "3:33",
+            "duration_ms": 213038,
+            "explicit": false,
+            "preview_url": "https://example.com/preview.mp3",
+            "url": "https://open.spotify.com/track/6bp0DUXnsAdLbueBfFTPFn"
+        }"#;
+        let track: SportifyTrack = serde_json::from_str(json).expect("playlist track parse");
+        assert_eq!(track.id.as_deref(), Some("6bp0DUXnsAdLbueBfFTPFn"));
+        assert_eq!(track.name.as_deref(), Some("The Descent"));
+        assert_eq!(track.primary_artist(), Some("Blue Wednesday"));
+        assert_eq!(track.duration_ms, Some(213038));
+        assert_eq!(
+            track.best_thumbnail().as_deref(),
+            Some("https://example.com/thumb.jpg"),
+        );
+    }
+
+    /// Track-detail shape ships both `artists` array AND flat `artist`.
+    /// `primary_artist()` should prefer the structured array.
+    #[test]
+    fn primary_artist_prefers_structured_array() {
+        let json = r#"{
+            "id": "x",
+            "title": "T",
+            "artist": "Flat Name",
+            "artists": [{ "id": "a1", "name": "Structured Name" }]
+        }"#;
+        let track: SportifyTrack = serde_json::from_str(json).expect("parse");
+        assert_eq!(track.primary_artist(), Some("Structured Name"));
+    }
+
+    /// Playlist owner can be a plain string ("Lofi Girl") or a nested
+    /// `{ id, display_name }`. Both must round-trip through the enum.
+    #[test]
+    fn playlist_owner_accepts_either_shape() {
+        let flat: SportifyPlaylist =
+            serde_json::from_str(r#"{ "id": "p", "owner": "Lofi Girl" }"#).expect("flat owner");
+        assert_eq!(
+            flat.owner.as_ref().and_then(|o| o.display_name()),
+            Some("Lofi Girl"),
+        );
+
+        let nested: SportifyPlaylist = serde_json::from_str(
+            r#"{ "id": "p", "owner": { "id": "u1", "display_name": "Bob" } }"#,
+        )
+        .expect("nested owner");
+        assert_eq!(
+            nested.owner.as_ref().and_then(|o| o.display_name()),
+            Some("Bob"),
+        );
+    }
+
+    #[test]
+    fn deserializes_compact_playlist_search_shape() {
+        let json = r#"{
+            "spotifyId": "3jVA3AuxV9aPO07YPt3Ist",
+            "title": "lost vietnamese classics",
+            "imageUrl": "https://example.com/cover.jpg",
+            "owner": "Felix",
+            "followerCount": 42,
+            "totalTracks": 11
+        }"#;
+        let playlist: SportifyPlaylist = serde_json::from_str(json).expect("compact playlist");
+        assert_eq!(
+            playlist.spotify_id().as_deref(),
+            Some("3jVA3AuxV9aPO07YPt3Ist"),
+        );
+        assert_eq!(playlist.title().as_deref(), Some("lost vietnamese classics"));
+        assert_eq!(
+            playlist.best_thumbnail().as_deref(),
+            Some("https://example.com/cover.jpg"),
+        );
+        assert_eq!(playlist.follower_count(), Some(42));
+        assert_eq!(playlist.total_track_count(), Some(11));
+    }
+}

--- a/noor-server/src/services/sportify/normalize.rs
+++ b/noor-server/src/services/sportify/normalize.rs
@@ -1,0 +1,374 @@
+//! Normalize Sportify DTOs into the discovery shape consumed by /discover.
+//!
+//! Output is camelCase JSON to match the design spec the user pinned. Each
+//! playable row carries a `tidal: { status, id, confidence, ... }` block;
+//! cache-resolved status is filled in by [`enrich_tracks_with_tidal_cache`],
+//! everything else lands as `pending`. Phase 4 will turn pending into
+//! resolved/unresolved via the eager-first-N + lazy-rest pipeline.
+
+use anyhow::Result;
+use rusqlite::Connection;
+use serde::Serialize;
+
+use super::cache::{self as sp_cache, SportifyCacheConfig};
+use super::models::{
+    SportifyAlbum, SportifyArtist, SportifyArtistRef, SportifyImage, SportifyPlaylist,
+    SportifySearchResults, SportifyTrack,
+};
+// Owner accessor is on the model enum; pull it via SportifyPlaylistOwner.
+use super::resolver::{self, ResolutionStatus};
+
+#[derive(Debug, Clone, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ArtistRef {
+    pub id: Option<String>,
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct TidalState {
+    /// `pending` | `resolved` | `low_confidence` | `unresolved` | `error`
+    pub status: String,
+    pub id: Option<i64>,
+    pub confidence: f64,
+    pub match_reason: Option<String>,
+    pub from_cache: bool,
+}
+
+impl TidalState {
+    pub fn pending() -> Self {
+        Self {
+            status: "pending".to_string(),
+            id: None,
+            confidence: 0.0,
+            match_reason: None,
+            from_cache: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct DiscoveryMeta {
+    pub score: f64,
+    pub contexts: Vec<String>,
+    pub seeds: Vec<String>,
+    pub source_endpoint: String,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct DiscoveryTrack {
+    pub source: &'static str,
+    pub spotify_id: Option<String>,
+    pub r#type: &'static str,
+    pub title: Option<String>,
+    pub primary_artist: Option<String>,
+    pub artists: Vec<ArtistRef>,
+    pub album: Option<String>,
+    pub album_id: Option<String>,
+    pub thumbnail: Option<String>,
+    pub duration_ms: Option<i64>,
+    pub release_date: Option<String>,
+    pub explicit: Option<bool>,
+    pub track_number: Option<i32>,
+    pub disc_number: Option<i32>,
+    pub spotify_url: Option<String>,
+    pub preview_url: Option<String>,
+    pub playcount: Option<i64>,
+    pub popularity: Option<i32>,
+    pub isrc: Option<String>,
+    pub tidal: TidalState,
+    pub discovery: DiscoveryMeta,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct DiscoveryAlbum {
+    pub source: &'static str,
+    pub spotify_id: Option<String>,
+    pub r#type: &'static str,
+    pub title: Option<String>,
+    pub primary_artist: Option<String>,
+    pub artists: Vec<ArtistRef>,
+    pub thumbnail: Option<String>,
+    pub release_date: Option<String>,
+    pub total_tracks: Option<i32>,
+    pub album_type: Option<String>,
+    pub label: Option<String>,
+    pub genres: Vec<String>,
+    pub spotify_url: Option<String>,
+    pub tracks: Vec<DiscoveryTrack>,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct DiscoveryArtist {
+    pub source: &'static str,
+    pub spotify_id: Option<String>,
+    pub r#type: &'static str,
+    pub name: Option<String>,
+    pub thumbnail: Option<String>,
+    pub genres: Vec<String>,
+    pub popularity: Option<i32>,
+    pub monthly_listeners: Option<i64>,
+    pub followers: Option<i64>,
+    pub world_rank: Option<i64>,
+    pub biography: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct DiscoveryPlaylist {
+    pub source: &'static str,
+    pub spotify_id: Option<String>,
+    pub r#type: &'static str,
+    pub title: Option<String>,
+    pub description: Option<String>,
+    pub thumbnail: Option<String>,
+    pub owner: Option<String>,
+    pub followers: Option<i64>,
+    pub total_tracks: Option<i32>,
+    pub snapshot_id: Option<String>,
+    pub tracks: Vec<DiscoveryTrack>,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct DiscoverySearchResults {
+    pub tracks: Vec<DiscoveryTrack>,
+    pub albums: Vec<DiscoveryAlbum>,
+    pub artists: Vec<DiscoveryArtist>,
+    pub playlists: Vec<DiscoveryPlaylist>,
+}
+
+// ─── Conversions ─────────────────────────────────────────────
+
+fn pick_image(images: &[SportifyImage]) -> Option<String> {
+    images
+        .iter()
+        .max_by_key(|i| i.width.unwrap_or(0))
+        .and_then(|i| i.url.clone())
+}
+
+fn artist_refs(artists: &[SportifyArtistRef]) -> Vec<ArtistRef> {
+    artists
+        .iter()
+        .map(|a| ArtistRef {
+            id: a.id.clone(),
+            name: a.name.clone(),
+        })
+        .collect()
+}
+
+fn primary_artist_name(artists: &[SportifyArtistRef]) -> Option<String> {
+    artists.first().and_then(|a| a.name.clone())
+}
+
+fn spotify_url_from_map(map: &std::collections::HashMap<String, String>, fallback_id: Option<&str>, kind: &str) -> Option<String> {
+    if let Some(url) = map.get("spotify").cloned() {
+        return Some(url);
+    }
+    fallback_id.map(|id| format!("https://open.spotify.com/{}/{}", kind, id))
+}
+
+pub fn track_from_sportify(t: &SportifyTrack, source_endpoint: &str) -> DiscoveryTrack {
+    let isrc = t.external_ids.as_ref().and_then(|e| e.isrc.clone());
+    // Spotify URL: prefer the flat `url` Sportify ships on the track body,
+    // then the typed `external_urls.spotify`, then build one from the id.
+    let spotify_url = t
+        .url
+        .clone()
+        .or_else(|| spotify_url_from_map(&t.external_urls, t.id.as_deref(), "track"));
+
+    DiscoveryTrack {
+        source: "spotify",
+        spotify_id: t.id.clone(),
+        r#type: "track",
+        title: t.name.clone(),
+        primary_artist: t.primary_artist().map(str::to_string),
+        // Synthesize an artists array from the flat `artist` string when the
+        // structured `artists` field is absent (playlist/search shape).
+        artists: if !t.artists.is_empty() {
+            artist_refs(&t.artists)
+        } else if let Some(name) = t.artist.clone() {
+            vec![ArtistRef { id: None, name: Some(name) }]
+        } else {
+            Vec::new()
+        },
+        album: t.album.as_ref().and_then(|a| a.name.clone()),
+        album_id: t.album.as_ref().and_then(|a| a.id.clone()),
+        thumbnail: t.best_thumbnail(),
+        duration_ms: t.duration_ms,
+        release_date: t
+            .album
+            .as_ref()
+            .and_then(|a| a.release_date.clone())
+            .or_else(|| {
+                // Track-detail responses sometimes ship release_date on the
+                // track itself rather than the album block.
+                t.extra
+                    .get("release_date")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string)
+            }),
+        explicit: t.explicit,
+        track_number: t.track_number,
+        disc_number: t.disc_number,
+        spotify_url,
+        preview_url: t.preview_url.clone(),
+        playcount: t.playcount,
+        popularity: t.popularity,
+        isrc,
+        tidal: TidalState::pending(),
+        discovery: DiscoveryMeta {
+            source_endpoint: source_endpoint.to_string(),
+            ..DiscoveryMeta::default()
+        },
+    }
+}
+
+pub fn album_from_sportify(a: &SportifyAlbum, source_endpoint: &str) -> DiscoveryAlbum {
+    let thumb = pick_image(&a.images);
+    let tracks = a
+        .tracks
+        .iter()
+        .map(|t| {
+            let mut row = track_from_sportify(t, source_endpoint);
+            // Tracks fetched as part of an album payload often omit the
+            // album block — backfill it from the parent so downstream UI has
+            // artwork + album name without an extra fetch.
+            if row.album.is_none() {
+                row.album = a.name.clone();
+            }
+            if row.album_id.is_none() {
+                row.album_id = a.id.clone();
+            }
+            if row.thumbnail.is_none() {
+                row.thumbnail = thumb.clone();
+            }
+            if row.release_date.is_none() {
+                row.release_date = a.release_date.clone();
+            }
+            row
+        })
+        .collect();
+    DiscoveryAlbum {
+        source: "spotify",
+        spotify_id: a.id.clone(),
+        r#type: "album",
+        title: a.name.clone(),
+        primary_artist: primary_artist_name(&a.artists),
+        artists: artist_refs(&a.artists),
+        thumbnail: thumb,
+        release_date: a.release_date.clone(),
+        total_tracks: a.total_tracks,
+        album_type: a.album_type.clone(),
+        label: a.label.clone(),
+        genres: a.genres.clone(),
+        spotify_url: a
+            .id
+            .as_deref()
+            .map(|id| format!("https://open.spotify.com/album/{}", id)),
+        tracks,
+    }
+}
+
+pub fn artist_from_sportify(a: &SportifyArtist) -> DiscoveryArtist {
+    DiscoveryArtist {
+        source: "spotify",
+        spotify_id: a.id.clone(),
+        r#type: "artist",
+        name: a.name.clone(),
+        thumbnail: pick_image(&a.images),
+        genres: a.genres.clone(),
+        popularity: a.popularity,
+        monthly_listeners: a.monthly_listeners,
+        followers: a.followers,
+        world_rank: a.world_rank,
+        biography: a.biography.clone(),
+    }
+}
+
+pub fn playlist_from_sportify(p: &SportifyPlaylist, source_endpoint: &str) -> DiscoveryPlaylist {
+    DiscoveryPlaylist {
+        source: "spotify",
+        spotify_id: p.spotify_id(),
+        r#type: "playlist",
+        title: p.title(),
+        description: p.description.clone(),
+        thumbnail: p.best_thumbnail(),
+        owner: p.owner.as_ref().and_then(|o| o.display_name().map(str::to_string)),
+        followers: p.follower_count(),
+        total_tracks: p.total_track_count(),
+        snapshot_id: p.snapshot_id.clone(),
+        tracks: p
+            .tracks
+            .iter()
+            .map(|t| track_from_sportify(t, source_endpoint))
+            .collect(),
+    }
+}
+
+pub fn search_from_sportify(
+    s: &SportifySearchResults,
+    source_endpoint: &str,
+) -> DiscoverySearchResults {
+    DiscoverySearchResults {
+        tracks: s
+            .tracks
+            .iter()
+            .map(|t| track_from_sportify(t, source_endpoint))
+            .collect(),
+        albums: s
+            .albums
+            .iter()
+            .map(|a| album_from_sportify(a, source_endpoint))
+            .collect(),
+        artists: s.artists.iter().map(artist_from_sportify).collect(),
+        playlists: s
+            .playlists
+            .iter()
+            .map(|p| playlist_from_sportify(p, source_endpoint))
+            .collect(),
+    }
+}
+
+// ─── Tidal cache enrichment ──────────────────────────────────
+
+/// Fill in each track's `tidal:` block from the resolution cache. Tracks
+/// without a cache hit keep their `pending` state.
+pub fn enrich_tracks_with_tidal_cache(
+    conn: &Connection,
+    cfg: &SportifyCacheConfig,
+    tracks: &mut [DiscoveryTrack],
+) -> Result<()> {
+    for track in tracks.iter_mut() {
+        let Some(spotify_id) = track.spotify_id.as_deref() else {
+            continue;
+        };
+        if let Some(hit) = sp_cache::get_tidal_resolution(conn, cfg, spotify_id)? {
+            track.tidal = TidalState {
+                status: resolver::classify(hit.confidence).as_str().to_string(),
+                id: Some(hit.tidal_track_id),
+                confidence: hit.confidence,
+                match_reason: hit.match_reason,
+                from_cache: true,
+            };
+            continue;
+        }
+        if let Some(record) = sp_cache::get_unresolved(conn, spotify_id)? {
+            if sp_cache::unresolved_is_cold(&record, cfg) {
+                track.tidal = TidalState {
+                    status: ResolutionStatus::Unresolved.as_str().to_string(),
+                    id: None,
+                    confidence: 0.0,
+                    match_reason: record.reason,
+                    from_cache: true,
+                };
+            }
+        }
+    }
+    Ok(())
+}

--- a/noor-server/src/services/sportify/recommend.rs
+++ b/noor-server/src/services/sportify/recommend.rs
@@ -1,0 +1,405 @@
+//! Relationship / radio-network composer.
+//!
+//! Sportify only exposes primitives — search, track, album, artist,
+//! artist top-tracks. "Related" rows for the discovery UI are derived by
+//! composing those primitives:
+//!
+//! Artist related:
+//!   - top tracks                  (existing top-tracks endpoint)
+//!   - deep cuts                   (search artist:NAME, drop top-tracks)
+//!   - recent releases             (search artist:NAME type=album, sort by date)
+//!   - similar artists             (search primary genre type=artist)
+//!
+//! Album related:
+//!   - more from this artist       (artist top-tracks, drop album tracks)
+//!   - more albums by this artist  (search artist:NAME type=album, drop self)
+//!
+//! Track related:
+//!   - more from this album        (album tracks, drop self)
+//!   - more from this artist       (artist top-tracks, drop self)
+//!
+//! Every fetch funnels through cache helpers so a deep-page open hits at
+//! most a handful of cold Sportify calls.
+
+use anyhow::Result;
+use serde::Serialize;
+
+use crate::db::Database;
+
+use super::cache::{self as sp_cache, SportifyCacheConfig};
+use super::client::{SportifyClient, SportifySearchKind};
+use super::models::{
+    SportifyAlbum, SportifyArtist, SportifyPlaylist, SportifySearchResults, SportifyTrack,
+};
+use super::stats;
+
+/// Cap on per-row item counts so a `/related` response stays small enough to
+/// resolve eagerly without hammering TIDAL.
+const ROW_LIMIT: usize = 12;
+/// Sportify search fan-out limit per row.
+const SEARCH_FETCH: u32 = 25;
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct ArtistRelated {
+    pub top_tracks: Vec<SportifyTrack>,
+    pub deep_cuts: Vec<SportifyTrack>,
+    pub recent_releases: Vec<SportifyAlbum>,
+    pub similar_artists: Vec<SportifyArtist>,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct AlbumRelated {
+    pub more_from_artist: Vec<SportifyTrack>,
+    pub more_albums_by_artist: Vec<SportifyAlbum>,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct TrackRelated {
+    pub more_from_album: Vec<SportifyTrack>,
+    pub more_from_artist: Vec<SportifyTrack>,
+}
+
+// ─── Cache-aware fetchers ────────────────────────────────────
+
+pub async fn cached_track(
+    client: &SportifyClient,
+    db: &Database,
+    cfg: &SportifyCacheConfig,
+    id: &str,
+) -> Result<SportifyTrack> {
+    if let Some(t) = db.with_conn(|conn| sp_cache::get_track_meta(conn, cfg, id))? {
+        return Ok(t);
+    }
+    let fetched = client.track(id).await?;
+    db.with_conn(|conn| {
+        sp_cache::put_track_meta(conn, id, &fetched)?;
+        // World-playcount writeback. Best-effort — a missing field never
+        // fails the surrounding fetch.
+        stats::write_track_playcount(conn, &fetched);
+        Ok::<_, anyhow::Error>(())
+    })?;
+    Ok(fetched)
+}
+
+pub async fn cached_album(
+    client: &SportifyClient,
+    db: &Database,
+    cfg: &SportifyCacheConfig,
+    id: &str,
+) -> Result<SportifyAlbum> {
+    if let Some(a) = db.with_conn(|conn| sp_cache::get_album_meta(conn, cfg, id))? {
+        return Ok(a);
+    }
+    let fetched = client.album(id).await?;
+    db.with_conn(|conn| {
+        sp_cache::put_album_meta(conn, id, &fetched)?;
+        stats::write_track_playcounts(conn, &fetched.tracks);
+        Ok::<_, anyhow::Error>(())
+    })?;
+    Ok(fetched)
+}
+
+pub async fn cached_artist(
+    client: &SportifyClient,
+    db: &Database,
+    cfg: &SportifyCacheConfig,
+    id: &str,
+) -> Result<SportifyArtist> {
+    if let Some(a) = db.with_conn(|conn| sp_cache::get_artist_meta(conn, cfg, id))? {
+        return Ok(a);
+    }
+    let fetched = client.artist(id).await?;
+    db.with_conn(|conn| {
+        sp_cache::put_artist_meta(conn, id, &fetched)?;
+        stats::write_artist_monthly_listeners(conn, &fetched);
+        Ok::<_, anyhow::Error>(())
+    })?;
+    Ok(fetched)
+}
+
+pub async fn cached_playlist(
+    client: &SportifyClient,
+    db: &Database,
+    cfg: &SportifyCacheConfig,
+    id: &str,
+) -> Result<SportifyPlaylist> {
+    if let Some(p) = db.with_conn(|conn| sp_cache::get_playlist_meta(conn, cfg, id))? {
+        return Ok(p);
+    }
+    let fetched = client.playlist(id).await?;
+    db.with_conn(|conn| {
+        sp_cache::put_playlist_meta(conn, id, &fetched)?;
+        stats::write_track_playcounts(conn, &fetched.tracks);
+        Ok::<_, anyhow::Error>(())
+    })?;
+    Ok(fetched)
+}
+
+pub async fn cached_artist_top_tracks(
+    client: &SportifyClient,
+    db: &Database,
+    _cfg: &SportifyCacheConfig,
+    id: &str,
+) -> Result<Vec<SportifyTrack>> {
+    // Top-tracks isn't cached as a unit — the per-track meta cache absorbs
+    // repeats. Always make the call but write each track through.
+    let tracks = client.artist_top_tracks(id).await?;
+    db.with_conn(|conn| {
+        for t in &tracks {
+            if let Some(track_id) = t.id.as_deref() {
+                let _ = sp_cache::put_track_meta(conn, track_id, t);
+            }
+        }
+        stats::write_track_playcounts(conn, &tracks);
+        Ok::<_, anyhow::Error>(())
+    })?;
+    Ok(tracks)
+}
+
+pub async fn cached_search(
+    client: &SportifyClient,
+    db: &Database,
+    cfg: &SportifyCacheConfig,
+    q: &str,
+    kind: SportifySearchKind,
+    limit: u32,
+    offset: u32,
+) -> Result<SportifySearchResults> {
+    if let Some(s) = db.with_conn(|conn| sp_cache::get_search(conn, cfg, q, kind, limit, offset))? {
+        return Ok(s);
+    }
+    let fetched = client.search(q, kind, limit, offset).await?;
+    db.with_conn(|conn| sp_cache::put_search(conn, q, kind, limit, offset, &fetched))?;
+    Ok(fetched)
+}
+
+// ─── Composed `related` rows ─────────────────────────────────
+
+/// Build "radio network" rows for an artist. Sub-fetches run concurrently
+/// where they don't depend on one another.
+pub async fn artist_related(
+    client: &SportifyClient,
+    db: &Database,
+    cfg: &SportifyCacheConfig,
+    artist_id: &str,
+) -> Result<ArtistRelated> {
+    let artist = cached_artist(client, db, cfg, artist_id).await?;
+    let artist_name = artist.name.clone().unwrap_or_default();
+    let primary_genre = artist.genres.first().cloned();
+
+    if artist_name.trim().is_empty() {
+        return Ok(ArtistRelated::default());
+    }
+
+    let (top_res, deep_search_res, album_search_res, similar_res) = tokio::join!(
+        cached_artist_top_tracks(client, db, cfg, artist_id),
+        cached_search(client, db, cfg, &artist_name, SportifySearchKind::Track, SEARCH_FETCH, 0),
+        cached_search(client, db, cfg, &artist_name, SportifySearchKind::Album, SEARCH_FETCH, 0),
+        async {
+            match primary_genre.as_deref() {
+                Some(g) if !g.trim().is_empty() => {
+                    cached_search(client, db, cfg, g, SportifySearchKind::Artist, SEARCH_FETCH, 0)
+                        .await
+                }
+                _ => Ok(SportifySearchResults::default()),
+            }
+        },
+    );
+
+    let top_tracks: Vec<SportifyTrack> = top_res.unwrap_or_default().into_iter().take(ROW_LIMIT).collect();
+    let top_ids: std::collections::HashSet<String> = top_tracks
+        .iter()
+        .filter_map(|t| t.id.clone())
+        .collect();
+
+    let deep_cuts: Vec<SportifyTrack> = deep_search_res
+        .unwrap_or_default()
+        .tracks
+        .into_iter()
+        .filter(|t| {
+            // Same primary artist + not already in top tracks.
+            primary_artist_matches(t, &artist_name)
+                && t.id.as_deref().map_or(true, |id| !top_ids.contains(id))
+        })
+        .take(ROW_LIMIT)
+        .collect();
+
+    let mut recent_releases: Vec<SportifyAlbum> = album_search_res
+        .unwrap_or_default()
+        .albums
+        .into_iter()
+        .filter(|a| {
+            a.artists
+                .first()
+                .and_then(|x| x.name.as_deref())
+                .map(|n| n.eq_ignore_ascii_case(artist_name.trim()))
+                .unwrap_or(false)
+        })
+        .collect();
+    recent_releases.sort_by(|a, b| b.release_date.cmp(&a.release_date));
+    recent_releases.truncate(ROW_LIMIT);
+
+    let similar_artists: Vec<SportifyArtist> = similar_res
+        .unwrap_or_default()
+        .artists
+        .into_iter()
+        .filter(|a| {
+            // Drop the seed artist itself.
+            a.id.as_deref().map_or(true, |id| id != artist_id)
+        })
+        .take(ROW_LIMIT)
+        .collect();
+
+    Ok(ArtistRelated {
+        top_tracks,
+        deep_cuts,
+        recent_releases,
+        similar_artists,
+    })
+}
+
+pub async fn album_related(
+    client: &SportifyClient,
+    db: &Database,
+    cfg: &SportifyCacheConfig,
+    album_id: &str,
+) -> Result<AlbumRelated> {
+    let album = cached_album(client, db, cfg, album_id).await?;
+    let primary_artist = album.artists.first().cloned();
+    let artist_id = primary_artist.as_ref().and_then(|a| a.id.clone());
+    let artist_name = primary_artist
+        .as_ref()
+        .and_then(|a| a.name.clone())
+        .unwrap_or_default();
+
+    if artist_name.trim().is_empty() {
+        return Ok(AlbumRelated::default());
+    }
+
+    let album_track_ids: std::collections::HashSet<String> = album
+        .tracks
+        .iter()
+        .filter_map(|t| t.id.clone())
+        .collect();
+
+    let top_fut = async {
+        match artist_id.as_deref() {
+            Some(id) => cached_artist_top_tracks(client, db, cfg, id).await,
+            None => Ok(Vec::new()),
+        }
+    };
+    let albums_fut =
+        cached_search(client, db, cfg, &artist_name, SportifySearchKind::Album, SEARCH_FETCH, 0);
+
+    let (top_res, albums_res) = tokio::join!(top_fut, albums_fut);
+
+    let more_from_artist: Vec<SportifyTrack> = top_res
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|t| t.id.as_deref().map_or(true, |id| !album_track_ids.contains(id)))
+        .take(ROW_LIMIT)
+        .collect();
+
+    let mut more_albums_by_artist: Vec<SportifyAlbum> = albums_res
+        .unwrap_or_default()
+        .albums
+        .into_iter()
+        .filter(|a| {
+            // Same primary artist, not the seed album itself.
+            let same_artist = a
+                .artists
+                .first()
+                .and_then(|x| x.name.as_deref())
+                .map(|n| n.eq_ignore_ascii_case(artist_name.trim()))
+                .unwrap_or(false);
+            same_artist && a.id.as_deref().map_or(true, |id| id != album_id)
+        })
+        .collect();
+    more_albums_by_artist.sort_by(|a, b| b.release_date.cmp(&a.release_date));
+    more_albums_by_artist.truncate(ROW_LIMIT);
+
+    Ok(AlbumRelated {
+        more_from_artist,
+        more_albums_by_artist,
+    })
+}
+
+pub async fn track_related(
+    client: &SportifyClient,
+    db: &Database,
+    cfg: &SportifyCacheConfig,
+    track_id: &str,
+) -> Result<TrackRelated> {
+    let track = cached_track(client, db, cfg, track_id).await?;
+    let album_id = track.album.as_ref().and_then(|a| a.id.clone());
+    let primary_artist_id = track.artists.first().and_then(|a| a.id.clone());
+
+    let album_fut = async {
+        match album_id.as_deref() {
+            Some(id) => cached_album(client, db, cfg, id).await,
+            None => Ok(SportifyAlbum::default()),
+        }
+    };
+    let top_fut = async {
+        match primary_artist_id.as_deref() {
+            Some(id) => cached_artist_top_tracks(client, db, cfg, id).await,
+            None => Ok(Vec::new()),
+        }
+    };
+    let (album_res, top_res) = tokio::join!(album_fut, top_fut);
+
+    let more_from_album: Vec<SportifyTrack> = album_res
+        .unwrap_or_default()
+        .tracks
+        .into_iter()
+        .filter(|t| t.id.as_deref() != Some(track_id))
+        .take(ROW_LIMIT)
+        .collect();
+
+    let more_from_artist: Vec<SportifyTrack> = top_res
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|t| t.id.as_deref() != Some(track_id))
+        .take(ROW_LIMIT)
+        .collect();
+
+    Ok(TrackRelated {
+        more_from_album,
+        more_from_artist,
+    })
+}
+
+fn primary_artist_matches(track: &SportifyTrack, artist_name: &str) -> bool {
+    track
+        .artists
+        .first()
+        .and_then(|a| a.name.as_deref())
+        .map(|n| n.eq_ignore_ascii_case(artist_name.trim()))
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::sportify::models::{SportifyArtistRef, SportifyTrack};
+
+    #[test]
+    fn primary_artist_matches_case_insensitive() {
+        let t = SportifyTrack {
+            artists: vec![SportifyArtistRef {
+                name: Some("Daft Punk".into()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        assert!(primary_artist_matches(&t, "daft punk"));
+        assert!(primary_artist_matches(&t, "  Daft Punk  "));
+        assert!(!primary_artist_matches(&t, "Stardust"));
+    }
+
+    #[test]
+    fn primary_artist_matches_handles_no_artist() {
+        let t = SportifyTrack::default();
+        assert!(!primary_artist_matches(&t, "Daft Punk"));
+    }
+}

--- a/noor-server/src/services/sportify/resolver.rs
+++ b/noor-server/src/services/sportify/resolver.rs
@@ -1,0 +1,580 @@
+//! Spotify (via Sportify) → TIDAL track resolver.
+//!
+//! Two-stage match:
+//!   1. Hard reject candidates whose version markers (live / acoustic /
+//!      remix / remaster / sped-up / slowed / instrumental / demo / edit /
+//!      extended) disagree with the Spotify side. A studio track must not
+//!      resolve to a live recording, regardless of how close the title is.
+//!   2. Score remaining candidates on title token Jaccard + primary-artist
+//!      token Jaccard + duration delta + explicit-flag agreement, picking
+//!      the best.
+//!
+//! Confidence buckets (matches the design spec):
+//!   ≥ 0.90  → Resolved (autoplay-eligible)
+//!   0.75–0.89 → Low confidence (playable but no autoplay; UI shows badge)
+//!   < 0.75  → Unresolved (kept visible, but greyed out)
+//!
+//! The ISRC fast path described in the design spec is intentionally deferred
+//! to a follow-up: TIDAL search-result rows do not include `isrc`, so an
+//! ISRC fast path needs an extra `tracks/{id}` round-trip per candidate.
+//! It will land alongside the bulk resolver in phase 4 where the cost
+//! amortizes across many tracks.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use tokio::sync::Semaphore;
+
+use crate::services::sportify::models::SportifyTrack;
+use crate::services::tidal::client::{TidalClient, TidalSearchTrack};
+
+pub const RESOLVED_THRESHOLD: f64 = 0.90;
+pub const LOW_CONFIDENCE_THRESHOLD: f64 = 0.75;
+const TIDAL_SEARCH_LIMIT: i32 = 15;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResolutionStatus {
+    Resolved,
+    LowConfidence,
+    Unresolved,
+}
+
+impl ResolutionStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Resolved => "resolved",
+            Self::LowConfidence => "low_confidence",
+            Self::Unresolved => "unresolved",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ResolutionOutcome {
+    pub status: ResolutionStatus,
+    pub tidal_track_id: Option<i64>,
+    pub confidence: f64,
+    pub reason: String,
+}
+
+impl ResolutionOutcome {
+    pub fn unresolved(reason: impl Into<String>) -> Self {
+        Self {
+            status: ResolutionStatus::Unresolved,
+            tidal_track_id: None,
+            confidence: 0.0,
+            reason: reason.into(),
+        }
+    }
+}
+
+pub fn classify(score: f64) -> ResolutionStatus {
+    if score >= RESOLVED_THRESHOLD {
+        ResolutionStatus::Resolved
+    } else if score >= LOW_CONFIDENCE_THRESHOLD {
+        ResolutionStatus::LowConfidence
+    } else {
+        ResolutionStatus::Unresolved
+    }
+}
+
+/// Resolve one Spotify track against TIDAL. Returns the best outcome — may
+/// be Unresolved if no candidate passed the version guard or the best score
+/// is below the low-confidence threshold.
+pub async fn resolve_track(
+    client: &TidalClient,
+    sportify: &SportifyTrack,
+) -> Result<ResolutionOutcome> {
+    let title = sportify.name.as_deref().unwrap_or("").trim();
+    let primary_artist = sportify.primary_artist().unwrap_or("").trim();
+
+    if title.is_empty() || primary_artist.is_empty() {
+        return Ok(ResolutionOutcome::unresolved("missing title or artist"));
+    }
+
+    let query = format!("{} {}", title, primary_artist);
+    let candidates = client
+        .search(&query, TIDAL_SEARCH_LIMIT)
+        .await
+        .context("tidal search for resolver")?;
+
+    if candidates.is_empty() {
+        return Ok(ResolutionOutcome::unresolved("no tidal candidates"));
+    }
+
+    let sp_versions = version_tags(title);
+    let mut best: Option<ScoredCandidate> = None;
+    let mut best_pre_guard: Option<f64> = None;
+
+    for cand in &candidates {
+        let scored = score(sportify, title, primary_artist, cand);
+
+        // Track the highest pre-guard score so we can give a useful reason
+        // when everything got rejected by the version guard.
+        if best_pre_guard.map_or(true, |s| scored.score > s) {
+            best_pre_guard = Some(scored.score);
+        }
+
+        let cand_versions = version_tags(&cand.title);
+        if cand_versions != sp_versions {
+            continue;
+        }
+
+        if best.as_ref().map_or(true, |b| scored.score > b.score) {
+            best = Some(ScoredCandidate {
+                tidal_id: cand.id,
+                score: scored.score,
+                reason: scored.reason,
+            });
+        }
+    }
+
+    let outcome = match best {
+        None => ResolutionOutcome {
+            status: ResolutionStatus::Unresolved,
+            tidal_track_id: None,
+            confidence: best_pre_guard.unwrap_or(0.0),
+            reason: "version_mismatch".to_string(),
+        },
+        Some(c) => ResolutionOutcome {
+            status: classify(c.score),
+            tidal_track_id: Some(c.tidal_id),
+            confidence: c.score,
+            reason: c.reason,
+        },
+    };
+
+    Ok(outcome)
+}
+
+/// Resolve a batch of Spotify tracks against TIDAL with bounded concurrency.
+/// Each input keeps its position in the output: `outcomes[i]` corresponds to
+/// `inputs[i]`.
+pub async fn resolve_many(
+    client: &TidalClient,
+    inputs: &[(String, SportifyTrack)],
+    concurrency: usize,
+) -> Vec<(String, ResolutionOutcome)> {
+    if inputs.is_empty() {
+        return Vec::new();
+    }
+    let concurrency = concurrency.max(1);
+    let sem = Arc::new(Semaphore::new(concurrency));
+    let mut handles: Vec<tokio::task::JoinHandle<(usize, String, ResolutionOutcome)>> =
+        Vec::with_capacity(inputs.len());
+    for (idx, (spotify_id, track)) in inputs.iter().enumerate() {
+        let sem = sem.clone();
+        let client = client.clone();
+        let id = spotify_id.clone();
+        let track = track.clone();
+        let handle = tokio::spawn(async move {
+            let _permit = match sem.acquire_owned().await {
+                Ok(p) => p,
+                Err(_) => {
+                    return (idx, id, ResolutionOutcome::unresolved("semaphore_closed"));
+                }
+            };
+            let outcome = match resolve_track(&client, &track).await {
+                Ok(o) => o,
+                Err(e) => ResolutionOutcome::unresolved(format!("resolver_error:{e}")),
+            };
+            (idx, id, outcome)
+        });
+        handles.push(handle);
+    }
+    let mut results: Vec<Option<(String, ResolutionOutcome)>> = (0..inputs.len()).map(|_| None).collect();
+    for h in handles {
+        match h.await {
+            Ok((idx, id, outcome)) => {
+                results[idx] = Some((id, outcome));
+            }
+            Err(e) => {
+                tracing::warn!("resolve_many task join failed: {}", e);
+            }
+        }
+    }
+    results
+        .into_iter()
+        .enumerate()
+        .map(|(i, r)| {
+            r.unwrap_or_else(|| {
+                (
+                    inputs[i].0.clone(),
+                    ResolutionOutcome::unresolved("task_join_failed"),
+                )
+            })
+        })
+        .collect()
+}
+
+#[derive(Debug)]
+struct ScoredCandidate {
+    tidal_id: i64,
+    score: f64,
+    reason: String,
+}
+
+#[derive(Debug, Clone)]
+struct ScoreBreakdown {
+    score: f64,
+    reason: String,
+}
+
+fn score(
+    sportify: &SportifyTrack,
+    sp_title: &str,
+    sp_primary_artist: &str,
+    cand: &TidalSearchTrack,
+) -> ScoreBreakdown {
+    let sp_title_norm = normalize_title(sp_title);
+    let cand_title_norm = normalize_title(&cand.title);
+    let title_jaccard = token_jaccard(&sp_title_norm, &cand_title_norm);
+
+    let cand_artist = cand.artist_name.as_deref().unwrap_or("");
+    let artist_jaccard = token_jaccard(
+        &normalize_artist(sp_primary_artist),
+        &normalize_artist(cand_artist),
+    );
+
+    // Duration delta in milliseconds. Sportify durations are in `duration_ms`,
+    // TIDAL `TidalSearchTrack.duration` is seconds.
+    let duration_score = match sportify.duration_ms {
+        Some(ms) if ms > 0 => {
+            let cand_ms = (cand.duration as i64) * 1000;
+            let diff = (ms - cand_ms).abs();
+            if diff < 1500 {
+                1.0
+            } else if diff < 4000 {
+                0.5
+            } else if diff < 8000 {
+                0.0
+            } else {
+                -1.0
+            }
+        }
+        _ => 0.0,
+    };
+
+    let explicit_match = match sportify.explicit {
+        Some(_) => 0.0, // TIDAL search rows don't expose explicit flag, skip.
+        None => 0.0,
+    };
+
+    // Weighted sum, clamped into [0,1]. Title and artist are the primary
+    // signals; duration acts as a real penalty so a 12" mix that shares a
+    // title with the single edit doesn't autoplay over the wrong version.
+    let raw = title_jaccard * 0.55 + artist_jaccard * 0.40 + duration_score * 0.10 + explicit_match;
+    let score = raw.clamp(0.0, 1.0);
+
+    let reason = format!(
+        "title={:.2} artist={:.2} dur={:.2}",
+        title_jaccard, artist_jaccard, duration_score
+    );
+    ScoreBreakdown { score, reason }
+}
+
+/// Lower-case, fold common Latin diacritics, drop parentheticals + the
+/// "(feat. X)" / " - feat. X" tail, collapse whitespace.
+pub fn normalize_title(s: &str) -> String {
+    let lowered = s.to_lowercase();
+    let no_parens = strip_brackets(&lowered);
+    let no_feat = strip_feat_tail(&no_parens);
+    let folded: String = no_feat.chars().map(ascii_fold_char).collect();
+    folded.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Like `normalize_title`, but also drops trailing role markers like "the band"
+/// and treats `&`, `and`, `,` as separators.
+pub fn normalize_artist(s: &str) -> String {
+    let base = normalize_title(s);
+    base.replace('&', " ")
+        .replace(',', " ")
+        .split_whitespace()
+        .filter(|t| *t != "and" && *t != "with" && *t != "feat" && *t != "ft")
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn strip_brackets(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut depth_paren = 0i32;
+    let mut depth_brack = 0i32;
+    for ch in s.chars() {
+        match ch {
+            '(' => depth_paren += 1,
+            ')' => {
+                if depth_paren > 0 {
+                    depth_paren -= 1;
+                }
+            }
+            '[' => depth_brack += 1,
+            ']' => {
+                if depth_brack > 0 {
+                    depth_brack -= 1;
+                }
+            }
+            _ if depth_paren == 0 && depth_brack == 0 => out.push(ch),
+            _ => {}
+        }
+    }
+    out
+}
+
+fn strip_feat_tail(s: &str) -> String {
+    let markers = [" feat.", " feat ", " ft.", " ft ", " featuring "];
+    for m in &markers {
+        if let Some(idx) = s.find(m) {
+            return s[..idx].to_string();
+        }
+    }
+    // Common dash separator: " - feat. X"
+    if let Some(idx) = s.find(" - ") {
+        let tail = &s[idx + 3..];
+        if tail.starts_with("feat") || tail.starts_with("ft") {
+            return s[..idx].to_string();
+        }
+    }
+    s.to_string()
+}
+
+fn ascii_fold_char(c: char) -> char {
+    match c {
+        'à' | 'á' | 'â' | 'ã' | 'ä' | 'å' | 'ā' | 'ă' | 'ą' => 'a',
+        'ç' | 'č' | 'ć' => 'c',
+        'è' | 'é' | 'ê' | 'ë' | 'ē' | 'ě' | 'ę' => 'e',
+        'ì' | 'í' | 'î' | 'ï' | 'ī' => 'i',
+        'ñ' | 'ń' => 'n',
+        'ò' | 'ó' | 'ô' | 'õ' | 'ö' | 'ø' | 'ō' => 'o',
+        'š' | 'ś' => 's',
+        'ù' | 'ú' | 'û' | 'ü' | 'ū' => 'u',
+        'ý' | 'ÿ' => 'y',
+        'ž' | 'ź' | 'ż' => 'z',
+        '\u{2018}' | '\u{2019}' | '\u{2032}' => '\'',
+        '\u{201c}' | '\u{201d}' => '"',
+        '\u{2013}' | '\u{2014}' => '-',
+        _ => c,
+    }
+}
+
+fn tokens(s: &str) -> HashSet<String> {
+    s.split(|c: char| !c.is_alphanumeric())
+        .filter(|t| !t.is_empty())
+        .map(|t| t.to_string())
+        .collect()
+}
+
+fn token_jaccard(a: &str, b: &str) -> f64 {
+    let ta = tokens(a);
+    let tb = tokens(b);
+    if ta.is_empty() && tb.is_empty() {
+        return 0.0;
+    }
+    let intersection = ta.intersection(&tb).count() as f64;
+    let union = ta.union(&tb).count() as f64;
+    if union == 0.0 { 0.0 } else { intersection / union }
+}
+
+/// Detect version markers in a track title. Two tracks are eligible for
+/// matching only when their tag sets are equal (a studio track has an empty
+/// set; a live track has `live`; a 2011 remaster has `remaster`; etc.).
+pub fn version_tags(title: &str) -> HashSet<&'static str> {
+    let t = title.to_lowercase();
+    let mut tags: HashSet<&'static str> = HashSet::new();
+    if contains_word(&t, "live") || t.contains("live at ") || t.contains("live from ") {
+        tags.insert("live");
+    }
+    if contains_word(&t, "acoustic") {
+        tags.insert("acoustic");
+    }
+    if contains_word(&t, "remix")
+        || t.contains(" mix)")
+        || t.contains(" mix]")
+        || t.contains("- mix")
+    {
+        tags.insert("remix");
+    }
+    if contains_word(&t, "remaster") || t.contains("remastered") {
+        tags.insert("remaster");
+    }
+    if contains_word(&t, "sped") || t.contains("sped up") || t.contains("sped-up") {
+        tags.insert("sped_up");
+    }
+    if contains_word(&t, "slowed") {
+        tags.insert("slowed");
+    }
+    if contains_word(&t, "instrumental") {
+        tags.insert("instrumental");
+    }
+    if contains_word(&t, "demo") {
+        tags.insert("demo");
+    }
+    if t.contains("radio edit") || contains_word(&t, "edit") {
+        tags.insert("edit");
+    }
+    if contains_word(&t, "extended") {
+        tags.insert("extended");
+    }
+    if contains_word(&t, "karaoke") {
+        tags.insert("karaoke");
+    }
+    tags
+}
+
+fn contains_word(haystack: &str, word: &str) -> bool {
+    let mut start = 0usize;
+    while let Some(idx) = haystack[start..].find(word) {
+        let abs = start + idx;
+        let before_ok = abs == 0
+            || !haystack
+                .as_bytes()
+                .get(abs - 1)
+                .map(|b| b.is_ascii_alphanumeric())
+                .unwrap_or(false);
+        let end = abs + word.len();
+        let after_ok = end == haystack.len()
+            || !haystack
+                .as_bytes()
+                .get(end)
+                .map(|b| b.is_ascii_alphanumeric())
+                .unwrap_or(false);
+        if before_ok && after_ok {
+            return true;
+        }
+        start = abs + word.len();
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::sportify::models::{SportifyArtistRef, SportifyTrack};
+
+    fn sp(title: &str, artist: &str, dur_ms: Option<i64>) -> SportifyTrack {
+        SportifyTrack {
+            name: Some(title.to_string()),
+            artists: vec![SportifyArtistRef {
+                name: Some(artist.to_string()),
+                ..Default::default()
+            }],
+            duration_ms: dur_ms,
+            ..Default::default()
+        }
+    }
+
+    fn cand(id: i64, title: &str, artist: &str, dur_secs: i64) -> TidalSearchTrack {
+        TidalSearchTrack {
+            id,
+            title: title.to_string(),
+            duration: dur_secs,
+            artist_id: None,
+            artist_name: Some(artist.to_string()),
+            artist_picture: None,
+            album_title: None,
+            album_id: None,
+            artwork_url: None,
+            audio_quality: None,
+            stream_ready: Some(true),
+            extra: Default::default(),
+        }
+    }
+
+    #[test]
+    fn normalize_strips_parens_and_feat() {
+        assert_eq!(
+            normalize_title("Hey Ya! (feat. André 3000)"),
+            "hey ya!".to_string()
+        );
+        assert_eq!(
+            normalize_title("Get Lucky - Radio Edit"),
+            "get lucky - radio edit".to_string()
+        );
+        assert_eq!(
+            normalize_title("Café del Mar"),
+            "cafe del mar".to_string()
+        );
+    }
+
+    #[test]
+    fn version_tags_distinguishes_live_studio() {
+        assert!(version_tags("Hey Ya!").is_empty());
+        assert!(version_tags("Hey Ya! - Live at Sydney").contains("live"));
+        assert!(version_tags("Wonderwall - Acoustic").contains("acoustic"));
+        assert!(version_tags("Bohemian Rhapsody - 2011 Remaster").contains("remaster"));
+        assert!(version_tags("Animals - Henrik Schwarz Remix").contains("remix"));
+    }
+
+    #[test]
+    fn version_tags_word_boundary_ignores_substrings() {
+        // "live" inside "alive" should NOT trigger the live tag.
+        assert!(!version_tags("Alive").contains("live"));
+        assert!(!version_tags("Believe").contains("live"));
+    }
+
+    #[test]
+    fn token_jaccard_basic() {
+        assert!((token_jaccard("hey ya", "hey ya") - 1.0).abs() < 1e-9);
+        assert!((token_jaccard("hey ya", "ya hey") - 1.0).abs() < 1e-9);
+        assert!(token_jaccard("hey ya", "completely different") < 0.1);
+    }
+
+    #[test]
+    fn score_high_for_exact_match() {
+        let s = sp("Get Lucky", "Daft Punk", Some(248_000));
+        let c = cand(123, "Get Lucky", "Daft Punk", 248);
+        let breakdown = score(&s, "Get Lucky", "Daft Punk", &c);
+        assert!(
+            breakdown.score >= 0.90,
+            "expected >= 0.90 but got {} ({})",
+            breakdown.score,
+            breakdown.reason
+        );
+    }
+
+    #[test]
+    fn score_low_for_artist_mismatch() {
+        let s = sp("Get Lucky", "Daft Punk", Some(248_000));
+        let c = cand(123, "Get Lucky", "Some Cover Band", 250);
+        let breakdown = score(&s, "Get Lucky", "Daft Punk", &c);
+        assert!(
+            breakdown.score < LOW_CONFIDENCE_THRESHOLD,
+            "expected < {} but got {} ({})",
+            LOW_CONFIDENCE_THRESHOLD,
+            breakdown.score,
+            breakdown.reason
+        );
+    }
+
+    #[test]
+    fn score_in_low_confidence_band_when_duration_off() {
+        // Same title and artist but a very different duration (single edit
+        // vs 12" mix). Should land in the playable-but-no-autoplay band.
+        let s = sp("Music Sounds Better With You", "Stardust", Some(213_000));
+        let c = cand(
+            123,
+            "Music Sounds Better With You",
+            "Stardust",
+            420, // 7-minute version
+        );
+        let breakdown = score(&s, "Music Sounds Better With You", "Stardust", &c);
+        assert!(breakdown.score < RESOLVED_THRESHOLD);
+        assert!(breakdown.score >= LOW_CONFIDENCE_THRESHOLD - 0.05);
+    }
+
+    #[test]
+    fn classify_buckets() {
+        assert_eq!(classify(0.95), ResolutionStatus::Resolved);
+        assert_eq!(classify(0.80), ResolutionStatus::LowConfidence);
+        assert_eq!(classify(0.50), ResolutionStatus::Unresolved);
+    }
+
+    #[tokio::test]
+    async fn resolve_many_empty_input_returns_empty() {
+        // Smoke test: with no inputs the bulk path doesn't even need a working
+        // TIDAL client, so we can exercise it without mocks.
+        let client = TidalClient::new("dummy".into(), "US".into());
+        let outcomes = resolve_many(&client, &[], 4).await;
+        assert!(outcomes.is_empty());
+    }
+}

--- a/noor-server/src/services/sportify/stats.rs
+++ b/noor-server/src/services/sportify/stats.rs
@@ -1,0 +1,230 @@
+//! Writeback for world playcount + monthly-listener stats lifted from
+//! Sportify responses into the existing `spotify_track_stats` /
+//! `spotify_artist_stats` tables (`MIGRATION_029`).
+//!
+//! Why these tables and not new `sportify_*_stats`: the existing artist page
+//! already reads `spotify_artist_stats` via
+//! `/api/artists/{id}/spotify-stats`, so funnelling Sportify-sourced numbers
+//! through the same table means stats appear automatically on the legacy
+//! library page with zero frontend wiring. Tracks resolve to TIDAL anyway
+//! (the resolver writes `spotify_track_id → tidal_track_id` mappings), so a
+//! library track's `spotify_track_id` lookup → `spotify_track_stats` lookup
+//! gives us "1.2B plays" labels for free.
+//!
+//! Failure policy: every writeback is best-effort. Sportify is upstream and
+//! subject to breakage; a missing `playcount` or a malformed value must
+//! never bubble up an error that fails the surrounding request. Each helper
+//! takes a connection and returns `()` — write what we can, log what we
+//! can't, move on.
+
+use rusqlite::{Connection, params};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use super::models::{SportifyArtist, SportifyTrack};
+
+fn now_secs() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+/// If the Sportify track payload carries a `playcount`, upsert it into
+/// `spotify_track_stats`. No-op when playcount is missing, zero, or negative.
+pub fn write_track_playcount(conn: &Connection, track: &SportifyTrack) {
+    let Some(spotify_id) = track.id.as_deref() else {
+        return;
+    };
+    let Some(playcount) = track.playcount.filter(|c| *c > 0) else {
+        return;
+    };
+    if let Err(e) = conn.execute(
+        "INSERT INTO spotify_track_stats (spotify_track_id, playcount, fetched_at)
+         VALUES (?1, ?2, ?3)
+         ON CONFLICT(spotify_track_id) DO UPDATE SET
+            playcount = excluded.playcount,
+            fetched_at = excluded.fetched_at",
+        params![spotify_id, playcount, now_secs()],
+    ) {
+        tracing::warn!(
+            "spotify_track_stats writeback for {} failed: {}",
+            spotify_id,
+            e
+        );
+    }
+
+    // ISRC mapping is permanent (Spotify track IDs don't change), so opportunistically
+    // populate the index when Sportify gives it to us. Cheap to keep; lets the
+    // existing Spotify-stats path reuse the same lookup.
+    if let Some(isrc) = track
+        .external_ids
+        .as_ref()
+        .and_then(|e| e.isrc.as_deref())
+        .filter(|s| !s.is_empty())
+    {
+        if let Err(e) = conn.execute(
+            "INSERT INTO spotify_isrc_map (isrc, spotify_track_id, resolved_at)
+             VALUES (?1, ?2, ?3)
+             ON CONFLICT(isrc) DO UPDATE SET
+                spotify_track_id = excluded.spotify_track_id,
+                resolved_at = excluded.resolved_at",
+            params![isrc, spotify_id, now_secs()],
+        ) {
+            tracing::warn!("spotify_isrc_map writeback for {} failed: {}", isrc, e);
+        }
+    }
+}
+
+/// If the Sportify artist payload carries `monthly_listeners`, upsert it
+/// into `spotify_artist_stats`. No-op on missing/zero/negative values.
+pub fn write_artist_monthly_listeners(conn: &Connection, artist: &SportifyArtist) {
+    let Some(spotify_id) = artist.id.as_deref() else {
+        return;
+    };
+    let Some(monthly) = artist.monthly_listeners.filter(|c| *c > 0) else {
+        return;
+    };
+    if let Err(e) = conn.execute(
+        "INSERT INTO spotify_artist_stats (spotify_artist_id, monthly_listeners, fetched_at)
+         VALUES (?1, ?2, ?3)
+         ON CONFLICT(spotify_artist_id) DO UPDATE SET
+            monthly_listeners = excluded.monthly_listeners,
+            fetched_at = excluded.fetched_at",
+        params![spotify_id, monthly, now_secs()],
+    ) {
+        tracing::warn!(
+            "spotify_artist_stats writeback for {} failed: {}",
+            spotify_id,
+            e
+        );
+    }
+}
+
+/// Bulk variant — write every track in a batch, ignoring individual failures.
+pub fn write_track_playcounts(conn: &Connection, tracks: &[SportifyTrack]) {
+    for t in tracks {
+        write_track_playcount(conn, t);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::schema::run_migrations;
+    use crate::services::sportify::models::{SportifyExternalIds, SportifyTrack};
+
+    fn fresh_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        run_migrations(&conn).unwrap();
+        conn
+    }
+
+    #[test]
+    fn writes_playcount_when_present() {
+        let conn = fresh_db();
+        let track = SportifyTrack {
+            id: Some("abc".into()),
+            playcount: Some(1_234_567),
+            ..Default::default()
+        };
+        write_track_playcount(&conn, &track);
+        let count: i64 = conn
+            .query_row(
+                "SELECT playcount FROM spotify_track_stats WHERE spotify_track_id = 'abc'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1_234_567);
+    }
+
+    #[test]
+    fn skips_playcount_when_missing_or_zero() {
+        let conn = fresh_db();
+        let no_count = SportifyTrack {
+            id: Some("abc".into()),
+            playcount: None,
+            ..Default::default()
+        };
+        let zero = SportifyTrack {
+            id: Some("def".into()),
+            playcount: Some(0),
+            ..Default::default()
+        };
+        write_track_playcount(&conn, &no_count);
+        write_track_playcount(&conn, &zero);
+        let n: i64 = conn
+            .query_row("SELECT COUNT(*) FROM spotify_track_stats", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(n, 0);
+    }
+
+    #[test]
+    fn writes_isrc_map_when_present() {
+        let conn = fresh_db();
+        let track = SportifyTrack {
+            id: Some("abc".into()),
+            playcount: Some(100),
+            external_ids: Some(SportifyExternalIds {
+                isrc: Some("USRC17607839".into()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        write_track_playcount(&conn, &track);
+        let mapped: String = conn
+            .query_row(
+                "SELECT spotify_track_id FROM spotify_isrc_map WHERE isrc = 'USRC17607839'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(mapped, "abc");
+    }
+
+    #[test]
+    fn writes_monthly_listeners_when_present() {
+        let conn = fresh_db();
+        let artist = SportifyArtist {
+            id: Some("artistX".into()),
+            monthly_listeners: Some(47_000_000),
+            ..Default::default()
+        };
+        write_artist_monthly_listeners(&conn, &artist);
+        let n: i64 = conn
+            .query_row(
+                "SELECT monthly_listeners FROM spotify_artist_stats WHERE spotify_artist_id = 'artistX'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(n, 47_000_000);
+    }
+
+    #[test]
+    fn upsert_replaces_stale_value() {
+        let conn = fresh_db();
+        let t1 = SportifyTrack {
+            id: Some("abc".into()),
+            playcount: Some(100),
+            ..Default::default()
+        };
+        let t2 = SportifyTrack {
+            id: Some("abc".into()),
+            playcount: Some(200),
+            ..Default::default()
+        };
+        write_track_playcount(&conn, &t1);
+        write_track_playcount(&conn, &t2);
+        let count: i64 = conn
+            .query_row(
+                "SELECT playcount FROM spotify_track_stats WHERE spotify_track_id = 'abc'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 200);
+    }
+}

--- a/noor-server/src/services/tidal/client.rs
+++ b/noor-server/src/services/tidal/client.rs
@@ -285,13 +285,14 @@ impl TidalClient {
         self.get_json(&url).await
     }
 
-    pub async fn search_playlists(&self, query: &str, limit: i32) -> Result<Vec<TidalPlaylist>> {
+    pub async fn search_playlists(&self, query: &str, limit: i32, offset: i32) -> Result<Vec<TidalPlaylist>> {
         let url = format!(
-            "{}/search?query={}&countryCode={}&limit={}&types=PLAYLISTS",
+            "{}/search?query={}&countryCode={}&limit={}&offset={}&types=PLAYLISTS",
             TIDAL_API_URL,
             urlencoding::encode(query),
             self.country_code,
             limit,
+            offset.max(0),
         );
         let payload: serde_json::Value = self.get_json(&url).await?;
         let items = payload
@@ -359,13 +360,14 @@ impl TidalClient {
 
     // ─── Search ────────────────────────────────────────────
 
-    pub async fn search_catalog(&self, query: &str, limit: i32) -> Result<TidalSearchCatalog> {
+    pub async fn search_catalog(&self, query: &str, limit: i32, offset: i32) -> Result<TidalSearchCatalog> {
         let url = format!(
-            "{}/search?query={}&countryCode={}&limit={}&types=TRACKS,ALBUMS,ARTISTS",
+            "{}/search?query={}&countryCode={}&limit={}&offset={}&types=TRACKS,ALBUMS,ARTISTS",
             TIDAL_API_URL,
             urlencoding::encode(query),
             self.country_code,
-            limit
+            limit,
+            offset.max(0)
         );
         let payload: serde_json::Value = self.get_json(&url).await?;
 
@@ -405,7 +407,7 @@ impl TidalClient {
     }
 
     pub async fn search(&self, query: &str, limit: i32) -> Result<Vec<TidalSearchTrack>> {
-        Ok(self.search_catalog(query, limit).await?.tracks)
+        Ok(self.search_catalog(query, limit, 0).await?.tracks)
     }
 
     /// Fetch Tidal editorial "Top Tracks" for the user's region.


### PR DESCRIPTION
… and playlist route

Adds the sportify proxy service — an anonymous Spotify metadata cache with Spotify→TIDAL resolution, DB migrations 031-032, new /spotify-playlist route, and search filter pills that switch to multi-row grids for single-category views.