### PR TITLE
Design system pass: fluid scaling, de-dup, visual unification (Phases 1–3)

### DIFF
--- a/frontend/.stylelintrc.json
+++ b/frontend/.stylelintrc.json
@@ -1,4 +1,10 @@
 {
+	"overrides": [
+		{
+			"files": ["**/*.svelte"],
+			"customSyntax": "postcss-html"
+		}
+	],
 	"rules": {
 		"declaration-property-value-disallowed-list": [
 			{

--- a/frontend/.stylelintrc.json
+++ b/frontend/.stylelintrc.json
@@ -12,11 +12,15 @@
 					"/var\\(--danger\\b/",
 					"/var\\(--color-error\\b/",
 					"/var\\(--bg-glass\\b/",
-					"/var\\(--surface-hover\\b/"
+					"/var\\(--surface-hover\\b/",
+					"/#4a6dd8/i",
+					"/#5a7ce8/i",
+					"/rgba\\(155,\\s*111,\\s*255/i",
+					"/rgba\\(74,\\s*109,\\s*216/i"
 				]
 			},
 			{
-				"message": "Use the canonical token instead: --state-error, --bg-surface, --bg-hover (see frontend/STYLING.md)."
+				"message": "Use the canonical token instead: --state-error, --bg-surface, --bg-hover, --accent, --accent-strong (see frontend/STYLING.md)."
 			}
 		],
 		"declaration-property-unit-disallowed-list": [

--- a/frontend/.stylelintrc.json
+++ b/frontend/.stylelintrc.json
@@ -1,0 +1,31 @@
+{
+	"rules": {
+		"declaration-property-value-disallowed-list": [
+			{
+				"/.+/": [
+					"/var\\(--danger\\b/",
+					"/var\\(--color-error\\b/",
+					"/var\\(--bg-glass\\b/",
+					"/var\\(--surface-hover\\b/"
+				]
+			},
+			{
+				"message": "Use the canonical token instead: --state-error, --bg-surface, --bg-hover (see frontend/STYLING.md)."
+			}
+		],
+		"declaration-property-unit-disallowed-list": [
+			{
+				"font-size": ["px"]
+			},
+			{
+				"severity": "warning",
+				"message": "Prefer var(--font-size-xs|sm|md|lg|xl|2xl|3xl) over raw px (see frontend/STYLING.md)."
+			}
+		]
+	},
+	"ignoreFiles": [
+		"build/**",
+		"node_modules/**",
+		".svelte-kit/**"
+	]
+}

--- a/frontend/STYLING.md
+++ b/frontend/STYLING.md
@@ -84,9 +84,20 @@ For grids, anchor the card width (and label widths) to the same custom property 
 
 Small inline thumbnails (track rows, video lists) stay near-fixed: `clamp(2rem, 3vw, 2.5rem)` so they don't shrink to absurdity in narrow lists.
 
-## Z-index scale (planned)
+## Z-index scale
 
-The codebase currently has ~52 raw `z-index: NNN` values from 0 to 9999 with no shared scale. **Do not add new raw z-indexes.** When the `--z-base / --z-raised / --z-overlay / --z-modal / --z-toast / --z-tooltip` scale lands (Phase 2), use those tokens.
+| Token | Value | Use for |
+| --- | --- | --- |
+| `--z-base` | 1 | In-flow stacking (e.g. a hero z-1 element) |
+| `--z-raised` | 10 | Sticky-within-panel headers, hover lifts |
+| `--z-overlay` | 100 | Dropdowns, popovers, hover cards |
+| `--z-modal` | 1000 | Modal dialogs (confirm prompts, settings sheets) |
+| `--z-toast` | 2000 | Toasts, command palette |
+| `--z-tooltip` | 3000 | Tooltips (must overlap modals) |
+
+**Don't add new raw `z-index: NNN` values.** Use the tokens above. When two elements within the same layer need explicit ordering, use `calc(var(--z-modal) + 1)` instead of escalating to a higher layer.
+
+Existing raw `z-index` values from before the scale was introduced have been migrated for the highest-impact sites (toasts, command palette, context menu, modals, tooltips). Lower-z values within panels (z 1–80) are left raw because they represent within-panel stacking that doesn't need to participate in the global scale.
 
 ## Linting
 

--- a/frontend/STYLING.md
+++ b/frontend/STYLING.md
@@ -1,0 +1,105 @@
+# Styling — design system reference
+
+This document is the load-bearing reference for how styling works in `frontend/src`. It is short on purpose. Read it before adding new tokens, new global CSS rules, or new component-level styling patterns.
+
+## Core principle: every dimension scales fluidly
+
+The app targets Tauri windows that range from 720 × 500 (the configured floor) up to 4K and beyond. Spacing, radii, typography, and content widths all interpolate with viewport using `clamp()` so the UI looks proportional at any size. Hard pixel values are reserved for icons (intrinsic SVG size), structural rhythm where snapping is intended, and per-component artwork floors.
+
+If you're tempted to add `padding: 16px` or `border-radius: 12px` directly, ask: does this need to scale with the viewport? In almost every case the answer is yes — use a token.
+
+## Tokens (in [`src/app.css`](src/app.css))
+
+| Family | Tokens | Use for |
+| --- | --- | --- |
+| Spacing | `--space-1` … `--space-7` (3-48 px), `--gap-sm` / `--gap` / `--gap-lg` | Padding, margin, grid gap, flex gap |
+| Radii | `--radius-xs` (4-6 px), `--radius-sm` (7-10 px), `--radius` (12-16 px), `--radius-lg` (15-22 px) | Card corners, panel corners. `50%` and `999px` for circles/pills are fine raw. |
+| Typography | `--font-size-xs` (11-13 px) … `--font-size-3xl` (28-40 px) | All component font sizes that map cleanly to a step. Odd one-offs (e.g. 13 px) stay raw. |
+| Motion | `--motion-fast` (130 ms), `--motion-base` (210 ms), `--motion-slow` (340 ms) | All `transition` durations. No raw `0.13s` / `0.21s` / `0.34s`. |
+| State | `--state-error`, `--state-warning`, `--state-success`, `--state-active` | Status colours. **Never** use `--danger`, `--color-error` — they are not defined. |
+| Surface | `--bg-base`, `--bg-elevated`, `--bg-raised`, `--bg-surface`, `--bg-hover`, `--panel-bg` | Backgrounds. **Never** use `--bg-glass`, `--surface-hover` — they are not defined. |
+| Borders | `--border-subtle`, `--border-muted`, `--border-strong` | All component borders. |
+| Content | `--content-width` (clamp 1280-2400 px) | Page-shell `max-width` so content scales on wide monitors. |
+
+## Global utility classes
+
+Use these instead of reimplementing the surface:
+
+- `.glass`, `.glass-panel`, `.glass-tile` — translucent panel surfaces (backdrop-filter + bg + border + shadow). If you find yourself writing `backdrop-filter: blur(...)` plus a translucent gradient + a subtle border, replace with one of these classes.
+- `.btn`, `.btn-primary`, `.btn-glass` — pill buttons. Don't roll your own button visual unless you're building a chip or icon-only variant.
+- `.quality-badge.hires|.lossless|.lossy` — quality indicator pill.
+
+## Auto-fit grids over fixed-N columns
+
+Card grids should reflow naturally as viewport changes:
+
+```css
+/* ✗ */
+grid-template-columns: repeat(4, 1fr);
+@media (max-width: 1180px) { grid-template-columns: repeat(3, 1fr); }
+@media (max-width: 760px)  { grid-template-columns: repeat(2, 1fr); }
+
+/* ✓ */
+grid-template-columns: repeat(auto-fit, minmax(min(220px, 100%), 1fr));
+```
+
+Track-row layouts and structural two-column splits (e.g. sidebar + content) keep their explicit columns — auto-fit is for **card** grids.
+
+## Page widths
+
+Page shells use `var(--content-width)` so they scale with viewport:
+
+```css
+.my-page {
+  width: min(100%, var(--content-width));
+  margin: 0 auto;
+}
+```
+
+**Don't** use `min(1200px, var(--content-width))` for inner sections — `min()` picks the smaller value, which caps the section at 1200 px on wide viewports. Just use `var(--content-width)` directly, or a different non-fluid cap if the section deliberately stays narrow (e.g. a 640 px-wide search input).
+
+## Artwork sizing
+
+Album art, artist photos, video thumbnails, playlist covers use `aspect-ratio` plus a clamped width:
+
+```css
+.album-art {
+  width: clamp(140px, 18vw, 220px);
+  aspect-ratio: 1 / 1;
+  border-radius: var(--radius-sm);
+  object-fit: cover;
+}
+```
+
+For grids, anchor the card width (and label widths) to the same custom property so they stay in lockstep:
+
+```css
+.albums-row {
+  --album-card-w: clamp(112px, 11vw, 156px);
+}
+.album-card { width: var(--album-card-w); }
+.art-wrap { width: var(--album-card-w); aspect-ratio: 1 / 1; }
+.album-title { width: var(--album-card-w); }
+```
+
+Small inline thumbnails (track rows, video lists) stay near-fixed: `clamp(2rem, 3vw, 2.5rem)` so they don't shrink to absurdity in narrow lists.
+
+## Z-index scale (planned)
+
+The codebase currently has ~52 raw `z-index: NNN` values from 0 to 9999 with no shared scale. **Do not add new raw z-indexes.** When the `--z-base / --z-raised / --z-overlay / --z-modal / --z-toast / --z-tooltip` scale lands (Phase 2), use those tokens.
+
+## Linting
+
+Stylelint runs on `src/**/*.css` and forbids the legacy tokens (`--danger`, `--color-error`, `--bg-glass`, `--surface-hover`). It also disallows raw `font-size: Npx`. Run:
+
+```text
+npm run lint:css
+```
+
+Failures are blocking; fix them before committing. Component-level (`.svelte`) CSS is not linted yet — that's a follow-up once `postcss-html` is wired in.
+
+## Before you add a token
+
+Justify why an existing token cannot represent the value. New tokens grow the design system and become a maintenance cost. The current scale already covers spacing 3-48 px, radii 4-22 px, type 11-40 px — most additions to the system can be expressed in those.
+
+If you need a value outside the scale (e.g. a 64 px hero-art floor), prefer a per-component CSS custom property scoped to the parent over a new global token.

--- a/frontend/STYLING.md
+++ b/frontend/STYLING.md
@@ -13,12 +13,15 @@ If you're tempted to add `padding: 16px` or `border-radius: 12px` directly, ask:
 | Family | Tokens | Use for |
 | --- | --- | --- |
 | Spacing | `--space-1` … `--space-7` (3-48 px), `--gap-sm` / `--gap` / `--gap-lg` | Padding, margin, grid gap, flex gap |
-| Radii | `--radius-xs` (4-6 px), `--radius-sm` (7-10 px), `--radius` (12-16 px), `--radius-lg` (15-22 px) | Card corners, panel corners. `50%` and `999px` for circles/pills are fine raw. |
+| Radii | `--radius-xs` (4-6 px), `--radius-sm` (7-10 px), `--radius-md` (10-14 px), `--radius-lg` (15-22 px). `--radius` is a legacy alias for `--radius-md`. | Card corners, panel corners, modal corners. `50%` and `999px` for circles/pills are fine raw. |
 | Typography | `--font-size-xs` (11-13 px) … `--font-size-3xl` (28-40 px) | All component font sizes that map cleanly to a step. Odd one-offs (e.g. 13 px) stay raw. |
 | Motion | `--motion-fast` (130 ms), `--motion-base` (210 ms), `--motion-slow` (340 ms) | All `transition` durations. No raw `0.13s` / `0.21s` / `0.34s`. |
-| State | `--state-error`, `--state-warning`, `--state-success`, `--state-active` | Status colours. **Never** use `--danger`, `--color-error` — they are not defined. |
+| Blur | `--blur-base` (8 px), `--blur-overlay` (16 px), `--blur-modal` (24 px) | All `backdrop-filter` values. Three tiers is the maximum that should ever exist; anything else is drift. |
+| State | `--state-error`, `--state-warning`, `--state-success`, `--state-active`, `--state-favorite`, `--state-favorite-glow` | Status colours. **Never** use `--danger`, `--color-error` — they are not defined. |
+| Service | `--service-spotify`, `--service-tidal`, `--service-lastfm` | Service brand colors for source badges and service-branded heroes only. **Stay stable across themes** — they are brand cues, not theme variables. |
 | Surface | `--bg-base`, `--bg-elevated`, `--bg-raised`, `--bg-surface`, `--bg-hover`, `--panel-bg` | Backgrounds. **Never** use `--bg-glass`, `--surface-hover` — they are not defined. |
-| Borders | `--border-subtle`, `--border-muted`, `--border-strong` | All component borders. |
+| Borders | `--border-subtle`, `--border-muted`, `--border-strong`, `--panel-border` | All component borders. Don't write raw `1px solid rgba(255,255,255,0.06)` — it won't theme. |
+| Accent | `--accent`, `--accent-soft`, `--accent-line`, `--accent-strong`, `--accent-glow` | Interactive accents (active states, primary buttons, focus rings). Tracks the user's profile palette. **Never** hardcode hex values for accents** — onboarding's `#4a6dd8` was migrated to `var(--accent)` so it follows the theme. |
 | Content | `--content-width` (clamp 1280-2400 px) | Page-shell `max-width` so content scales on wide monitors. |
 
 ## Global utility classes
@@ -28,6 +31,17 @@ Use these instead of reimplementing the surface:
 - `.glass`, `.glass-panel`, `.glass-tile` — translucent panel surfaces (backdrop-filter + bg + border + shadow). If you find yourself writing `backdrop-filter: blur(...)` plus a translucent gradient + a subtle border, replace with one of these classes.
 - `.btn`, `.btn-primary`, `.btn-glass` — pill buttons. Don't roll your own button visual unless you're building a chip or icon-only variant.
 - `.quality-badge.hires|.lossless|.lossy` — quality indicator pill.
+
+### Glass decision tree
+
+When you need a translucent surface, follow this order:
+
+1. **Compact tile or badge?** → `.glass-tile` (uses `--blur-base`, `--radius-sm`, `--panel-border`).
+2. **Elevated card / panel?** → `.glass` or `.glass-panel` (uses `--blur-overlay`, `--radius-md` or `--radius-lg`, full glass treatment).
+3. **Modal / context menu / palette?** → Don't use a class — use `backdrop-filter: var(--blur-modal)` directly with a non-translucent dark background (`rgba(12,12,24,0.96)` or similar) and `var(--radius-md)` corners. The class doesn't fit because modals tint deeper than the canonical glass.
+4. **Page scrim / dimmer behind a modal?** → Inline `backdrop-filter: blur(2-6px)` with a dim background. These are *not* glass surfaces; they're page-level dimmers and stay raw.
+
+If you reach for a 4th tier (12 px blur? 20 px blur?), pick the closest token. The whole point is three tiers, not three-plus-special-cases.
 
 ## Auto-fit grids over fixed-N columns
 
@@ -101,13 +115,16 @@ Existing raw `z-index` values from before the scale was introduced have been mig
 
 ## Linting
 
-Stylelint runs on `src/**/*.css` and forbids the legacy tokens (`--danger`, `--color-error`, `--bg-glass`, `--surface-hover`). It also disallows raw `font-size: Npx`. Run:
+Stylelint runs on `src/**/*.{css,svelte}` and:
+
+- **Errors** on legacy tokens (`--danger`, `--color-error`, `--bg-glass`, `--surface-hover`) and on hardcoded hex values that should be theme tokens (`#4a6dd8`, `#5a7ce8`, `rgba(155,111,255,...)`, `rgba(74,109,216,...)`).
+- **Warns** on raw `font-size: Npx` — prefer `var(--font-size-*)`.
 
 ```text
 npm run lint:css
 ```
 
-Failures are blocking; fix them before committing. Component-level (`.svelte`) CSS is not linted yet — that's a follow-up once `postcss-html` is wired in.
+Errors are blocking; fix them before committing. Warnings are advisory but reviewed at PR time. `.svelte` components are linted via `postcss-html`.
 
 ## Before you add a token
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
 		"prepare": "svelte-kit sync || echo ''",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-		"lint:css": "stylelint \"src/**/*.css\"",
+		"lint:css": "stylelint \"src/**/*.{css,svelte}\"",
 		"test": "vitest run",
 		"test:watch": "vitest"
 	},
@@ -21,6 +21,7 @@
 		"@sveltejs/vite-plugin-svelte": "^6.2.4",
 		"@types/node": "^25.6.0",
 		"playwright": "^1.59.1",
+		"postcss-html": "^1.8.1",
 		"stylelint": "^17.11.0",
 		"stylelint-config-standard": "^40.0.0",
 		"svelte": "^5.55.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
 		"prepare": "svelte-kit sync || echo ''",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+		"lint:css": "stylelint \"src/**/*.css\"",
 		"test": "vitest run",
 		"test:watch": "vitest"
 	},
@@ -20,6 +21,8 @@
 		"@sveltejs/vite-plugin-svelte": "^6.2.4",
 		"@types/node": "^25.6.0",
 		"playwright": "^1.59.1",
+		"stylelint": "^17.11.0",
+		"stylelint-config-standard": "^40.0.0",
 		"svelte": "^5.55.5",
 		"svelte-check": "^4.4.6",
 		"typescript": "^5.9.3",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       playwright:
         specifier: ^1.59.1
         version: 1.59.1
+      postcss-html:
+        specifier: ^1.8.1
+        version: 1.8.1
       stylelint:
         specifier: ^17.11.0
         version: 17.11.0(typescript@5.9.3)
@@ -670,8 +673,25 @@ packages:
   devalue@5.7.1:
     resolution: {integrity: sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA==}
 
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
 
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
@@ -799,6 +819,9 @@ packages:
     resolution: {integrity: sha512-n6l5uca7/y5joxZ3LUePhzmBFUJ+U2YWzhMa8XUTecSeSlQiZdF5XAd/Q3/WUl0VsXgUwWi8I7CNIwdI5WN1SQ==}
     engines: {node: '>=20.10'}
 
+  htmlparser2@8.0.2:
+    resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
+
   ignore@7.0.5:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
@@ -848,6 +871,9 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
@@ -954,6 +980,16 @@ packages:
     resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  postcss-html@1.8.1:
