### PR TITLE
fix(audio): improve WASAPI exclusive recovery

### DIFF
--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -215,6 +215,9 @@
 		const tick = setInterval(() => {
 			nowEpochSeconds = Math.floor(Date.now() / 1000);
 		}, 1000);
+		const discoveryTrainingPoll = setInterval(() => {
+			if (discoveryIsRunning) void loadDiscoveryStatus();
+		}, 3000);
 		wsUnsubscribe = wsMessages.subscribe((messages) => {
 			const latest = messages.at(-1);
 			if (!latest) return;
@@ -296,6 +299,7 @@
 		return () => {
 			if (pollTimer) clearInterval(pollTimer);
 			if (mbPollTimer) clearInterval(mbPollTimer);
+			clearInterval(discoveryTrainingPoll);
 			clearInterval(tick);
 			wsUnsubscribe?.();
 		};
@@ -732,9 +736,9 @@
 		}
 	}
 
-	async function startDiscoveryTraining(mode: 'full' | 'incremental') {
+	async function startDiscoveryTraining(mode: 'full' | 'incremental', rebuildAudio = false) {
 		try {
-			const response = await api.startDiscoveryTraining(mode);
+			const response = await api.startDiscoveryTraining(mode, rebuildAudio);
 			if (response.status === 'legacy_trainer_unavailable') {
 				errorMsg = response.message ?? 'Switch to V2 to train discovery.';
 			} else {
@@ -2033,7 +2037,7 @@
 							<strong>Incremental refresh</strong> reuses the cached audio-proxy features from the last run and only rebuilds the behavioural + similarity stages. Faster — typically 30–50% of a Full Retrain wall-clock. Use this for routine refreshes.
 						</p>
 						<p>
-							<strong>Full retrain</strong> wipes the audio cache and recomputes everything from scratch. Use this if you've changed intensity tier, suspect the cache is stale, or it's been a long time since the last clean rebuild.
+							<strong>Full retrain</strong> bypasses cached audio-proxy features and recomputes current library tracks from scratch. Use this if you've changed intensity tier, suspect the cache is stale, or it's been a long time since the last clean rebuild.
 						</p>
 						<p>
 							On the very first run there's nothing cached, so both buttons do identical work.
@@ -2206,7 +2210,7 @@
 
 				<div class="action-row">
 					<button class="btn btn-primary" onclick={() => void startDiscoveryTraining('incremental')} disabled={discoveryIsRunning || !discoveryEngineTrainable}>Incremental refresh</button>
-					<button class="btn btn-glass" onclick={() => void startDiscoveryTraining('full')} disabled={discoveryIsRunning || !discoveryEngineTrainable}>Full retrain</button>
+					<button class="btn btn-glass" onclick={() => void startDiscoveryTraining('full', true)} disabled={discoveryIsRunning || !discoveryEngineTrainable}>Full retrain</button>
 					{#if discoveryIsRunning}
 						<button class="btn btn-glass" onclick={() => void stopDiscoveryTraining()}>Stop</button>
 					{/if}

--- a/noor-server/src/db/queries.rs
+++ b/noor-server/src/db/queries.rs
@@ -4206,6 +4206,16 @@ pub fn update_embedding_model_metrics(
     Ok(())
 }
 
+pub fn fail_embedding_model(conn: &Connection, model_id: i64) -> Result<()> {
+    conn.execute(
+        "UPDATE embedding_models
+         SET status = 'failed'
+         WHERE id = ?1",
+        params![model_id],
+    )?;
+    Ok(())
+}
+
 fn read_embedding_model(row: &Row<'_>) -> rusqlite::Result<EmbeddingModel> {
     Ok(EmbeddingModel {
         id: row.get(0)?,

--- a/noor-server/src/playback/runtime.rs
+++ b/noor-server/src/playback/runtime.rs
@@ -484,7 +484,7 @@ fn run_runtime_loop(
                     &config,
                     &command_tx,
                     &device,
-                    &output_config,
+                    &mut output_config,
                     output_sample_format,
                     &event_tx,
                     &mut state,
@@ -500,7 +500,7 @@ fn run_runtime_loop(
                     &config,
                     &command_tx,
                     &device,
-                    &output_config,
+                    &mut output_config,
                     output_sample_format,
                     &event_tx,
                     &mut state,
@@ -652,7 +652,7 @@ fn run_runtime_loop(
                         "Resume: rebuilding exclusive stream after idle release on {}",
                         state.device_name
                     );
-                    let _ = engine.swap_stream(
+                    match engine.swap_stream(
                         &device,
                         &output_config,
                         output_sample_format,
@@ -664,7 +664,15 @@ fn run_runtime_loop(
                             state.device_sample_rate,
                         ),
                         state.current_exclusive_release_grace_secs,
-                    );
+                    ) {
+                        Ok(actual_rate) => {
+                            output_config.sample_rate = cpal::SampleRate(actual_rate);
+                            state.device_sample_rate = actual_rate;
+                        }
+                        Err(err) => {
+                            warn!("Resume: failed to rebuild exclusive stream: {err:?}");
+                        }
+                    }
                 }
 
                 if let Some(engine) = state.engine.as_mut() {
@@ -809,7 +817,13 @@ fn run_runtime_loop(
                     None if sample_rate_follow => Some(new_config.sample_rate.0),
                     _ => None,
                 };
-                let effective_config = effective_output_config(&new_config, desired_rate);
+                let requested_backend = if exclusive {
+                    SwapBackend::Exclusive
+                } else {
+                    SwapBackend::Shared
+                };
+                let requested_plan = swap_stream_plan(&new_config, desired_rate, requested_backend);
+                let mut actual_config = requested_plan.stream_config.clone();
 
                 // In exclusive mode only one stream can hold the device, so
                 // drop the pre-buffered + fading engines and only swap the
@@ -839,7 +853,7 @@ fn run_runtime_loop(
                 .into_iter()
                 .flatten()
                 {
-                    if let Err(err) = engine_slot.swap_stream(
+                    match engine_slot.swap_stream(
                         &new_device,
                         &new_config,
                         new_format,
@@ -849,11 +863,16 @@ fn run_runtime_loop(
                         desired_rate,
                         exclusive_release_grace_secs,
                     ) {
-                        warn!(
-                            "DeviceSwap: failed to rebuild stream for track {}: {err:?}",
-                            engine_slot.track_id
-                        );
-                        swap_failed = true;
+                        Ok(actual_rate) => {
+                            actual_config.sample_rate = cpal::SampleRate(actual_rate);
+                        }
+                        Err(err) => {
+                            warn!(
+                                "DeviceSwap: failed to rebuild stream for track {}: {err:?}",
+                                engine_slot.track_id
+                            );
+                            swap_failed = true;
+                        }
                     }
                 }
 
@@ -868,7 +887,7 @@ fn run_runtime_loop(
                 // engines spin up at the new rate (their initial
                 // `target_sample_rate` is seeded from this value).
                 device = new_device;
-                output_config = effective_config;
+                output_config = actual_config;
                 output_sample_format = new_format;
                 state.device_name = new_name.clone();
                 state.device_sample_rate = output_config.sample_rate.0;
@@ -898,7 +917,7 @@ fn transition_to_job(
     config: &PlaybackRuntimeConfig,
     command_tx: &mpsc::Sender<PlaybackRuntimeCommand>,
     device: &cpal::Device,
-    output_config: &StreamConfig,
+    output_config: &mut StreamConfig,
     output_sample_format: SampleFormat,
     event_tx: &tokio::sync::broadcast::Sender<PlaybackRuntimeEvent>,
     state: &mut PlaybackRuntimeLoopState,
@@ -976,8 +995,8 @@ fn transition_to_job(
         // doesn't silently get shared-mode output for every new track.
         // swap_stream itself handles the fallback-to-cpal + event emission
         // when the WASAPI grab fails, so a hard error here is rare.
-        if state.current_exclusive
-            && let Err(err) = eng.swap_stream(
+        if state.current_exclusive {
+            match eng.swap_stream(
                 device,
                 output_config,
                 output_sample_format,
@@ -986,9 +1005,17 @@ fn transition_to_job(
                 true,
                 exclusive_rebuild_rate(state.current_sample_rate_follow, state.device_sample_rate),
                 state.current_exclusive_release_grace_secs,
-            )
-        {
-            warn!("transition_to_job: swap_stream errored cold-starting new engine: {err:?}");
+            ) {
+                Ok(actual_rate) => {
+                    output_config.sample_rate = cpal::SampleRate(actual_rate);
+                    state.device_sample_rate = actual_rate;
+                }
+                Err(err) => {
+                    warn!(
+                        "transition_to_job: swap_stream errored cold-starting new engine: {err:?}"
+                    );
+                }
+            }
         }
         eng
     };
@@ -1247,39 +1274,28 @@ impl PlaybackEngine {
         desired_sample_rate: Option<u32>,
         #[cfg_attr(not(target_os = "windows"), allow(unused_variables))]
         exclusive_release_grace_secs: u32,
-    ) -> Result<()> {
+    ) -> Result<u32> {
         // Pause first so the decoder side doesn't keep filling while the
         // callback is gone, then drop the old stream before building the new
         // one (some host APIs reject a second exclusive grab while the first
         // stream is alive).
-        let was_paused = self.shared.paused.load(Ordering::SeqCst);
-        self.shared.paused.store(true, Ordering::SeqCst);
+        let pause_guard = SwapPauseGuard::new(Arc::clone(&self.shared));
         drop(self.stream.take());
-
-        let effective_config = build_stream_config(output_config, desired_sample_rate);
-
-        // Re-target the decoder's resampler to the new stream rate so the
-        // sample stream stays at the right pitch. We do this AFTER computing
-        // `effective_config` so the value we publish to the decoder matches
-        // exactly what the new cpal stream will play out at.
-        if desired_sample_rate.is_some() {
-            self.shared
-                .target_sample_rate
-                .store(effective_config.sample_rate.0, Ordering::Relaxed);
-        }
 
         let device_label = device
             .name()
             .unwrap_or_else(|_| "default output device".to_string());
 
         #[cfg(target_os = "windows")]
-        let new_stream = if exclusive {
+        let (new_stream, active_plan) = if exclusive {
+            let exclusive_plan =
+                swap_stream_plan(output_config, desired_sample_rate, SwapBackend::Exclusive);
             let device_name = device.name().ok();
             match crate::playback::wasapi_exclusive::build_exclusive_stream(
                 device_name.as_deref(),
                 device_label.clone(),
-                effective_config.sample_rate.0,
-                effective_config.channels,
+                exclusive_plan.stream_config.sample_rate.0,
+                exclusive_plan.stream_config.channels,
                 exclusive_release_grace_secs,
                 Arc::clone(&self.shared),
                 command_tx.clone(),
@@ -1289,7 +1305,7 @@ impl PlaybackEngine {
                     let _ = event_tx.send(PlaybackRuntimeEvent::ExclusiveModeEngaged {
                         device_name: device_label.clone(),
                     });
-                    OutputStream::Wasapi(exclusive_stream)
+                    (OutputStream::Wasapi(exclusive_stream), exclusive_plan)
                 }
                 Err(failure) => {
                     let reason = failure.user_message();
@@ -1298,46 +1314,136 @@ impl PlaybackEngine {
                         reason,
                         device_name: device_label.clone(),
                     });
-                    OutputStream::Cpal(build_output_stream(
-                        device,
-                        &effective_config,
-                        output_sample_format,
-                        Arc::clone(&self.shared),
-                        command_tx,
-                        event_tx,
-                    )?)
+                    let fallback_plan = swap_stream_plan(
+                        output_config,
+                        desired_sample_rate,
+                        SwapBackend::SharedFallback,
+                    );
+                    (
+                        OutputStream::Cpal(build_output_stream(
+                            device,
+                            &fallback_plan.stream_config,
+                            output_sample_format,
+                            Arc::clone(&self.shared),
+                            command_tx,
+                            event_tx,
+                        )?),
+                        fallback_plan,
+                    )
                 }
             }
         } else {
-            OutputStream::Cpal(build_output_stream(
-                device,
-                &effective_config,
-                output_sample_format,
-                Arc::clone(&self.shared),
-                command_tx,
-                event_tx,
-            )?)
+            let shared_plan =
+                swap_stream_plan(output_config, desired_sample_rate, SwapBackend::Shared);
+            (
+                OutputStream::Cpal(build_output_stream(
+                    device,
+                    &shared_plan.stream_config,
+                    output_sample_format,
+                    Arc::clone(&self.shared),
+                    command_tx,
+                    event_tx,
+                )?),
+                shared_plan,
+            )
         };
         #[cfg(not(target_os = "windows"))]
-        let new_stream = {
+        let (new_stream, active_plan) = {
             let _ = exclusive;
             let _ = device_label;
-            OutputStream::Cpal(build_output_stream(
-                device,
-                &effective_config,
-                output_sample_format,
-                Arc::clone(&self.shared),
-                command_tx,
-                event_tx,
-            )?)
+            let shared_plan =
+                swap_stream_plan(output_config, desired_sample_rate, SwapBackend::Shared);
+            (
+                OutputStream::Cpal(build_output_stream(
+                    device,
+                    &shared_plan.stream_config,
+                    output_sample_format,
+                    Arc::clone(&self.shared),
+                    command_tx,
+                    event_tx,
+                )?),
+                shared_plan,
+            )
         };
 
         new_stream
             .start()
             .context("failed to start swapped output stream")?;
+        if let Some(target_sample_rate) = active_plan.target_sample_rate {
+            self.shared
+                .target_sample_rate
+                .store(target_sample_rate, Ordering::Relaxed);
+        }
         self.stream = Some(new_stream);
-        self.shared.paused.store(was_paused, Ordering::SeqCst);
-        Ok(())
+        pause_guard.restore();
+        Ok(active_plan.stream_config.sample_rate.0)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SwapBackend {
+    Exclusive,
+    Shared,
+    SharedFallback,
+}
+
+#[derive(Debug, Clone)]
+struct SwapStreamPlan {
+    stream_config: StreamConfig,
+    target_sample_rate: Option<u32>,
+}
+
+fn swap_stream_plan(
+    base: &StreamConfig,
+    desired_sample_rate: Option<u32>,
+    backend: SwapBackend,
+) -> SwapStreamPlan {
+    let stream_config = match backend {
+        SwapBackend::Exclusive | SwapBackend::Shared => {
+            effective_output_config(base, desired_sample_rate)
+        }
+        SwapBackend::SharedFallback => base.clone(),
+    };
+    let target_sample_rate = match (backend, desired_sample_rate) {
+        (SwapBackend::SharedFallback, Some(_)) => Some(stream_config.sample_rate.0),
+        (_, Some(_)) => Some(stream_config.sample_rate.0),
+        (_, None) => None,
+    };
+
+    SwapStreamPlan {
+        stream_config,
+        target_sample_rate,
+    }
+}
+
+struct SwapPauseGuard {
+    shared: Arc<PlaybackSharedState>,
+    was_paused: bool,
+    active: bool,
+}
+
+impl SwapPauseGuard {
+    fn new(shared: Arc<PlaybackSharedState>) -> Self {
+        let was_paused = shared.paused.load(Ordering::SeqCst);
+        shared.paused.store(true, Ordering::SeqCst);
+        Self {
+            shared,
+            was_paused,
+            active: true,
+        }
+    }
+
+    fn restore(mut self) {
+        self.active = false;
+        self.shared.paused.store(self.was_paused, Ordering::SeqCst);
+    }
+}
+
+impl Drop for SwapPauseGuard {
+    fn drop(&mut self) {
+        if self.active {
+            self.shared.paused.store(self.was_paused, Ordering::SeqCst);
+        }
     }
 }
 
@@ -1354,10 +1460,6 @@ fn effective_output_config(base: &StreamConfig, desired_sample_rate: Option<u32>
         config.sample_rate = cpal::SampleRate(rate);
     }
     config
-}
-
-fn build_stream_config(base: &StreamConfig, desired_sample_rate: Option<u32>) -> StreamConfig {
-    effective_output_config(base, desired_sample_rate)
 }
 
 fn exclusive_rebuild_rate(sample_rate_follow: bool, device_sample_rate: u32) -> Option<u32> {
@@ -2532,6 +2634,58 @@ mod tests {
     fn exclusive_rebuild_rate_follows_current_output_rate_only_when_enabled() {
         assert_eq!(exclusive_rebuild_rate(true, 96_000), Some(96_000));
         assert_eq!(exclusive_rebuild_rate(false, 96_000), None);
+    }
+
+    #[test]
+    fn swap_stream_plan_uses_track_rate_for_exclusive_backend() {
+        let base = StreamConfig {
+            channels: 2,
+            sample_rate: cpal::SampleRate(48_000),
+            buffer_size: cpal::BufferSize::Default,
+        };
+
+        let plan = swap_stream_plan(&base, Some(96_000), SwapBackend::Exclusive);
+
+        assert_eq!(plan.stream_config.sample_rate.0, 96_000);
+        assert_eq!(plan.target_sample_rate, Some(96_000));
+    }
+
+    #[test]
+    fn swap_stream_plan_uses_device_rate_for_shared_fallback() {
+        let base = StreamConfig {
+            channels: 2,
+            sample_rate: cpal::SampleRate(48_000),
+            buffer_size: cpal::BufferSize::Default,
+        };
+
+        let plan = swap_stream_plan(&base, Some(192_000), SwapBackend::SharedFallback);
+
+        assert_eq!(plan.stream_config.sample_rate.0, 48_000);
+        assert_eq!(plan.target_sample_rate, Some(48_000));
+    }
+
+    #[test]
+    fn swap_pause_guard_restores_previous_pause_state_on_drop() {
+        let (command_tx, _command_rx) = mpsc::channel();
+        let shared = Arc::new(PlaybackSharedState::new(
+            42,
+            0,
+            PlaybackSourceKind::TidalStream,
+            GaplessPlan::disabled(),
+            48_000,
+            2,
+            None,
+            command_tx,
+            Arc::new(AtomicU32::new(1.0f32.to_bits())),
+            Arc::new(AtomicU64::new(0)),
+        ));
+
+        {
+            let _guard = SwapPauseGuard::new(Arc::clone(&shared));
+            assert!(shared.paused.load(Ordering::SeqCst));
+        }
+
+        assert!(!shared.paused.load(Ordering::SeqCst));
     }
 
     #[test]

--- a/noor-server/src/playback/wasapi_exclusive.rs
+++ b/noor-server/src/playback/wasapi_exclusive.rs
@@ -78,8 +78,8 @@ impl ExclusiveInitFailure {
                     .to_string()
             }
             Self::NoFormatAccepted => {
-                "This device rejected every exclusive-mode format we tried (f32, 24-in-32, \
-                 16-bit). Pick a different output device."
+                "This device rejected every exclusive-mode format we tried (32-bit, packed \
+                 24-bit, 24-in-32, 16-bit, f32). Pick a different output device."
                     .to_string()
             }
             Self::Other(s) => format!("Exclusive mode failed: {s}"),
@@ -129,7 +129,51 @@ impl Drop for ExclusiveStream {
 enum Format {
     F32,
     I32,
+    I24In32,
+    I24Packed,
     I16,
+}
+
+struct CandidateFormat {
+    storebits: usize,
+    validbits: usize,
+    sample_type: SampleType,
+    format: Format,
+}
+
+fn exclusive_candidate_formats() -> &'static [CandidateFormat] {
+    &[
+        CandidateFormat {
+            storebits: 32,
+            validbits: 32,
+            sample_type: SampleType::Int,
+            format: Format::I32,
+        },
+        CandidateFormat {
+            storebits: 24,
+            validbits: 24,
+            sample_type: SampleType::Int,
+            format: Format::I24Packed,
+        },
+        CandidateFormat {
+            storebits: 32,
+            validbits: 24,
+            sample_type: SampleType::Int,
+            format: Format::I24In32,
+        },
+        CandidateFormat {
+            storebits: 16,
+            validbits: 16,
+            sample_type: SampleType::Int,
+            format: Format::I16,
+        },
+        CandidateFormat {
+            storebits: 32,
+            validbits: 32,
+            sample_type: SampleType::Float,
+            format: Format::F32,
+        },
+    ]
 }
 
 struct MmcssGuard {
@@ -490,15 +534,6 @@ fn init_audio_client(
         }
     }
 
-    // We re-resolve the device fresh inside try_initialize_one so each
-    // candidate format gets a clean IAudioClient (the COM object is in a bad
-    // state after a failed Initialize).
-    let candidates: &[(usize, usize, SampleType, Format)] = &[
-        (32, 32, SampleType::Float, Format::F32),
-        (32, 24, SampleType::Int, Format::I32),
-        (16, 16, SampleType::Int, Format::I16),
-    ];
-
     let mut last_failure: Option<ExclusiveInitFailure> = None;
 
     // Backoff schedule for AUDCLNT_E_DEVICE_IN_USE retries. Some drivers /
@@ -510,17 +545,17 @@ fn init_audio_client(
     // ms, retry, sleep 750 ms, give up.
     const DEVICE_IN_USE_BACKOFF_MS: &[u64] = &[50, 150, 350, 750];
 
-    'candidate: for (storebits, validbits, sample_type, fmt_tag) in candidates {
+    'candidate: for candidate in exclusive_candidate_formats() {
         let mut attempt: usize = 0;
         loop {
             match try_initialize_one(
                 device_pref,
-                *storebits,
-                *validbits,
-                sample_type,
+                candidate.storebits,
+                candidate.validbits,
+                &candidate.sample_type,
                 desired_sample_rate,
                 channels,
-                *fmt_tag,
+                candidate.format,
             ) {
                 Ok(v) => {
                     if attempt > 0 {
@@ -528,7 +563,7 @@ fn init_audio_client(
                             target: "playback",
                             "WASAPI exclusive grab succeeded on attempt {} ({:?})",
                             attempt + 1,
-                            fmt_tag_label(*fmt_tag)
+                            fmt_tag_label(candidate.format)
                         );
                     }
                     return Ok(v);
@@ -543,7 +578,7 @@ fn init_audio_client(
                             "WASAPI exclusive grab attempt {} hit DEVICE_IN_USE ({:?}); \
                              retrying after {} ms",
                             attempt + 1,
-                            fmt_tag_label(*fmt_tag),
+                            fmt_tag_label(candidate.format),
                             sleep_ms
                         );
                         std::thread::sleep(Duration::from_millis(sleep_ms));
@@ -566,7 +601,7 @@ fn init_audio_client(
                             "WASAPI exclusive grab: DEVICE_IN_USE persisted across {} attempts ({:?}); \
                              trying next format",
                             DEVICE_IN_USE_BACKOFF_MS.len() + 1,
-                            fmt_tag_label(*fmt_tag)
+                            fmt_tag_label(candidate.format)
                         );
                         last_failure = Some(ExclusiveInitFailure::DeviceInUse);
                         continue 'candidate;
@@ -576,7 +611,7 @@ fn init_audio_client(
                             target: "playback",
                             "WASAPI exclusive grab attempt {} ({:?}) rejected: {}",
                             attempt + 1,
-                            fmt_tag_label(*fmt_tag),
+                            fmt_tag_label(candidate.format),
                             other
                         );
                         last_failure = Some(other);
@@ -739,7 +774,9 @@ fn try_initialize_one(
 fn fmt_tag_label(fmt: Format) -> &'static str {
     match fmt {
         Format::F32 => "f32",
-        Format::I32 => "i24-in-32",
+        Format::I32 => "i32",
+        Format::I24In32 => "i24-in-32",
+        Format::I24Packed => "i24-packed",
         Format::I16 => "i16",
     }
 }
@@ -817,6 +854,13 @@ fn convert_f32_to_bytes(
             }
         }
         Format::I32 => {
+            debug_assert_eq!(blockalign, channels * 4);
+            for (chunk, &s) in dst.chunks_exact_mut(4).zip(src.iter()) {
+                let v = f32_to_i32_pcm(s);
+                chunk.copy_from_slice(&v.to_le_bytes());
+            }
+        }
+        Format::I24In32 => {
             // 24-in-32: WAVEFORMATEXTENSIBLE with 32 storebits + 24 validbits
             // means the device looks at the high 24 bits. Filling the full
             // i32 range is acceptable; the bottom 8 bits are ignored.
@@ -824,6 +868,13 @@ fn convert_f32_to_bytes(
             for (chunk, &s) in dst.chunks_exact_mut(4).zip(src.iter()) {
                 let v = f32_to_i32_pcm(s);
                 chunk.copy_from_slice(&v.to_le_bytes());
+            }
+        }
+        Format::I24Packed => {
+            debug_assert_eq!(blockalign, channels * 3);
+            for (chunk, &s) in dst.chunks_exact_mut(3).zip(src.iter()) {
+                let v = f32_to_i24_pcm(s);
+                chunk.copy_from_slice(&v.to_le_bytes()[0..3]);
             }
         }
         Format::I16 => {
@@ -843,6 +894,16 @@ fn f32_to_i16_pcm(sample: f32) -> i16 {
         i16::MAX
     } else {
         (sample * i16::MAX as f32) as i16
+    }
+}
+
+fn f32_to_i24_pcm(sample: f32) -> i32 {
+    if sample <= -1.0 {
+        -8_388_608
+    } else if sample >= 1.0 {
+        8_388_607
+    } else {
+        (sample * 8_388_607.0) as i32
     }
 }
 
@@ -918,9 +979,33 @@ mod tests {
     }
 
     #[test]
+    fn convert_f32_to_bytes_writes_packed_i24_little_endian() {
+        let mut dst = vec![0_u8; 9];
+
+        convert_f32_to_bytes(&[1.0, -1.0, 0.0], &mut dst, Format::I24Packed, 3, 1);
+
+        assert_eq!(
+            dst,
+            vec![0xff, 0xff, 0x7f, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00]
+        );
+    }
+
+    #[test]
+    fn candidate_formats_prefer_integer_formats_before_float() {
+        let labels: Vec<_> = exclusive_candidate_formats()
+            .iter()
+            .map(|candidate| fmt_tag_label(candidate.format))
+            .collect();
+
+        assert_eq!(labels, vec!["i32", "i24-packed", "i24-in-32", "i16", "f32"]);
+    }
+
+    #[test]
     fn format_labels_match_candidate_formats() {
         assert_eq!(fmt_tag_label(Format::F32), "f32");
-        assert_eq!(fmt_tag_label(Format::I32), "i24-in-32");
+        assert_eq!(fmt_tag_label(Format::I32), "i32");
+        assert_eq!(fmt_tag_label(Format::I24In32), "i24-in-32");
+        assert_eq!(fmt_tag_label(Format::I24Packed), "i24-packed");
         assert_eq!(fmt_tag_label(Format::I16), "i16");
     }
 }

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -12542,8 +12542,12 @@ async fn ensure_playback_runtime_for_track(
         })?;
     drop(state_guard);
 
-    if let Some(listener_handle) = spawned_handle {
+    if let Some(listener_handle) = spawned_handle.clone() {
         spawn_playback_runtime_listener(state.clone(), listener_handle);
+    }
+
+    if let Some(runtime_handle) = spawned_handle.as_ref() {
+        apply_persisted_runtime_output_settings(state, runtime_handle).await;
     }
 
     Ok(handle)
@@ -13311,6 +13315,53 @@ async fn current_user_audio_quality(
         .map(|s| s.quality)
 }
 
+struct RuntimeOutputSettings {
+    device: playback_runtime::OutputDeviceSelection,
+    exclusive_mode: bool,
+    sample_rate_follow: bool,
+    exclusive_release_grace_secs: u32,
+}
+
+fn runtime_output_settings_from_audio_settings(
+    settings: &crate::db::audio_settings::AudioSettings,
+) -> RuntimeOutputSettings {
+    RuntimeOutputSettings {
+        device: playback_runtime::OutputDeviceSelection::from_pref(
+            settings.output_device.as_deref(),
+        ),
+        exclusive_mode: settings.exclusive_mode,
+        sample_rate_follow: settings.sample_rate_follow,
+        exclusive_release_grace_secs: settings.exclusive_release_grace_secs,
+    }
+}
+
+async fn apply_persisted_runtime_output_settings(
+    state: &SharedState,
+    handle: &playback_runtime::PlaybackRuntimeHandle,
+) {
+    let settings = {
+        let guard = state.read().await;
+        guard
+            .db
+            .with_conn(|conn| crate::db::audio_settings::load(conn).map_err(Into::into))
+            .ok()
+    };
+
+    let Some(settings) = settings else {
+        return;
+    };
+    let output = runtime_output_settings_from_audio_settings(&settings);
+    if let Err(e) = handle.device_swap(
+        output.device,
+        output.exclusive_mode,
+        output.sample_rate_follow,
+        None,
+        output.exclusive_release_grace_secs,
+    ) {
+        warn!("Failed to apply persisted audio settings to playback runtime: {e}");
+    }
+}
+
 // If sample-rate-follow is enabled and the freshly-resolved stream's native
 // rate differs from the device's current rate, swap the device to the new
 // rate before the track starts. Without this, the first track of a session
@@ -13351,16 +13402,13 @@ async fn align_device_to_stream_rate(
         (next_rate, settings, info.sample_rate)
     };
 
-    let device_sel = match settings.output_device.as_ref() {
-        Some(name) => playback_runtime::OutputDeviceSelection::Named(name.clone()),
-        None => playback_runtime::OutputDeviceSelection::Default,
-    };
+    let output = runtime_output_settings_from_audio_settings(&settings);
     if let Err(e) = handle.device_swap(
-        device_sel,
-        settings.exclusive_mode,
-        settings.sample_rate_follow,
+        output.device,
+        output.exclusive_mode,
+        output.sample_rate_follow,
         Some(next_rate),
-        settings.exclusive_release_grace_secs,
+        output.exclusive_release_grace_secs,
     ) {
         warn!(
             "align_device_to_stream_rate: device_swap to {next_rate} Hz (from {current_rate} Hz) failed: {e}"
@@ -13401,19 +13449,20 @@ async fn post_audio_exclusive_retry(
         ));
     }
 
-    if let Some(runtime) = guard.playback_runtime.as_ref()
-        && let Err(e) = runtime.handle.device_swap(
-            playback_runtime::OutputDeviceSelection::from_pref(settings.output_device.as_deref()),
-            settings.exclusive_mode,
-            settings.sample_rate_follow,
+    if let Some(runtime) = guard.playback_runtime.as_ref() {
+        let output = runtime_output_settings_from_audio_settings(&settings);
+        if let Err(e) = runtime.handle.device_swap(
+            output.device,
+            output.exclusive_mode,
+            output.sample_rate_follow,
             None,
-            settings.exclusive_release_grace_secs,
-        )
-    {
-        return Err((
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "message": e.to_string() })),
-        ));
+            output.exclusive_release_grace_secs,
+        ) {
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "message": e.to_string() })),
+            ));
+        }
     }
 
     Ok(Json(serde_json::json!({ "ok": true })))
@@ -13487,17 +13536,17 @@ async fn put_audio_settings(
             || old.sample_rate_follow != saved.sample_rate_follow
             || old.exclusive_release_grace_secs != saved.exclusive_release_grace_secs;
 
-        if needs_swap
-            && let Some(runtime) = guard.playback_runtime.as_ref()
-            && let Err(e) = runtime.handle.device_swap(
-                playback_runtime::OutputDeviceSelection::from_pref(saved.output_device.as_deref()),
-                saved.exclusive_mode,
-                saved.sample_rate_follow,
+        if needs_swap && let Some(runtime) = guard.playback_runtime.as_ref() {
+            let output = runtime_output_settings_from_audio_settings(&saved);
+            if let Err(e) = runtime.handle.device_swap(
+                output.device,
+                output.exclusive_mode,
+                output.sample_rate_follow,
                 None,
-                saved.exclusive_release_grace_secs,
-            )
-        {
-            warn!("Audio settings update: live device_swap failed: {e}");
+                output.exclusive_release_grace_secs,
+            ) {
+                warn!("Audio settings update: live device_swap failed: {e}");
+            }
         }
 
         (old, saved)
@@ -16423,6 +16472,29 @@ mod tests {
         assert_eq!(synthetic.tidal_id, Some(456));
         assert_eq!(synthetic.best_quality.as_deref(), Some("HI_RES_LOSSLESS"));
         assert_eq!(synthetic.source, "tidal_ephemeral");
+    }
+
+    #[test]
+    fn runtime_output_settings_preserve_persisted_exclusive_preferences() {
+        let mut settings = crate::db::audio_settings::AudioSettings::default();
+        settings.output_device = Some("Zen DAC V2".to_string());
+        settings.exclusive_mode = true;
+        settings.sample_rate_follow = true;
+        settings.exclusive_release_grace_secs = 12;
+
+        let output = runtime_output_settings_from_audio_settings(&settings);
+
+        match output.device {
+            playback_runtime::OutputDeviceSelection::Named(name) => {
+                assert_eq!(name, "Zen DAC V2");
+            }
+            playback_runtime::OutputDeviceSelection::Default => {
+                panic!("expected named output device")
+            }
+        }
+        assert!(output.exclusive_mode);
+        assert!(output.sample_rate_follow);
+        assert_eq!(output.exclusive_release_grace_secs, 12);
     }
 
     #[test]

--- a/noor-server/src/services/learning.rs
+++ b/noor-server/src/services/learning.rs
@@ -827,6 +827,19 @@ pub async fn start_training(
         Ok((model, run))
     })?;
 
+    macro_rules! fail_training_on_err {
+        ($expr:expr) => {
+            match $expr {
+                Ok(value) => value,
+                Err(error) => {
+                    let error: anyhow::Error = error.into();
+                    mark_training_failure(&db, run.id, model.id, &error);
+                    return Err(error);
+                }
+            }
+        };
+    }
+
     // If cancel is requested at any stage boundary, mark the run as cancelled
     // and skip remaining persistence + model activation. Callers MUST `return Ok(())`
     // when this returns `Ok(true)` — otherwise a later stage may double-finish the run.
@@ -863,15 +876,17 @@ pub async fn start_training(
         Ok(false)
     };
 
-    db.with_conn(|conn| {
+    fail_training_on_err!(db.with_conn(|conn| {
         queries::update_training_run_progress(conn, run.id, "corpus", "running", 0.05, None, 0)
-    })?;
+    }));
 
     // Backfill listen_history columns added in MIGRATION_023, exactly once per
     // database lifetime. The trainer is the natural trigger — sequence-aware
     // features depend on session_id and transition_from_track_id, so we do
     // this before the corpus build runs.
-    if let Some(report) = db.with_conn(crate::services::listen_history_backfill::run_if_needed)? {
+    if let Some(report) =
+        fail_training_on_err!(db.with_conn(crate::services::listen_history_backfill::run_if_needed))
+    {
         tracing::info!(
             target: "noor.discovery.training",
             rows_updated = report.rows_updated,
@@ -881,7 +896,7 @@ pub async fn start_training(
         );
     }
 
-    let external_last_refresh_at = load_external_provider_last_refresh(&db)?;
+    let external_last_refresh_at = fail_training_on_err!(load_external_provider_last_refresh(&db));
     let external_refresh_report =
         match refresh_external_provider_candidates(&db, &external_refresh_clients, full_mode).await
         {
@@ -899,14 +914,19 @@ pub async fn start_training(
     // Build trainer input directly from DB (no JSON round-trip). The intensity
     // tier overrides dimension / top_k / window_size and decides whether to
     // include the audio-proxy stage (Low skips it).
-    let input = db.with_conn(|conn| build_trainer_input(conn, intensity_params, full_mode))?;
+    let input = fail_training_on_err!(db.with_conn(|conn| build_trainer_input(
+        conn,
+        intensity_params,
+        full_mode,
+        rebuild_audio
+    )));
     let provider_budget =
         plan_external_provider_refresh(full_mode, external_last_refresh_at, input.tracks.len());
     let heldout_examples = input.heldout_examples.clone();
 
-    db.with_conn(|conn| {
+    fail_training_on_err!(db.with_conn(|conn| {
         queries::update_training_run_progress(conn, run.id, "behavioral", "running", 0.2, None, 0)
-    })?;
+    }));
 
     // Progress channel — broadcasts to WebSocket + logs to tracing
     let (progress_tx, mut progress_rx) = mpsc::unbounded_channel::<TrainingProgressUpdate>();
@@ -953,7 +973,7 @@ pub async fn start_training(
         watchdog_flag.store(true, Ordering::Relaxed);
         watchdog_cancel.store(true, Ordering::Relaxed);
     });
-    let output_result = tokio::task::spawn_blocking(move || -> Result<_> {
+    let output_join = tokio::task::spawn_blocking(move || -> Result<_> {
         let pool = rayon::ThreadPoolBuilder::new()
             .num_threads(worker_threads)
             .thread_name(|idx| format!("discovery-v2-{idx}"))
@@ -965,8 +985,16 @@ pub async fn start_training(
     })
     .await
     .context("discovery trainer panicked");
+    let output_result = match output_join {
+        Ok(output_result) => output_result,
+        Err(error) => {
+            watchdog_task.abort();
+            mark_training_failure(&db, run.id, model.id, &error);
+            return Err(error);
+        }
+    };
     watchdog_task.abort();
-    let mut output = output_result??;
+    let mut output = fail_training_on_err!(output_result);
     output.metrics.insert(
         "safety.timeout_seconds".to_string(),
         safety_timeout.as_secs() as f64,
@@ -1059,12 +1087,12 @@ pub async fn start_training(
     drop(progress_tx);
     let _ = log_task.await;
 
-    if bail_if_cancelled("audio")? {
+    if fail_training_on_err!(bail_if_cancelled("audio")) {
         return Ok(());
     }
-    db.with_conn(|conn| {
+    fail_training_on_err!(db.with_conn(|conn| {
         queries::update_training_run_progress(conn, run.id, "audio", "running", 0.55, None, 0)
-    })?;
+    }));
 
     let audio_features = output
         .audio_features
@@ -1080,13 +1108,15 @@ pub async fn start_training(
         })
         .collect::<Vec<_>>();
 
-    if bail_if_cancelled("audio_features")? {
+    if fail_training_on_err!(bail_if_cancelled("audio_features")) {
         return Ok(());
     }
-    db.with_conn(|conn| queries::replace_track_audio_features(conn, &audio_features))?;
-    db.with_conn(|conn| {
+    fail_training_on_err!(
+        db.with_conn(|conn| queries::replace_track_audio_features(conn, &audio_features))
+    );
+    fail_training_on_err!(db.with_conn(|conn| {
         queries::update_training_run_progress(conn, run.id, "fusion", "running", 0.72, None, 0)
-    })?;
+    }));
 
     let embeddings = output
         .fusion_embeddings
@@ -1096,10 +1126,14 @@ pub async fn start_training(
             (track_id, pack_vector_f64(vector), norm)
         })
         .collect::<Vec<_>>();
-    if bail_if_cancelled("fusion")? {
+    if fail_training_on_err!(bail_if_cancelled("fusion")) {
         return Ok(());
     }
-    db.with_conn(|conn| queries::replace_track_embeddings(conn, model.id, &embeddings))?;
+    fail_training_on_err!(db.with_conn(|conn| queries::replace_track_embeddings(
+        conn,
+        model.id,
+        &embeddings
+    )));
 
     let neighbors = output
         .neighbors
@@ -1138,14 +1172,14 @@ pub async fn start_training(
             }
         })
         .collect::<Vec<_>>();
-    if bail_if_cancelled("neighbors")? {
+    if fail_training_on_err!(bail_if_cancelled("neighbors")) {
         return Ok(());
     }
-    db.with_conn(|conn| {
+    fail_training_on_err!(db.with_conn(|conn| {
         queries::update_training_run_progress(conn, run.id, "neighbors", "running", 0.88, None, 0)?;
         queries::replace_track_neighbors(conn, model.id, &neighbors)?;
         persist_external_neighbors(conn, model.id, &output.external_neighbors)
-    })?;
+    }));
 
     // Persist per-reason hit-rate diagnostics. The trainer's primary_reason
     // tags drive these rows; the next iteration of metadata-bonus tuning reads
@@ -1164,11 +1198,19 @@ pub async fn start_training(
             insufficient_data: r.insufficient_data,
         })
         .collect();
-    db.with_conn(|conn| queries::replace_discovery_diagnostics(conn, model.id, &reason_rows))?;
+    fail_training_on_err!(db.with_conn(|conn| queries::replace_discovery_diagnostics(
+        conn,
+        model.id,
+        &reason_rows
+    )));
 
-    append_active_baseline_metrics(&db, &mut output.metrics, &heldout_examples)?;
+    fail_training_on_err!(append_active_baseline_metrics(
+        &db,
+        &mut output.metrics,
+        &heldout_examples
+    ));
 
-    let metrics_json = serde_json::to_string(&output.metrics)?;
+    let metrics_json = fail_training_on_err!(serde_json::to_string(&output.metrics));
     let coverage = output.metrics.get("coverage_ratio").copied().unwrap_or(0.0);
     let recall = output
         .metrics
@@ -1227,19 +1269,36 @@ pub async fn start_training(
         } else {
             coverage >= 0.5
         };
-    if bail_if_cancelled("evaluate")? {
+    if fail_training_on_err!(bail_if_cancelled("evaluate")) {
         return Ok(());
     }
-    db.with_conn(|conn| {
+    fail_training_on_err!(db.with_conn(|conn| {
         queries::update_training_run_progress(conn, run.id, "evaluate", "running", 0.96, None, 0)?;
         queries::update_embedding_model_metrics(conn, model.id, "ready", Some(&metrics_json))?;
         if should_activate {
             queries::activate_embedding_model(conn, model.id)?;
         }
         queries::finish_training_run(conn, run.id, "completed")
-    })?;
+    }));
 
     Ok(())
+}
+
+fn mark_training_failure(db: &Database, run_id: i64, model_id: i64, error: &anyhow::Error) {
+    let error_text = error.to_string();
+    if let Err(mark_error) = db.with_conn(|conn| {
+        queries::fail_training_run(conn, run_id, &error_text)?;
+        queries::fail_embedding_model(conn, model_id)
+    }) {
+        tracing::error!(
+            target: "noor.discovery.training",
+            run_id,
+            model_id,
+            original_error = %error,
+            mark_error = %mark_error,
+            "failed to persist discovery training failure"
+        );
+    }
 }
 
 pub fn load_active_learning_model(db: &Database) -> Result<Option<ActiveLearningModel>> {
@@ -1597,6 +1656,7 @@ fn build_trainer_input(
     conn: &rusqlite::Connection,
     intensity: IntensityParams,
     full_mode: bool,
+    rebuild_audio: bool,
 ) -> Result<TrainerInput> {
     let tracks = queries::get_embedding_track_rows(conn)?;
     let external_candidates =
@@ -1681,13 +1741,23 @@ fn build_trainer_input(
     // run. We only reuse rows whose stored vector dim matches the current
     // intensity tier — flipping Max→Medium changes the vector size, in which
     // case the cache is invalid and we recompute. None when full_mode is true,
-    // when intensity skips audio entirely (Low), or when no cache rows match.
-    let cached_audio_features = if !full_mode && intensity.include_audio_proxy {
-        let expected_dim = intensity.dimension as usize;
-        hydrate_cached_audio_features(queries::get_cached_audio_features(conn)?, expected_dim)
-    } else {
-        None
-    };
+    // the caller requested an audio refit, intensity skips audio entirely
+    // (Low), or no cache rows match.
+    let cached_audio_features =
+        if should_reuse_cached_audio_features(intensity, full_mode, rebuild_audio) {
+            let expected_dim = intensity.dimension as usize;
+            let expected_track_ids = tracks
+                .iter()
+                .map(|track| track.track_id)
+                .collect::<HashSet<_>>();
+            hydrate_cached_audio_features(
+                queries::get_cached_audio_features(conn)?,
+                expected_dim,
+                &expected_track_ids,
+            )
+        } else {
+            None
+        };
 
     Ok(TrainerInput {
         seed: 13,
@@ -1748,13 +1818,25 @@ fn build_trainer_input(
     })
 }
 
+fn should_reuse_cached_audio_features(
+    intensity: IntensityParams,
+    full_mode: bool,
+    rebuild_audio: bool,
+) -> bool {
+    !full_mode && !rebuild_audio && intensity.include_audio_proxy
+}
+
 fn hydrate_cached_audio_features(
     rows: Vec<queries::CachedAudioFeatureRow>,
     expected_dim: usize,
+    expected_track_ids: &HashSet<i64>,
 ) -> Option<HashMap<i64, crate::services::discovery_trainer::TrainerAudioFeature>> {
     let map: HashMap<i64, crate::services::discovery_trainer::TrainerAudioFeature> = rows
         .into_iter()
         .filter_map(|row| {
+            if !expected_track_ids.contains(&row.track_id) {
+                return None;
+            }
             if row.feature_version != AUDIO_PROXY_FEATURE_VERSION {
                 return None;
             }
@@ -1773,7 +1855,16 @@ fn hydrate_cached_audio_features(
             ))
         })
         .collect();
-    if map.is_empty() { None } else { Some(map) }
+    if !expected_track_ids.is_empty()
+        && map.len() == expected_track_ids.len()
+        && expected_track_ids
+            .iter()
+            .all(|track_id| map.contains_key(track_id))
+    {
+        Some(map)
+    } else {
+        None
+    }
 }
 
 fn centroid_for_ids(active: &ActiveLearningModel, anchor_ids: &[i64]) -> Vec<f64> {
@@ -2066,12 +2157,68 @@ mod tests {
             clip_duration_ms: 20_000,
         }];
 
-        let hydrated = hydrate_cached_audio_features(rows, 2);
+        let hydrated = hydrate_cached_audio_features(rows, 2, &HashSet::from([1]));
 
         assert!(
             hydrated.is_none(),
             "v1 proxy vectors must not be reused after v2 DSP token expansion"
         );
+    }
+
+    #[test]
+    fn cached_audio_features_reject_partial_track_coverage() {
+        let rows = vec![queries::CachedAudioFeatureRow {
+            track_id: 1,
+            feature_version: AUDIO_PROXY_FEATURE_VERSION.to_string(),
+            vector_blob: pack_vector_f64(&[0.5, 0.5]),
+            clip_start_ms: 0,
+            clip_duration_ms: 20_000,
+        }];
+
+        let hydrated = hydrate_cached_audio_features(rows, 2, &HashSet::from([1, 2]));
+
+        assert!(
+            hydrated.is_none(),
+            "partial audio cache must recompute instead of silently dropping uncached tracks to behavioral-only fusion"
+        );
+    }
+
+    #[test]
+    fn cached_audio_features_ignore_stale_rows_outside_training_corpus() {
+        let rows = vec![
+            queries::CachedAudioFeatureRow {
+                track_id: 1,
+                feature_version: AUDIO_PROXY_FEATURE_VERSION.to_string(),
+                vector_blob: pack_vector_f64(&[0.5, 0.5]),
+                clip_start_ms: 0,
+                clip_duration_ms: 20_000,
+            },
+            queries::CachedAudioFeatureRow {
+                track_id: 99,
+                feature_version: AUDIO_PROXY_FEATURE_VERSION.to_string(),
+                vector_blob: pack_vector_f64(&[0.25, 0.75]),
+                clip_start_ms: 0,
+                clip_duration_ms: 20_000,
+            },
+        ];
+
+        let hydrated = hydrate_cached_audio_features(rows, 2, &HashSet::from([1]))
+            .expect("stale cache row should not force recompute");
+
+        assert_eq!(hydrated.len(), 1);
+        assert!(hydrated.contains_key(&1));
+        assert!(!hydrated.contains_key(&99));
+    }
+
+    #[test]
+    fn cached_audio_features_are_skipped_when_audio_rebuild_requested() {
+        let medium = DiscoveryIntensity::Medium.params();
+        let low = DiscoveryIntensity::Low.params();
+
+        assert!(should_reuse_cached_audio_features(medium, false, false));
+        assert!(!should_reuse_cached_audio_features(medium, false, true));
+        assert!(!should_reuse_cached_audio_features(medium, true, false));
+        assert!(!should_reuse_cached_audio_features(low, false, false));
     }
 
     #[test]
@@ -2243,6 +2390,57 @@ mod tests {
             })
             .expect("count models");
         assert_eq!(model_count, 0);
+    }
+
+    #[tokio::test]
+    async fn start_training_marks_run_and_model_failed_when_setup_errors_after_creation() {
+        let db = Database::open_in_memory().expect("in-memory db");
+        db.run_migrations().expect("migrations");
+        db.with_conn(|conn| {
+            conn.execute("DROP TABLE tracks", [])?;
+            Ok(())
+        })
+        .expect("break trainer input setup");
+        let (event_tx, _) = tokio::sync::broadcast::channel::<AppEvent>(1);
+
+        let err = start_training(
+            db.clone(),
+            event_tx,
+            false,
+            false,
+            Arc::new(AtomicBool::new(false)),
+            ExternalProviderRefreshClients::default(),
+        )
+        .await
+        .expect_err("broken setup should fail training");
+
+        assert!(
+            err.to_string().contains("no such table: tracks"),
+            "unexpected error: {err}"
+        );
+        let (run_status, run_progress, run_error, model_status) = db
+            .with_conn(|conn| {
+                let run =
+                    queries::get_latest_training_run(conn)?.expect("training run should exist");
+                let model_id = run.model_id.expect("training run should have model");
+                let model_status: String = conn.query_row(
+                    "SELECT status FROM embedding_models WHERE id = ?1",
+                    [model_id],
+                    |row| row.get(0),
+                )?;
+                Ok((run.status, run.progress, run.error_text, model_status))
+            })
+            .expect("read failed run");
+
+        assert_eq!(run_status, "failed");
+        assert_eq!(run_progress, 0.05);
+        assert!(
+            run_error
+                .as_deref()
+                .is_some_and(|text| text.contains("no such table: tracks")),
+            "run should store failure text, got {run_error:?}"
+        );
+        assert_eq!(model_status, "failed");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Improve WASAPI exclusive format negotiation and fallback recovery.
- Apply persisted exclusive output settings when the runtime starts.
- Merge the remaining discovery audio refit branch work for trainer failure handling.

## Test Plan
- cargo test -p noor-server wasapi_exclusive
- cargo test -p noor-server playback::runtime::tests
- cargo test -p noor-server learning
- cargo test -p noor-server runtime_output_settings_preserve_persisted_exclusive_preferences
- cargo test -p noor-server disabling_exclusive_clears_runtime_engaged_state
- cargo test -p noor-server audio_settings
- cargo fmt --all -- --check
- npm run check