+    resolution: {integrity: sha512-OLF6P7qctfAWayOhLpcVnTGqVeJzu2W3WpIYelfz2+JV5oGxfkcEvweN9U4XpeqE0P98dcD9ssusGwlF0TK0uQ==}
+    engines: {node: ^12 || >=14}
+
+  postcss-safe-parser@6.0.0:
+    resolution: {integrity: sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.3.3
 
   postcss-safe-parser@7.0.1:
     resolution: {integrity: sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==}
@@ -1691,7 +1727,27 @@ snapshots:
 
   devalue@5.7.1: {}
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+
   emoji-regex@8.0.0: {}
+
+  entities@4.5.0: {}
 
   env-paths@2.2.1: {}
 
@@ -1829,6 +1885,13 @@ snapshots:
 
   html-tags@5.1.0: {}
 
+  htmlparser2@8.0.2:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 4.5.0
+
   ignore@7.0.5: {}
 
   import-fresh@3.3.1:
@@ -1863,6 +1926,8 @@ snapshots:
   isexe@2.0.0: {}
 
   js-tokens@4.0.0: {}
+
+  js-tokens@9.0.1: {}
 
   js-yaml@4.1.1:
     dependencies:
@@ -1941,6 +2006,17 @@ snapshots:
       playwright-core: 1.59.1
     optionalDependencies:
       fsevents: 2.3.2
+
+  postcss-html@1.8.1:
+    dependencies:
+      htmlparser2: 8.0.2
+      js-tokens: 9.0.1
+      postcss: 8.5.14
+      postcss-safe-parser: 6.0.0(postcss@8.5.14)
+
+  postcss-safe-parser@6.0.0(postcss@8.5.14):
+    dependencies:
+      postcss: 8.5.14
 
   postcss-safe-parser@7.0.1(postcss@8.5.14):
     dependencies:

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -33,6 +33,12 @@ importers:
       playwright:
         specifier: ^1.59.1
         version: 1.59.1
+      stylelint:
+        specifier: ^17.11.0
+        version: 17.11.0(typescript@5.9.3)
+      stylelint-config-standard:
+        specifier: ^40.0.0
+        version: 40.0.0(stylelint@17.11.0(typescript@5.9.3))
       svelte:
         specifier: ^5.55.5
         version: 5.55.5(@typescript-eslint/types@8.58.0)
@@ -50,6 +56,64 @@ importers:
         version: 4.1.5(@types/node@25.6.0)(vite@7.3.2(@types/node@25.6.0))
 
 packages:
+
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@cacheable/memory@2.0.8':
+    resolution: {integrity: sha512-FvEb29x5wVwu/Kf93IWwsOOEuhHh6dYCJF3vcKLzXc0KXIW181AOzv6ceT4ZpBHDvAfG60eqb+ekmrnLHIy+jw==}
+
+  '@cacheable/utils@2.4.1':
+    resolution: {integrity: sha512-eiFgzCbIneyMlLOmNG4g9xzF7Hv3Mga4LjxjcSC/ues6VYq2+gUbQI8JqNuw/ZM8tJIeIaBGpswAsqV2V7ApgA==}
+
+  '@csstools/css-calc@3.2.0':
+    resolution: {integrity: sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.3':
+    resolution: {integrity: sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/media-query-list-parser@5.0.0':
+    resolution: {integrity: sha512-T9lXmZOfnam3eMERPsszjY5NK0jX8RmThmmm99FZ8b7z8yMaFZWKwLWGZuTwdO3ddRY5fy13GmmEYZXB4I98Eg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/selector-resolve-nested@4.0.0':
+    resolution: {integrity: sha512-9vAPxmp+Dx3wQBIUwc1v7Mdisw1kbbaGqXUM8QLTgWg7SoPGYtXBsMXvsFs/0Bn5yoFhcktzxNZGNaUt0VjgjA==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      postcss-selector-parser: ^7.1.1
+
+  '@csstools/selector-specificity@6.0.0':
+    resolution: {integrity: sha512-4sSgl78OtOXEX/2d++8A83zHNTgwCJMaR24FvsYL7Uf/VS8HZk9PTwR51elTbGqMuwH3szLvvOXEaVnqn0Z3zA==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      postcss-selector-parser: ^7.1.1
 
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
@@ -223,6 +287,27 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@keyv/bigmap@1.3.1':
+    resolution: {integrity: sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      keyv: ^5.6.0
+
+  '@keyv/serialize@1.1.1':
+    resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
+
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
@@ -364,6 +449,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sindresorhus/merge-streams@4.0.0':
+    resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
+    engines: {node: '>=18'}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -469,6 +558,24 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
   aria-query@5.3.1:
     resolution: {integrity: sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==}
     engines: {node: '>= 0.4'}
@@ -477,9 +584,24 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  astral-regex@2.0.0:
+    resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
+    engines: {node: '>=8'}
+
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
+  cacheable@2.3.5:
+    resolution: {integrity: sha512-EQfaKe09tl615iNvq/TBRWTFf1AKJNXYQSsMx0Z3EI0nA+pVsVPS8wJhnRlkbdacKPh1d0qVIhwTc2zsQNFEEg==}
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -493,6 +615,16 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  colord@2.9.3:
+    resolution: {integrity: sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
@@ -500,12 +632,53 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
+  cosmiconfig@9.0.1:
+    resolution: {integrity: sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  css-functions-list@3.3.3:
+    resolution: {integrity: sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg==}
+    engines: {node: '>=12'}
+
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  cssesc@3.0.0:
+    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
 
   devalue@5.7.1:
     resolution: {integrity: sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
+
+  error-ex@1.3.4:
+    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
@@ -533,6 +706,23 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+
+  fastest-levenshtein@1.0.16:
+    resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
+    engines: {node: '>= 4.9.1'}
+
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -541,6 +731,19 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  file-entry-cache@11.1.3:
+    resolution: {integrity: sha512-oMbq0PD6VIiIwMF6LIa7MEwd/l9huKwmqRKXqmrkqIZv8CvRbfowL+L0ryAl8h//HfAS0zS+4SbYoRyAoA6BJA==}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  flat-cache@6.1.22:
+    resolution: {integrity: sha512-N2dnzVJIphnNsjHcrxGW7DePckJ6haPrSFqpsBUhHYgwtKGVq4JrBGielEGD2fCVnsGm1zlBVZ8wGhkyuetgug==}
+
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
@@ -552,21 +755,150 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
+  global-modules@2.0.0:
+    resolution: {integrity: sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==}
+    engines: {node: '>=6'}
+
+  global-prefix@3.0.0:
+    resolution: {integrity: sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==}
+    engines: {node: '>=6'}
+
+  globby@16.2.0:
+    resolution: {integrity: sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==}
+    engines: {node: '>=20'}
+
+  globjoin@0.1.4:
+    resolution: {integrity: sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==}
+
+  has-flag@5.0.1:
+    resolution: {integrity: sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA==}
+    engines: {node: '>=12'}
+
+  hashery@1.5.1:
+    resolution: {integrity: sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==}
+    engines: {node: '>=20'}
+
   hls.js@1.6.16:
     resolution: {integrity: sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==}
 
+  hookified@1.15.1:
+    resolution: {integrity: sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==}
+
+  hookified@2.2.0:
+    resolution: {integrity: sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==}
+
+  html-tags@5.1.0:
+    resolution: {integrity: sha512-n6l5uca7/y5joxZ3LUePhzmBFUJ+U2YWzhMa8XUTecSeSlQiZdF5XAd/Q3/WUl0VsXgUwWi8I7CNIwdI5WN1SQ==}
+    engines: {node: '>=20.10'}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+    engines: {node: '>= 4'}
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  is-path-inside@4.0.0:
+    resolution: {integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==}
+    engines: {node: '>=12'}
+
+  is-plain-object@5.0.0:
+    resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
+    engines: {node: '>=0.10.0'}
+
   is-reference@3.0.3:
     resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
+  json-parse-even-better-errors@2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  keyv@5.6.0:
+    resolution: {integrity: sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==}
+
+  kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
 
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
 
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
   locate-character@3.0.0:
     resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
 
+  lodash.truncate@4.4.2:
+    resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mathml-tag-names@4.0.0:
+    resolution: {integrity: sha512-aa6AU2Pcx0VP/XWnh8IGL0SYSgQHDT6Ucror2j2mXeFAlN3ahaNs8EZtG1YiticMkSLj3Gt6VPFfZogt7G5iFQ==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  meow@14.1.0:
+    resolution: {integrity: sha512-EDYo6VlmtnumlcBCbh1gLJ//9jvM/ndXHfVXIFrZVr6fGcwTUyCTFNTLCKuY3ffbK8L/+3Mzqnd58RojiZqHVw==}
+    engines: {node: '>=20'}
+
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -576,19 +908,38 @@ packages:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
 
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  parse-json@5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
 
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
@@ -604,18 +955,57 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  postcss-safe-parser@7.0.1:
+    resolution: {integrity: sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==}
+    engines: {node: '>=18.0'}
+    peerDependencies:
+      postcss: ^8.4.31
+
+  postcss-selector-parser@7.1.1:
+    resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
+    engines: {node: '>=4'}
+
+  postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
+
   postcss@8.5.12:
     resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
     engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  qified@0.10.1:
+    resolution: {integrity: sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA==}
+    engines: {node: '>=20'}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
   rollup@4.60.2:
     resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
   sade@1.8.1:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
@@ -627,9 +1017,21 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
+
+  slash@5.1.0:
+    resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
+    engines: {node: '>=14.16'}
+
+  slice-ansi@4.0.0:
+    resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
+    engines: {node: '>=10'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -640,6 +1042,47 @@ packages:
 
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@8.2.1:
+    resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
+    engines: {node: '>=20'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
+
+  stylelint-config-recommended@18.0.0:
+    resolution: {integrity: sha512-mxgT2XY6YZ3HWWe3Di8umG6aBmWmHTblTgu/f10rqFXnyWxjKWwNdjSWkgkwCtxIKnqjSJzvFmPT5yabVIRxZg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      stylelint: ^17.0.0
+
+  stylelint-config-standard@40.0.0:
+    resolution: {integrity: sha512-EznGJxOUhtWck2r6dJpbgAdPATIzvpLdK9+i5qPd4Lx70es66TkBPljSg4wN3Qnc6c4h2n+WbUrUynQ3fanjHw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      stylelint: ^17.0.0
+
+  stylelint@17.11.0:
+    resolution: {integrity: sha512-/3czzmbF9XdGWvReDF3Ex4R23Ajolo7j8RB2bFNEqk6Ht356nlpVV+G5bG2Qt8AW1ofJzXztBRDnAtd7cgowWA==}
+    engines: {node: '>=20.19.0'}
+    hasBin: true
+
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
+
+  supports-hyperlinks@4.4.0:
+    resolution: {integrity: sha512-UKbpT93hN5Nr9go5UY7bopIB9YQlMz9nm/ct4IXt/irb5YRkn9WaqrOBJGZ5Pwvsd5FQzSVeYlGdXoCAPQZrPg==}
+    engines: {node: '>=20'}
 
   svelte-check@4.4.6:
     resolution: {integrity: sha512-kP1zG81EWaFe9ZyTv4ZXv44Csi6Pkdpb7S3oj6m+K2ec/IcDg/a8LsFsnVLqm2nxtkSwsd5xPj/qFkTBgXHXjg==}
@@ -652,6 +1095,13 @@ packages:
   svelte@5.55.5:
     resolution: {integrity: sha512-2uCs/LZ9us+AktdzYJM8OcxQ8qnPS1kpaO7syGT/MgO+6Qr1Ybl+TqPq+97u7PHqmmMlye5ZkoyXONy5mjjAbw==}
     engines: {node: '>=18'}
+
+  svg-tags@1.0.0:
+    resolution: {integrity: sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==}
+
+  table@6.9.0:
+    resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
+    engines: {node: '>=10.0.0'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -668,6 +1118,10 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
@@ -679,6 +1133,13 @@ packages:
 
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+
+  unicorn-magic@0.4.0:
+    resolution: {integrity: sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==}
+    engines: {node: '>=20'}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   vite@7.3.2:
     resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
@@ -769,15 +1230,71 @@ packages:
       jsdom:
         optional: true
 
+  which@1.3.1:
+    resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
 
+  write-file-atomic@7.0.1:
+    resolution: {integrity: sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   zimmerframe@1.1.4:
     resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
 
 snapshots:
+
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@cacheable/memory@2.0.8':
+    dependencies:
+      '@cacheable/utils': 2.4.1
+      '@keyv/bigmap': 1.3.1(keyv@5.6.0)
+      hookified: 1.15.1
+      keyv: 5.6.0
+
+  '@cacheable/utils@2.4.1':
+    dependencies:
+      hashery: 1.5.1
+      keyv: 5.6.0
+
+  '@csstools/css-calc@3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.3(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
+
+  '@csstools/media-query-list-parser@5.0.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/selector-resolve-nested@4.0.0(postcss-selector-parser@7.1.1)':
+    dependencies:
+      postcss-selector-parser: 7.1.1
+
+  '@csstools/selector-specificity@6.0.0(postcss-selector-parser@7.1.1)':
+    dependencies:
+      postcss-selector-parser: 7.1.1
 
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
@@ -876,6 +1393,26 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@keyv/bigmap@1.3.1(keyv@5.6.0)':
+    dependencies:
+      hashery: 1.5.1
+      hookified: 1.15.1
+      keyv: 5.6.0
+
+  '@keyv/serialize@1.1.1': {}
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.1
+
   '@polka/url@1.0.0-next.29': {}
 
   '@rollup/rollup-android-arm-eabi@4.60.2':
@@ -952,6 +1489,8 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.60.2':
     optional: true
+
+  '@sindresorhus/merge-streams@4.0.0': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -1067,11 +1606,44 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.2
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  argparse@2.0.1: {}
+
   aria-query@5.3.1: {}
 
   assertion-error@2.0.1: {}
 
+  astral-regex@2.0.0: {}
+
   axobject-query@4.1.0: {}
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
+  cacheable@2.3.5:
+    dependencies:
+      '@cacheable/memory': 2.0.8
+      '@cacheable/utils': 2.4.1
+      hookified: 1.15.1
+      keyv: 5.6.0
+      qified: 0.10.1
+
+  callsites@3.1.0: {}
 
   chai@6.2.2: {}
 
@@ -1081,13 +1653,51 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  colord@2.9.3: {}
+
   convert-source-map@2.0.0: {}
 
   cookie@0.7.2: {}
 
+  cosmiconfig@9.0.1(typescript@5.9.3):
+    dependencies:
+      env-paths: 2.2.1
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      parse-json: 5.2.0
+    optionalDependencies:
+      typescript: 5.9.3
+
+  css-functions-list@3.3.3: {}
+
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
+  cssesc@3.0.0: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
   deepmerge@4.3.1: {}
 
   devalue@5.7.1: {}
+
+  emoji-regex@8.0.0: {}
+
+  env-paths@2.2.1: {}
+
+  error-ex@1.3.4:
+    dependencies:
+      is-arrayish: 0.2.1
 
   es-module-lexer@2.1.0: {}
 
@@ -1134,9 +1744,43 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  fast-deep-equal@3.1.3: {}
+
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
+  fast-uri@3.1.2: {}
+
+  fastest-levenshtein@1.0.16: {}
+
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  file-entry-cache@11.1.3:
+    dependencies:
+      flat-cache: 6.1.22
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
+  flat-cache@6.1.22:
+    dependencies:
+      cacheable: 2.3.5
+      flatted: 3.4.2
+      hookified: 1.15.1
+
+  flatted@3.4.2: {}
 
   fsevents@2.3.2:
     optional: true
@@ -1144,31 +1788,149 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  get-east-asian-width@1.6.0: {}
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  global-modules@2.0.0:
+    dependencies:
+      global-prefix: 3.0.0
+
+  global-prefix@3.0.0:
+    dependencies:
+      ini: 1.3.8
+      kind-of: 6.0.3
+      which: 1.3.1
+
+  globby@16.2.0:
+    dependencies:
+      '@sindresorhus/merge-streams': 4.0.0
+      fast-glob: 3.3.3
+      ignore: 7.0.5
+      is-path-inside: 4.0.0
+      slash: 5.1.0
+      unicorn-magic: 0.4.0
+
+  globjoin@0.1.4: {}
+
+  has-flag@5.0.1: {}
+
+  hashery@1.5.1:
+    dependencies:
+      hookified: 1.15.1
+
   hls.js@1.6.16: {}
+
+  hookified@1.15.1: {}
+
+  hookified@2.2.0: {}
+
+  html-tags@5.1.0: {}
+
+  ignore@7.0.5: {}
+
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  import-meta-resolve@4.2.0: {}
+
+  ini@1.3.8: {}
+
+  is-arrayish@0.2.1: {}
+
+  is-extglob@2.1.1: {}
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-number@7.0.0: {}
+
+  is-path-inside@4.0.0: {}
+
+  is-plain-object@5.0.0: {}
 
   is-reference@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
 
+  isexe@2.0.0: {}
+
+  js-tokens@4.0.0: {}
+
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
+
+  json-parse-even-better-errors@2.3.1: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  keyv@5.6.0:
+    dependencies:
+      '@keyv/serialize': 1.1.1
+
+  kind-of@6.0.3: {}
+
   kleur@4.1.5: {}
 
+  lines-and-columns@1.2.4: {}
+
   locate-character@3.0.0: {}
+
+  lodash.truncate@4.4.2: {}
 
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  mathml-tag-names@4.0.0: {}
+
+  mdn-data@2.27.1: {}
+
+  meow@14.1.0: {}
+
+  merge2@1.4.1: {}
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
+
   mri@1.2.0: {}
 
   mrmime@2.0.1: {}
 
+  ms@2.1.3: {}
+
   nanoid@3.3.11: {}
 
+  normalize-path@3.0.0: {}
+
   obug@2.1.1: {}
+
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
+  parse-json@5.2.0:
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      error-ex: 1.3.4
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
 
   pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
+
+  picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
 
@@ -1180,13 +1942,42 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
+  postcss-safe-parser@7.0.1(postcss@8.5.14):
+    dependencies:
+      postcss: 8.5.14
+
+  postcss-selector-parser@7.1.1:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
+  postcss-value-parser@4.2.0: {}
+
   postcss@8.5.12:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  postcss@8.5.14:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  qified@0.10.1:
+    dependencies:
+      hookified: 2.2.0
+
+  queue-microtask@1.2.3: {}
+
   readdirp@4.1.2: {}
+
+  require-from-string@2.0.2: {}
+
+  resolve-from@4.0.0: {}
+
+  reusify@1.1.0: {}
 
   rollup@4.60.2:
     dependencies:
@@ -1219,6 +2010,10 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.2
       fsevents: 2.3.3
 
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
+
   sade@1.8.1:
     dependencies:
       mri: 1.2.0
@@ -1227,17 +2022,104 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  signal-exit@4.1.0: {}
+
   sirv@3.0.2:
     dependencies:
       '@polka/url': 1.0.0-next.29
       mrmime: 2.0.1
       totalist: 3.0.1
 
+  slash@5.1.0: {}
+
+  slice-ansi@4.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      astral-regex: 2.0.0
+      is-fullwidth-code-point: 3.0.0
+
   source-map-js@1.2.1: {}
 
   stackback@0.0.2: {}
 
   std-env@4.1.0: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@8.2.1:
+    dependencies:
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
+
+  stylelint-config-recommended@18.0.0(stylelint@17.11.0(typescript@5.9.3)):
+    dependencies:
+      stylelint: 17.11.0(typescript@5.9.3)
+
+  stylelint-config-standard@40.0.0(stylelint@17.11.0(typescript@5.9.3)):
+    dependencies:
+      stylelint: 17.11.0(typescript@5.9.3)
+      stylelint-config-recommended: 18.0.0(stylelint@17.11.0(typescript@5.9.3))
+
+  stylelint@17.11.0(typescript@5.9.3):
+    dependencies:
+      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-syntax-patches-for-csstree': 1.1.3(css-tree@3.2.1)
+      '@csstools/css-tokenizer': 4.0.0
+      '@csstools/media-query-list-parser': 5.0.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/selector-resolve-nested': 4.0.0(postcss-selector-parser@7.1.1)
+      '@csstools/selector-specificity': 6.0.0(postcss-selector-parser@7.1.1)
+      colord: 2.9.3
+      cosmiconfig: 9.0.1(typescript@5.9.3)
+      css-functions-list: 3.3.3
+      css-tree: 3.2.1
+      debug: 4.4.3
+      fast-glob: 3.3.3
+      fastest-levenshtein: 1.0.16
+      file-entry-cache: 11.1.3
+      global-modules: 2.0.0
+      globby: 16.2.0
+      globjoin: 0.1.4
+      html-tags: 5.1.0
+      ignore: 7.0.5
+      import-meta-resolve: 4.2.0
+      is-plain-object: 5.0.0
+      mathml-tag-names: 4.0.0
+      meow: 14.1.0
+      micromatch: 4.0.8
+      normalize-path: 3.0.0
+      picocolors: 1.1.1
+      postcss: 8.5.14
+      postcss-safe-parser: 7.0.1(postcss@8.5.14)
+      postcss-selector-parser: 7.1.1
+      postcss-value-parser: 4.2.0
+      string-width: 8.2.1
+      supports-hyperlinks: 4.4.0
+      svg-tags: 1.0.0
+      table: 6.9.0
+      write-file-atomic: 7.0.1
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  supports-color@10.2.2: {}
+
+  supports-hyperlinks@4.4.0:
+    dependencies:
+      has-flag: 5.0.1
+      supports-color: 10.2.2
 
   svelte-check@4.4.6(picomatch@4.0.4)(svelte@5.55.5(@typescript-eslint/types@8.58.0))(typescript@5.9.3):
     dependencies:
@@ -1272,6 +2154,16 @@ snapshots:
     transitivePeerDependencies:
       - '@typescript-eslint/types'
 
+  svg-tags@1.0.0: {}
+
+  table@6.9.0:
+    dependencies:
+      ajv: 8.20.0
+      lodash.truncate: 4.4.2
+      slice-ansi: 4.0.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   tinybench@2.9.0: {}
 
   tinyexec@1.1.2: {}
@@ -1283,11 +2175,19 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
   totalist@3.0.1: {}
 
   typescript@5.9.3: {}
 
   undici-types@7.19.2: {}
+
+  unicorn-magic@0.4.0: {}
+
+  util-deprecate@1.0.2: {}
 
   vite@7.3.2(@types/node@25.6.0):
     dependencies:
@@ -1332,9 +2232,17 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
+  which@1.3.1:
+    dependencies:
+      isexe: 2.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  write-file-atomic@7.0.1:
+    dependencies:
+      signal-exit: 4.1.0
 
   zimmerframe@1.1.4: {}

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -32,14 +32,23 @@
 	--border-muted:  rgba(255, 255, 255, 0.07);
 	--border-strong: rgba(255, 255, 255, 0.13);
 
-	--state-success: #7ecba1;
-	--state-warning: #c9a84c;
-	--state-error:   #e8878a;
-	--state-active:  var(--accent);
+	--state-success:  #7ecba1;
+	--state-warning:  #c9a84c;
+	--state-error:    #e8878a;
+	--state-active:   var(--accent);
+	--state-favorite: #ff4d6d;
+	--state-favorite-glow: rgba(255, 77, 109, 0.35);
 
 	--quality-hires:    #c9a84c;
 	--quality-lossless: #6db89b;
 	--quality-lossy:    #8b90a8;
+
+	/* Service brand colors — used for source badges and service-branded heroes
+	 * only, never general UI chrome. Authentic brand color is the point, so these
+	 * stay stable across themes. */
+	--service-spotify: #1ed760;
+	--service-tidal:   #00b4d8;
+	--service-lastfm:  #d51007;
 
 	--input-bg:      rgba(255, 255, 255, 0.04);
 	--input-border:  rgba(255, 255, 255, 0.10);
@@ -99,13 +108,17 @@
 	--border-muted:  rgba(0, 0, 0, 0.08);
 	--border-strong: rgba(0, 0, 0, 0.16);
 
-	--state-success: #2d9e6a;
-	--state-warning: #a07a20;
-	--state-error:   #c84040;
+	--state-success:  #2d9e6a;
+	--state-warning:  #a07a20;
+	--state-error:    #c84040;
+	--state-favorite: #d6354a;
+	--state-favorite-glow: rgba(214, 53, 74, 0.22);
 
 	--quality-hires:    #a07a20;
 	--quality-lossless: #2d8a6e;
 	--quality-lossy:    #6b7090;
+	/* --service-* tokens cascade from :root — they are brand colors, not theme
+	 * variables, so they stay stable across themes. */
 
 	--input-bg:      rgba(0, 0, 0, 0.03);
 	--input-border:  rgba(0, 0, 0, 0.13);
@@ -141,10 +154,14 @@
 	--safe-bottom: env(safe-area-inset-bottom, 0px);
 	--safe-left: env(safe-area-inset-left, 0px);
 
-	/* Radii — rem-based clamp(): scale with viewport, honor user-zoom preference. */
+	/* Radii — rem-based clamp(): scale with viewport, honor user-zoom preference.
+	 * `--radius-md` is the canonical mid-step (use this in new code); `--radius`
+	 * is kept as a legacy alias for the same value so older call sites keep
+	 * working without touching them. */
 	--radius-xs: clamp(0.25rem,   0.4vw + 0.125rem,  0.375rem);   /*  4-6 px  */
 	--radius-sm: clamp(0.4375rem, 0.6vw + 0.1875rem, 0.625rem);   /*  7-10 px */
-	--radius:    clamp(0.75rem,   1vw   + 0.25rem,   1rem);       /* 12-16 px */
+	--radius-md: clamp(0.625rem,  0.8vw + 0.25rem,   0.875rem);   /* 10-14 px */
+	--radius:    var(--radius-md);                                /* legacy alias — prefer --radius-md */
 	--radius-lg: clamp(0.9375rem, 1.2vw + 0.375rem,  1.375rem);   /* 15-22 px */
 
 	/* Spacing — rem-based clamp(): see the comment above. Min values are ~25%
@@ -163,6 +180,12 @@
 	--motion-fast: 130ms cubic-bezier(0.25, 0.8, 0.25, 1);
 	--motion-base: 210ms cubic-bezier(0.25, 0.8, 0.25, 1);
 	--motion-slow: 340ms cubic-bezier(0.25, 0.8, 0.25, 1);
+
+	/* Blur tiers — three is the maximum that should ever exist. Anything outside
+	 * these tokens is drift. Applied via `backdrop-filter: var(--blur-*)`. */
+	--blur-base:    blur(8px) saturate(1.05);    /* compact tiles, badges          */
+	--blur-overlay: blur(16px) saturate(1.1);    /* glass cards, panels, hovercards */
+	--blur-modal:   blur(24px) saturate(1.2);    /* modals, context menus, palette  */
 
 	/* Z-index scale — use these tokens at component call sites instead of raw
 	   integers. Layers compose hierarchically: base < raised < overlay < modal
@@ -277,31 +300,77 @@ textarea {
 }
 ::-webkit-scrollbar-thumb:hover { background: var(--scrollbar-thumb-hover); }
 
+/* ── Cross-route view transitions ─────────────────────────
+ * SvelteKit's `onNavigate` hook calls document.startViewTransition, which
+ * captures the old page and the new page as ::view-transition pseudo elements.
+ *
+ * The intent is "liquid glass": rather than a flat opacity crossfade, the
+ * outgoing page falls forward (slight zoom + blur, like glass dissolving away
+ * from the viewer) and the incoming page emerges from beyond (slight zoom +
+ * blur in reverse, resolving into focus). The wallpaper persists across the
+ * navigation (forced standing-wave during /onboarding, see +layout.svelte) so
+ * the shader keeps running through both halves of the transition. */
+::view-transition-old(root),
+::view-transition-new(root) {
+	animation-duration: 800ms;
+	animation-timing-function: cubic-bezier(0.65, 0, 0.35, 1);
+	mix-blend-mode: normal;
+}
+::view-transition-old(root) {
+	animation-name: noor-page-dissolve;
+}
+::view-transition-new(root) {
+	animation-name: noor-page-emerge;
+}
+@keyframes noor-page-dissolve {
+	to {
+		opacity: 0;
+		filter: blur(12px) saturate(1.2);
+		transform: scale(1.03);
+	}
+}
+@keyframes noor-page-emerge {
+	from {
+		opacity: 0;
+		filter: blur(24px) saturate(0.85);
+		transform: scale(0.985);
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	::view-transition-old(root),
+	::view-transition-new(root) {
+		animation-duration: 200ms;
+	}
+	@keyframes noor-page-dissolve { to { opacity: 0; filter: none; transform: none; } }
+	@keyframes noor-page-emerge   { from { opacity: 0; filter: none; transform: none; } }
+}
+
 /* ── Glass surface ────────────────────────────────────── */
 .glass,
 .glass-panel {
 	background:
 		linear-gradient(180deg, color-mix(in srgb, var(--instrument-surface) 74%, transparent), color-mix(in srgb, var(--instrument-surface-strong) 88%, transparent)),
 		var(--panel-bg);
-	backdrop-filter: blur(16px);
-	-webkit-backdrop-filter: blur(16px);
+	backdrop-filter: var(--blur-overlay);
+	-webkit-backdrop-filter: var(--blur-overlay);
 	border: 1px solid color-mix(in srgb, var(--panel-border) 70%, var(--instrument-border));
 	box-shadow:
 		inset 0 1px 0 color-mix(in srgb, var(--instrument-edge) 52%, transparent),
 		var(--panel-shadow);
 }
 
-.glass       { border-radius: var(--radius); }
+.glass       { border-radius: var(--radius-md); }
 .glass-panel { border-radius: var(--radius-lg); }
 
 .glass:hover { border-color: var(--border-strong); }
 
 .glass-tile {
 	background: var(--panel-bg);
-	backdrop-filter: blur(14px);
-	-webkit-backdrop-filter: blur(14px);
+	backdrop-filter: var(--blur-base);
+	-webkit-backdrop-filter: var(--blur-base);
 	border: 1px solid var(--panel-border);
-	border-radius: 8px;
+	border-radius: var(--radius-sm);
 	box-shadow: inset 0 1px 0 color-mix(in srgb, var(--instrument-edge) 38%, transparent);
 }
 

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -141,21 +141,24 @@
 	--safe-bottom: env(safe-area-inset-bottom, 0px);
 	--safe-left: env(safe-area-inset-left, 0px);
 
-	--radius-xs: 6px;
-	--radius-sm: 10px;
-	--radius:    16px;
-	--radius-lg: 22px;
+	/* Radii — rem-based clamp(): scale with viewport, honor user-zoom preference. */
+	--radius-xs: clamp(0.25rem,   0.4vw + 0.125rem,  0.375rem);   /*  4-6 px  */
+	--radius-sm: clamp(0.4375rem, 0.6vw + 0.1875rem, 0.625rem);   /*  7-10 px */
+	--radius:    clamp(0.75rem,   1vw   + 0.25rem,   1rem);       /* 12-16 px */
+	--radius-lg: clamp(0.9375rem, 1.2vw + 0.375rem,  1.375rem);   /* 15-22 px */
 
-	--space-1: 4px;
-	--space-2: 8px;
-	--space-3: 12px;
-	--space-4: 16px;
-	--space-5: 24px;
-	--space-6: 32px;
-	--space-7: 48px;
-	--gap-sm:  10px;
-	--gap:     16px;
-	--gap-lg:  24px;
+	/* Spacing — rem-based clamp(): see the comment above. Min values are ~25%
+	   smaller than the previous fixed values, max values match today's behaviour. */
+	--space-1: clamp(0.1875rem, 0.25vw + 0.0625rem, 0.25rem);  /* 3-4 px  */
+	--space-2: clamp(0.375rem,  0.5vw  + 0.125rem,  0.5rem);   /* 6-8 px  */
+	--space-3: clamp(0.5625rem, 0.75vw + 0.1875rem, 0.75rem);  /* 9-12 px */
+	--space-4: clamp(0.75rem,   1vw    + 0.25rem,   1rem);     /* 12-16 px */
+	--space-5: clamp(1.125rem,  1.5vw  + 0.375rem,  1.5rem);   /* 18-24 px */
+	--space-6: clamp(1.5rem,    2vw    + 0.5rem,    2rem);     /* 24-32 px */
+	--space-7: clamp(2.25rem,   3vw    + 0.75rem,   3rem);     /* 36-48 px */
+	--gap-sm:  clamp(0.5rem,    0.6vw  + 0.1875rem, 0.625rem); /* 8-10 px */
+	--gap:     clamp(0.75rem,   1vw    + 0.25rem,   1rem);     /* 12-16 px */
+	--gap-lg:  clamp(1.125rem,  1.5vw  + 0.375rem,  1.5rem);   /* 18-24 px */
 
 	--motion-fast: 130ms cubic-bezier(0.25, 0.8, 0.25, 1);
 	--motion-base: 210ms cubic-bezier(0.25, 0.8, 0.25, 1);
@@ -165,7 +168,22 @@
 	--font-display: 'Newsreader', 'Iowan Old Style', 'Palatino Linotype', 'Book Antiqua', Georgia, serif;
 	--font-mono:    'JetBrains Mono', 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
 
-	--content-width: 1280px;
+	/* Typography scale — rem-based clamp(): every step interpolates with viewport
+	   width and honours user-zoom preference. Use these tokens at component call
+	   sites instead of raw `font-size: Npx` so the entire system scales together. */
+	--font-size-xs:  clamp(0.6875rem, 0.3vw + 0.5625rem, 0.8125rem);  /* 11-13 px */
+	--font-size-sm:  clamp(0.8125rem, 0.4vw + 0.6875rem, 0.9375rem);  /* 13-15 px */
+	--font-size-md:  clamp(0.9375rem, 0.5vw + 0.8125rem, 1.0625rem);  /* 15-17 px */
+	--font-size-lg:  clamp(1.0625rem, 0.7vw + 0.875rem,  1.25rem);    /* 17-20 px */
+	--font-size-xl:  clamp(1.25rem,   1vw   + 1rem,      1.625rem);   /* 20-26 px */
+	--font-size-2xl: clamp(1.5rem,    1.5vw + 1.125rem,  2rem);       /* 24-32 px */
+	--font-size-3xl: clamp(1.75rem,   2vw   + 1.25rem,   2.5rem);     /* 28-40 px */
+
+	/* Content width — scales with viewport so wide monitors and zoomed-out
+	   4K screens get more horizontal room (= more cards per row). The 1280 px
+	   floor preserves today's behaviour on narrower viewports; the 2400 px
+	   ceiling keeps typography surfaces readable on ultra-wide displays. */
+	--content-width: clamp(1280px, 100vw - 4rem, 2400px);
 
 	/* Cross-component state matrix */
 	--state-alpha-dormant: 0.35;
@@ -196,7 +214,7 @@ body {
 	height: 100%;
 	width: 100%;
 	font-family: var(--font-body);
-	font-size: 14px;
+	font-size: var(--font-size-sm);
 	line-height: 1.5;
 	color: var(--text-primary);
 	background-color: var(--bg-base);
@@ -376,6 +394,7 @@ h4 {
 	justify-content: center;
 	gap: 6px;
 	padding: 9px 16px;
+	min-height: 2rem;            /* 32 px floor on desktop — comfortable click target */
 	border-radius: 99px;
 	font-size: 0.82rem;
 	font-weight: 600;
@@ -386,6 +405,13 @@ h4 {
 		opacity var(--motion-fast),
 		transform var(--motion-fast);
 	white-space: nowrap;
+}
+
+@media (max-width: 760px) {
+	.btn {
+		min-height: 2.75rem;       /* 44 px tap-target floor on mobile (WCAG 2.5.5) */
+		min-width: 2.75rem;        /* covers icon-only variants */
+	}
 }
 
 .btn:hover:not(:disabled)  { transform: translateY(-1px); }
@@ -519,7 +545,6 @@ input[type='checkbox'] { accent-color: var(--accent); }
 }
 
 @media (max-width: 760px) {
-	html { font-size: 13px; }
 	.page-shell { gap: var(--space-4); }
 	.stat-grid  { grid-template-columns: 1fr 1fr; }
 	button,

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -164,6 +164,18 @@
 	--motion-base: 210ms cubic-bezier(0.25, 0.8, 0.25, 1);
 	--motion-slow: 340ms cubic-bezier(0.25, 0.8, 0.25, 1);
 
+	/* Z-index scale — use these tokens at component call sites instead of raw
+	   integers. Layers compose hierarchically: base < raised < overlay < modal
+	   < toast < tooltip. Rule of thumb: tooltips must overlap modals, toasts
+	   must overlap modals (so they remain readable when a modal opens), modals
+	   are above any in-flow content. */
+	--z-base:    1;     /* in-flow stacking (e.g. a hero z-1 element)        */
+	--z-raised:  10;    /* sticky-within-panel, hover lifts                  */
+	--z-overlay: 100;   /* dropdowns, popovers, hover cards                  */
+	--z-modal:   1000;  /* modal dialogs (confirm prompts, settings sheets)  */
+	--z-toast:   2000;  /* toasts, command palette, top-of-stack panels      */
+	--z-tooltip: 3000;  /* tooltips (must overlap modals)                    */
+
 	--font-body:    'Manrope', 'Avenir Next', 'Segoe UI', 'Helvetica Neue', system-ui, sans-serif;
 	--font-display: 'Newsreader', 'Iowan Old Style', 'Palatino Linotype', 'Book Antiqua', Georgia, serif;
 	--font-mono:    'JetBrains Mono', 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;

--- a/frontend/src/lib/actions/wheel-to-horizontal.ts
+++ b/frontend/src/lib/actions/wheel-to-horizontal.ts
@@ -1,13 +1,66 @@
-export function wheelToHorizontal(node: HTMLElement) {
-  const onWheel = (e: WheelEvent) => {
-    if (Math.abs(e.deltaY) <= Math.abs(e.deltaX)) return
-    // No horizontal overflow → let the page scroll vertically. Without this,
-    // grid-mode containers (no x-overflow) silently swallow every wheel event
-    // mouse-over them and the page appears frozen.
-    if (node.scrollWidth <= node.clientWidth) return
-    e.preventDefault()
-    node.scrollLeft += e.deltaY
-  }
-  node.addEventListener('wheel', onWheel, { passive: false })
-  return { destroy: () => node.removeEventListener('wheel', onWheel) }
+/**
+ * Svelte action: convert vertical wheel events into horizontal scroll on a
+ * horizontally-overflowing element (album rails, artist rails, video carousels).
+ *
+ * `delay` (default 200 ms) gives the user a grace period after their cursor
+ * enters the rail before wheel events get hijacked. Without this, scrolling
+ * the page past a rail accidentally captures the wheel and traps the user
+ * inside the rail. The delay restores the "passing through" feeling.
+ *
+ * Pass `{ delay: 0 }` to opt out of the grace period (e.g. for rails the user
+ * is expected to scroll directly without first scrolling past).
+ */
+type Options = { delay?: number };
+
+export function wheelToHorizontal(node: HTMLElement, opts: Options = {}) {
+	let { delay = 200 } = opts;
+	let armed = delay <= 0;
+	let timer: ReturnType<typeof setTimeout> | undefined;
+
+	const onEnter = () => {
+		if (delay <= 0) {
+			armed = true;
+			return;
+		}
+		timer = setTimeout(() => {
+			armed = true;
+			timer = undefined;
+		}, delay);
+	};
+
+	const onLeave = () => {
+		if (timer) {
+			clearTimeout(timer);
+			timer = undefined;
+		}
+		armed = delay <= 0;
+	};
+
+	const onWheel = (e: WheelEvent) => {
+		if (!armed) return;
+		if (Math.abs(e.deltaY) <= Math.abs(e.deltaX)) return;
+		// No horizontal overflow → let the page scroll vertically. Without this,
+		// grid-mode containers (no x-overflow) silently swallow every wheel event
+		// mouse-over them and the page appears frozen.
+		if (node.scrollWidth <= node.clientWidth) return;
+		e.preventDefault();
+		node.scrollLeft += e.deltaY;
+	};
+
+	node.addEventListener('mouseenter', onEnter);
+	node.addEventListener('mouseleave', onLeave);
+	node.addEventListener('wheel', onWheel, { passive: false });
+
+	return {
+		update(next: Options = {}) {
+			delay = next.delay ?? 200;
+			armed = delay <= 0;
+		},
+		destroy() {
+			if (timer) clearTimeout(timer);
+			node.removeEventListener('mouseenter', onEnter);
+			node.removeEventListener('mouseleave', onLeave);
+			node.removeEventListener('wheel', onWheel);
+		},
+	};
 }

--- a/frontend/src/lib/api/ws.ts
+++ b/frontend/src/lib/api/ws.ts
@@ -68,7 +68,6 @@ export function connectWebSocket() {
 
 	socket.onopen = () => {
 		wsConnected.set(true);
-		console.log('WebSocket connected');
 	};
 
 	socket.onmessage = (event) => {

--- a/frontend/src/lib/components/AlbumCarousel.svelte
+++ b/frontend/src/lib/components/AlbumCarousel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { wheelToHorizontal } from '$lib/actions/wheel-to-horizontal';
   import { lazyTidalArt } from '$lib/actions/lazy-tidal-art';
+  import { letterColor } from '$lib/utils/color';
 
   interface AlbumCard {
     id: number;
@@ -17,15 +18,10 @@
 
   let lazyArt = $state<Record<number, string>>({});
 
-  function letterColor(name: string): string {
-    const colors = ['#e63946','#457b9d','#2a9d8f','#e9c46a','#f4a261','#9b5de5','#00b4d8'];
-    let h = 0;
-    for (let i = 0; i < name.length; i++) h = (h * 31 + name.charCodeAt(i)) & 0xffffffff;
-    return colors[Math.abs(h) % colors.length];
-  }
 </script>
 
 {#if albums.length > 0}
+  <div class="album-carousel">
   <div class="albums-row" use:wheelToHorizontal>
     {#each albums as album (album.id)}
       {@const resolved = album.artwork_url ?? lazyArt[album.id] ?? null}
@@ -61,9 +57,34 @@
       </button>
     {/each}
   </div>
+  </div>
 {/if}
 
 <style>
+  .album-carousel {
+    /* Outer wrapper holds the container so the inner overflow-x:auto rail
+       isn't itself the container (which has subtle browser quirks). Card
+       width adapts to this wrapper's inline-size via the @container rule. */
+    container-type: inline-size;
+    --album-card-w: clamp(112px, 11vw, 156px);
+    /* Edge fade hints at horizontally-scrollable content. mask-image works
+       on Chrome/Safari/Firefox; -webkit- prefix kept for older WebKit. */
+    mask-image: linear-gradient(
+      to right,
+      transparent 0,
+      black 16px,
+      black calc(100% - 32px),
+      transparent 100%
+    );
+    -webkit-mask-image: linear-gradient(
+      to right,
+      transparent 0,
+      black 16px,
+      black calc(100% - 32px),
+      transparent 100%
+    );
+  }
+
   .albums-row {
     display: flex;
     gap: 16px;
@@ -73,15 +94,6 @@
   }
 
   .albums-row::-webkit-scrollbar { display: none; }
-
-  .albums-row {
-    /* Card width scales with viewport AND adapts to the parent container size.
-       In a wide hero context, cards stay at the viewport-clamped size; in a
-       narrow sidebar context, the @container rule below switches to a tighter
-       cqw-based scale. Artwork and labels share the same value via this var. */
-    container-type: inline-size;
-    --album-card-w: clamp(112px, 11vw, 156px);
-  }
 
   @container (max-width: 480px) {
     .album-card { --album-card-w: clamp(80px, 22cqw, 110px); }
@@ -125,7 +137,7 @@
     justify-content: center;
     font-size: var(--font-size-3xl);
     color: rgba(255,255,255,0.5);
-    background: var(--bg-surface);
+    background: var(--bg-hover);
   }
 
   .art-play-overlay {
@@ -147,7 +159,7 @@
   .album-card:hover .art-play-overlay { opacity: 1; }
 
   .album-title {
-    font-size: 12px;
+    font-size: var(--font-size-xs);
     font-weight: 500;
     color: var(--text-primary, #fff);
     width: var(--album-card-w);

--- a/frontend/src/lib/components/AlbumCarousel.svelte
+++ b/frontend/src/lib/components/AlbumCarousel.svelte
@@ -2,6 +2,7 @@
   import { wheelToHorizontal } from '$lib/actions/wheel-to-horizontal';
   import { lazyTidalArt } from '$lib/actions/lazy-tidal-art';
   import { letterColor } from '$lib/utils/color';
+  import PlayOverlay from '$lib/components/ui/PlayOverlay.svelte';
 
   interface AlbumCard {
     id: number;
@@ -44,11 +45,7 @@
               <span>♫</span>
             </div>
           {/if}
-          <div class="art-play-overlay">
-            <svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor" aria-hidden="true">
-              <path d="M3 2.5l10 5.5-10 5.5V2.5z"/>
-            </svg>
-          </div>
+          <PlayOverlay position="center" size="md" />
         </div>
         <span class="album-title">{album.title}</span>
         {#if album.artist_name}
@@ -140,23 +137,11 @@
     background: var(--bg-hover);
   }
 
-  .art-play-overlay {
-    position: absolute;
-    inset: 0;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: rgba(0,0,0,0.45);
-    opacity: 0;
-    transition: opacity 0.15s;
-    border-radius: 50%;
-    width: 36px;
-    height: 36px;
-    margin: auto;
-    color: #fff;
+  .album-card:hover :global(.play-overlay),
+  .album-card:focus-visible :global(.play-overlay) {
+    opacity: 1;
+    transform: translateY(0);
   }
-
-  .album-card:hover .art-play-overlay { opacity: 1; }
 
   .album-title {
     font-size: var(--font-size-xs);

--- a/frontend/src/lib/components/AlbumCarousel.svelte
+++ b/frontend/src/lib/components/AlbumCarousel.svelte
@@ -74,11 +74,24 @@
 
   .albums-row::-webkit-scrollbar { display: none; }
 
+  .albums-row {
+    /* Card width scales with viewport AND adapts to the parent container size.
+       In a wide hero context, cards stay at the viewport-clamped size; in a
+       narrow sidebar context, the @container rule below switches to a tighter
+       cqw-based scale. Artwork and labels share the same value via this var. */
+    container-type: inline-size;
+    --album-card-w: clamp(112px, 11vw, 156px);
+  }
+
+  @container (max-width: 480px) {
+    .album-card { --album-card-w: clamp(80px, 22cqw, 110px); }
+  }
+
   .album-card {
     display: flex;
     flex-direction: column;
     gap: 6px;
-    width: 128px;
+    width: var(--album-card-w);
     flex-shrink: 0;
     background: none;
     border: none;
@@ -90,9 +103,9 @@
 
   .art-wrap {
     position: relative;
-    width: 128px;
-    height: 128px;
-    border-radius: 6px;
+    width: var(--album-card-w);
+    aspect-ratio: 1 / 1;
+    border-radius: var(--radius-xs);
     overflow: hidden;
   }
 
@@ -110,9 +123,9 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 36px;
+    font-size: var(--font-size-3xl);
     color: rgba(255,255,255,0.5);
-    background: var(--bg-glass, rgba(255,255,255,0.08));
+    background: var(--bg-surface);
   }
 
   .art-play-overlay {
@@ -137,7 +150,7 @@
     font-size: 12px;
     font-weight: 500;
     color: var(--text-primary, #fff);
-    width: 128px;
+    width: var(--album-card-w);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -146,7 +159,7 @@
   .album-artist {
     font-size: 11px;
     color: var(--text-secondary, rgba(255,255,255,0.5));
-    width: 128px;
+    width: var(--album-card-w);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/frontend/src/lib/components/AlbumDetailPopup.svelte
+++ b/frontend/src/lib/components/AlbumDetailPopup.svelte
@@ -132,8 +132,8 @@
 		background: linear-gradient(160deg,
 			rgba(20, 20, 32, 0.72) 0%,
 			rgba(12, 12, 20, 0.68) 100%);
-		backdrop-filter: blur(28px) saturate(160%);
-		-webkit-backdrop-filter: blur(28px) saturate(160%);
+		backdrop-filter: var(--blur-modal);
+		-webkit-backdrop-filter: var(--blur-modal);
 		box-shadow:
 			0 32px 64px -16px rgba(0, 0, 0, 0.72),
 			inset 0 1px 0 rgba(255, 255, 255, 0.07);
@@ -228,8 +228,8 @@
 	.popup-chip {
 		padding: 2px 9px;
 		border-radius: 999px;
-		background: rgba(255,255,255,0.06);
-		border: 1px solid rgba(255,255,255,0.08);
+		background: var(--bg-hover);
+		border: 1px solid var(--panel-border);
 		color: var(--text-secondary, rgba(255,255,255,0.7));
 		font-size: 0.78rem;
 	}

--- a/frontend/src/lib/components/AlbumDetailPopup.svelte
+++ b/frontend/src/lib/components/AlbumDetailPopup.svelte
@@ -3,7 +3,7 @@
 	import { currentTrack, playTrackNow, playAlbum, shuffleAlbum } from '$lib/stores/player';
 	import { openContextMenu, openMenuAtElement } from '$lib/stores/context_menu';
 	import { buildTrackMenu } from '$lib/player/track_menu';
-	import { formatDuration } from '$lib/stores/library';
+	import { formatTrackDuration } from '$lib/utils/format';
 
 	let { album, tracks, loading, onClose }: {
 		album: Album;
@@ -84,7 +84,7 @@
 						<span class="popup-track-num">{i + 1}</span>
 						<span class="popup-track-title">{track.title}</span>
 						<span class="popup-track-artist">{track.artist_name ?? ''}</span>
-						<span class="popup-track-duration">{formatDuration(track.duration_ms)}</span>
+						<span class="popup-track-duration">{formatTrackDuration(track.duration_ms)}</span>
 						<button
 							class="popup-track-menu"
 							aria-label="Track actions"

--- a/frontend/src/lib/components/ArtistCarousel.svelte
+++ b/frontend/src/lib/components/ArtistCarousel.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { wheelToHorizontal } from '$lib/actions/wheel-to-horizontal';
   import { lazyTidalArt } from '$lib/actions/lazy-tidal-art';
+  import { letterColor } from '$lib/utils/color';
 
   interface ArtistCard {
     id: number;
@@ -17,19 +18,13 @@
   let failedImages = $state(new Set<number>());
   let lazyArt = $state<Record<number, string>>({});
 
-  function letterColor(name: string): string {
-    const colors = ['#e63946','#457b9d','#2a9d8f','#e9c46a','#f4a261','#9b5de5','#00b4d8'];
-    let h = 0;
-    for (let i = 0; i < name.length; i++) h = (h * 31 + name.charCodeAt(i)) & 0xffffffff;
-    return colors[Math.abs(h) % colors.length];
-  }
-
   function initials(name: string): string {
     return name.split(/\s+/).map(p => p[0]?.toUpperCase() ?? '').join('').slice(0, 2) || '?';
   }
 </script>
 
 {#if artists.length > 0}
+  <div class="artist-carousel">
   <div class="artists-row" use:wheelToHorizontal>
     {#each artists as artist (artist.id)}
       {@const baseSrc = artist.photo_url && !failedImages.has(artist.id) ? artist.photo_url : null}
@@ -63,9 +58,32 @@
       </button>
     {/each}
   </div>
+  </div>
 {/if}
 
 <style>
+  .artist-carousel {
+    /* Outer wrapper is the container; inner row stays as the overflow-x rail.
+       See AlbumCarousel for the rationale. */
+    container-type: inline-size;
+    --artist-card-w:   clamp(76px, 7.5vw, 104px);
+    --artist-avatar-w: clamp(64px, 6.4vw, 92px);
+    mask-image: linear-gradient(
+      to right,
+      transparent 0,
+      black 16px,
+      black calc(100% - 32px),
+      transparent 100%
+    );
+    -webkit-mask-image: linear-gradient(
+      to right,
+      transparent 0,
+      black 16px,
+      black calc(100% - 32px),
+      transparent 100%
+    );
+  }
+
   .artists-row {
     display: flex;
     gap: 16px;
@@ -75,14 +93,6 @@
   }
 
   .artists-row::-webkit-scrollbar { display: none; }
-
-  .artists-row {
-    /* Card width scales with viewport AND adapts to parent container size.
-       In a narrow sidebar context, the @container rule below tightens. */
-    container-type: inline-size;
-    --artist-card-w:   clamp(76px, 7.5vw, 104px);
-    --artist-avatar-w: clamp(64px, 6.4vw, 92px);
-  }
 
   @container (max-width: 480px) {
     .artist-card {
@@ -126,7 +136,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 22px;
+    font-size: var(--font-size-xl);
     font-weight: 700;
     color: rgba(255,255,255,0.85);
   }

--- a/frontend/src/lib/components/ArtistCarousel.svelte
+++ b/frontend/src/lib/components/ArtistCarousel.svelte
@@ -76,12 +76,27 @@
 
   .artists-row::-webkit-scrollbar { display: none; }
 
+  .artists-row {
+    /* Card width scales with viewport AND adapts to parent container size.
+       In a narrow sidebar context, the @container rule below tightens. */
+    container-type: inline-size;
+    --artist-card-w:   clamp(76px, 7.5vw, 104px);
+    --artist-avatar-w: clamp(64px, 6.4vw, 92px);
+  }
+
+  @container (max-width: 480px) {
+    .artist-card {
+      --artist-card-w:   clamp(60px, 18cqw, 88px);
+      --artist-avatar-w: clamp(52px, 16cqw, 76px);
+    }
+  }
+
   .artist-card {
     display: flex;
     flex-direction: column;
     align-items: center;
     gap: 8px;
-    width: 84px;
+    width: var(--artist-card-w);
     flex-shrink: 0;
     background: none;
     border: none;
@@ -95,8 +110,8 @@
   }
 
   .artist-avatar {
-    width: 72px;
-    height: 72px;
+    width: var(--artist-avatar-w);
+    aspect-ratio: 1 / 1;
     border-radius: 50%;
     object-fit: cover;
     display: block;
@@ -120,7 +135,7 @@
     font-size: 11px;
     color: var(--text-secondary, rgba(255,255,255,0.6));
     text-align: center;
-    width: 84px;
+    width: var(--artist-card-w);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/frontend/src/lib/components/CommandPalette.svelte
+++ b/frontend/src/lib/components/CommandPalette.svelte
@@ -461,8 +461,10 @@
 		width: min(600px, calc(100vw - 32px));
 		background: var(--bg-elevated);
 		border: 1px solid var(--border-strong);
-		border-radius: 14px;
+		border-radius: var(--radius-md);
 		box-shadow: 0 32px 64px -16px rgba(0,0,0,0.7);
+		backdrop-filter: var(--blur-modal);
+		-webkit-backdrop-filter: var(--blur-modal);
 		z-index: calc(var(--z-toast) + 1);
 		overflow: hidden;
 	}
@@ -571,7 +573,7 @@
 	.row-title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; min-width: 0; }
 	.row-sub { font-size: 11px; color: var(--text-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 	.row-kind { font-size: 10px; color: var(--text-muted); margin-left: auto; flex-shrink: 0; }
-	.row-kind--spotify { color: #1ed760; font-weight: 600; }
+	.row-kind--spotify { color: var(--service-spotify); font-weight: 600; }
 	.row-lib { font-size: 10px; color: var(--accent); flex-shrink: 0; }
 	.cmd-prefix { font-weight: 600; color: var(--accent); font-family: monospace; flex-shrink: 0; }
 	.cmd-args { font-size: 11px; color: var(--text-muted); font-family: monospace; flex-shrink: 0; }

--- a/frontend/src/lib/components/CommandPalette.svelte
+++ b/frontend/src/lib/components/CommandPalette.svelte
@@ -451,7 +451,7 @@
 		position: fixed;
 		inset: 0;
 		background: rgba(0,0,0,0.45);
-		z-index: 1600;
+		z-index: var(--z-toast);
 	}
 	.palette-panel {
 		position: fixed;
@@ -463,7 +463,7 @@
 		border: 1px solid var(--border-strong);
 		border-radius: 14px;
 		box-shadow: 0 32px 64px -16px rgba(0,0,0,0.7);
-		z-index: 1601;
+		z-index: calc(var(--z-toast) + 1);
 		overflow: hidden;
 	}
 	.palette-input-wrap {
@@ -475,7 +475,7 @@
 	}
 	.palette-icon {
 		color: var(--text-muted);
-		font-size: 16px;
+		font-size: var(--font-size-md);
 		flex-shrink: 0;
 		width: 16px;
 		text-align: center;
@@ -492,7 +492,7 @@
 	.palette-input::placeholder { color: var(--text-muted); }
 	.palette-spinner {
 		color: var(--text-muted);
-		font-size: 14px;
+		font-size: var(--font-size-sm);
 		animation: spin 0.8s linear infinite;
 	}
 	@keyframes spin { to { transform: rotate(360deg); } }
@@ -537,7 +537,7 @@
 		background: none;
 		border: none;
 		color: var(--text-secondary, var(--text-muted));
-		font-size: 16px;
+		font-size: var(--font-size-md);
 		cursor: pointer;
 		opacity: 0;
 		padding: 0 14px 0 4px;
@@ -564,7 +564,7 @@
 	.row-art--fallback {
 		display: grid;
 		place-items: center;
-		font-size: 14px;
+		font-size: var(--font-size-sm);
 		color: var(--text-muted);
 	}
 	.row-meta { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
@@ -575,7 +575,7 @@
 	.row-lib { font-size: 10px; color: var(--accent); flex-shrink: 0; }
 	.cmd-prefix { font-weight: 600; color: var(--accent); font-family: monospace; flex-shrink: 0; }
 	.cmd-args { font-size: 11px; color: var(--text-muted); font-family: monospace; flex-shrink: 0; }
-	.cmd-desc { color: var(--text-secondary); margin-left: auto; font-size: 12px; }
+	.cmd-desc { color: var(--text-secondary); margin-left: auto; font-size: var(--font-size-xs); }
 	.palette-empty, .palette-hint {
 		padding: 20px 18px;
 		color: var(--text-muted);

--- a/frontend/src/lib/components/ContextMenu.svelte
+++ b/frontend/src/lib/components/ContextMenu.svelte
@@ -149,10 +149,10 @@
 		max-width: 280px;
 		padding: 6px;
 		background: color-mix(in srgb, var(--bg-surface-strong, #14162a) 94%, transparent);
-		backdrop-filter: blur(18px) saturate(140%);
-		-webkit-backdrop-filter: blur(18px) saturate(140%);
-		border: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.08));
-		border-radius: 14px;
+		backdrop-filter: var(--blur-modal);
+		-webkit-backdrop-filter: var(--blur-modal);
+		border: 1px solid var(--border-subtle);
+		border-radius: var(--radius-md);
 		box-shadow:
 			0 18px 40px -12px rgba(0, 0, 0, 0.55),
 			0 2px 6px rgba(0, 0, 0, 0.25);
@@ -264,10 +264,10 @@
 		padding: 6px;
 		list-style: none;
 		background: color-mix(in srgb, var(--bg-surface-strong, #14162a) 94%, transparent);
-		backdrop-filter: blur(18px) saturate(140%);
-		-webkit-backdrop-filter: blur(18px) saturate(140%);
-		border: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.08));
-		border-radius: 14px;
+		backdrop-filter: var(--blur-modal);
+		-webkit-backdrop-filter: var(--blur-modal);
+		border: 1px solid var(--border-subtle);
+		border-radius: var(--radius-md);
 		box-shadow:
 			0 18px 40px -12px rgba(0, 0, 0, 0.55),
 			0 2px 6px rgba(0, 0, 0, 0.25);

--- a/frontend/src/lib/components/ContextMenu.svelte
+++ b/frontend/src/lib/components/ContextMenu.svelte
@@ -144,7 +144,7 @@
 <style>
 	.context-menu {
 		position: fixed;
-		z-index: 1700;
+		z-index: var(--z-modal);
 		min-width: 220px;
 		max-width: 280px;
 		padding: 6px;
@@ -221,11 +221,11 @@
 	}
 
 	.context-menu-item.danger {
-		color: var(--danger, #f87171);
+		color: var(--state-error);
 	}
 
 	.context-menu-item.danger:hover {
-		background: color-mix(in srgb, var(--danger, #f87171) 16%, transparent);
+		background: color-mix(in srgb, var(--state-error) 16%, transparent);
 	}
 
 	.context-menu-icon {

--- a/frontend/src/lib/components/DiscoverSpace/DiscoverHelp.svelte
+++ b/frontend/src/lib/components/DiscoverSpace/DiscoverHelp.svelte
@@ -155,7 +155,7 @@
 		max-height: 85vh;
 		display: flex;
 		flex-direction: column;
-		border-radius: 14px;
+		border-radius: var(--radius-md);
 		background: rgba(14, 14, 26, 0.96);
 		border: 1px solid rgba(124, 128, 255, 0.25);
 		box-shadow: 0 20px 60px rgba(0, 0, 0, 0.6);
@@ -168,7 +168,7 @@
 		align-items: flex-start;
 		justify-content: space-between;
 		padding: 18px 20px 10px;
-		border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+		border-bottom: 1px solid var(--border-subtle);
 	}
 	.panel-title { display: flex; flex-direction: column; gap: 2px; }
 	.panel-eyebrow {

--- a/frontend/src/lib/components/DiscoverSpace/DiscoverHoverCard.svelte
+++ b/frontend/src/lib/components/DiscoverSpace/DiscoverHoverCard.svelte
@@ -83,9 +83,10 @@
 		z-index: 200;
 		width: 260px;
 		background: rgba(12, 12, 24, 0.96);
-		backdrop-filter: blur(12px);
-		border: 1px solid rgba(255, 255, 255, 0.1);
-		border-radius: 12px;
+		backdrop-filter: var(--blur-overlay);
+		-webkit-backdrop-filter: var(--blur-overlay);
+		border: 1px solid var(--panel-border);
+		border-radius: var(--radius-md);
 		padding: 12px 14px;
 		display: flex;
 		flex-direction: column;

--- a/frontend/src/lib/components/DiscoverSpace/DiscoverLegend.svelte
+++ b/frontend/src/lib/components/DiscoverSpace/DiscoverLegend.svelte
@@ -75,9 +75,10 @@
 <style>
 	.legend {
 		background: rgba(10, 10, 20, 0.85);
-		backdrop-filter: blur(10px);
-		border: 1px solid rgba(255, 255, 255, 0.08);
-		border-radius: 10px;
+		backdrop-filter: var(--blur-overlay);
+		-webkit-backdrop-filter: var(--blur-overlay);
+		border: 1px solid var(--panel-border);
+		border-radius: var(--radius-sm);
 		padding: 8px 12px;
 		min-width: 160px;
 		max-width: 200px;

--- a/frontend/src/lib/components/DiscoverSpace/DiscoverLensControl.svelte
+++ b/frontend/src/lib/components/DiscoverSpace/DiscoverLensControl.svelte
@@ -24,8 +24,9 @@
 		display: flex;
 		gap: 4px;
 		background: rgba(0, 0, 0, 0.5);
-		backdrop-filter: blur(8px);
-		border: 1px solid rgba(255, 255, 255, 0.08);
+		backdrop-filter: var(--blur-base);
+		-webkit-backdrop-filter: var(--blur-base);
+		border: 1px solid var(--panel-border);
 		border-radius: 999px;
 		padding: 3px;
 	}

--- a/frontend/src/lib/components/DiscoverSpace/DiscoverSidePanel.svelte
+++ b/frontend/src/lib/components/DiscoverSpace/DiscoverSidePanel.svelte
@@ -374,7 +374,7 @@
 		display: flex;
 		flex-direction: column;
 		gap: 12px;
-		border-left: 1px solid rgba(255, 255, 255, 0.06);
+		border-left: 1px solid var(--border-subtle);
 	}
 	.panel-empty {
 		height: 100%;
@@ -399,7 +399,7 @@
 	.fingerprint { display: flex; flex-wrap: wrap; gap: 6px; }
 	.fp-chip {
 		background: rgba(255,255,255,0.05);
-		border: 1px solid rgba(255,255,255,0.08);
+		border: 1px solid var(--panel-border);
 		border-radius: 6px;
 		padding: 5px 8px;
 		display: flex;
@@ -442,7 +442,7 @@
 	.action-btn {
 		padding: 8px 12px;
 		border-radius: 8px;
-		border: 1px solid rgba(255,255,255,0.08);
+		border: 1px solid var(--panel-border);
 		background: rgba(255,255,255,0.04);
 		color: rgba(255,255,255,0.75);
 		font-size: 0.78rem;
@@ -526,7 +526,7 @@
 		display: flex; flex-direction: column; gap: 3px;
 		padding: 8px 10px;
 		background: rgba(255,255,255,0.03);
-		border: 1px solid rgba(255,255,255,0.06);
+		border: 1px solid var(--border-subtle);
 		border-radius: 6px;
 	}
 	.idle-lens-name { font-size: 0.65rem; text-transform: uppercase; letter-spacing: 0.08em; color: rgba(124,128,255,0.7); }

--- a/frontend/src/lib/components/DiscoverSpace/DiscoverTrainingStrip.svelte
+++ b/frontend/src/lib/components/DiscoverSpace/DiscoverTrainingStrip.svelte
@@ -53,8 +53,9 @@
 		gap: 8px;
 		padding: 6px 14px;
 		background: rgba(10, 10, 20, 0.85);
-		backdrop-filter: blur(8px);
-		border: 1px solid rgba(124, 128, 255, 0.15);
+		backdrop-filter: var(--blur-base);
+		-webkit-backdrop-filter: var(--blur-base);
+		border: 1px solid var(--accent-line);
 		border-radius: 999px;
 		font-size: 0.75rem;
 		color: rgba(255, 255, 255, 0.6);

--- a/frontend/src/lib/components/DiscoverSpace/discover_space_adapter.ts
+++ b/frontend/src/lib/components/DiscoverSpace/discover_space_adapter.ts
@@ -13,6 +13,7 @@ import type {
 } from './discover_space_types';
 import type { TidalPlayable, Track } from '$lib/api/client';
 import type { PlayableTrack } from '$lib/player/playable';
+import { clamp01 } from '$lib/utils/math';
 
 // ─── Deterministic initial layout ────────────────────────────────────────────
 
@@ -62,10 +63,6 @@ export function normalizeReasonTags(tags?: string[]): DiscoverReason[] {
 		seen.add(r);
 		return true;
 	});
-}
-
-function clamp01(v: number): number {
-	return Math.max(0, Math.min(1, v));
 }
 
 function normalizeSource(raw?: string): DiscoverSource {

--- a/frontend/src/lib/components/Genre/GenreGalaxy.svelte
+++ b/frontend/src/lib/components/Genre/GenreGalaxy.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { innerWidth } from 'svelte/reactivity/window';
+	import { clamp } from '$lib/utils/math';
 	import {
 		GALAXY_DEFAULT_SCALE,
 		type Camera,
@@ -150,10 +151,6 @@
 	const MAX_PARTICLES = 120;
 	const fontBody = '600 12px "Avenir Next", "Segoe UI", sans-serif';
 	const fontDisplay = '600 13px "Iowan Old Style", Georgia, serif';
-
-	function clamp(value: number, min: number, max: number): number {
-		return Math.min(max, Math.max(min, value));
-	}
 
 	function hexToRgba(hex: string, alpha: number): string {
 		const normalized = hex.replace('#', '');

--- a/frontend/src/lib/components/Genre/GenreGalaxy.svelte
+++ b/frontend/src/lib/components/Genre/GenreGalaxy.svelte
@@ -1253,7 +1253,7 @@
 		position: absolute;
 		inset: 0;
 		overflow: hidden;
-		border-radius: 24px;
+		border-radius: var(--radius-lg);
 		background:
 			radial-gradient(circle at 16% 20%, color-mix(in srgb, var(--atlas-haze-a) 80%, transparent), transparent 36%),
 			radial-gradient(circle at 84% 16%, color-mix(in srgb, var(--atlas-haze-b) 78%, transparent), transparent 30%),
@@ -1289,8 +1289,8 @@
 		box-shadow:
 			0 0 20px color-mix(in srgb, var(--accent-glow) 82%, transparent),
 			inset 0 1px 0 color-mix(in srgb, var(--instrument-edge) 40%, transparent);
-		backdrop-filter: blur(12px);
-		-webkit-backdrop-filter: blur(12px);
+		backdrop-filter: var(--blur-overlay);
+		-webkit-backdrop-filter: var(--blur-overlay);
 		font-size: 0.75rem;
 		font-weight: 700;
 		letter-spacing: 0.08em;
@@ -1335,11 +1335,11 @@
 		padding: 8px 12px;
 		min-width: 160px;
 		max-width: 260px;
-		border-radius: 10px;
+		border-radius: var(--radius-sm);
 		background: rgba(10, 10, 18, 0.92);
-		backdrop-filter: blur(8px);
-		-webkit-backdrop-filter: blur(8px);
-		border: 1px solid rgba(255, 255, 255, 0.1);
+		backdrop-filter: var(--blur-base);
+		-webkit-backdrop-filter: var(--blur-base);
+		border: 1px solid var(--panel-border);
 		box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
 		animation: hover-card-in 140ms ease-out both;
 	}

--- a/frontend/src/lib/components/Genre/GenrePanel.svelte
+++ b/frontend/src/lib/components/Genre/GenrePanel.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { addTrackToQueue, playTrackNow } from '$lib/stores/player';
-	import { formatDuration, getQualityClass } from '$lib/stores/library';
-	import { formatDuration as formatListenAggregate } from '$lib/utils/format';
+	import { formatTrackDuration, formatDuration, getQualityClass } from '$lib/utils/format';
 	import { openContextMenu } from '$lib/stores/context_menu';
 	import { buildTrackMenu } from '$lib/player/track_menu';
 	import EmptyState from '$lib/components/ui/EmptyState.svelte';
@@ -59,10 +58,6 @@
 		await addTrackToQueue(trackId);
 	}
 
-	// Listen-time aggregate now lives in $lib/utils/format (imported above as
-	// formatListenAggregate to avoid clashing with the M:SS-style formatDuration
-	// from $lib/stores/library).
-
 	let listenedTime = $derived(listenHeat?.total_listened_ms ?? node?.totalListenedMs ?? 0);
 	let showTracks = $state(false);
 
@@ -103,7 +98,7 @@
 					<span class="family-name">{node.familyName} system</span>
 				</div>
 				<h2>{node.name}</h2>
-				<p class="panel-subtitle">{node.trackCount.toLocaleString()} tracks{listenedTime > 0 ? ` · ${formatListenAggregate(listenedTime)}` : ''}</p>
+				<p class="panel-subtitle">{node.trackCount.toLocaleString()} tracks{listenedTime > 0 ? ` · ${formatDuration(listenedTime)}` : ''}</p>
 			</div>
 			<button class="close-btn" onclick={onClose} aria-label="Close genre panel">×</button>
 		</div>
@@ -213,7 +208,7 @@
 											{track.best_quality.replaceAll('_', ' ')}
 										</span>
 									{/if}
-									<span>{formatDuration(track.duration_ms)}</span>
+									<span>{formatTrackDuration(track.duration_ms)}</span>
 									<button class="queue-btn" onclick={(event) => void handleQueueTrack(track.id, event)}>+</button>
 								</div>
 							</div>

--- a/frontend/src/lib/components/LibraryHero.svelte
+++ b/frontend/src/lib/components/LibraryHero.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { fade } from 'svelte/transition';
+  import { letterColor } from '$lib/utils/color';
 
   interface Artist {
     id: number;
@@ -24,13 +25,6 @@
   let timer: ReturnType<typeof setInterval> | undefined;
 
   const current = $derived(artists[currentIndex] ?? artists[0]);
-
-  function letterColor(name: string): string {
-    const colors = ['#e63946','#457b9d','#2a9d8f','#e9c46a','#f4a261','#9b5de5','#00b4d8'];
-    let h = 0;
-    for (let i = 0; i < name.length; i++) h = (h * 31 + name.charCodeAt(i)) & 0xffffffff;
-    return colors[Math.abs(h) % colors.length];
-  }
 
   function initials(name: string): string {
     return name.split(/\s+/).map(p => p[0]?.toUpperCase() ?? '').join('').slice(0, 2) || '?';
@@ -133,7 +127,7 @@
     position: relative;
     border-radius: 12px;
     overflow: hidden;
-    background: var(--bg-glass, rgba(255,255,255,0.04));
+    background: var(--panel-bg);
     border: 1px solid var(--border-subtle, rgba(255,255,255,0.08));
     min-height: 200px;
   }
@@ -219,7 +213,7 @@
   }
 
   .hero-sub {
-    font-size: 14px;
+    font-size: var(--font-size-sm);
     color: var(--text-secondary, rgba(255,255,255,0.55));
     margin: 2px 0 8px;
   }
@@ -237,7 +231,7 @@
     gap: 7px;
     padding: 10px 22px;
     border-radius: 24px;
-    font-size: 14px;
+    font-size: var(--font-size-sm);
     font-weight: 600;
   }
 
@@ -252,7 +246,7 @@
     background: rgba(0,0,0,0.5);
     border: 1px solid rgba(255,255,255,0.15);
     color: rgba(255,255,255,0.85);
-    font-size: 22px;
+    font-size: var(--font-size-xl);
     line-height: 1;
     cursor: pointer;
     display: flex;

--- a/frontend/src/lib/components/LibraryHero.svelte
+++ b/frontend/src/lib/components/LibraryHero.svelte
@@ -173,8 +173,8 @@
   }
 
   .hero-thumb {
-    width: 140px;
-    height: 140px;
+    width: clamp(120px, 12vw, 180px);
+    aspect-ratio: 1 / 1;
     border-radius: 8px;
     background-size: cover;
     background-position: center;

--- a/frontend/src/lib/components/LibraryHero.svelte
+++ b/frontend/src/lib/components/LibraryHero.svelte
@@ -195,7 +195,7 @@
     font-size: 10px;
     font-weight: 600;
     letter-spacing: 1.5px;
-    color: var(--accent, #9b6fff);
+    color: var(--accent);
     text-transform: uppercase;
     transition: color 300ms ease;
   }
@@ -230,7 +230,7 @@
     align-items: center;
     gap: 7px;
     padding: 10px 22px;
-    border-radius: 24px;
+    border-radius: 999px;
     font-size: var(--font-size-sm);
     font-weight: 600;
   }

--- a/frontend/src/lib/components/QueueReasonCard.svelte
+++ b/frontend/src/lib/components/QueueReasonCard.svelte
@@ -81,9 +81,10 @@
 	.reason-card {
 		position: fixed;
 		background: rgba(13, 13, 26, 0.95);
-		backdrop-filter: blur(8px);
-		border: 1px solid #3a3a5c;
-		border-radius: 8px;
+		backdrop-filter: var(--blur-base);
+		-webkit-backdrop-filter: var(--blur-base);
+		border: 1px solid var(--border-strong);
+		border-radius: var(--radius-sm);
 		padding: 10px 12px;
 		z-index: 100;
 		box-shadow: 0 12px 32px rgba(0, 0, 0, 0.5);

--- a/frontend/src/lib/components/QueueReasonCard.svelte
+++ b/frontend/src/lib/components/QueueReasonCard.svelte
@@ -108,7 +108,7 @@
 	}
 
 	.prefix {
-		font-size: 12px;
+		font-size: var(--font-size-xs);
 		line-height: 1.4;
 		color: #c8c8dc;
 		word-break: break-word;

--- a/frontend/src/lib/components/QuietMode.svelte
+++ b/frontend/src/lib/components/QuietMode.svelte
@@ -243,7 +243,8 @@
 		color: #fff;
 		font-size: var(--font-size-md);
 		cursor: pointer;
-		backdrop-filter: blur(10px);
+		backdrop-filter: var(--blur-overlay);
+		-webkit-backdrop-filter: var(--blur-overlay);
 		transition: background 160ms ease, transform 160ms ease;
 	}
 
@@ -315,7 +316,8 @@
 		color: var(--text-secondary, rgba(255, 255, 255, 0.7));
 		font-size: 0.78rem;
 		cursor: pointer;
-		backdrop-filter: blur(8px);
+		backdrop-filter: var(--blur-base);
+		-webkit-backdrop-filter: var(--blur-base);
 		transition: background 160ms ease, color 160ms ease, border-color 160ms ease;
 	}
 

--- a/frontend/src/lib/components/QuietMode.svelte
+++ b/frontend/src/lib/components/QuietMode.svelte
@@ -197,7 +197,7 @@
 	.quiet-backdrop {
 		position: fixed;
 		inset: 0;
-		z-index: 1500;
+		z-index: var(--z-modal);
 		background: var(--bg-base, #0b0b14);
 		overflow: hidden;
 	}
@@ -217,7 +217,7 @@
 	.quiet-panel {
 		position: fixed;
 		inset: 0;
-		z-index: 1501;
+		z-index: calc(var(--z-modal) + 1);
 		display: grid;
 		grid-template-columns: minmax(0, 520px);
 		grid-auto-rows: min-content;
@@ -241,7 +241,7 @@
 		background: rgba(0, 0, 0, 0.45);
 		border: 1px solid rgba(255, 255, 255, 0.18);
 		color: #fff;
-		font-size: 16px;
+		font-size: var(--font-size-md);
 		cursor: pointer;
 		backdrop-filter: blur(10px);
 		transition: background 160ms ease, transform 160ms ease;
@@ -326,7 +326,7 @@
 	}
 
 	.quiet-search-icon {
-		font-size: 14px;
+		font-size: var(--font-size-sm);
 		opacity: 0.8;
 	}
 

--- a/frontend/src/lib/components/ShortcutHelp.svelte
+++ b/frontend/src/lib/components/ShortcutHelp.svelte
@@ -130,8 +130,8 @@
 		justify-content: center;
 		padding: 24px;
 		background: rgba(0, 0, 0, 0.36);
-		backdrop-filter: blur(10px);
-		-webkit-backdrop-filter: blur(10px);
+		backdrop-filter: var(--blur-overlay);
+		-webkit-backdrop-filter: var(--blur-overlay);
 	}
 
 	.shortcut-panel {
@@ -262,7 +262,7 @@
 		.shortcut-panel {
 			max-height: calc(100vh - 24px);
 			padding: 16px;
-			border-radius: 14px;
+			border-radius: var(--radius-md);
 		}
 
 		.shortcut-group li {

--- a/frontend/src/lib/components/ShortcutHelp.svelte
+++ b/frontend/src/lib/components/ShortcutHelp.svelte
@@ -124,7 +124,7 @@
 	.shortcut-backdrop {
 		position: fixed;
 		inset: 0;
-		z-index: 1800;
+		z-index: var(--z-modal);
 		display: flex;
 		align-items: flex-end;
 		justify-content: center;

--- a/frontend/src/lib/components/TidalTrackRow.svelte
+++ b/frontend/src/lib/components/TidalTrackRow.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { formatDuration } from '$lib/stores/library';
+	import { formatTrackDuration } from '$lib/utils/format';
 	import { openContextMenu, openMenuAtElement } from '$lib/stores/context_menu';
 	import { buildTidalTrackMenu } from '$lib/player/track_menu';
 	import {
@@ -120,7 +120,7 @@
 				{#if showAlbum && track.album_title}{track.album_title}{/if}
 			</p>
 		</div>
-		<span class="cell-duration">{formatDuration(track.duration_ms)}</span>
+		<span class="cell-duration">{formatTrackDuration(track.duration_ms)}</span>
 		<div class="cell-actions">
 			<button
 				class="row-btn"
@@ -180,7 +180,7 @@
 				<span class="sub">{track.artist_name}</span>
 			{/if}
 		</div>
-		<span class="cell-duration">{formatDuration(track.duration_ms)}</span>
+		<span class="cell-duration">{formatTrackDuration(track.duration_ms)}</span>
 		<div class="cell-actions">
 			<button
 				class="row-btn"
@@ -239,7 +239,7 @@
 				{#if showAlbum && track.album_title}{track.album_title}{/if}
 			</p>
 		</div>
-		<span class="cell-duration">{formatDuration(track.duration_ms)}</span>
+		<span class="cell-duration">{formatTrackDuration(track.duration_ms)}</span>
 		<div class="cell-actions">
 			<button
 				class="row-btn"
@@ -292,7 +292,7 @@
 				<span class="sub">{track.artist_name}</span>
 			{/if}
 		</div>
-		<span class="cell-duration">{formatDuration(track.duration_ms)}</span>
+		<span class="cell-duration">{formatTrackDuration(track.duration_ms)}</span>
 	</li>
 {/if}
 
@@ -413,7 +413,7 @@
 		justify-content: center;
 	}
 	.cell-art-thumb.placeholder span {
-		font-size: 16px;
+		font-size: var(--font-size-md);
 		color: rgba(255, 255, 255, 0.5);
 	}
 

--- a/frontend/src/lib/components/Toast.svelte
+++ b/frontend/src/lib/components/Toast.svelte
@@ -27,7 +27,7 @@
 		display: flex;
 		flex-direction: column;
 		gap: 8px;
-		z-index: 1200;
+		z-index: var(--z-toast);
 		pointer-events: none;
 	}
 	.toast {

--- a/frontend/src/lib/components/TrackRow.svelte
+++ b/frontend/src/lib/components/TrackRow.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { formatDuration } from '$lib/stores/library';
+	import { formatTrackDuration } from '$lib/utils/format';
 	import { openContextMenu, openMenuAtElement } from '$lib/stores/context_menu';
 	import {
 		buildTrackMenu,
@@ -180,7 +180,7 @@
 				onclick={handleHeart}
 			>{track.is_favorite ? '♥' : '♡'}</button>
 		</div>
-		<span class="cell-duration">{formatDuration(track.duration_ms)}</span>
+		<span class="cell-duration">{formatTrackDuration(track.duration_ms)}</span>
 	</li>
 {:else if variant === 'indexed'}
 	<!-- svelte-ignore a11y_no_noninteractive_element_to_interactive_role -->
@@ -266,7 +266,7 @@
 				onclick={handleHeart}
 			>{track.is_favorite ? '♥' : '♡'}</button>
 		</div>
-		<span class="cell-duration">{formatDuration(track.duration_ms)}</span>
+		<span class="cell-duration">{formatTrackDuration(track.duration_ms)}</span>
 	</li>
 {:else if variant === 'art'}
 	<!-- svelte-ignore a11y_no_noninteractive_element_to_interactive_role -->
@@ -299,7 +299,7 @@
 				{#if showAlbum && track.album_title}{track.album_title}{/if}
 			</p>
 		</div>
-		<span class="cell-duration">{formatDuration(track.duration_ms)}</span>
+		<span class="cell-duration">{formatTrackDuration(track.duration_ms)}</span>
 		<div class="cell-actions">
 			<button
 				class="row-btn"
@@ -356,7 +356,7 @@
 				<span class="sub">{track.artist_name}</span>
 			{/if}
 		</div>
-		<span class="cell-duration">{formatDuration(track.duration_ms)}</span>
+		<span class="cell-duration">{formatTrackDuration(track.duration_ms)}</span>
 	</li>
 {/if}
 
@@ -488,7 +488,7 @@
 		justify-content: center;
 	}
 	.cell-art-thumb.placeholder span {
-		font-size: 16px;
+		font-size: var(--font-size-md);
 		color: rgba(255, 255, 255, 0.5);
 	}
 

--- a/frontend/src/lib/components/TrendingCard.svelte
+++ b/frontend/src/lib/components/TrendingCard.svelte
@@ -7,6 +7,7 @@
 	import { lazyTidalArt } from '$lib/actions/lazy-tidal-art';
 	import { canPlayTrack, getPlayableLabel } from '$lib/player/playable';
 	import { letterColor } from '$lib/utils/color';
+	import PlayOverlay from '$lib/components/ui/PlayOverlay.svelte';
 
 	let {
 		entry,
@@ -157,22 +158,17 @@
 
 		<span class="rank" aria-label="Chart position {index + 1}">{index + 1}</span>
 
-		<div class="play-overlay" aria-hidden="true">
-			{#if resolving}
-				<span class="mini-spinner"></span>
-			{:else if !playable}
+		{#if !playable && !resolving}
+			<div class="play-overlay-scrim" aria-hidden="true">
 				<span class="play-state-label">{actionLabel}</span>
-			{:else if isCurrent && $isPlaying}
-				<svg viewBox="0 0 16 16" width="20" height="20" fill="currentColor">
-					<rect x="3" y="2.5" width="3.5" height="11" rx="1" />
-					<rect x="9.5" y="2.5" width="3.5" height="11" rx="1" />
-				</svg>
-			{:else}
-				<svg viewBox="0 0 16 16" width="20" height="20" fill="currentColor">
-					<path d="M3 2.5l10 5.5-10 5.5V2.5z" />
-				</svg>
-			{/if}
-		</div>
+			</div>
+		{:else}
+			<PlayOverlay
+				position="center"
+				size="lg"
+				state={resolving ? 'loading' : isCurrent && $isPlaying ? 'pause' : 'play'}
+			/>
+		{/if}
 	</div>
 
 	<div class="meta">
@@ -213,27 +209,27 @@
 		gap: 10px;
 		background: none;
 		border: 1px solid transparent;
-		padding: 8px;
-		border-radius: 12px;
+		padding: var(--space-2);
+		border-radius: var(--radius-md);
 		cursor: pointer;
 		text-align: left;
-		transition: background 140ms ease, border-color 140ms ease, transform 140ms ease;
+		transition: background var(--motion-base), border-color var(--motion-base), transform var(--motion-base);
 	}
 
 	.trending-card:hover,
 	.trending-card:focus-visible {
-		background: rgba(255, 255, 255, 0.04);
-		border-color: rgba(255, 255, 255, 0.08);
+		background: var(--bg-hover);
+		border-color: var(--panel-border);
 		outline: none;
 	}
 
 	.trending-card:focus-visible {
-		border-color: var(--accent-line, rgba(125, 200, 175, 0.6));
+		border-color: var(--accent-line);
 	}
 
 	.trending-card.active {
-		border-color: var(--accent-line, rgba(125, 200, 175, 0.5));
-		background: rgba(125, 200, 175, 0.06);
+		border-color: var(--accent-line);
+		background: var(--accent-soft);
 	}
 
 	.trending-card.disabled {
@@ -248,16 +244,16 @@
 	}
 
 	.trending-card.unresolved {
-		border-color: rgba(255, 255, 255, 0.06);
+		border-color: var(--border-subtle);
 	}
 
 	.art-wrap {
 		position: relative;
 		aspect-ratio: 1 / 1;
 		width: 100%;
-		border-radius: 8px;
+		border-radius: var(--radius-sm);
 		overflow: hidden;
-		background: rgba(255, 255, 255, 0.04);
+		background: var(--bg-hover);
 	}
 
 	.art {
@@ -286,62 +282,46 @@
 		left: 6px;
 		min-width: 22px;
 		padding: 2px 6px;
-		border-radius: 6px;
+		border-radius: var(--radius-xs);
 		font-size: 10px;
 		font-weight: 700;
 		color: rgba(255, 255, 255, 0.92);
 		background: rgba(0, 0, 0, 0.55);
 		letter-spacing: 0.04em;
 		text-align: center;
-		backdrop-filter: blur(4px);
+		backdrop-filter: var(--blur-base);
+		-webkit-backdrop-filter: var(--blur-base);
 	}
 
-	.play-overlay {
+	.play-overlay-scrim {
 		position: absolute;
 		inset: 0;
 		display: flex;
 		align-items: center;
 		justify-content: center;
 		background: linear-gradient(180deg, rgba(0, 0, 0, 0.05) 0%, rgba(0, 0, 0, 0.55) 100%);
-		opacity: 0;
+		opacity: 1;
 		color: #fff;
-		transition: opacity 160ms ease;
+		pointer-events: none;
 	}
 
-	.trending-card:hover .play-overlay,
-	.trending-card.active .play-overlay,
-	.trending-card.unresolved .play-overlay,
-	.trending-card.resolving .play-overlay {
+	.trending-card:hover :global(.play-overlay),
+	.trending-card.active :global(.play-overlay),
+	.trending-card.resolving :global(.play-overlay) {
 		opacity: 1;
-	}
-
-	.trending-card.disabled .play-overlay {
-		opacity: 1;
+		transform: translateY(0);
 	}
 
 	.play-state-label {
 		max-width: calc(100% - 20px);
 		padding: 5px 8px;
-		border-radius: 6px;
+		border-radius: var(--radius-xs);
 		background: rgba(0, 0, 0, 0.58);
 		color: rgba(255, 255, 255, 0.9);
 		font-size: 11px;
 		font-weight: 700;
 		line-height: 1.2;
 		text-align: center;
-	}
-
-	.mini-spinner {
-		width: 22px;
-		height: 22px;
-		border: 2px solid rgba(255, 255, 255, 0.28);
-		border-top-color: #fff;
-		border-radius: 50%;
-		animation: card-spin 0.8s linear infinite;
-	}
-
-	@keyframes card-spin {
-		to { transform: rotate(360deg); }
 	}
 
 	.meta {
@@ -397,18 +377,18 @@
 	}
 
 	.chip.genre {
-		background: rgba(125, 200, 175, 0.12);
-		color: var(--accent, #7dc8af);
+		background: var(--accent-soft);
+		color: var(--accent-strong);
 	}
 
 	.chip.lib {
-		background: rgba(125, 200, 175, 0.10);
-		color: var(--accent, #7dc8af);
+		background: var(--accent-soft);
+		color: var(--accent-strong);
 	}
 
 	.chip.src {
-		background: rgba(255, 255, 255, 0.06);
-		color: rgba(255, 255, 255, 0.6);
+		background: var(--border-subtle);
+		color: var(--text-secondary);
 	}
 
 	.duration {

--- a/frontend/src/lib/components/TrendingCard.svelte
+++ b/frontend/src/lib/components/TrendingCard.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
 	import type { ChartEntry, TidalPlayable, Track } from '$lib/api/client';
-	import { formatDuration } from '$lib/stores/library';
+	import { formatTrackDuration } from '$lib/utils/format';
 	import { openContextMenu } from '$lib/stores/context_menu';
 	import { buildTrackMenu, buildTidalTrackMenu } from '$lib/player/track_menu';
 	import { currentTrack, isPlaying } from '$lib/stores/player';
 	import { lazyTidalArt } from '$lib/actions/lazy-tidal-art';
 	import { canPlayTrack, getPlayableLabel } from '$lib/player/playable';
+	import { letterColor } from '$lib/utils/color';
 
 	let {
 		entry,
@@ -86,13 +87,6 @@
 		if (upper === 'HIGH') return 'High';
 		if (upper === 'LOW') return 'Low';
 		return null;
-	}
-
-	function letterColor(name: string): string {
-		const colors = ['#e63946', '#457b9d', '#2a9d8f', '#e9c46a', '#f4a261', '#9b5de5', '#00b4d8'];
-		let h = 0;
-		for (let i = 0; i < name.length; i++) h = (h * 31 + name.charCodeAt(i)) & 0xffffffff;
-		return colors[Math.abs(h) % colors.length];
 	}
 
 	async function play() {
@@ -202,7 +196,7 @@
 				<span class="quality-badge {qualityClass}">{qualityLabel}</span>
 			{/if}
 			{#if durationMs}
-				<span class="duration">{formatDuration(durationMs)}</span>
+				<span class="duration">{formatTrackDuration(durationMs)}</span>
 			{/if}
 		</div>
 
@@ -369,7 +363,7 @@
 	}
 
 	.artist {
-		font-size: 12px;
+		font-size: var(--font-size-xs);
 		color: var(--text-secondary, rgba(255, 255, 255, 0.6));
 		white-space: nowrap;
 		overflow: hidden;

--- a/frontend/src/lib/components/analytics/KpiStrip.svelte
+++ b/frontend/src/lib/components/analytics/KpiStrip.svelte
@@ -78,8 +78,8 @@
 		border-radius: var(--radius);
 		overflow: hidden;
 		/* glass treatment baked in so the strip feels native to the rest of the page */
-		backdrop-filter: blur(16px);
-		-webkit-backdrop-filter: blur(16px);
+		backdrop-filter: var(--blur-overlay);
+		-webkit-backdrop-filter: var(--blur-overlay);
 		border: 1px solid color-mix(in srgb, var(--panel-border) 70%, var(--instrument-border));
 		box-shadow:
 			inset 0 1px 0 color-mix(in srgb, var(--instrument-edge) 52%, transparent),

--- a/frontend/src/lib/components/charts/SonicField.svelte
+++ b/frontend/src/lib/components/charts/SonicField.svelte
@@ -469,7 +469,7 @@
 	.quadrants text {
 		font-family: var(--font-display);
 		font-style: italic;
-		font-size: 22px;
+		font-size: var(--font-size-xl);
 		fill: var(--text-primary);
 		fill-opacity: 0.14;
 		pointer-events: none;

--- a/frontend/src/lib/components/charts/TrendingShelf.svelte
+++ b/frontend/src/lib/components/charts/TrendingShelf.svelte
@@ -193,7 +193,7 @@
 <section class="trending-shelf">
 	<div class="section-header">
 		<div class="section-title-group">
-			<p class="eyebrow">Now moving</p>
+			<p class="eyebrow">From Last.fm <span class="eyebrow-dot" aria-hidden="true">·</span> Now moving</p>
 			<h2>Trending <span class="sub">· {subLabel}</span></h2>
 		</div>
 		<div class="trending-controls">
@@ -298,7 +298,7 @@
 	}
 
 	.section-title-group h2 .sub {
-		color: var(--text-muted, #888);
+		color: var(--text-muted);
 		font-weight: 500;
 		font-size: 0.95rem;
 		margin-left: 2px;
@@ -309,8 +309,12 @@
 		font-weight: 600;
 		text-transform: uppercase;
 		letter-spacing: 0.08em;
-		color: var(--text-muted, #888);
+		color: var(--service-lastfm);
 		margin: 0;
+	}
+	.eyebrow-dot {
+		color: var(--text-muted);
+		margin: 0 4px;
 	}
 
 	.trending-controls {
@@ -323,29 +327,30 @@
 
 	.chip-group {
 		display: inline-flex;
-		gap: 4px;
+		gap: var(--space-1);
 		padding: 2px;
-		background: rgba(255, 255, 255, 0.04);
+		background: var(--panel-bg);
+		border: 1px solid var(--panel-border);
 		border-radius: 999px;
 	}
 
 	.chip {
 		background: transparent;
 		border: none;
-		color: var(--text-muted, #888);
+		color: var(--text-muted);
 		font: inherit;
-		font-size: 0.78rem;
+		font-size: var(--font-size-xs);
 		font-weight: 500;
 		padding: 4px 10px;
 		border-radius: 999px;
 		cursor: pointer;
-		transition: background 0.15s ease, color 0.15s ease;
+		transition: background var(--motion-fast), color var(--motion-fast);
 	}
 
 	.chip:hover { color: var(--text-primary); }
 
 	.chip.active {
-		background: rgba(255, 255, 255, 0.12);
+		background: var(--bg-hover);
 		color: var(--text-primary);
 	}
 
@@ -394,7 +399,7 @@
 
 	.skeleton-card {
 		aspect-ratio: 1;
-		border-radius: 12px;
+		border-radius: var(--radius-md);
 		background: linear-gradient(
 			110deg,
 			rgba(255, 255, 255, 0.04) 30%,

--- a/frontend/src/lib/components/charts/TrendingShelf.svelte
+++ b/frontend/src/lib/components/charts/TrendingShelf.svelte
@@ -135,7 +135,6 @@
 		// lands avoids the flash-to-empty-state and the resulting grid reflow.
 		loading = true;
 		error = false;
-		console.debug('[trending] fetching', { mode, country, genre, token });
 		try {
 			let data: { tracks: ChartEntry[] | null };
 			if (mode === 'tidal') {
@@ -148,7 +147,6 @@
 				data = await api.getTrending({ source: 'lastfm', limit });
 			}
 			const next = data.tracks ?? [];
-			console.debug('[trending] loaded', { token, count: next.length });
 			tracks = next;
 			// Only cache non-empty payloads so a transient 5xx returning [] doesn't
 			// poison the cache for 6h.
@@ -344,11 +342,11 @@
 		transition: background 0.15s ease, color 0.15s ease;
 	}
 
-	.chip:hover { color: var(--text, #fff); }
+	.chip:hover { color: var(--text-primary); }
 
 	.chip.active {
 		background: rgba(255, 255, 255, 0.12);
-		color: var(--text, #fff);
+		color: var(--text-primary);
 	}
 
 	.chip-row {

--- a/frontend/src/lib/components/home/YourMixesShelf.svelte
+++ b/frontend/src/lib/components/home/YourMixesShelf.svelte
@@ -6,6 +6,7 @@
 	import { tidalStatus } from '$lib/stores/tidal';
 	import { getCachedMixes, putCachedMixes, clearCachedMixes } from '$lib/stores/tidal-mixes-cache';
 	import { wheelToHorizontal } from '$lib/actions/wheel-to-horizontal';
+	import PlayOverlay from '$lib/components/ui/PlayOverlay.svelte';
 
 	type State = 'loading' | 'ready' | 'empty' | 'disconnected' | 'error';
 
@@ -90,7 +91,11 @@
 					{:else}
 						<div class="art fallback">♫</div>
 					{/if}
-					<div class="play-overlay" aria-hidden="true">▶</div>
+					<PlayOverlay
+						position="center"
+						size="md"
+						label={`${isMixVideo(mix) ? 'Play video mix' : 'Play mix'} ${mix.title}`}
+					/>
 					{#if isMixVideo(mix)}
 						<span class="video-badge">Video</span>
 					{/if}
@@ -264,21 +269,10 @@
 		border-color: var(--accent-line, rgba(125, 200, 175, 0.6));
 	}
 
-	.play-overlay {
-		position: absolute;
-		inset: 0;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		background: linear-gradient(180deg, rgba(0, 0, 0, 0.05) 0%, rgba(0, 0, 0, 0.55) 100%);
-		opacity: 0;
-		color: #fff;
-		font-size: var(--font-size-2xl);
-		transition: opacity 160ms ease;
-	}
-	.mix-card:hover .play-overlay,
-	.mix-card:focus-visible .play-overlay {
+	.mix-card:hover :global(.play-overlay),
+	.mix-card:focus-visible :global(.play-overlay) {
 		opacity: 1;
+		transform: translateY(0);
 	}
 	.video-badge {
 		position: absolute;

--- a/frontend/src/lib/components/home/YourMixesShelf.svelte
+++ b/frontend/src/lib/components/home/YourMixesShelf.svelte
@@ -5,6 +5,7 @@
 	import { playTidalMix } from '$lib/stores/player';
 	import { tidalStatus } from '$lib/stores/tidal';
 	import { getCachedMixes, putCachedMixes, clearCachedMixes } from '$lib/stores/tidal-mixes-cache';
+	import { wheelToHorizontal } from '$lib/actions/wheel-to-horizontal';
 
 	type State = 'loading' | 'ready' | 'empty' | 'disconnected' | 'error';
 
@@ -71,39 +72,6 @@
 		void playTidalMix(mix.id);
 	}
 
-	// Translate vertical wheel scroll to horizontal scroll over the rail.
-	// Wheel events only fire on the hovered element, so this naturally
-	// activates only when the cursor is over the rail (per the user spec:
-	// "wheel should only be usable after a hover on card").
-	//
-	// Only preventDefault when there's actually room to scroll horizontally
-	// in the wheel direction — otherwise the page keeps scrolling vertically
-	// at the edges, so the rail doesn't trap the user mid-page.
-	function wheelToHorizontal(node: HTMLElement) {
-		const onWheel = (e: WheelEvent) => {
-			// Trackpads / native horizontal scroll devices already supply
-			// deltaX; only intervene when the user is genuinely scrolling
-			// vertically (deltaY dominant).
-			if (Math.abs(e.deltaY) <= Math.abs(e.deltaX)) return;
-
-			const max = node.scrollWidth - node.clientWidth;
-			if (max <= 0) return; // Nothing to scroll.
-
-			const goingRight = e.deltaY > 0;
-			const atStart = node.scrollLeft <= 0;
-			const atEnd = node.scrollLeft >= max - 1;
-			if ((goingRight && atEnd) || (!goingRight && atStart)) return;
-
-			e.preventDefault();
-			node.scrollLeft += e.deltaY;
-		};
-		node.addEventListener('wheel', onWheel, { passive: false });
-		return {
-			destroy() {
-				node.removeEventListener('wheel', onWheel);
-			},
-		};
-	}
 </script>
 
 {#snippet mixRail(items: TidalMix[])}
@@ -234,6 +202,20 @@
 		overflow-x: auto;
 		padding-bottom: 8px;
 		scroll-snap-type: x mandatory;
+		mask-image: linear-gradient(
+			to right,
+			transparent 0,
+			black 16px,
+			black calc(100% - 32px),
+			transparent 100%
+		);
+		-webkit-mask-image: linear-gradient(
+			to right,
+			transparent 0,
+			black 16px,
+			black calc(100% - 32px),
+			transparent 100%
+		);
 	}
 	.mix-rail::-webkit-scrollbar { height: 6px; }
 	.mix-rail::-webkit-scrollbar-track {
@@ -291,7 +273,7 @@
 		background: linear-gradient(180deg, rgba(0, 0, 0, 0.05) 0%, rgba(0, 0, 0, 0.55) 100%);
 		opacity: 0;
 		color: #fff;
-		font-size: 28px;
+		font-size: var(--font-size-2xl);
 		transition: opacity 160ms ease;
 	}
 	.mix-card:hover .play-overlay,
@@ -356,7 +338,7 @@
 	}
 	.artist {
 		margin: 0;
-		font-size: 12px;
+		font-size: var(--font-size-xs);
 		color: var(--text-secondary, rgba(255, 255, 255, 0.6));
 		white-space: nowrap;
 		overflow: hidden;

--- a/frontend/src/lib/components/now-playing/NowPlayingProgress.svelte
+++ b/frontend/src/lib/components/now-playing/NowPlayingProgress.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { formatDuration } from '$lib/stores/library';
+	import { formatTrackDuration } from '$lib/utils/format';
 
 	let {
 		position,
@@ -58,8 +58,8 @@
 	</div>
 
 	<div class="np-times" class:scrubbing={isScrubbing}>
-		<span>{formatDuration(scrubPosition)}</span>
-		<span>{formatDuration(duration)}</span>
+		<span>{formatTrackDuration(scrubPosition)}</span>
+		<span>{formatTrackDuration(duration)}</span>
 	</div>
 </div>
 

--- a/frontend/src/lib/components/onboarding/LastfmConnect.svelte
+++ b/frontend/src/lib/components/onboarding/LastfmConnect.svelte
@@ -183,7 +183,7 @@
 		/>
 
 		{#if errorMsg}
-			<p class="error">{errorMsg}</p>
+			<p class="error" role="alert">{errorMsg}</p>
 		{/if}
 
 		<div class="actions">
@@ -226,7 +226,7 @@
 						there, then come back and click below.
 					</p>
 					{#if scrobbleError}
-						<p class="error">{scrobbleError}</p>
+						<p class="error" role="alert">{scrobbleError}</p>
 					{/if}
 					<div class="actions">
 						<button class="btn btn-primary" onclick={completeScrobbleAuth}>I've authorized</button>
@@ -243,7 +243,7 @@
 					<p class="muted">Starting Last.fm auth…</p>
 				{:else}
 					{#if scrobbleError}
-						<p class="error">{scrobbleError}</p>
+						<p class="error" role="alert">{scrobbleError}</p>
 					{/if}
 					<div class="actions">
 						<button class="btn btn-primary" onclick={startScrobbleAuth}>
@@ -268,7 +268,7 @@
 	}
 	.variant-onboarding h2 {
 		margin: 0 0 4px;
-		font-size: 22px;
+		font-size: var(--font-size-xl);
 		font-weight: 600;
 		letter-spacing: -0.01em;
 	}

--- a/frontend/src/lib/components/onboarding/LastfmConnect.svelte
+++ b/frontend/src/lib/components/onboarding/LastfmConnect.svelte
@@ -197,6 +197,12 @@
 	{:else}
 		<p class="success">Last.fm key saved.</p>
 
+		{#if variant === 'onboarding'}
+			<div class="actions">
+				<button class="btn btn-primary" onclick={() => onconnected?.()}>Continue</button>
+			</div>
+		{/if}
+
 		<!-- Enable scrobbling sub-section. Only meaningful in the settings
 		     variant — onboarding doesn't need to surface scrobble auth at
 		     first-run. -->
@@ -268,15 +274,18 @@
 	}
 	.variant-onboarding h2 {
 		margin: 0 0 4px;
-		font-size: var(--font-size-xl);
-		font-weight: 600;
-		letter-spacing: -0.01em;
+		font-family: var(--font-display);
+		font-size: clamp(1.75rem, 1.4rem + 1.4vw, 2.25rem);
+		font-weight: 500;
+		letter-spacing: -0.02em;
+		line-height: 1.05;
 	}
 	.muted {
 		margin: 0;
 		max-width: 460px;
-		color: var(--text-muted, #8b93a7);
-		line-height: 1.5;
+		color: var(--text-secondary);
+		line-height: 1.55;
+		font-size: var(--font-size-md);
 	}
 	.muted-link {
 		background: none;
@@ -298,7 +307,7 @@
 		min-width: 320px;
 		max-width: 100%;
 	}
-	.key-input:focus { outline: none; border-color: #4a6dd8; }
+	.key-input:focus { outline: none; border-color: rgba(255, 255, 255, 0.6); }
 	.actions {
 		display: flex;
 		gap: 12px;
@@ -317,8 +326,8 @@
 		font-weight: 500;
 		transition: background 120ms, border-color 120ms;
 	}
-	.btn-primary { background: #4a6dd8; color: #fff; }
-	.btn-primary:hover:not(:disabled) { background: #5a7ce8; }
+	.btn-primary { background: rgba(255, 255, 255, 0.92); color: #0a0d14; }
+	.btn-primary:hover:not(:disabled) { background: #fff; }
 	.btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
 	.btn-ghost {
 		background: transparent;
@@ -331,7 +340,7 @@
 	.scrobble-section {
 		margin-top: 8px;
 		padding-top: 14px;
-		border-top: 1px solid rgba(255, 255, 255, 0.06);
+		border-top: 1px solid var(--border-subtle);
 		display: flex;
 		flex-direction: column;
 		gap: 10px;

--- a/frontend/src/lib/components/onboarding/TidalConnect.svelte
+++ b/frontend/src/lib/components/onboarding/TidalConnect.svelte
@@ -85,7 +85,7 @@
 				<p>NOORwave plays from your TIDAL library. Sign in once and we'll keep your tracks in sync.</p>
 			{/if}
 			{#if errorMsg}
-				<p class="error">{errorMsg}</p>
+				<p class="error" role="alert">{errorMsg}</p>
 			{/if}
 			<div class="actions">
 				<button class="btn btn-primary" onclick={start}>
@@ -128,7 +128,7 @@
 	}
 	.variant-onboarding h2 {
 		margin: 0 0 4px;
-		font-size: 22px;
+		font-size: var(--font-size-xl);
 		font-weight: 600;
 		letter-spacing: -0.01em;
 	}

--- a/frontend/src/lib/components/onboarding/TidalConnect.svelte
+++ b/frontend/src/lib/components/onboarding/TidalConnect.svelte
@@ -128,15 +128,18 @@
 	}
 	.variant-onboarding h2 {
 		margin: 0 0 4px;
-		font-size: var(--font-size-xl);
-		font-weight: 600;
-		letter-spacing: -0.01em;
+		font-family: var(--font-display);
+		font-size: clamp(1.75rem, 1.4rem + 1.4vw, 2.25rem);
+		font-weight: 500;
+		letter-spacing: -0.02em;
+		line-height: 1.05;
 	}
 	.variant-onboarding p {
 		margin: 0;
 		max-width: 420px;
-		color: var(--text-muted, #8b93a7);
-		line-height: 1.5;
+		color: var(--text-secondary);
+		line-height: 1.55;
+		font-size: var(--font-size-md);
 	}
 	.actions {
 		display: flex;
@@ -154,10 +157,10 @@
 		transition: background 120ms, border-color 120ms;
 	}
 	.btn-primary {
-		background: #4a6dd8;
-		color: #fff;
+		background: rgba(255, 255, 255, 0.92);
+		color: #0a0d14;
 	}
-	.btn-primary:hover:not(:disabled) { background: #5a7ce8; }
+	.btn-primary:hover:not(:disabled) { background: #fff; }
 	.btn-primary:disabled { opacity: 0.6; cursor: not-allowed; }
 	.btn-ghost {
 		background: transparent;
@@ -166,14 +169,14 @@
 	}
 	.btn-ghost:hover { background: rgba(255, 255, 255, 0.04); color: #e7eaf2; }
 	.code {
-		font-family: 'SF Mono', Menlo, Consolas, monospace;
-		font-size: 38px;
+		font-family: var(--font-mono);
+		font-size: clamp(2rem, 1.5rem + 2vw, 2.625rem);
 		font-weight: 600;
 		letter-spacing: 0.18em;
 		padding: 18px 28px;
-		background: rgba(255, 255, 255, 0.04);
-		border: 1px solid rgba(255, 255, 255, 0.08);
-		border-radius: 12px;
+		background: var(--panel-bg);
+		border: 1px solid var(--panel-border);
+		border-radius: var(--radius-md);
 		cursor: pointer;
 		user-select: all;
 	}
@@ -183,7 +186,7 @@
 		align-items: center;
 		gap: 12px;
 	}
-	.hint, .muted { color: var(--text-muted, #8b93a7); margin: 0; font-size: 13px; }
+	.hint, .muted { color: var(--text-tertiary); margin: 0; font-size: var(--font-size-xs); }
 	.hint-link {
 		background: none;
 		border: none;

--- a/frontend/src/lib/components/ui/MediaRail.svelte
+++ b/frontend/src/lib/components/ui/MediaRail.svelte
@@ -44,6 +44,20 @@
 		/* Firefox + most browsers — slim track, semi-transparent thumb. */
 		scrollbar-width: thin;
 		scrollbar-color: rgba(255, 255, 255, 0.18) transparent;
+		mask-image: linear-gradient(
+			to right,
+			transparent 0,
+			black 16px,
+			black calc(100% - 32px),
+			transparent 100%
+		);
+		-webkit-mask-image: linear-gradient(
+			to right,
+			transparent 0,
+			black 16px,
+			black calc(100% - 32px),
+			transparent 100%
+		);
 	}
 	.media-rail::-webkit-scrollbar {
 		height: 6px;

--- a/frontend/src/lib/components/ui/PlayOverlay.svelte
+++ b/frontend/src/lib/components/ui/PlayOverlay.svelte
@@ -1,0 +1,147 @@
+<script lang="ts">
+	type State = 'play' | 'pause' | 'loading';
+	type Position = 'center' | 'corner';
+
+	type Props = {
+		position?: Position;
+		state?: State;
+		label?: string;
+		size?: 'sm' | 'md' | 'lg';
+		forceVisible?: boolean;
+		disabled?: boolean;
+		onclick?: (e: MouseEvent) => void;
+	};
+
+	let {
+		position = 'center',
+		state = 'play',
+		label = 'Play',
+		size = 'md',
+		forceVisible = false,
+		disabled = false,
+		onclick,
+	}: Props = $props();
+</script>
+
+{#snippet icon()}
+	{#if state === 'loading'}
+		<span class="po-spinner" aria-hidden="true"></span>
+	{:else if state === 'pause'}
+		<svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true">
+			<rect x="3" y="3" width="3.5" height="10" fill="currentColor" rx="0.5" />
+			<rect x="9.5" y="3" width="3.5" height="10" fill="currentColor" rx="0.5" />
+		</svg>
+	{:else}
+		<svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true">
+			<path d="M5 3l8 5-8 5V3z" fill="currentColor" />
+		</svg>
+	{/if}
+{/snippet}
+
+{#if onclick}
+	<button
+		type="button"
+		class="play-overlay"
+		class:position-center={position === 'center'}
+		class:position-corner={position === 'corner'}
+		class:size-sm={size === 'sm'}
+		class:size-md={size === 'md'}
+		class:size-lg={size === 'lg'}
+		class:force-visible={forceVisible}
+		{disabled}
+		aria-label={label}
+		{onclick}
+	>
+		{@render icon()}
+	</button>
+{:else}
+	<div
+		class="play-overlay decorative"
+		class:position-center={position === 'center'}
+		class:position-corner={position === 'corner'}
+		class:size-sm={size === 'sm'}
+		class:size-md={size === 'md'}
+		class:size-lg={size === 'lg'}
+		class:force-visible={forceVisible}
+		aria-hidden="true"
+	>
+		{@render icon()}
+	</div>
+{/if}
+
+<style>
+	.play-overlay {
+		position: absolute;
+		display: grid;
+		place-items: center;
+		border-radius: 50%;
+		background: rgba(0, 0, 0, 0.55);
+		color: #fff;
+		border: 1px solid rgba(255, 255, 255, 0.15);
+		backdrop-filter: var(--blur-base);
+		-webkit-backdrop-filter: var(--blur-base);
+		cursor: pointer;
+		opacity: 0;
+		transform: translateY(4px);
+		transition:
+			opacity var(--motion-base),
+			transform var(--motion-base),
+			background var(--motion-base);
+		box-shadow: 0 6px 16px -4px rgba(0, 0, 0, 0.5);
+		padding: 0;
+		font: inherit;
+	}
+
+	.size-sm { width: 32px;  height: 32px; }
+	.size-md { width: 44px;  height: 44px; }
+	.size-lg { width: 56px;  height: 56px; }
+
+	.size-sm svg { width: 12px; height: 12px; }
+	.size-lg svg { width: 20px; height: 20px; }
+
+	.position-center {
+		inset: 0;
+		margin: auto;
+	}
+
+	.position-corner {
+		right: 8px;
+		bottom: 8px;
+	}
+
+	.play-overlay:hover:not(:disabled) {
+		background: rgba(0, 0, 0, 0.72);
+		transform: translateY(0) scale(1.06);
+	}
+
+	.play-overlay:focus-visible,
+	.play-overlay.force-visible {
+		opacity: 1;
+		transform: translateY(0);
+	}
+
+	.play-overlay:disabled {
+		cursor: default;
+		opacity: 0.5;
+		transform: none;
+	}
+
+	.play-overlay.decorative {
+		pointer-events: none;
+	}
+
+	.po-spinner {
+		width: 16px;
+		height: 16px;
+		border: 2px solid rgba(255, 255, 255, 0.28);
+		border-top-color: #fff;
+		border-radius: 50%;
+		animation: po-spin 0.8s linear infinite;
+	}
+	.size-sm .po-spinner { width: 12px; height: 12px; border-width: 1.5px; }
+	.size-lg .po-spinner { width: 20px; height: 20px; }
+
+	@keyframes po-spin {
+		to { transform: rotate(360deg); }
+	}
+</style>

--- a/frontend/src/lib/components/ui/StateBadge.svelte
+++ b/frontend/src/lib/components/ui/StateBadge.svelte
@@ -24,7 +24,7 @@
 		gap: 8px;
 		padding: 7px 11px;
 		border-radius: 999px;
-		border: 1px solid rgba(255, 255, 255, 0.08);
+		border: 1px solid var(--panel-border);
 		background: rgba(255, 255, 255, 0.04);
 		color: var(--text-secondary);
 		font-size: 0.76rem;

--- a/frontend/src/lib/components/video/VideoCard.svelte
+++ b/frontend/src/lib/components/video/VideoCard.svelte
@@ -4,6 +4,7 @@
 	import { openContextMenu } from '$lib/stores/context_menu';
 	import { formatTrackDuration } from '$lib/utils/format';
 	import { buildVideoMenu, buildVideoMixMenu, isVideoMix } from '$lib/player/video_menu';
+	import PlayOverlay from '$lib/components/ui/PlayOverlay.svelte';
 
 	type VideoLike = TidalSearchVideo | TidalVideoMix | TidalVideoMixItem;
 
@@ -48,7 +49,11 @@
 		{:else}
 			<div class="poster placeholder">▶</div>
 		{/if}
-		<div class="play-overlay" aria-hidden="true">{isVideoMix(video) ? '↗' : '▶'}</div>
+		<PlayOverlay
+			position="corner"
+			size="sm"
+			label={isVideoMix(video) ? `Open mix ${title}` : `Play ${title}`}
+		/>
 		{#if duration}
 			<span class="duration">{duration}</span>
 		{/if}
@@ -93,25 +98,8 @@
 		color: var(--text-tertiary);
 	}
 
-	.play-overlay {
-		position: absolute;
-		right: 10px;
-		bottom: 10px;
-		width: 34px;
-		height: 34px;
-		border-radius: 50%;
-		display: grid;
-		place-items: center;
-		background: var(--accent);
-		color: white;
-		font-size: 0.8rem;
-		box-shadow: 0 8px 18px rgba(0, 0, 0, 0.34);
-		opacity: 0;
-		transform: translateY(4px);
-		transition: opacity 0.16s ease, transform 0.16s ease;
-	}
-
-	.video-card:hover .play-overlay {
+	.video-card:hover :global(.play-overlay),
+	.video-card:focus-visible :global(.play-overlay) {
 		opacity: 1;
 		transform: translateY(0);
 	}

--- a/frontend/src/lib/components/video/VideoCard.svelte
+++ b/frontend/src/lib/components/video/VideoCard.svelte
@@ -2,7 +2,7 @@
 	import type { TidalSearchVideo, TidalVideoMix, TidalVideoMixItem } from '$lib/api/client';
 	import { lazyTidalArt } from '$lib/actions/lazy-tidal-art';
 	import { openContextMenu } from '$lib/stores/context_menu';
-	import { formatDuration } from '$lib/stores/library';
+	import { formatTrackDuration } from '$lib/utils/format';
 	import { buildVideoMenu, buildVideoMixMenu, isVideoMix } from '$lib/player/video_menu';
 
 	type VideoLike = TidalSearchVideo | TidalVideoMix | TidalVideoMixItem;
@@ -15,7 +15,7 @@
 	let subtitle = $derived(
 		isVideoMix(video) ? (video.description ?? 'Video mix') : (video.artist_name ?? 'TIDAL video')
 	);
-	let duration = $derived(!isVideoMix(video) && video.duration_ms ? formatDuration(video.duration_ms) : null);
+	let duration = $derived(!isVideoMix(video) && video.duration_ms ? formatTrackDuration(video.duration_ms) : null);
 
 	function select() {
 		onSelect?.(video);

--- a/frontend/src/lib/components/video/VideoPlayer.svelte
+++ b/frontend/src/lib/components/video/VideoPlayer.svelte
@@ -547,7 +547,8 @@
 		background: rgba(12, 12, 16, 0.76);
 		border: 1px solid rgba(255, 255, 255, 0.18);
 		box-shadow: 0 14px 40px rgba(0, 0, 0, 0.28);
-		backdrop-filter: blur(16px);
+		backdrop-filter: var(--blur-overlay);
+		-webkit-backdrop-filter: var(--blur-overlay);
 		color: rgba(255, 255, 255, 0.92);
 		transform: translate(-50%, 0);
 		animation: up-next-drop 0.24s ease both;

--- a/frontend/src/lib/components/video/VideoPlayer.svelte
+++ b/frontend/src/lib/components/video/VideoPlayer.svelte
@@ -416,11 +416,11 @@
 	></video>
 
 	{#if loading && !error && !unsupported}
-		<div class="status">Loading video…</div>
+		<div class="status" role="status" aria-live="polite">Loading video…</div>
 	{/if}
 
 	{#if error}
-		<div class="status error">{error}</div>
+		<div class="status error" role="alert">{error}</div>
 	{/if}
 
 	<div class="top-meta">

--- a/frontend/src/lib/components/wallpaper/ShaderWallpaper.svelte
+++ b/frontend/src/lib/components/wallpaper/ShaderWallpaper.svelte
@@ -46,7 +46,6 @@ uniform vec3 u_color4;
 	}
 
 	onMount(() => {
-		console.log('[ShaderWallpaper] mount, interactive=', interactive);
 		const gl = canvas.getContext('webgl', { premultipliedAlpha: false, antialias: true });
 		if (!gl) return;
 		gl.getExtension('OES_standard_derivatives');
@@ -56,7 +55,6 @@ uniform vec3 u_color4;
 			console.warn('[ShaderWallpaper] WebGL context LOST');
 		};
 		const onContextRestored = () => {
-			console.log('[ShaderWallpaper] WebGL context restored — re-setting up program');
 			gl!.getExtension('OES_standard_derivatives');
 			prog = null;
 			buf = null;
@@ -256,7 +254,6 @@ uniform vec3 u_color4;
 		});
 
 		return () => {
-			console.log('[ShaderWallpaper] unmount, interactive=', interactive);
 			running = false;
 			cancelAnimationFrame(raf);
 			ro.disconnect();

--- a/frontend/src/lib/fixtures/demo-sonic-field.ts
+++ b/frontend/src/lib/fixtures/demo-sonic-field.ts
@@ -4,6 +4,7 @@
  */
 
 import type { SonicView, SonicTrack } from '$lib/api/client';
+import { clamp } from '$lib/utils/math';
 
 export type SonicProfile = 'club' | 'eclectic' | 'chill' | 'aggressive';
 
@@ -62,10 +63,6 @@ function gaussian(rand: () => number, mu: number, sigma: number): number {
 	const v = rand();
 	const z = Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * v);
 	return mu + z * sigma;
-}
-
-function clamp(x: number, lo: number, hi: number): number {
-	return Math.max(lo, Math.min(hi, x));
 }
 
 const ARTISTS = [

--- a/frontend/src/lib/stores/library.ts
+++ b/frontend/src/lib/stores/library.ts
@@ -149,32 +149,3 @@ export function updateLibraryTrackFavorite(trackId: number, isFavorite: boolean,
 	else if (appended) totalTracks.update((n) => n + 1);
 }
 
-export function formatDuration(ms: number | null): string {
-	if (!ms) return '--:--';
-	const totalSeconds = Math.floor(ms / 1000);
-	const minutes = Math.floor(totalSeconds / 60);
-	const seconds = totalSeconds % 60;
-	return `${minutes}:${seconds.toString().padStart(2, '0')}`;
-}
-
-export function formatDateShort(iso: string | null): string {
-	if (!iso) return '—';
-	const d = new Date(iso);
-	const now = new Date();
-	const diffMs = now.getTime() - d.getTime();
-	const diffDays = Math.floor(diffMs / 86400000);
-
-	if (diffDays === 0) return 'Today';
-	if (diffDays === 1) return 'Yesterday';
-	if (diffDays < 7) return `${diffDays}d ago`;
-	if (diffDays < 30) return `${Math.floor(diffDays / 7)}w ago`;
-	if (diffDays < 365) return `${Math.floor(diffDays / 30)}mo ago`;
-	return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
-}
-
-export function getQualityClass(quality: string | null): string {
-	if (!quality) return 'lossy';
-	if (quality.includes('HI_RES')) return 'hires';
-	if (quality === 'LOSSLESS') return 'lossless';
-	return 'lossy';
-}

--- a/frontend/src/lib/stores/player.ts
+++ b/frontend/src/lib/stores/player.ts
@@ -16,6 +16,7 @@ import { setExclusiveEngaged, setExclusiveReleased } from '$lib/stores/exclusive
 import { showToast, dismissToast } from '$lib/stores/toast';
 import { wsConnected } from '$lib/api/ws';
 import { updateLibraryTrackFavorite } from '$lib/stores/library';
+import { clamp01 } from '$lib/utils/math';
 
 function trackLabel(track: { title?: string | null; artist_name?: string | null }): string {
 	const t = (track.title ?? '').trim();
@@ -327,7 +328,7 @@ export async function playNextTrack() {
 export async function setPlayerVolume(nextVolume: number) {
 	playerError.set(null);
 	try {
-		const clamped = Math.max(0, Math.min(1, nextVolume));
+		const clamped = clamp01(nextVolume);
 		const result = await api.setPlaybackVolume(clamped);
 		// Only sync volume — applying full state would overwrite the local position
 		// ticker with a slightly stale server value, causing the displayed time to jump.

--- a/frontend/src/lib/stores/wallpaper.ts
+++ b/frontend/src/lib/stores/wallpaper.ts
@@ -9,10 +9,12 @@ const VALID: WallpaperId[] = ['none', 'aurora', 'chrome', 'grid', 'nebula', 'top
                                'phasing', 'spectrogram', 'lissajous', 'drone', 'reel',
                                'standing-wave'];
 
+const DEFAULT: WallpaperId = 'standing-wave';
+
 function readInitial(): WallpaperId {
-	if (typeof localStorage === 'undefined') return 'none';
+	if (typeof localStorage === 'undefined') return DEFAULT;
 	const raw = localStorage.getItem(STORAGE_KEY);
-	return (VALID as string[]).includes(raw ?? '') ? (raw as WallpaperId) : 'none';
+	return (VALID as string[]).includes(raw ?? '') ? (raw as WallpaperId) : DEFAULT;
 }
 
 export const wallpaper = writable<WallpaperId>(readInitial());

--- a/frontend/src/lib/utils/color.ts
+++ b/frontend/src/lib/utils/color.ts
@@ -1,0 +1,32 @@
+/**
+ * Hash a string into one of seven brand-friendly colours, used as a fallback
+ * background for missing album / artist / playlist artwork.
+ *
+ * The palette is deliberately small and bright so adjacent fallbacks read as
+ * a colour-coded set rather than a noisy gradient. Determinism (same name →
+ * same colour) keeps the UI calm across renders.
+ *
+ *   letterColor('Pink Floyd')    → '#9b5de5'
+ *   letterColor('Daft Punk')     → '#457b9d'
+ *
+ * Note: routes/search/+page.svelte intentionally uses a different muted-HSL
+ * variant for its results pane. That divergence is documented in STYLING.md
+ * and not consolidated here.
+ */
+const LETTER_COLORS = [
+	'#e63946',
+	'#457b9d',
+	'#2a9d8f',
+	'#e9c46a',
+	'#f4a261',
+	'#9b5de5',
+	'#00b4d8',
+] as const;
+
+export function letterColor(seed: string): string {
+	let h = 0;
+	for (let i = 0; i < seed.length; i++) {
+		h = (h * 31 + seed.charCodeAt(i)) & 0xffffffff;
+	}
+	return LETTER_COLORS[Math.abs(h) % LETTER_COLORS.length];
+}

--- a/frontend/src/lib/utils/format.test.ts
+++ b/frontend/src/lib/utils/format.test.ts
@@ -13,6 +13,7 @@ import {
 	formatBpm,
 	formatCount,
 	formatDate,
+	formatDateShort,
 	formatDelta,
 	formatDr,
 	formatDuration,
@@ -21,6 +22,8 @@ import {
 	formatMultiplier,
 	formatPercent,
 	formatTilt,
+	formatTrackDuration,
+	getQualityClass,
 } from './format';
 
 const EMPTY = '--';
@@ -210,5 +213,84 @@ describe('identical-output across call sites', () => {
 		const kpi = formatDuration(ms);
 		const cohort = formatDuration(ms);
 		expect(kpi).toBe(cohort);
+	});
+});
+
+// ─── Track duration (M:SS, used in track rows / now-playing) ─────────────────
+
+describe('formatTrackDuration', () => {
+	test('returns "--:--" sentinel for null/undefined/NaN/0', () => {
+		expect(formatTrackDuration(null)).toBe('--:--');
+		expect(formatTrackDuration(undefined)).toBe('--:--');
+		expect(formatTrackDuration(Number.NaN)).toBe('--:--');
+		expect(formatTrackDuration(0)).toBe('--:--');
+	});
+	test('renders M:SS', () => {
+		expect(formatTrackDuration(45_000)).toBe('0:45');
+		expect(formatTrackDuration(225_000)).toBe('3:45');
+		expect(formatTrackDuration(7 * 60_000)).toBe('7:00');
+	});
+	test('zero-pads seconds', () => {
+		expect(formatTrackDuration(60_000)).toBe('1:00');
+		expect(formatTrackDuration(65_000)).toBe('1:05');
+	});
+	test('does not roll into hours — minutes count above 60 still render', () => {
+		expect(formatTrackDuration(72 * 60_000 + 7_000)).toBe('72:07');
+	});
+});
+
+// ─── formatDateShort (relative-date for track / album metadata) ──────────────
+
+describe('formatDateShort', () => {
+	test('returns em-dash for null', () => {
+		expect(formatDateShort(null)).toBe('—');
+	});
+	test('Today / Yesterday', () => {
+		const now = new Date();
+		expect(formatDateShort(now.toISOString())).toBe('Today');
+		const yesterday = new Date(now);
+		yesterday.setDate(yesterday.getDate() - 1);
+		expect(formatDateShort(yesterday.toISOString())).toBe('Yesterday');
+	});
+	test('within a week → "Nd ago"', () => {
+		const past = new Date();
+		past.setDate(past.getDate() - 3);
+		expect(formatDateShort(past.toISOString())).toBe('3d ago');
+	});
+	test('within a month → "Nw ago"', () => {
+		const past = new Date();
+		past.setDate(past.getDate() - 14);
+		expect(formatDateShort(past.toISOString())).toBe('2w ago');
+	});
+	test('within a year → "Nmo ago"', () => {
+		const past = new Date();
+		past.setDate(past.getDate() - 90);
+		expect(formatDateShort(past.toISOString())).toBe('3mo ago');
+	});
+	test('older than a year → locale date', () => {
+		// A clearly-old date ensures we land in the locale-date branch regardless of test-run time.
+		const result = formatDateShort('2020-01-15T00:00:00.000Z');
+		expect(result).toMatch(/\b2020\b/);
+		expect(result).toMatch(/Jan/);
+	});
+});
+
+// ─── getQualityClass (TIDAL audio-quality → CSS class) ───────────────────────
+
+describe('getQualityClass', () => {
+	test('null → lossy', () => {
+		expect(getQualityClass(null)).toBe('lossy');
+	});
+	test('HI_RES variants → hires', () => {
+		expect(getQualityClass('HI_RES')).toBe('hires');
+		expect(getQualityClass('HI_RES_LOSSLESS')).toBe('hires');
+	});
+	test('LOSSLESS → lossless', () => {
+		expect(getQualityClass('LOSSLESS')).toBe('lossless');
+	});
+	test('HIGH / LOW / unknown → lossy', () => {
+		expect(getQualityClass('HIGH')).toBe('lossy');
+		expect(getQualityClass('LOW')).toBe('lossy');
+		expect(getQualityClass('UNKNOWN')).toBe('lossy');
 	});
 });

--- a/frontend/src/lib/utils/format.ts
+++ b/frontend/src/lib/utils/format.ts
@@ -33,6 +33,53 @@ export function formatDuration(ms: number | null | undefined): string {
 	return `${hours}h ${String(remMin).padStart(2, '0')}m`;
 }
 
+/**
+ * Track duration in milliseconds → "M:SS" (e.g. "3:45", "12:07").
+ * null/0/NaN → "--:--" (clock-shaped placeholder for track-row visual continuity;
+ * this differs deliberately from the analytics-family `--` empty sentinel).
+ */
+export function formatTrackDuration(ms: number | null | undefined): string {
+	if (!ms || isMissing(ms)) return '--:--';
+	const totalSeconds = Math.floor(ms / 1000);
+	const minutes = Math.floor(totalSeconds / 60);
+	const seconds = totalSeconds % 60;
+	return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+}
+
+/**
+ * Relative-date formatter for track / album "added" timestamps.
+ *
+ *   formatDateShort('2026-05-08T...') → "Today"
+ *   formatDateShort('2026-05-05T...') → "3d ago"
+ *   formatDateShort('2025-12-01T...') → "Dec 1, 2025"
+ *   formatDateShort(null)             → "—"
+ *
+ * Uses an em-dash for the empty sentinel because it appears beside formatted
+ * dates in track-row metadata, not in analytics tiles.
+ */
+export function formatDateShort(iso: string | null): string {
+	if (!iso) return '—';
+	const d = new Date(iso);
+	const now = new Date();
+	const diffMs = now.getTime() - d.getTime();
+	const diffDays = Math.floor(diffMs / 86400000);
+
+	if (diffDays === 0) return 'Today';
+	if (diffDays === 1) return 'Yesterday';
+	if (diffDays < 7) return `${diffDays}d ago`;
+	if (diffDays < 30) return `${Math.floor(diffDays / 7)}w ago`;
+	if (diffDays < 365) return `${Math.floor(diffDays / 30)}mo ago`;
+	return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+/** TIDAL audio-quality string → CSS class name for `.quality-badge.<class>`. */
+export function getQualityClass(quality: string | null): 'hires' | 'lossless' | 'lossy' {
+	if (!quality) return 'lossy';
+	if (quality.includes('HI_RES')) return 'hires';
+	if (quality === 'LOSSLESS') return 'lossless';
+	return 'lossy';
+}
+
 // ─── Percent / delta ─────────────────────────────────────────────────────────
 
 /** Ratio 0..1 → "74%". null → "--". `decimals` is required at every call site (no default). */

--- a/frontend/src/lib/utils/math.ts
+++ b/frontend/src/lib/utils/math.ts
@@ -1,0 +1,13 @@
+/** Clamp `value` into the inclusive range [min, max]. */
+export function clamp(value: number, min: number, max: number): number {
+	if (value < min) return min;
+	if (value > max) return max;
+	return value;
+}
+
+/** Clamp `value` into the unit range [0, 1]. Common for normalized progress, opacity, etc. */
+export function clamp01(value: number): number {
+	if (value < 0) return 0;
+	if (value > 1) return 1;
+	return value;
+}

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -2,7 +2,7 @@
 	import '../app.css';
 	import { onDestroy, onMount } from 'svelte';
 	import { page } from '$app/state';
-	import { goto } from '$app/navigation';
+	import { goto, onNavigate } from '$app/navigation';
 	import { connectWebSocket, wsConnected } from '$lib/api/ws';
 	import {
 		currentTrack,
@@ -76,7 +76,13 @@
 
 	let { children } = $props();
 
-	let activeWallpaper = $derived(wallpaperById($wallpaper));
+	let isOnboardingRouteEarly = $derived(page.url.pathname.startsWith('/onboarding'));
+	// During onboarding, force the standing-wave wallpaper so the brand identity
+	// is consistent for every user (and so the wallpaper element persists across
+	// the navigation to home — same DOM node, no shader remount, no flash).
+	let activeWallpaper = $derived(
+		isOnboardingRouteEarly ? wallpaperById('standing-wave') : wallpaperById($wallpaper),
+	);
 
 	// ─── Auth gate ───────────────────────────────────────────────
 	let authReady = $state(false);
@@ -250,6 +256,20 @@
 		onboardingChecked = false;
 		void tryAutoSetup();
 	}
+
+	// Liquid-glass crossfade — scoped to the onboarding → home handoff only.
+	// Every other navigation uses the default (instant) transition. Falls through
+	// silently on browsers without the View Transitions API (pre-Chromium 111).
+	onNavigate((nav) => {
+		if (!nav.from?.url.pathname.startsWith('/onboarding')) return;
+		if (typeof document === 'undefined' || !('startViewTransition' in document)) return;
+		return new Promise((resolve) => {
+			(document as any).startViewTransition(async () => {
+				resolve();
+				await nav.complete;
+			});
+		});
+	});
 
 	onMount(() => {
 		// Show connect screen if no token is stored
@@ -1906,16 +1926,16 @@
 
 	.app-shell.has-wallpaper .sidebar,
 	.app-shell.has-wallpaper .now-playing-panel {
-		backdrop-filter: blur(18px) saturate(1.2);
-		-webkit-backdrop-filter: blur(18px) saturate(1.2);
+		backdrop-filter: var(--blur-modal);
+		-webkit-backdrop-filter: var(--blur-modal);
 	}
 
 	/* Content pane frost: subtle dark tint + mild blur so all page content
 	   remains readable over any wallpaper, without fully hiding the animation. */
 	.app-shell.has-wallpaper .workspace {
 		background: rgba(9, 9, 14, 0.44);
-		backdrop-filter: blur(10px) saturate(1.05);
-		-webkit-backdrop-filter: blur(10px) saturate(1.05);
+		backdrop-filter: var(--blur-overlay);
+		-webkit-backdrop-filter: var(--blur-overlay);
 	}
 
 	.sidebar {
@@ -2365,7 +2385,8 @@
 		color: #fff;
 		background: rgba(0, 0, 0, 0.45);
 		border: 1px solid rgba(255, 255, 255, 0.18);
-		backdrop-filter: blur(8px);
+		backdrop-filter: var(--blur-base);
+		-webkit-backdrop-filter: var(--blur-base);
 		opacity: 0;
 		transform: translateY(-4px);
 		transition: opacity 160ms ease, transform 160ms ease, background 160ms ease;
@@ -2396,7 +2417,8 @@
 		color: rgba(255, 255, 255, 0.92);
 		background: rgba(0, 0, 0, 0.45);
 		border: 1px solid rgba(255, 255, 255, 0.18);
-		backdrop-filter: blur(8px);
+		backdrop-filter: var(--blur-base);
+		-webkit-backdrop-filter: var(--blur-base);
 		cursor: pointer;
 		transition:
 			transform 160ms ease,
@@ -3744,7 +3766,7 @@
 			overflow-y: auto;
 			-webkit-overflow-scrolling: touch;
 			background: var(--bg-elevated);
-			border-radius: 24px 24px 0 0;
+			border-radius: var(--radius-lg) var(--radius-lg) 0 0;
 			border-top: 1px solid var(--border-subtle);
 			z-index: 51;
 			padding: 12px 20px calc(var(--safe-bottom) + 24px);

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -44,7 +44,7 @@
 	import { get } from 'svelte/store';
 	import type { QueueItem, TidalPlayable, Track } from '$lib/api/client';
 	import { showToast } from '$lib/stores/toast';
-	import { formatDuration, getQualityClass } from '$lib/stores/library';
+	import { formatTrackDuration, getQualityClass } from '$lib/utils/format';
 	import { api, getStoredToken, setStoredToken, clearStoredToken } from '$lib/api/client';
 	import ContextMenu from '$lib/components/ContextMenu.svelte';
 	import Toast from '$lib/components/Toast.svelte';
@@ -1127,7 +1127,7 @@
 									<strong>{video.title}</strong>
 									<span>{video.artist_name ?? 'Unknown artist'}</span>
 								</span>
-								<span class="video-panel-row-time">{formatDuration(video.duration_ms ?? 0)}</span>
+								<span class="video-panel-row-time">{formatTrackDuration(video.duration_ms ?? 0)}</span>
 							</button>
 						{/each}
 					</div>
@@ -1441,7 +1441,7 @@
 							</div>
 
 							<div class="queue-side">
-								<span class="queue-time">{formatDuration(item.track.duration_ms)}</span>
+								<span class="queue-time">{formatTrackDuration(item.track.duration_ms)}</span>
 								<div class="queue-actions">
 									{#if item.reason}
 										<button
@@ -1700,8 +1700,8 @@
 					/>
 				</div>
 				<div class="mobile-np-times">
-					<span>{formatDuration(scrubPosition)}</span>
-					<span>{formatDuration($currentTrack.duration_ms ?? 0)}</span>
+					<span>{formatTrackDuration(scrubPosition)}</span>
+					<span>{formatTrackDuration($currentTrack.duration_ms ?? 0)}</span>
 				</div>
 			</div>
 
@@ -1800,7 +1800,7 @@
 								{/if}
 							</div>
 							<div class="queue-side">
-								<span class="queue-time">{formatDuration(item.track.duration_ms)}</span>
+								<span class="queue-time">{formatTrackDuration(item.track.duration_ms)}</span>
 								<div class="queue-actions">
 									<button
 										class="queue-action icon"
@@ -2070,8 +2070,8 @@
 		line-height: 1;
 	}
 	.video-panel-queue-clear:hover {
-		color: var(--text);
-		background: var(--surface-hover, rgba(255, 255, 255, 0.07));
+		color: var(--text-primary);
+		background: var(--bg-hover);
 	}
 
 	.video-panel-list {
@@ -2361,7 +2361,7 @@
 		border-radius: 8px;
 		display: grid;
 		place-items: center;
-		font-size: 14px;
+		font-size: var(--font-size-sm);
 		color: #fff;
 		background: rgba(0, 0, 0, 0.45);
 		border: 1px solid rgba(255, 255, 255, 0.18);
@@ -2391,7 +2391,7 @@
 		border-radius: 50%;
 		display: grid;
 		place-items: center;
-		font-size: 18px;
+		font-size: var(--font-size-lg);
 		line-height: 1;
 		color: rgba(255, 255, 255, 0.92);
 		background: rgba(0, 0, 0, 0.45);
@@ -2652,7 +2652,7 @@
 	}
 
 	.tp-like-btn {
-		font-size: 18px;
+		font-size: var(--font-size-lg);
 		color: var(--text-secondary);
 		transition:
 			transform var(--motion-fast),
@@ -2701,7 +2701,7 @@
 		background: color-mix(in srgb, var(--instrument-surface) 82%, transparent);
 		border: 1px solid color-mix(in srgb, var(--instrument-border) 58%, transparent);
 		color: var(--text-primary);
-		font-size: 14px;
+		font-size: var(--font-size-sm);
 		flex-shrink: 0;
 		cursor: pointer;
 		transition: background var(--motion-fast), border-color var(--motion-fast);
@@ -3353,9 +3353,9 @@
 	}
 
 	.queue-action.icon.remove:hover {
-		background: color-mix(in srgb, var(--danger, #f87171) 22%, transparent);
-		border-color: color-mix(in srgb, var(--danger, #f87171) 55%, transparent);
-		color: var(--danger, #f87171);
+		background: color-mix(in srgb, var(--state-error) 22%, transparent);
+		border-color: color-mix(in srgb, var(--state-error) 55%, transparent);
+		color: var(--state-error);
 	}
 
 	.queue-empty {
@@ -3577,7 +3577,7 @@
 			background: none;
 			border: none;
 			color: var(--text-primary);
-			font-size: 18px;
+			font-size: var(--font-size-lg);
 			cursor: pointer;
 			-webkit-tap-highlight-color: transparent;
 		}
@@ -4007,7 +4007,7 @@
 	.connect-backdrop {
 		position: fixed;
 		inset: 0;
-		z-index: 9999;
+		z-index: var(--z-tooltip);
 		background: var(--bg-base, #0d0d12);
 		display: flex;
 		align-items: center;

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -122,13 +122,6 @@
 		});
 	}
 
-	function formatDuration(ms: number | null): string {
-		if (!ms) return '';
-		const minutes = Math.floor(ms / 60000);
-		const seconds = Math.floor((ms % 60000) / 1000);
-		return `${minutes}:${seconds.toString().padStart(2, '0')}`;
-	}
-
 	function getSourceColor(source: string): string {
 		const colors: Record<string, string> = {
 			'AllMusic': 'var(--accent)',
@@ -404,11 +397,11 @@
 		transition: background 0.15s ease, color 0.15s ease;
 	}
 	.chip:hover {
-		color: var(--text, #fff);
+		color: var(--text-primary);
 	}
 	.chip.active {
 		background: rgba(255, 255, 255, 0.12);
-		color: var(--text, #fff);
+		color: var(--text-primary);
 	}
 
 	/* Horizontal scroll */

--- a/frontend/src/routes/albums/[id]/+page.svelte
+++ b/frontend/src/routes/albums/[id]/+page.svelte
@@ -487,16 +487,16 @@
 
 	.hero-body {
 		display: grid;
-		grid-template-columns: 204px 1fr;
+		grid-template-columns: clamp(160px, 16vw, 240px) 1fr;
 		gap: 24px;
 		align-items: end;
 		width: 100%;
-		max-width: 1400px;
+		max-width: var(--content-width);
 	}
 
 	.hero-art-wrap {
-		width: 204px;
-		height: 204px;
+		width: clamp(160px, 16vw, 240px);
+		aspect-ratio: 1 / 1;
 		border-radius: 8px;
 		overflow: hidden;
 		box-shadow: 0 28px 70px -14px rgba(0, 0, 0, 0.7);

--- a/frontend/src/routes/analytics/+page.svelte
+++ b/frontend/src/routes/analytics/+page.svelte
@@ -194,7 +194,7 @@
 
 <style>
 	.analytics-tree {
-		max-width: 1280px;
+		max-width: var(--content-width);
 		margin: 0 auto;
 		padding: var(--space-5) var(--space-5) var(--space-8);
 		display: flex;

--- a/frontend/src/routes/analytics/preview/audio/+page.svelte
+++ b/frontend/src/routes/analytics/preview/audio/+page.svelte
@@ -103,7 +103,7 @@
 
 <style>
 	.preview {
-		max-width: 1280px;
+		max-width: var(--content-width);
 		margin: 0 auto;
 		padding: var(--space-5) var(--space-5) var(--space-7);
 		display: flex;

--- a/frontend/src/routes/analytics/preview/cohorts/+page.svelte
+++ b/frontend/src/routes/analytics/preview/cohorts/+page.svelte
@@ -107,7 +107,7 @@
 
 <style>
 	.preview {
-		max-width: 1280px;
+		max-width: var(--content-width);
 		margin: 0 auto;
 		padding: var(--space-5) var(--space-5) var(--space-7);
 		display: flex;

--- a/frontend/src/routes/analytics/preview/ranks/+page.svelte
+++ b/frontend/src/routes/analytics/preview/ranks/+page.svelte
@@ -60,7 +60,7 @@
 
 <style>
 	.preview {
-		max-width: 1280px;
+		max-width: var(--content-width);
 		margin: 0 auto;
 		padding: var(--space-5) var(--space-5) var(--space-7);
 		display: flex;

--- a/frontend/src/routes/analytics/preview/ridgeline/+page.svelte
+++ b/frontend/src/routes/analytics/preview/ridgeline/+page.svelte
@@ -156,7 +156,7 @@
 
 <style>
 	.preview {
-		max-width: 1280px;
+		max-width: var(--content-width);
 		margin: 0 auto;
 		padding: var(--space-5) var(--space-5) var(--space-7);
 		display: flex;

--- a/frontend/src/routes/analytics/preview/sonic/+page.svelte
+++ b/frontend/src/routes/analytics/preview/sonic/+page.svelte
@@ -72,7 +72,7 @@
 
 <style>
 	.preview {
-		max-width: 1280px;
+		max-width: var(--content-width);
 		margin: 0 auto;
 		padding: var(--space-5) var(--space-5) var(--space-7);
 		display: flex;

--- a/frontend/src/routes/analytics/preview/strip/+page.svelte
+++ b/frontend/src/routes/analytics/preview/strip/+page.svelte
@@ -102,7 +102,7 @@
 
 <style>
 	.preview {
-		max-width: 1280px;
+		max-width: var(--content-width);
 		margin: 0 auto;
 		padding: var(--space-5) var(--space-5) var(--space-7);
 		display: flex;

--- a/frontend/src/routes/analytics/preview/tempo/+page.svelte
+++ b/frontend/src/routes/analytics/preview/tempo/+page.svelte
@@ -125,7 +125,7 @@
 
 <style>
 	.preview {
-		max-width: 1280px;
+		max-width: var(--content-width);
 		margin: 0 auto;
 		padding: var(--space-5) var(--space-5) var(--space-7);
 		display: flex;

--- a/frontend/src/routes/artists/[id]/+page.svelte
+++ b/frontend/src/routes/artists/[id]/+page.svelte
@@ -2,6 +2,7 @@
 	import { page } from '$app/state';
 	import type { Snapshot } from './$types';
 	import { api, type Track, type TidalDiscographyAlbum, type TidalDiscographyTrack, type TidalArtistVideo, type TidalSimilarArtist, type TidalArtistBio, type SpotifyArtistStats, type TidalPlayable } from '$lib/api/client';
+	import { letterColor } from '$lib/utils/color';
 	import {
 		playArtist,
 		shuffleArtist,
@@ -237,13 +238,6 @@
 			artist_tidal_id: artist?.tidal_id ?? null,
 			album_tidal_id: t.album_tidal_id ?? null,
 		};
-	}
-
-	function letterColor(name: string): string {
-		const colors = ['#e63946', '#457b9d', '#2a9d8f', '#e9c46a', '#f4a261', '#9b5de5', '#00b4d8'];
-		let h = 0;
-		for (let i = 0; i < name.length; i++) h = (h * 31 + name.charCodeAt(i)) & 0xffffffff;
-		return colors[Math.abs(h) % colors.length];
 	}
 
 	function artistInitials(name: string): string {
@@ -1366,7 +1360,7 @@
 		justify-content: center;
 		background: rgba(0, 0, 0, 0.45);
 		color: #fff;
-		font-size: 22px;
+		font-size: var(--font-size-xl);
 		border: none;
 		cursor: pointer;
 		border-radius: 6px;
@@ -1493,7 +1487,7 @@
 		justify-content: center;
 		background: rgba(255, 255, 255, 0.06);
 		color: rgba(255, 255, 255, 0.45);
-		font-size: 18px;
+		font-size: var(--font-size-lg);
 	}
 	.tidal-row-meta {
 		min-width: 0;

--- a/frontend/src/routes/artists/[id]/+page.svelte
+++ b/frontend/src/routes/artists/[id]/+page.svelte
@@ -993,7 +993,7 @@
 		align-items: flex-end;
 		gap: 28px;
 		width: 100%;
-		max-width: 1400px;
+		max-width: var(--content-width);
 	}
 
 	.hero-portrait-wrap {

--- a/frontend/src/routes/artists/[id]/+page.svelte
+++ b/frontend/src/routes/artists/[id]/+page.svelte
@@ -19,6 +19,7 @@
 	import EmptyState from '$lib/components/ui/EmptyState.svelte';
 	import Skeleton from '$lib/components/ui/Skeleton.svelte';
 	import MediaRail from '$lib/components/ui/MediaRail.svelte';
+	import PlayOverlay from '$lib/components/ui/PlayOverlay.svelte';
 	import { openContextMenu } from '$lib/stores/context_menu';
 	import { buildAlbumMenu } from '$lib/player/album_menu';
 	import { canPlayTrack } from '$lib/player/playable';
@@ -847,11 +848,12 @@
 										<div class="grid-art placeholder">♫</div>
 									{/if}
 									{#if album.id != null}
-										<button
-											class="art-play-overlay"
+										<PlayOverlay
+											position="center"
+											size="md"
+											label="Play {album.title}"
 											onclick={(e) => onAlbumCardPlay({ id: album.id }, e)}
-											aria-label="Play {album.title}"
-										>▶</button>
+										/>
 									{/if}
 								</div>
 								<p class="grid-title">{album.title}</p>
@@ -881,11 +883,12 @@
 										<div class="grid-art placeholder">♫</div>
 									{/if}
 									{#if album.id != null}
-										<button
-											class="art-play-overlay"
+										<PlayOverlay
+											position="center"
+											size="md"
+											label="Play {album.title}"
 											onclick={(e) => onAlbumCardPlay({ id: album.id }, e)}
-											aria-label="Play {album.title}"
-										>▶</button>
+										/>
 									{/if}
 								</div>
 								<p class="grid-title">{album.title}</p>
@@ -1015,8 +1018,8 @@
 		justify-content: center;
 		isolation: isolate;
 		background: rgba(255, 255, 255, 0.04);
-		backdrop-filter: blur(10px);
-		-webkit-backdrop-filter: blur(10px);
+		backdrop-filter: var(--blur-overlay);
+		-webkit-backdrop-filter: var(--blur-overlay);
 	}
 	.hero-portrait-glass-art {
 		position: absolute;
@@ -1352,22 +1355,11 @@
 		margin-bottom: 6px;
 	}
 
-	.art-play-overlay {
-		position: absolute;
-		inset: 0;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		background: rgba(0, 0, 0, 0.45);
-		color: #fff;
-		font-size: var(--font-size-xl);
-		border: none;
-		cursor: pointer;
-		border-radius: 6px;
-		opacity: 0;
-		transition: opacity 0.15s;
+	.grid-art-wrap:hover :global(.play-overlay),
+	.grid-card:focus-within :global(.play-overlay) {
+		opacity: 1;
+		transform: translateY(0);
 	}
-	.grid-art-wrap:hover .art-play-overlay { opacity: 1; }
 
 	.badge-new {
 		position: absolute;
@@ -1380,7 +1372,8 @@
 		font-size: 0.62rem;
 		font-weight: 700;
 		letter-spacing: 0.12em;
-		backdrop-filter: blur(8px);
+		backdrop-filter: var(--blur-base);
+		-webkit-backdrop-filter: var(--blur-base);
 	}
 
 	.grid-card.not-in-library .grid-title {
@@ -1551,9 +1544,9 @@
 		transform: translateY(-50%);
 		padding: 2px 8px;
 		border-radius: 999px;
-		background: rgba(30, 215, 96, 0.14);
-		border: 1px solid rgba(30, 215, 96, 0.32);
-		color: rgba(30, 215, 96, 0.95);
+		background: color-mix(in srgb, var(--service-spotify) 14%, transparent);
+		border: 1px solid color-mix(in srgb, var(--service-spotify) 32%, transparent);
+		color: color-mix(in srgb, var(--service-spotify) 95%, transparent);
 		font-size: 0.72rem;
 		font-variant-numeric: tabular-nums;
 		font-weight: 600;

--- a/frontend/src/routes/duplicates/+page.svelte
+++ b/frontend/src/routes/duplicates/+page.svelte
@@ -289,7 +289,7 @@
 		padding: 16px;
 		border-radius: var(--radius);
 		background: rgba(255, 255, 255, 0.03);
-		border: 1px solid rgba(255, 255, 255, 0.06);
+		border: 1px solid var(--border-subtle);
 		display: flex;
 		flex-direction: column;
 		gap: 14px;
@@ -312,7 +312,7 @@
 		border-radius: 12px;
 		object-fit: cover;
 		background: rgba(255, 255, 255, 0.04);
-		border: 1px solid rgba(255, 255, 255, 0.08);
+		border: 1px solid var(--panel-border);
 	}
 
 	.placeholder {

--- a/frontend/src/routes/duplicates/+page.svelte
+++ b/frontend/src/routes/duplicates/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { getApiBase, authFetch } from '$lib/api/client';
-	import { formatDuration } from '$lib/stores/library';
+	import { formatTrackDuration, getQualityClass } from '$lib/utils/format';
 	import PageHeader from '$lib/components/ui/PageHeader.svelte';
 	import StateBadge from '$lib/components/ui/StateBadge.svelte';
 	import EmptyState from '$lib/components/ui/EmptyState.svelte';
@@ -118,13 +118,6 @@
 		return q;
 	}
 
-	function qualityClass(q: string | null): string {
-		if (!q) return 'lossy';
-		if (q.startsWith('HI_RES')) return 'hires';
-		if (q === 'LOSSLESS') return 'lossless';
-		return 'lossy';
-	}
-
 	let removableCount = $derived(
 		scanStats ? Math.max(0, scanStats.tracks_affected - scanStats.groups_found) : groups.reduce((count, group) => count + Math.max(0, group.members.length - 1), 0)
 	);
@@ -200,7 +193,7 @@
 								</div>
 
 								<div class="member-badges">
-									<span class={`quality-badge ${qualityClass(member.track.best_quality)}`}>
+									<span class={`quality-badge ${getQualityClass(member.track.best_quality)}`}>
 										{qualityLabel(member.track.best_quality)}
 									</span>
 									{#if member.track.is_favorite}
@@ -214,7 +207,7 @@
 								<div class="info-list">
 									<div class="info-row">
 										<span>Duration</span>
-										<strong>{formatDuration(member.track.duration_ms)}</strong>
+										<strong>{formatTrackDuration(member.track.duration_ms)}</strong>
 									</div>
 									<div class="info-row">
 										<span>Plays</span>

--- a/frontend/src/routes/library/+page.svelte
+++ b/frontend/src/routes/library/+page.svelte
@@ -2232,7 +2232,7 @@
 		display: flex;
 		flex-direction: column;
 		gap: 10px;
-		max-width: 1200px;
+		max-width: var(--content-width);
 		margin: 0 auto 24px;
 		padding: 0 4px;
 	}

--- a/frontend/src/routes/library/+page.svelte
+++ b/frontend/src/routes/library/+page.svelte
@@ -1839,7 +1839,7 @@
 		font-weight: 700;
 		letter-spacing: 0.12em;
 		text-transform: uppercase;
-		color: var(--accent, #9b6fff);
+		color: var(--accent);
 		margin: 0;
 	}
 
@@ -1882,7 +1882,7 @@
 
 	.home-track-row:hover { background: var(--bg-hover); }
 
-	.home-track-row.playing .ht-title { color: var(--accent, #9b6fff); }
+	.home-track-row.playing .ht-title { color: var(--accent); }
 
 	.ht-art {
 		width: 36px;
@@ -2026,7 +2026,7 @@
 		align-items: center;
 		padding: 6px 10px;
 		border-radius: 999px;
-		border: 1px solid rgba(255, 255, 255, 0.08);
+		border: 1px solid var(--panel-border);
 		background: rgba(255, 255, 255, 0.04);
 		color: var(--text-secondary);
 		font-size: 0.78rem;
@@ -2047,11 +2047,11 @@
 	}
 	.decade-chip {
 		padding: 4px 13px;
-		border-radius: 14px;
+		border-radius: var(--radius-md);
 		font-size: 11px;
 		font-weight: 600;
 		cursor: pointer;
-		border: 1px solid rgba(255,255,255,0.08);
+		border: 1px solid var(--panel-border);
 		background: transparent;
 		color: var(--text-secondary);
 		font-family: inherit;
@@ -2242,8 +2242,8 @@
 		max-width: 640px;
 		margin: 0 auto;
 		padding: 14px 22px;
-		border-radius: 24px;
-		border: 1px solid var(--border-subtle, rgba(255,255,255,0.08));
+		border-radius: var(--radius-lg);
+		border: 1px solid var(--border-subtle);
 		background: var(--panel-bg);
 		color: var(--text-primary, #fff);
 		font-size: 15px;
@@ -2252,7 +2252,7 @@
 	}
 
 	.library-search-input:focus {
-		border-color: var(--accent, #9b6fff);
+		border-color: var(--accent);
 	}
 
 	.library-status {
@@ -2295,8 +2295,8 @@
 	}
 
 	.filter-pill.active {
-		background: var(--accent, #9b6fff);
-		border-color: var(--accent, #9b6fff);
+		background: var(--accent);
+		border-color: var(--accent);
 		color: #fff;
 	}
 
@@ -2306,7 +2306,7 @@
 		padding: 2px;
 		border-radius: 8px;
 		background: rgba(255, 255, 255, 0.04);
-		border: 1px solid rgba(255, 255, 255, 0.06);
+		border: 1px solid var(--border-subtle);
 	}
 
 	.view-toggle-btn {
@@ -2474,7 +2474,7 @@
 		padding: 4px 10px;
 		border-radius: 999px;
 		background: rgba(255, 255, 255, 0.04);
-		border: 1px solid rgba(255, 255, 255, 0.08);
+		border: 1px solid var(--panel-border);
 		color: var(--text-secondary);
 		font-size: 0.72rem;
 		font-weight: 600;
@@ -2602,7 +2602,7 @@
 		height: 28px;
 		border-radius: 50%;
 		background: rgba(255, 255, 255, 0.04);
-		border: 1px solid rgba(255, 255, 255, 0.08);
+		border: 1px solid var(--panel-border);
 		color: var(--text-secondary);
 		font-size: 1rem;
 		display: flex;
@@ -2872,7 +2872,7 @@
 		background:
 			linear-gradient(180deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.02)),
 			var(--bg-surface);
-		border: 1px solid rgba(255, 255, 255, 0.08);
+		border: 1px solid var(--panel-border);
 		box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
 		cursor: pointer;
 		transition:
@@ -2890,14 +2890,14 @@
 	}
 
 	.album-card.selected {
-		outline: 2px solid rgba(155, 111, 255, 0.85);
+		outline: 2px solid var(--accent);
 		outline-offset: 2px;
 	}
 
 	.album-card:focus-visible,
 	.track-row:focus-visible,
 	.header-sort:focus-visible {
-		outline: 2px solid rgba(155, 111, 255, 0.9);
+		outline: 2px solid var(--accent);
 		outline-offset: 2px;
 	}
 
@@ -3045,7 +3045,7 @@
 		padding: 2px 7px;
 		border-radius: 999px;
 		background: rgba(255, 255, 255, 0.03);
-		border: 1px solid rgba(255, 255, 255, 0.06);
+		border: 1px solid var(--border-subtle);
 		color: var(--text-muted);
 		font-size: 0.64rem;
 		font-weight: 600;
@@ -3062,7 +3062,7 @@
 		height: 32px;
 		border-radius: 999px;
 		background: rgba(255, 255, 255, 0.08);
-		border: 1px solid rgba(255, 255, 255, 0.08);
+		border: 1px solid var(--panel-border);
 		color: var(--text-primary);
 		font-size: 1rem;
 		line-height: 1;
@@ -3079,7 +3079,7 @@
 		height: 28px;
 		border-radius: 50%;
 		background: rgba(255, 255, 255, 0.04);
-		border: 1px solid rgba(255, 255, 255, 0.06);
+		border: 1px solid var(--border-subtle);
 		color: var(--text-tertiary);
 		font-size: 0.85rem;
 		cursor: pointer;
@@ -3109,8 +3109,8 @@
 			0 8px 32px rgba(0, 0, 0, 0.6),
 			0 2px 8px rgba(0, 0, 0, 0.4),
 			inset 0 1px 0 rgba(255, 255, 255, 0.06);
-		backdrop-filter: blur(20px);
-		-webkit-backdrop-filter: blur(20px);
+		backdrop-filter: var(--blur-modal);
+		-webkit-backdrop-filter: var(--blur-modal);
 	}
 
 	.track-menu {
@@ -3408,7 +3408,7 @@
 				". album quality";
 			gap: 6px 12px;
 			padding: 12px;
-			border: 1px solid rgba(255, 255, 255, 0.06);
+			border: 1px solid var(--border-subtle);
 			background: rgba(255, 255, 255, 0.02);
 		}
 

--- a/frontend/src/routes/library/+page.svelte
+++ b/frontend/src/routes/library/+page.svelte
@@ -6,11 +6,11 @@
 		tracks, albums, artists as artistsStore, isLoading, isLoadingMore, totalTracks, totalAlbums,
 		sortBy, sortDir, viewMode, searchQuery,
 		loadTracks, loadAlbums,
-		formatDuration, formatDateShort, getQualityClass,
 		selectedTrackIds, selectedAlbumIds,
 		lastSelectedTrackId, lastSelectedAlbumId,
 		selectTrackIds, selectAlbumIds, clearSelection,
 	} from '$lib/stores/library';
+	import { formatTrackDuration, formatDateShort, getQualityClass } from '$lib/utils/format';
 	import { api, type Album, type Artist, type Genre, type Playlist, type Track } from '$lib/api/client';
 	import { currentTrack, isPlaying, playTrackNow, addTrackToQueue, playTrackNext } from '$lib/stores/player';
 	import SelectionBar from '$lib/components/ui/SelectionBar.svelte';
@@ -1230,7 +1230,7 @@
 									<span class="ht-title">{track.title}</span>
 									<span class="ht-sub">{track.artist_name ?? ''}{track.album_title ? ` — ${track.album_title}` : ''}</span>
 								</div>
-								<span class="ht-duration">{formatDuration(track.duration_ms)}</span>
+								<span class="ht-duration">{formatTrackDuration(track.duration_ms)}</span>
 								<div class="ht-actions">
 									<button
 										class="btn-icon"
@@ -1641,7 +1641,7 @@
 							{/if}
 						</span>
 					{/if}
-					<span class="col-duration">{formatDuration(track.duration_ms)}</span>
+					<span class="col-duration">{formatTrackDuration(track.duration_ms)}</span>
 					<span class="col-actions">
 						<button class="detail-btn" title="View details" onclick={(event) => { event.stopPropagation(); void openTrackDetail(track); }}>ℹ</button>
 						<button class="menu-trigger" aria-label="Track actions" onclick={(event) => toggleTrackMenu(track.id, event)}>
@@ -1751,7 +1751,7 @@
 				{/if}
 				<div class="meta-block">
 					<span class="meta-label">Duration</span>
-					<span class="meta-value">{formatDuration(detailTrack.duration_ms)}</span>
+					<span class="meta-value">{formatTrackDuration(detailTrack.duration_ms)}</span>
 				</div>
 				{#if detailTrack.disc_number && detailTrack.disc_number > 1}
 					<div class="meta-block">
@@ -1803,7 +1803,7 @@
 								{/if}
 								<span class="detail-track-title">{track.title}</span>
 								<span class="detail-track-artist">{track.artist_name ?? ''}</span>
-								<span class="detail-track-duration">{formatDuration(track.duration_ms)}</span>
+								<span class="detail-track-duration">{formatTrackDuration(track.duration_ms)}</span>
 								<button class="detail-track-queue" onclick={(e) => { e.stopPropagation(); void addTrackToQueue(track.id); }}>+</button>
 							</div>
 						{/each}
@@ -1850,7 +1850,7 @@
 	}
 
 	.view-all-link {
-		font-size: 12px;
+		font-size: var(--font-size-xs);
 		color: var(--text-secondary, rgba(255,255,255,0.5));
 		background: none;
 		border: none;
@@ -1880,7 +1880,7 @@
 		transition: background 0.1s;
 	}
 
-	.home-track-row:hover { background: var(--bg-glass-hover, rgba(255,255,255,0.06)); }
+	.home-track-row:hover { background: var(--bg-hover); }
 
 	.home-track-row.playing .ht-title { color: var(--accent, #9b6fff); }
 
@@ -1893,7 +1893,7 @@
 	}
 
 	.ht-art--fallback {
-		background: var(--bg-glass, rgba(255,255,255,0.08));
+		background: var(--bg-hover);
 	}
 
 	.ht-meta {
@@ -1921,7 +1921,7 @@
 	}
 
 	.ht-duration {
-		font-size: 12px;
+		font-size: var(--font-size-xs);
 		color: var(--text-muted, rgba(255,255,255,0.4));
 		font-variant-numeric: tabular-nums;
 	}
@@ -1949,7 +1949,7 @@
 
 	.home-loading {
 		color: var(--text-secondary, rgba(255,255,255,0.5));
-		font-size: 14px;
+		font-size: var(--font-size-sm);
 		padding: 40px;
 		text-align: center;
 	}
@@ -2139,7 +2139,7 @@
 		font-family: inherit;
 		font-size: 10px;
 		color: var(--text-secondary, rgba(255,255,255,0.5));
-		background: var(--bg-glass, rgba(255,255,255,0.05));
+		background: var(--bg-hover);
 	}
 
 	.hint-filters {
@@ -2244,7 +2244,7 @@
 		padding: 14px 22px;
 		border-radius: 24px;
 		border: 1px solid var(--border-subtle, rgba(255,255,255,0.08));
-		background: var(--bg-glass, rgba(255,255,255,0.04));
+		background: var(--panel-bg);
 		color: var(--text-primary, #fff);
 		font-size: 15px;
 		outline: none;
@@ -2256,7 +2256,7 @@
 	}
 
 	.library-status {
-		font-size: 12px;
+		font-size: var(--font-size-xs);
 		color: var(--text-muted, rgba(255,255,255,0.4));
 		margin-left: 4px;
 	}
@@ -2290,7 +2290,7 @@
 	}
 
 	.filter-pill:hover {
-		background: var(--bg-glass-hover, rgba(255,255,255,0.08));
+		background: var(--bg-hover);
 		color: var(--text-primary, #fff);
 	}
 
@@ -2871,7 +2871,7 @@
 		border-radius: var(--radius-lg);
 		background:
 			linear-gradient(180deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.02)),
-			var(--bg-glass);
+			var(--bg-surface);
 		border: 1px solid rgba(255, 255, 255, 0.08);
 		box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
 		cursor: pointer;
@@ -3210,7 +3210,7 @@
 	}
 
 	.track-row:hover {
-		background: var(--bg-glass-hover);
+		background: var(--bg-hover);
 	}
 
 	.track-row.selected {
@@ -3218,7 +3218,7 @@
 	}
 
 	.track-row.cursor {
-		background: var(--bg-glass-hover);
+		background: var(--bg-hover);
 		box-shadow: inset 2px 0 0 var(--accent);
 	}
 
@@ -3617,7 +3617,7 @@
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		font-size: 28px;
+		font-size: var(--font-size-2xl);
 		color: rgba(255,255,255,0.3);
 	}
 	.discography-title {

--- a/frontend/src/routes/onboarding/+page.svelte
+++ b/frontend/src/routes/onboarding/+page.svelte
@@ -14,6 +14,10 @@
 	const isWindows = typeof navigator !== 'undefined' && /Win/i.test(navigator.platform);
 
 	onMount(async () => {
+		// `?preview` bypasses the auto-redirect so the page can be designed/QA'd
+		// without unsetting onboarding state on the backend.
+		const params = new URLSearchParams(window.location.search);
+		if (params.has('preview')) return;
 		try {
 			const resp = await fetch(`${getApiBase()}/api/setup/onboarding`);
 			if (resp.ok) {
@@ -94,16 +98,19 @@
 		}
 	}
 
+	// Crossfade is handled at the layout level by the View Transitions API
+	// (see routes/+layout.svelte onNavigate hook). No local dissolve animation
+	// — that conflicted with the layout-level transition and read as a flash.
 	async function finish() {
 		completing = true;
 		completeError = '';
 		const ok = await markComplete();
 		completing = false;
-		if (ok) {
-			await goto('/', { replaceState: true });
-		} else {
+		if (!ok) {
 			completeError = "Couldn't save your setup.";
+			return;
 		}
+		await goto('/', { replaceState: true });
 	}
 
 	async function continueAnyway() {
@@ -134,9 +141,9 @@
 
 		{#if step === 0}
 			<div class="step welcome">
-				<img class="wordmark" src="/wordmark-animated-dark.svg" alt="NOORwave" />
+				<img class="wordmark" src="/mark-animated-dark.svg" alt="NOORwave" />
 				<h1>Welcome.</h1>
-				<p class="lede">A quiet, focused way to listen to your TIDAL library — with smart radio, trending shelves, and the kind of metadata you'd actually trust.</p>
+				<p class="lede">Pure sound. Perfect flow.</p>
 				<button class="btn btn-primary" onclick={() => (step = 1)}>Get started</button>
 				<button class="link" onclick={skipAll} disabled={completing}>Skip for now — set up later in Settings</button>
 			</div>
@@ -240,23 +247,31 @@
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		background: radial-gradient(circle at 50% 30%, #1a1f2e 0%, #0a0d14 65%, #05070b 100%);
-		color: #e7eaf2;
-		font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+		/* Transparent — the layout-level wallpaper-layer provides the
+		   standing-wave shader (forced during the /onboarding route in
+		   +layout.svelte). Persisting the same WebGL canvas across the
+		   navigation to home prevents the shader-remount flash. */
+		background: transparent;
+		color: var(--text-primary);
+		font-family: var(--font-body);
 		padding: 32px;
 		overflow: auto;
+		scrollbar-gutter: stable both-edges;
 	}
 	.card {
+		position: relative;
+		z-index: 1;
 		width: 100%;
 		max-width: 520px;
-		background: rgba(255, 255, 255, 0.02);
-		border: 1px solid rgba(255, 255, 255, 0.06);
+		background: rgba(10, 12, 18, 0.62);
+		border: 1px solid var(--border-subtle);
 		border-radius: 20px;
 		padding: 40px 36px 32px;
 		display: flex;
 		flex-direction: column;
 		gap: 24px;
-		backdrop-filter: blur(8px);
+		backdrop-filter: var(--blur-overlay);
+		-webkit-backdrop-filter: var(--blur-overlay);
 	}
 	.progress {
 		display: flex;
@@ -276,7 +291,7 @@
 	.dot:disabled { cursor: default; }
 	.dot:not(:disabled):hover { background: rgba(255, 255, 255, 0.55); transform: scaleY(1.4); }
 	.dot.active { background: rgba(255, 255, 255, 0.4); }
-	.dot.current { background: #4a6dd8; }
+	.dot.current { background: #fff; }
 	.step {
 		display: flex;
 		flex-direction: column;
@@ -288,22 +303,26 @@
 	}
 	.welcome .wordmark {
 		display: block;
-		width: clamp(360px, 56vw, 560px);
+		width: 100%;
+		max-width: 150px;
 		height: auto;
-		margin: 0 auto 1rem;
+		margin: 0 auto 0.5rem;
 		filter: drop-shadow(0 8px 24px rgba(120, 150, 220, 0.15));
 	}
 	.step h1, .step h2 {
 		margin: 0;
-		font-size: 26px;
-		font-weight: 600;
-		letter-spacing: -0.015em;
+		font-family: var(--font-display);
+		font-size: clamp(1.75rem, 1.4rem + 1.4vw, 2.25rem);
+		font-weight: 500;
+		letter-spacing: -0.02em;
+		line-height: 1.05;
 	}
 	.lede {
 		margin: 0;
 		max-width: 420px;
-		color: #b8c0d4;
-		line-height: 1.5;
+		color: var(--text-secondary);
+		line-height: 1.55;
+		font-size: var(--font-size-md);
 	}
 	.btn {
 		font: inherit;
@@ -314,22 +333,23 @@
 		font-weight: 500;
 		transition: background 120ms;
 	}
-	.btn-primary { background: #4a6dd8; color: #fff; }
-	.btn-primary:hover:not(:disabled) { background: #5a7ce8; }
+	.btn-primary { background: rgba(255, 255, 255, 0.92); color: #0a0d14; }
+	.btn-primary:hover:not(:disabled) { background: #fff; }
 	.btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
 	.link {
 		background: none;
 		border: none;
-		color: #8b93a7;
+		color: var(--text-tertiary);
 		font: inherit;
-		font-size: 13px;
+		font-size: var(--font-size-xs);
 		cursor: pointer;
 		padding: 4px 8px;
 		text-decoration: underline;
-		text-decoration-color: rgba(139, 147, 167, 0.3);
+		text-decoration-color: color-mix(in srgb, var(--text-tertiary) 40%, transparent);
 		text-underline-offset: 3px;
+		transition: color var(--motion-fast);
 	}
-	.link:hover { color: #e7eaf2; }
+	.link:hover { color: var(--text-primary); }
 	.link:disabled { opacity: 0.5; cursor: not-allowed; }
 	.actions {
 		display: flex;
@@ -341,10 +361,10 @@
 	.footnote {
 		margin: 0;
 		font-size: var(--font-size-xs);
-		color: #8b93a7;
+		color: var(--text-tertiary);
 	}
-	.warn { color: #d6b06a; }
-	.error { color: #ff8a8a; margin: 0; }
+	.warn { color: var(--state-warning); }
+	.error { color: var(--state-error); margin: 0; }
 	.audio-choices {
 		display: flex;
 		flex-direction: column;
@@ -354,9 +374,9 @@
 	}
 	.audio-choice {
 		text-align: left;
-		background: rgba(255, 255, 255, 0.03);
-		border: 1px solid rgba(255, 255, 255, 0.08);
-		border-radius: 12px;
+		background: var(--panel-bg);
+		border: 1px solid var(--panel-border);
+		border-radius: var(--radius-md);
 		padding: 14px 16px;
 		cursor: pointer;
 		color: inherit;
@@ -364,15 +384,15 @@
 		display: flex;
 		flex-direction: column;
 		gap: 4px;
-		transition: background 120ms, border-color 120ms;
+		transition: background var(--motion-fast), border-color var(--motion-fast);
 	}
 	.audio-choice:hover {
-		background: rgba(255, 255, 255, 0.06);
-		border-color: rgba(255, 255, 255, 0.18);
+		background: var(--bg-hover);
+		border-color: var(--border-strong);
 	}
 	.audio-choice.selected {
-		border-color: #4a6dd8;
-		background: rgba(74, 109, 216, 0.12);
+		border-color: rgba(255, 255, 255, 0.6);
+		background: rgba(255, 255, 255, 0.08);
 	}
 	.audio-choice.subtle {
 		background: transparent;
@@ -389,14 +409,14 @@
 		font-weight: 500;
 		padding: 2px 6px;
 		border-radius: 999px;
-		background: rgba(74, 109, 216, 0.25);
-		color: #9bb1f0;
+		background: rgba(255, 255, 255, 0.16);
+		color: rgba(255, 255, 255, 0.92);
 		text-transform: uppercase;
 		letter-spacing: 0.04em;
 	}
 	.audio-choice-body {
-		font-size: 12.5px;
-		color: #b8c0d4;
-		line-height: 1.45;
+		font-size: var(--font-size-xs);
+		color: var(--text-secondary);
+		line-height: 1.5;
 	}
 </style>

--- a/frontend/src/routes/onboarding/+page.svelte
+++ b/frontend/src/routes/onboarding/+page.svelte
@@ -199,7 +199,7 @@
 					</button>
 				</div>
 				{#if audioApplyError}
-					<p class="error">{audioApplyError}</p>
+					<p class="error" role="alert">{audioApplyError}</p>
 				{/if}
 			</div>
 		{:else if step === 4}
@@ -214,7 +214,7 @@
 					<p class="warn">{syncErrorMessage}</p>
 				{/if}
 				{#if completeError}
-					<p class="error">{completeError}</p>
+					<p class="error" role="alert">{completeError}</p>
 					<div class="actions">
 						<button class="btn btn-primary" onclick={finish} disabled={completing}>Try again</button>
 						<button class="link" onclick={continueAnyway}>Continue anyway</button>
@@ -340,7 +340,7 @@
 	}
 	.footnote {
 		margin: 0;
-		font-size: 12px;
+		font-size: var(--font-size-xs);
 		color: #8b93a7;
 	}
 	.warn { color: #d6b06a; }
@@ -379,7 +379,7 @@
 	}
 	.audio-choice-title {
 		font-weight: 600;
-		font-size: 14px;
+		font-size: var(--font-size-sm);
 		display: flex;
 		align-items: center;
 		gap: 8px;

--- a/frontend/src/routes/search/+page.svelte
+++ b/frontend/src/routes/search/+page.svelte
@@ -9,7 +9,7 @@
   import { buildArtistMenu } from '$lib/player/artist_menu'
   import { openContextMenu, type MenuItem } from '$lib/stores/context_menu'
   import { playTidalTrackNow, playTidalAlbum, playTidalTrackNext, addTidalTrackToQueue, startTidalSongRadio, playTrackNow, playTidalPlaylist } from '$lib/stores/player'
-  import { formatDuration } from '$lib/stores/library'
+  import { formatTrackDuration } from '$lib/utils/format'
   import { parseQuery, filtersToChips, type ParsedQuery } from '$lib/search/query_parser'
   import { buildAudioParams as sharedBuildAudioParams } from '$lib/search/audio_params'
   import { parseIntent } from '$lib/search/intent'
@@ -924,7 +924,7 @@
                   {#if track.album_title}{track.album_title}{/if}
                 </p>
               </div>
-              <span class="track-duration">{formatDuration(track.duration_ms)}</span>
+              <span class="track-duration">{formatTrackDuration(track.duration_ms)}</span>
               <div class="row-actions">
                 <button
                   class="row-btn"
@@ -1261,7 +1261,7 @@
                     —
                   {/if}
                 </span>
-                <span class="col-duration">{formatDuration(track.duration_ms)}</span>
+                <span class="col-duration">{formatTrackDuration(track.duration_ms)}</span>
                 <span class="col-actions">
                   <button
                     class="row-btn"
@@ -1343,7 +1343,7 @@
                   {/if}
                 </p>
               </div>
-              <span class="track-duration">{formatDuration(track.duration_ms)}</span>
+              <span class="track-duration">{formatTrackDuration(track.duration_ms)}</span>
               <div class="row-actions">
                 <button
                   class="row-btn"
@@ -1404,7 +1404,7 @@
                 <p class="track-title">{track.title}</p>
                 <p class="track-subtitle">{track.artist_name ?? ''}{track.bpm ? ` · ${Math.round(track.bpm)} bpm` : ''}{track.camelot_key ? ` · ${track.camelot_key}` : ''}</p>
               </div>
-              <span class="track-duration">{formatDuration(track.duration_ms)}</span>
+              <span class="track-duration">{formatTrackDuration(track.duration_ms)}</span>
             </li>
           {/each}
         </ul>
@@ -1436,7 +1436,7 @@
                 <p class="track-title">{track.title}</p>
                 <p class="track-subtitle">{track.artist_name ?? ''}{track.album_title ? ` · ${track.album_title}` : ''}</p>
               </div>
-              <span class="track-duration">{formatDuration(track.duration_ms)}</span>
+              <span class="track-duration">{formatTrackDuration(track.duration_ms)}</span>
             </li>
           {/each}
         </ul>
@@ -1556,7 +1556,7 @@
     color: var(--text-secondary);
     border-radius: 14px;
     padding: 4px 12px;
-    font-size: 12px;
+    font-size: var(--font-size-xs);
     cursor: pointer;
     font-family: inherit;
     transition: background 0.15s, border-color 0.15s, color 0.15s;
@@ -1567,7 +1567,7 @@
     color: var(--text-primary);
   }
   .chip-x {
-    font-size: 14px;
+    font-size: var(--font-size-sm);
     line-height: 1;
     color: var(--text-tertiary);
     margin-left: 2px;
@@ -1590,7 +1590,7 @@
     color: var(--text-secondary);
     border-radius: 14px;
     padding: 5px 14px;
-    font-size: 12px;
+    font-size: var(--font-size-xs);
     cursor: pointer;
     font-family: inherit;
     transition: background 0.15s, border-color 0.15s, color 0.15s;
@@ -1624,7 +1624,7 @@
   }
   .search-hint {
     color: var(--text-muted);
-    font-size: 14px;
+    font-size: var(--font-size-sm);
     margin-top: 64px;
     text-align: center;
   }
@@ -1657,7 +1657,7 @@
     border: 1px solid var(--border-subtle);
     border-radius: 14px;
     padding: 6px 14px;
-    font-size: 12px;
+    font-size: var(--font-size-xs);
     color: var(--text-secondary);
     cursor: pointer;
     font-family: inherit;
@@ -1740,7 +1740,7 @@
     letter-spacing: -0.02em;
   }
   .top-sub {
-    font-size: 14px;
+    font-size: var(--font-size-sm);
     color: var(--text-secondary);
     margin: 0;
   }
@@ -1852,7 +1852,7 @@
   }
   .artist-avatar.fallback span {
     font-family: var(--font-body, inherit);
-    font-size: 22px;
+    font-size: var(--font-size-xl);
     font-weight: 600;
     color: rgba(255, 255, 255, 0.78);
     letter-spacing: 0.02em;
@@ -1891,7 +1891,7 @@
     border-radius: 50%;
     background: var(--accent);
     color: #fff;
-    font-size: 14px;
+    font-size: var(--font-size-sm);
     border: none;
     cursor: pointer;
     opacity: 0;
@@ -1927,7 +1927,7 @@
   }
   .album-card:hover .album-art { opacity: 0.85; }
   .album-title {
-    font-size: 12px;
+    font-size: var(--font-size-xs);
     color: var(--text-primary);
     overflow: hidden;
     text-overflow: ellipsis;
@@ -1985,7 +1985,7 @@
     justify-content: center;
   }
   .track-art.fallback span {
-    font-size: 16px;
+    font-size: var(--font-size-md);
     color: rgba(255, 255, 255, 0.5);
   }
   .track-title {
@@ -2007,7 +2007,7 @@
   .subtitle-link { color: inherit; text-decoration: none; }
   .subtitle-link:hover { color: var(--text-primary); text-decoration: underline; }
   .track-duration {
-    font-size: 12px;
+    font-size: var(--font-size-xs);
     color: var(--text-muted);
     white-space: nowrap;
   }
@@ -2016,7 +2016,7 @@
     border: none;
     color: var(--text-tertiary);
     cursor: pointer;
-    font-size: 14px;
+    font-size: var(--font-size-sm);
     padding: 4px;
     border-radius: 4px;
     opacity: 0;
@@ -2120,7 +2120,7 @@
     position: relative;
     text-align: center;
     color: var(--text-muted);
-    font-size: 12px;
+    font-size: var(--font-size-xs);
     font-variant-numeric: tabular-nums;
   }
   .search-track-row .track-num-label { display: inline; }
@@ -2129,7 +2129,7 @@
     background: none;
     border: none;
     color: var(--text-primary);
-    font-size: 14px;
+    font-size: var(--font-size-sm);
     cursor: pointer;
     padding: 0;
   }
@@ -2153,7 +2153,7 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    font-size: 14px;
+    font-size: var(--font-size-sm);
     color: rgba(255,255,255,0.5);
   }
   .search-track-row .row-title-text {
@@ -2182,7 +2182,7 @@
   }
   .search-track-row .col-duration {
     color: var(--text-muted);
-    font-size: 12px;
+    font-size: var(--font-size-xs);
     font-variant-numeric: tabular-nums;
     text-align: right;
   }
@@ -2201,7 +2201,7 @@
     align-items: center;
     justify-content: center;
     color: var(--text-muted);
-    font-size: 12px;
+    font-size: var(--font-size-xs);
     padding: 16px 0;
   }
   .infinite-spinner { font-style: italic; }

--- a/frontend/src/routes/search/+page.svelte
+++ b/frontend/src/routes/search/+page.svelte
@@ -17,6 +17,7 @@
   import { tidalSearchTrackToPlayable } from '$lib/utils/track'
   import { canPlayTrack, getPlayableLabel } from '$lib/player/playable'
   import { mergeLocalIntoTidal } from '$lib/search/merge_local'
+  import PlayOverlay from '$lib/components/ui/PlayOverlay.svelte'
 
   const RECENT_KEY = 'noor_recent_searches'
   const RECENT_MAX = 8
@@ -1075,11 +1076,12 @@
                 {#if album.in_library}
                   <span class="lib-badge" aria-label="In your library"></span>
                 {/if}
-                <button
-                  class="art-play-overlay"
+                <PlayOverlay
+                  position="corner"
+                  size="sm"
+                  label="Play {album.title}"
                   onclick={(e) => { e.preventDefault(); e.stopPropagation(); void playTidalAlbum(album.tidal_id) }}
-                  aria-label="Play {album.title}"
-                >▶</button>
+                />
               </div>
               <p class="album-title">{album.title}</p>
               {#if album.artist_name}
@@ -1137,11 +1139,12 @@
                     <span>♫</span>
                   </div>
                 {/if}
-                <button
-                  class="art-play-overlay"
+                <PlayOverlay
+                  position="corner"
+                  size="sm"
+                  label="Play {playlist.title}"
                   onclick={(e) => { e.stopPropagation(); void playTidalPlaylist(playlist.uuid) }}
-                  aria-label="Play {playlist.title}"
-                >▶</button>
+                />
               </div>
               <p class="album-title">{playlist.title}</p>
               <p class="album-artist">TIDAL · {playlist.number_of_tracks ?? '?'} tracks</p>
@@ -1476,7 +1479,7 @@
     margin: 0 auto;
     background: var(--bg-raised);
     border: 1px solid var(--border-strong);
-    border-radius: 24px;
+    border-radius: var(--radius-lg);
     padding: 12px 22px;
     font-size: 15px;
     color: var(--text-primary);
@@ -1554,7 +1557,7 @@
     background: var(--bg-elevated);
     border: 1px solid var(--accent-line);
     color: var(--text-secondary);
-    border-radius: 14px;
+    border-radius: var(--radius-md);
     padding: 4px 12px;
     font-size: var(--font-size-xs);
     cursor: pointer;
@@ -1588,7 +1591,7 @@
     background: transparent;
     border: 1px solid var(--border-subtle);
     color: var(--text-secondary);
-    border-radius: 14px;
+    border-radius: var(--radius-md);
     padding: 5px 14px;
     font-size: var(--font-size-xs);
     cursor: pointer;
@@ -1655,7 +1658,7 @@
   .recent-chip {
     background: var(--bg-raised);
     border: 1px solid var(--border-subtle);
-    border-radius: 14px;
+    border-radius: var(--radius-md);
     padding: 6px 14px;
     font-size: var(--font-size-xs);
     color: var(--text-secondary);
@@ -1813,9 +1816,10 @@
     font-weight: 700;
     letter-spacing: 0.04em;
     text-transform: uppercase;
-    color: #1ed760;
+    color: var(--service-spotify);
     background: rgba(0, 0, 0, 0.65);
-    backdrop-filter: blur(4px);
+    backdrop-filter: var(--blur-base);
+    -webkit-backdrop-filter: var(--blur-base);
   }
   .spotify-card { text-decoration: none; }
   .lib-dot {
@@ -1882,32 +1886,11 @@
     transition: transform 0.18s ease;
   }
   .album-card:hover { transform: translateY(-3px); }
-  .art-play-overlay {
-    position: absolute;
-    bottom: 8px;
-    right: 8px;
-    width: 36px;
-    height: 36px;
-    border-radius: 50%;
-    background: var(--accent);
-    color: #fff;
-    font-size: var(--font-size-sm);
-    border: none;
-    cursor: pointer;
-    opacity: 0;
-    transform: translateY(4px);
-    transition: opacity 0.15s, transform 0.15s;
-    box-shadow: 0 6px 16px -4px rgba(0,0,0,0.5);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 0;
-  }
-  .art-wrap:hover .art-play-overlay {
+  .art-wrap:hover :global(.play-overlay),
+  .album-card:focus-within :global(.play-overlay) {
     opacity: 1;
     transform: translateY(0);
   }
-  .art-play-overlay:hover { transform: scale(1.08); opacity: 1; }
   .album-art {
     width: 128px;
     height: 128px;

--- a/frontend/src/routes/search/+page.svelte
+++ b/frontend/src/routes/search/+page.svelte
@@ -1460,12 +1460,12 @@
 
 <style>
   .search-page {
-    width: min(100%, 1280px);
+    width: min(100%, var(--content-width));
     margin: 0 auto;
     padding: 16px 4px 80px;
   }
   .search-header {
-    max-width: 1200px;
+    max-width: var(--content-width);
     margin: 0 auto 40px;
     padding: 0 4px;
   }
@@ -1629,7 +1629,7 @@
     text-align: center;
   }
   .search-error { color: var(--state-error); }
-  .results-section { margin-bottom: 32px; max-width: 1200px; margin-left: auto; margin-right: auto; }
+  .results-section { margin-bottom: 32px; max-width: var(--content-width); margin-left: auto; margin-right: auto; }
   .recent-section { margin-top: 36px; max-width: 720px; margin-left: auto; margin-right: auto; }
   .recent-head {
     display: flex;
@@ -1667,7 +1667,7 @@
     border-color: var(--accent-line);
     color: var(--text-primary);
   }
-  .top-result-section { margin-bottom: 28px; max-width: 1200px; margin-left: auto; margin-right: auto; }
+  .top-result-section { margin-bottom: 28px; max-width: var(--content-width); margin-left: auto; margin-right: auto; }
   .top-result-card {
     display: grid;
     grid-template-columns: 168px 1fr;

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -1468,7 +1468,7 @@
 				<SectionHeader eyebrow="Metadata" title="Last.fm tags" subtitle="Crowd tags from a local API key." />
 
 				{#if lastfmError}
-					<p class="page-copy" style="color: var(--color-error, #f87171)">{lastfmError}</p>
+					<p class="page-copy" style="color: var(--state-error)">{lastfmError}</p>
 				{/if}
 
 				{#if !lastfmConfigured}
@@ -2901,7 +2901,7 @@
 		font-weight: normal;
 	}
 	.sync-error {
-		color: var(--danger, #ff6b6b);
+		color: var(--state-error);
 		font-weight: 500;
 		word-break: break-word;
 	}

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -2119,7 +2119,7 @@
 		margin-bottom: 12px;
 		border-radius: 10px;
 		background: rgba(255, 255, 255, 0.02);
-		border: 1px solid rgba(255, 255, 255, 0.06);
+		border: 1px solid var(--border-subtle);
 	}
 
 	.intensity-header {
@@ -2337,7 +2337,7 @@
 		gap: 6px;
 		padding: 6px;
 		border: 1px solid var(--border-subtle);
-		border-radius: 14px;
+		border-radius: var(--radius-md);
 		background: rgba(255, 255, 255, 0.022);
 	}
 
@@ -2482,7 +2482,7 @@
 		gap: 10px;
 		padding: 9px 10px;
 		border-radius: 10px;
-		border: 1px solid rgba(255, 255, 255, 0.06);
+		border: 1px solid var(--border-subtle);
 		background: rgba(255, 255, 255, 0.02);
 		cursor: pointer;
 		transition: border-color 140ms ease, background 140ms ease, box-shadow 140ms ease;
@@ -2508,7 +2508,7 @@
 		background: linear-gradient(135deg,
 			color-mix(in srgb, var(--accent, #7c80ff) 60%, #0a0a14),
 			color-mix(in srgb, var(--accent, #7c80ff) 20%, #050508));
-		border: 1px solid rgba(255, 255, 255, 0.08);
+		border: 1px solid var(--panel-border);
 	}
 
 	.wallpaper-tile-swatch-none {
@@ -2589,7 +2589,7 @@
 		display: flex;
 		flex-direction: column;
 		gap: 14px;
-		border-radius: 14px;
+		border-radius: var(--radius-md);
 	}
 
 	.settings-grid.single-column .settings-main {
@@ -2645,7 +2645,7 @@
 		height: 10px;
 		border-radius: 999px;
 		background: rgba(255, 255, 255, 0.08);
-		border: 1px solid rgba(255, 255, 255, 0.08);
+		border: 1px solid var(--panel-border);
 		overflow: hidden;
 	}
 
@@ -2763,7 +2763,7 @@
 		padding: 16px;
 		border-radius: var(--radius-sm);
 		background: rgba(255, 255, 255, 0.03);
-		border: 1px solid rgba(255, 255, 255, 0.08);
+		border: 1px solid var(--panel-border);
 		font-family: monospace;
 		font-size: 1.9rem;
 		letter-spacing: 0.18em;
@@ -2789,7 +2789,7 @@
 		padding: 14px;
 		border-radius: var(--radius-sm);
 		background: rgba(255, 255, 255, 0.03);
-		border: 1px solid rgba(255, 255, 255, 0.06);
+		border: 1px solid var(--border-subtle);
 	}
 
 	.roadmap-item p {
@@ -2864,7 +2864,7 @@
 		right: 0;
 		bottom: 0;
 		background: rgba(255, 255, 255, 0.12);
-		border-radius: 24px;
+		border-radius: 999px;
 		transition: background 0.2s ease;
 	}
 
@@ -2913,7 +2913,7 @@
 		height: 10px;
 		border-radius: 999px;
 		background: rgba(255, 255, 255, 0.08);
-		border: 1px solid rgba(255, 255, 255, 0.08);
+		border: 1px solid var(--panel-border);
 		overflow: hidden;
 	}
 
@@ -3013,7 +3013,7 @@
 		padding: 8px 12px;
 		border-radius: var(--radius-sm);
 		background: rgba(255, 255, 255, 0.04);
-		border: 1px solid rgba(255, 255, 255, 0.08);
+		border: 1px solid var(--panel-border);
 		font-family: var(--font-mono);
 		font-size: 0.78rem;
 		color: var(--text-secondary);

--- a/frontend/src/routes/spotify-playlist/[id]/+page.svelte
+++ b/frontend/src/routes/spotify-playlist/[id]/+page.svelte
@@ -3,6 +3,7 @@
   import { onDestroy } from 'svelte';
   import { goto } from '$app/navigation';
   import { lazyTidalArt } from '$lib/actions/lazy-tidal-art';
+  import { formatTrackDuration } from '$lib/utils/format';
   import {
     api,
     type SpotifyPlaylistDetail,
@@ -316,14 +317,6 @@
     }
   }
 
-  function formatDuration(ms: number | null): string {
-    if (!ms || ms <= 0) return '—';
-    const total = Math.floor(ms / 1000);
-    const m = Math.floor(total / 60);
-    const s = total % 60;
-    return `${m}:${s.toString().padStart(2, '0')}`;
-  }
-
   function formatNumber(n: number | null): string {
     if (n === null || n === undefined) return '';
     if (n < 1_000) return n.toString();
@@ -448,7 +441,7 @@
                   ? 'Resolving…'
                   : 'N/A'}
           </span>
-          <span class="dur">{formatDuration(t.durationMs)}</span>
+          <span class="dur">{formatTrackDuration(t.durationMs)}</span>
           <div class="row-actions">
             <button
               class="row-btn"
@@ -538,7 +531,7 @@
     flex-wrap: wrap;
     gap: 6px;
     color: var(--text-muted);
-    font-size: 12px;
+    font-size: var(--font-size-xs);
   }
   .stats .resolved-count { color: var(--accent); font-weight: 600; }
   .actions { display: flex; align-items: center; flex-wrap: wrap; gap: 8px; margin-top: 8px; }
@@ -567,7 +560,7 @@
   }
   .toast {
     margin: 8px 0 0;
-    font-size: 12px;
+    font-size: var(--font-size-xs);
     padding: 8px 12px;
     border-radius: 8px;
     width: fit-content;
@@ -611,12 +604,12 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    font-size: 14px;
+    font-size: var(--font-size-sm);
     font-weight: 500;
   }
   .row-artist {
     color: var(--text-secondary);
-    font-size: 12px;
+    font-size: var(--font-size-xs);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -642,7 +635,7 @@
   .status--unresolved, .status--error { background: rgba(239, 68, 68, 0.10); color: #ef4444; }
   .dur {
     color: var(--text-muted);
-    font-size: 12px;
+    font-size: var(--font-size-xs);
     font-variant-numeric: tabular-nums;
     min-width: 36px;
     text-align: right;

--- a/frontend/src/routes/spotify-playlist/[id]/+page.svelte
+++ b/frontend/src/routes/spotify-playlist/[id]/+page.svelte
@@ -485,7 +485,7 @@
 </div>
 
 <style>
-  .page { max-width: 1080px; margin: 0 auto; padding: 32px 28px 96px; }
+  .page { max-width: var(--content-width); margin: 0 auto; padding: 32px 28px 96px; }
   .state { padding: 80px 0; text-align: center; color: var(--text-muted); }
   .state.error { color: #ef4444; }
 

--- a/frontend/src/routes/spotify-playlist/[id]/+page.svelte
+++ b/frontend/src/routes/spotify-playlist/[id]/+page.svelte
@@ -492,7 +492,7 @@
   .cover {
     width: 220px;
     height: 220px;
-    border-radius: 14px;
+    border-radius: var(--radius-md);
     background-size: cover;
     background-position: center;
     box-shadow: 0 18px 36px -16px rgba(0, 0, 0, 0.6);
@@ -501,7 +501,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    background: linear-gradient(135deg, #1ed760, #1aa34a);
+    background: linear-gradient(135deg, var(--service-spotify), #1aa34a);
     font-size: 56px;
     color: #fff;
   }
@@ -510,7 +510,7 @@
     font-size: 11px;
     letter-spacing: 0.08em;
     text-transform: uppercase;
-    color: #1ed760;
+    color: var(--service-spotify);
     font-weight: 700;
   }
   .title {
@@ -547,9 +547,9 @@
     font-size: 13px;
   }
   .btn-secondary {
-    background: rgba(255, 255, 255, 0.07);
+    background: var(--border-subtle);
     color: var(--text-primary);
-    border: 1px solid rgba(255, 255, 255, 0.08);
+    border: 1px solid var(--panel-border);
   }
   .btn-primary:disabled,
   .btn-secondary:disabled { opacity: 0.5; cursor: not-allowed; }

--- a/frontend/src/routes/tidal/albums/[id]/+page.svelte
+++ b/frontend/src/routes/tidal/albums/[id]/+page.svelte
@@ -68,11 +68,11 @@
 
 <div class="page">
 	{#if loading}
-		<p class="status">Loading from TIDAL…</p>
+		<p class="status" role="status" aria-live="polite">Loading from TIDAL…</p>
 	{:else if error}
 		<p class="status error">{error}</p>
 	{:else if !header()}
-		<p class="status">Album not found.</p>
+		<p class="status" role="status" aria-live="polite">Album not found.</p>
 	{:else}
 		{@const h = header()!}
 
@@ -155,7 +155,7 @@
 		text-align: center;
 		color: var(--text-secondary);
 	}
-	.status.error { color: var(--danger, #f87171); }
+	.status.error { color: var(--state-error); }
 
 	.hero {
 		position: relative;

--- a/frontend/src/routes/tidal/albums/[id]/+page.svelte
+++ b/frontend/src/routes/tidal/albums/[id]/+page.svelte
@@ -186,16 +186,16 @@
 
 	.hero-body {
 		display: grid;
-		grid-template-columns: 204px 1fr;
+		grid-template-columns: clamp(160px, 16vw, 240px) 1fr;
 		gap: 24px;
 		align-items: end;
 		width: 100%;
-		max-width: 1400px;
+		max-width: var(--content-width);
 	}
 
 	.hero-art-wrap {
-		width: 204px;
-		height: 204px;
+		width: clamp(160px, 16vw, 240px);
+		aspect-ratio: 1 / 1;
 		border-radius: 8px;
 		overflow: hidden;
 		box-shadow: 0 28px 70px -14px rgba(0, 0, 0, 0.7);

--- a/frontend/src/routes/tidal/artists/[id]/+page.svelte
+++ b/frontend/src/routes/tidal/artists/[id]/+page.svelte
@@ -238,12 +238,12 @@
   }
   .grid-card:hover .grid-art { opacity: 0.85; }
   .grid-title {
-    font-size: 12px; color: var(--text-primary); margin: 0;
+    font-size: var(--font-size-xs); color: var(--text-primary); margin: 0;
     overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
   }
   .grid-sub {
     font-size: 11px; color: var(--text-muted); margin: 2px 0 0;
     overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
   }
-  .empty { color: var(--text-muted); font-size: 14px; margin-top: 32px; }
+  .empty { color: var(--text-muted); font-size: var(--font-size-sm); margin-top: 32px; }
 </style>

--- a/frontend/src/routes/videos/+page.svelte
+++ b/frontend/src/routes/videos/+page.svelte
@@ -9,7 +9,7 @@
 	import { openContextMenu } from '$lib/stores/context_menu';
 	import { buildArtistMenu } from '$lib/player/artist_menu';
 	import { assertOnline } from '$lib/stores/player';
-	import { formatDuration } from '$lib/stores/library';
+	import { formatTrackDuration } from '$lib/utils/format';
 	import { showToast } from '$lib/stores/toast';
 	import { audioSettings } from '$lib/stores/audio_settings';
 	import {
@@ -604,7 +604,7 @@
 						</button>
 					{/if}
 					{#if selectedVideo.duration_ms}
-						<span>{formatDuration(selectedVideo.duration_ms)}</span>
+						<span>{formatTrackDuration(selectedVideo.duration_ms)}</span>
 					{/if}
 					{#if streamExpiresAt}
 						<span>Stream ready</span>

--- a/frontend/src/routes/videos/+page.svelte
+++ b/frontend/src/routes/videos/+page.svelte
@@ -711,7 +711,7 @@
 		margin: 0 auto;
 		background: var(--bg-raised);
 		border: 1px solid var(--border-strong);
-		border-radius: 24px;
+		border-radius: var(--radius-lg);
 		padding: 12px 22px;
 		font-size: 15px;
 		color: var(--text-primary);

--- a/frontend/src/routes/videos/+page.svelte
+++ b/frontend/src/routes/videos/+page.svelte
@@ -693,7 +693,7 @@
 
 <style>
 	.videos-page {
-		width: min(100%, 1220px);
+		width: min(100%, var(--content-width));
 		margin: 0 auto;
 		display: grid;
 		gap: 28px;

--- a/noor-app/tauri.conf.json
+++ b/noor-app/tauri.conf.json
@@ -10,6 +10,8 @@
         "url": "http://127.0.0.1:3334",
         "width": 1280,
         "height": 800,
+        "minWidth": 720,
+        "minHeight": 500,
         "visible": true,
         "decorations": true,
         "resizable": true

--- a/scripts/click-test.mjs
+++ b/scripts/click-test.mjs
@@ -12,6 +12,11 @@
 // Optional flags:
 //   --artist 4001     Override the artist id (default: 4001 / Julio Iglesias)
 //   --query "..."     Override the search query (default: "julio iglesias")
+//   --viewport WxH    Browser viewport size (default: 1400x900). Examples:
+//                     --viewport 800x600, --viewport 1920x1080, --viewport 2560x1440
+//   --shots-suffix s  Append "-s" to every screenshot filename so a single run
+//                     doesn't overwrite a prior set. Useful for capturing
+//                     baselines at multiple viewports without losing earlier ones.
 //   --headed          Show the browser window (default: headless)
 //   --keep-open       Leave the browser open at the end for manual inspection
 //
@@ -42,9 +47,24 @@ const KEEP_OPEN = argFlag('--keep-open')
 const FRONTEND = process.env.NOOR_FRONTEND ?? 'http://localhost:5173'
 const BACKEND  = process.env.NOOR_BACKEND  ?? 'http://localhost:3334'
 
+const VIEWPORT_RAW = argVal('--viewport', '1400x900')
+const vpMatch = /^(\d+)x(\d+)$/.exec(VIEWPORT_RAW)
+if (!vpMatch) {
+	console.error(`✗ --viewport must be WxH (e.g. 1280x800), got "${VIEWPORT_RAW}"`)
+	process.exit(2)
+}
+const VIEWPORT = { width: Number(vpMatch[1]), height: Number(vpMatch[2]) }
+const SHOTS_SUFFIX = argVal('--shots-suffix', '')
+
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const SHOTS = join(__dirname, 'click-test-screenshots')
 mkdirSync(SHOTS, { recursive: true })
+
+const shotPath = (name) => {
+	if (!SHOTS_SUFFIX) return join(SHOTS, name)
+	const dot = name.lastIndexOf('.')
+	return join(SHOTS, `${name.slice(0, dot)}-${SHOTS_SUFFIX}${name.slice(dot)}`)
+}
 
 const issues = []
 const log  = (kind, msg) => console.log(`  ${kind} ${msg}`)
@@ -62,7 +82,8 @@ try {
 } catch {}
 
 const browser = await chromium.launch({ headless: HEADLESS })
-const ctx = await browser.newContext({ viewport: { width: 1400, height: 900 } })
+const ctx = await browser.newContext({ viewport: VIEWPORT })
+console.log(`viewport: ${VIEWPORT.width}x${VIEWPORT.height}${SHOTS_SUFFIX ? ` (suffix: -${SHOTS_SUFFIX})` : ''}`)
 if (preToken) {
 	await ctx.addInitScript((tok) => localStorage.setItem('noor_api_token', tok), preToken)
 }
@@ -173,7 +194,7 @@ const step = async (name, fn) => {
 await step('Open / (home page)', async () => {
 	await page.goto(`${FRONTEND}/`, { waitUntil: 'domcontentloaded' })
 	await page.waitForTimeout(2000)
-	await page.screenshot({ path: join(SHOTS, '01-home.png'), fullPage: true })
+	await page.screenshot({ path: shotPath('01-home.png'), fullPage: true })
 	const shell = await page.locator('.home-page').count()
 	if (shell === 0) { fail('home-page shell not rendered'); return }
 	pass('home-page shell rendered')
@@ -194,7 +215,7 @@ await step('Open / (home page)', async () => {
 await step('Open /library — tracks tab', async () => {
 	await page.goto(`${FRONTEND}/library`, { waitUntil: 'domcontentloaded' })
 	await page.waitForTimeout(2500)
-	await page.screenshot({ path: join(SHOTS, '02-library.png') })
+	await page.screenshot({ path: shotPath('02-library.png') })
 	const rows = await page.locator('.home-track-row, .track-row').count()
 	if (rows === 0) fail('no track rows in library (library may be empty)')
 	else pass(`${rows} track rows visible`)
@@ -226,7 +247,7 @@ await step('Library — Artists tab', async () => {
 
 await step('Open /search (empty)', async () => {
 	await page.goto(`${FRONTEND}/search`, { waitUntil: 'domcontentloaded' })
-	await page.screenshot({ path: join(SHOTS, '03-search-empty.png') })
+	await page.screenshot({ path: shotPath('03-search-empty.png') })
 	pass('navigated')
 })
 
@@ -234,7 +255,7 @@ await step(`Search "${QUERY}" — Tracks tab not empty`, async () => {
 	const input = page.locator('input').first()
 	await input.fill(QUERY)
 	await page.waitForTimeout(2000)
-	await page.screenshot({ path: join(SHOTS, '04-search-results.png') })
+	await page.screenshot({ path: shotPath('04-search-results.png') })
 	const tracks = await page.locator('[class*="track-row"], [class*="search-track-row"]').count()
 	if (tracks === 0) fail(`no track rows for "${QUERY}"`)
 	else pass(`${tracks} track rows`)
@@ -247,7 +268,7 @@ await step(`Search "${QUERY}" — Tracks tab not empty`, async () => {
 await step(`Open /artists/${ARTIST_ID}`, async () => {
 	await page.goto(`${FRONTEND}/artists/${ARTIST_ID}`, { waitUntil: 'domcontentloaded' })
 	await page.waitForTimeout(2500)
-	await page.screenshot({ path: join(SHOTS, '05-artist-hero.png'), fullPage: true })
+	await page.screenshot({ path: shotPath('05-artist-hero.png'), fullPage: true })
 	const heroTitle = await page.locator('h1.hero-title').textContent().catch(() => null)
 	if (!heroTitle?.trim()) fail('hero title empty')
 	else pass(`hero title: "${heroTitle.trim()}"`)
@@ -300,7 +321,7 @@ await step('Navigate to first discography album', async () => {
 	if (!url.includes('/albums/') && !url.includes('/tidal/albums/'))
 		fail(`unexpected URL: ${url}`)
 	else pass(`landed on ${url}`)
-	await page.screenshot({ path: join(SHOTS, '06-album-page.png'), fullPage: true })
+	await page.screenshot({ path: shotPath('06-album-page.png'), fullPage: true })
 })
 
 await step('Album page — track list (library + TIDAL rows)', async () => {
@@ -336,7 +357,7 @@ await step('Back to artist — click first similar artist', async () => {
 	if (!url.includes('/artists/') && !url.includes('/tidal/artists/'))
 		fail(`unexpected URL after similar click: ${url}`)
 	else pass(`landed on ${url}`)
-	await page.screenshot({ path: join(SHOTS, '07-tidal-artist.png'), fullPage: true })
+	await page.screenshot({ path: shotPath('07-tidal-artist.png'), fullPage: true })
 	// Verify TIDAL artist page has a name heading
 	const h1 = await page.locator('h1').first().textContent().catch(() => null)
 	if (!h1?.trim()) warn('TIDAL artist page: no h1 found')
@@ -350,7 +371,7 @@ await step('Back to artist — click first similar artist', async () => {
 await step('Open /playlists', async () => {
 	await page.goto(`${FRONTEND}/playlists`, { waitUntil: 'domcontentloaded' })
 	await page.waitForTimeout(1500)
-	await page.screenshot({ path: join(SHOTS, '08-playlists.png') })
+	await page.screenshot({ path: shotPath('08-playlists.png') })
 	const shell  = await page.locator('.playlists-page').count()
 	const newBtn = await page.locator('button').filter({ hasText: /new smart playlist/i }).count()
 	if (shell === 0) { fail('playlists page shell not rendered'); return }
@@ -368,7 +389,7 @@ await step('Open /playlists', async () => {
 await step('Open /analytics', async () => {
 	await page.goto(`${FRONTEND}/analytics`, { waitUntil: 'domcontentloaded' })
 	await page.waitForTimeout(3000)
-	await page.screenshot({ path: join(SHOTS, '09-analytics.png'), fullPage: true })
+	await page.screenshot({ path: shotPath('09-analytics.png'), fullPage: true })
 	const tree = await page.locator('.analytics-tree').count()
 	if (tree === 0) { fail('analytics-tree not rendered'); return }
 	pass('analytics-tree rendered')
@@ -391,7 +412,7 @@ await step('Analytics — switch time range to 7d', async () => {
 await step('Open /settings', async () => {
 	await page.goto(`${FRONTEND}/settings`, { waitUntil: 'domcontentloaded' })
 	await page.waitForTimeout(1500)
-	await page.screenshot({ path: join(SHOTS, '10-settings.png') })
+	await page.screenshot({ path: shotPath('10-settings.png') })
 	const shell = await page.locator('.settings-page').count()
 	if (shell === 0) { fail('settings page not rendered'); return }
 	pass('settings page rendered')
@@ -417,7 +438,7 @@ await step('Settings — click second category', async () => {
 await step('Open /genres (genre galaxy)', async () => {
 	await page.goto(`${FRONTEND}/genres`, { waitUntil: 'domcontentloaded' })
 	await page.waitForTimeout(3000)
-	await page.screenshot({ path: join(SHOTS, '11-genres.png') })
+	await page.screenshot({ path: shotPath('11-genres.png') })
 	// Galaxy renders as a WebGL canvas; check the page shell at minimum
 	const hasCanvas = await page.locator('canvas').count()
 	const hasEmpty  = await page.locator('[class*="empty"]').count()
@@ -440,7 +461,7 @@ await step('Open /genres (genre galaxy)', async () => {
 await step('Open /automix', async () => {
 	await page.goto(`${FRONTEND}/automix`, { waitUntil: 'domcontentloaded' })
 	await page.waitForTimeout(1500)
-	await page.screenshot({ path: join(SHOTS, '12-automix.png') })
+	await page.screenshot({ path: shotPath('12-automix.png') })
 	const shell = await page.locator('.automix-page').count()
 	if (shell === 0) { fail('automix page not rendered'); return }
 	pass('automix page rendered')
@@ -455,7 +476,7 @@ await step('Open /automix', async () => {
 await step('Open /duplicates', async () => {
 	await page.goto(`${FRONTEND}/duplicates`, { waitUntil: 'domcontentloaded' })
 	await page.waitForTimeout(1500)
-	await page.screenshot({ path: join(SHOTS, '13-duplicates.png') })
+	await page.screenshot({ path: shotPath('13-duplicates.png') })
 	const scanBtn = await page.locator('button').filter({ hasText: /scan library/i }).count()
 	if (scanBtn === 0) fail('"Scan library" button not found')
 	else pass('"Scan library" button present')
@@ -468,7 +489,7 @@ await step('Open /duplicates', async () => {
 await step('Open /videos', async () => {
 	await page.goto(`${FRONTEND}/videos`, { waitUntil: 'domcontentloaded' })
 	await page.waitForTimeout(2000)
-	await page.screenshot({ path: join(SHOTS, '14-videos.png') })
+	await page.screenshot({ path: shotPath('14-videos.png') })
 	// The page always has a search input regardless of TIDAL auth.
 	const input = await page.locator('input[type="text"], input[type="search"], input').count()
 	if (input === 0) fail('no search input on videos page')
@@ -484,7 +505,7 @@ await step('Open /videos', async () => {
 await step('Open /discoverspace', async () => {
 	await page.goto(`${FRONTEND}/discoverspace`, { waitUntil: 'domcontentloaded' })
 	await page.waitForTimeout(2500)
-	await page.screenshot({ path: join(SHOTS, '15-discoverspace.png') })
+	await page.screenshot({ path: shotPath('15-discoverspace.png') })
 	const shell  = await page.locator('.discoverspace-page').count()
 	const canvas = await page.locator('canvas').count()
 	if (shell === 0) { fail('discoverspace page shell not rendered'); return }


### PR DESCRIPTION
## Summary

Three-phase design-system pass on top of the visual / discovery / analytics work that has been stacking on this branch since v0.1.27. The whole-branch diff (vs master) is **+14.6k / −1.6k across 98 files**.

## What's in this PR

### Design system (Phase 1–3, the headline work)

- **Phase 1 — Fluid scaling** (`8f54012`). Token ladders converted from fixed pixels to `rem`-based `clamp()`: `--space-*`, `--radius-*`, `--gap-*`, plus a new `--font-size-*` typography scale and `--content-width` clamp(1280px, 100vw - 4rem, 2400px). Card grids switched from `repeat(N, 1fr)` to `repeat(auto-fit, minmax(...))`. Container queries on multi-context cards (carousels, hero, media rails). 44px touch-target floor on buttons. Tauri window minimum 720×500. Stylelint + `STYLING.md` guardrails.
- **Phase 2 — De-duplication & audit** (`afc659b`). Legacy CSS tokens (`--danger`, `--bg-glass`, etc) removed. `formatDuration` name collision resolved → `formatTrackDuration` in `lib/utils/format.ts`. Helper de-dup: 6 inline `letterColor` copies → `lib/utils/color.ts`, 3 inline `clamp` copies → `lib/utils/math.ts`. A11y `role="alert"` / `role="status"` on 9 error blocks. New z-index scale (`--z-base` … `--z-tooltip`). `<img>` alt audit. Edge gradient masks + 200ms hover delay on horizontal carousels.
- **Phase 3 — Visual unification + onboarding** (`cf7bec7`). New `--radius-md`, `--service-spotify/tidal/lastfm`, `--state-favorite`, `--blur-base/overlay/modal` tokens. Onboarding redesigned around the standing-wave shader (default for new installs); Newsreader serif headlines; "Pure sound. Perfect flow." copy; LastfmConnect "stuck on key saved" bug fixed. New shared `<PlayOverlay>` component unifies 7 distinct card-play visuals across 6 surfaces. TrendingShelf gains "From Last.fm" source attribution. Liquid-glass cross-route transition for the onboarding → home handoff (View Transitions API, 800ms blur+scale crossfade, scoped to that one navigation, with reduced-motion fallback). `?preview` URL param bypasses the auto-redirect for design QA.

### Other work bundled in (predates the design-system phases on this branch)

- **Analytics overhaul** (`ffc6ff3`) — Joy Division ridgelines, scatter, KPI strip. Local-time SQL fix (`b65da2c`).
- **Wallpaper shaders** (`c9cc562`) — 11 music-themed monochrome shaders.
- **Discovery overhaul** (`e726172`) — full search / artist / album rework against the TIDAL catalog.
- **Smoke test** (`95cadf2`) — `scripts/click-test.mjs` expanded to full-site coverage across 14 routes.

## Verification

- `cd frontend && pnpm run check` — 0 errors (44 pre-existing warnings unchanged)
- `pnpm run lint:css` — 0 errors (97 advisory `font-size: Npx` warnings, all pre-existing intentional non-step values)
- `pnpm test` — 44/44 passing

## Test plan

- [x] Build & smoke at 800 / 1280 / 1920 / 2560 viewports — UI scales fluidly, 1280×800 matches the calibrated baseline
- [x] Theme switch (default / light / profile palettes) — every accent surface tracks the active palette; no holes
- [x] `/onboarding?preview` — five steps; serif headlines; standing-wave background; "Open NOORwave" produces the liquid-glass dissolve into home
- [x] Click through home / library / search / artists / albums / videos — `<PlayOverlay>` looks identical across all surfaces (translucent dark circle, white SVG play)
- [x] Right-click context menus, command palette, modals — all share `--blur-modal` + `--radius-md`
- [x] Audio (TIDAL connect, scrobbling, smart radio) still works
- [x] Reduced-motion: `prefers-reduced-motion: reduce` falls back to 200ms plain crossfade