### PR TITLE
Radio: auto-build track_similarity index, + db projection refactor

### DIFF
--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -2087,6 +2087,12 @@ export const api = {
 		});
 	},
 
+	getRadioSimilarityStatus() {
+		return fetchApi<{ row_count: number; computed_at: string | null }>(
+			'/api/discovery/radio/status',
+		);
+	},
+
 	search(query: string, limit = 20) {
 		return fetchApi<SearchResults>('/api/search', { q: query, limit: String(limit) });
 	},

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -2088,7 +2088,7 @@ export const api = {
 	},
 
 	getRadioSimilarityStatus() {
-		return fetchApi<{ row_count: number; computed_at: string | null }>(
+		return fetchApi<{ row_count: number; built_at: string | null }>(
 			'/api/discovery/radio/status',
 		);
 	},

--- a/frontend/src/lib/api/ws.ts
+++ b/frontend/src/lib/api/ws.ts
@@ -19,6 +19,7 @@ export type WsMessage =
 	| { type: 'listen_history_updated'; track_id: number }
 	| { type: 'playback_failed'; message: string }
 	| { type: 'library_synced' }
+	| { type: 'radio_similarity_computed'; pairs: number }
 	| { type: 'musicbrainz_enriched' }
 	| { type: 'sync_progress'; service: string; progress: number }
 	| { type: 'sync_failed'; service: string; message: string }

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -100,7 +100,7 @@
 	let galaxyRefreshLabel = $state('');
 
 	let radioSimilarityRowCount = $state<number | null>(null);
-	let radioSimilarityComputedAt = $state<string | null>(null);
+	let radioSimilarityBuiltAt = $state<string | null>(null);
 	let radioSimilarityBusy = $state(false);
 	let radioSimilarityLabel = $state('');
 	// Set on unmount so the build poll loop can't outlive the component.
@@ -869,7 +869,7 @@
 		try {
 			const status = await api.getRadioSimilarityStatus();
 			radioSimilarityRowCount = status.row_count;
-			radioSimilarityComputedAt = status.computed_at;
+			radioSimilarityBuiltAt = status.built_at;
 			markServerOnline();
 		} catch (error) {
 			if (isFetchConnectionError(error)) markServerOffline();
@@ -883,12 +883,18 @@
 	async function buildRadioSimilarity() {
 		if (radioSimilarityBusy) return;
 		radioSimilarityBusy = true;
-		// Detect completion by a change in computed_at, not row count — a rebuild
-		// can legitimately produce the same number of pairs.
-		const before = radioSimilarityComputedAt;
+		// Detect completion by a change in built_at, not row count — a rebuild
+		// can legitimately produce the same number of pairs, or zero.
+		const before = radioSimilarityBuiltAt;
 		try {
 			const response = await api.computeRadioSimilarity();
 			markServerOnline();
+			if (response.status === 'busy') {
+				// The server declined: a sync/playback/enrichment writer is
+				// active. Nothing is building, so don't poll.
+				radioSimilarityLabel = response.message;
+				return;
+			}
 			radioSimilarityLabel =
 				response.status === 'already_running'
 					? 'A rebuild is already running. Watching for it to finish…'
@@ -898,7 +904,7 @@
 				await new Promise((resolve) => setTimeout(resolve, 3000));
 				if (componentUnmounted) return;
 				await loadRadioSimilarityStatus();
-				if (radioSimilarityComputedAt !== before) {
+				if (radioSimilarityBuiltAt !== before) {
 					radioSimilarityLabel = `Index ready: ${radioSimilarityRowCount?.toLocaleString()} pairs.`;
 					return;
 				}
@@ -2527,7 +2533,7 @@
 					</div>
 					<div class="info-row">
 						<span>Last built</span>
-						<strong>{radioSimilarityComputedAt ?? 'Never'}</strong>
+						<strong>{radioSimilarityBuiltAt ?? 'Never'}</strong>
 					</div>
 				</div>
 				<div class="action-row">

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -99,6 +99,13 @@
 	let portableStatusLabel = $state('');
 	let galaxyRefreshLabel = $state('');
 
+	let radioSimilarityRowCount = $state<number | null>(null);
+	let radioSimilarityComputedAt = $state<string | null>(null);
+	let radioSimilarityBusy = $state(false);
+	let radioSimilarityLabel = $state('');
+	// Set on unmount so the build poll loop can't outlive the component.
+	let componentUnmounted = false;
+
 	let spotifyConfigured = $state(false);
 	let spotifyClientId = $state('');
 	let spotifyClientSecret = $state('');
@@ -295,6 +302,16 @@
 			) {
 				void loadPlaybackRuntime();
 			}
+
+			if (latest.type === 'radio_similarity_computed') {
+				void loadRadioSimilarityStatus();
+				if (!radioSimilarityBusy) {
+					const pairs = typeof latest.pairs === 'number' ? latest.pairs : null;
+					radioSimilarityLabel = pairs
+						? `Index rebuilt automatically: ${pairs.toLocaleString()} pairs.`
+						: 'Radio similarity index rebuilt automatically.';
+				}
+			}
 		});
 
 		void refreshTidalStatus();
@@ -307,6 +324,7 @@
 		void loadDiscoveryIntensity();
 		void loadDiscoverySafetyProfile();
 		void loadDiscoverySafety();
+		void loadRadioSimilarityStatus();
 		void loadAudioStats();
 		void syncAnalysisStatus();
 		void loadPassiveDspState();
@@ -320,6 +338,7 @@
 			clearInterval(discoveryTrainingPoll);
 			clearInterval(tick);
 			wsUnsubscribe?.();
+			componentUnmounted = true;
 		};
 	});
 
@@ -845,6 +864,59 @@
 	let discoveryIsRunning = $derived(
 		discoveryStatus?.latest_run?.status === 'running'
 	);
+
+	async function loadRadioSimilarityStatus() {
+		try {
+			const status = await api.getRadioSimilarityStatus();
+			radioSimilarityRowCount = status.row_count;
+			radioSimilarityComputedAt = status.computed_at;
+			markServerOnline();
+		} catch (error) {
+			if (isFetchConnectionError(error)) markServerOffline();
+		}
+	}
+
+	// The compute route is fire-and-forget. Completion normally arrives via the
+	// `radio_similarity_computed` WS event; this poll is the fallback for a
+	// dropped socket. It exits when the row count moves, on unmount, or after
+	// the deadline.
+	async function buildRadioSimilarity() {
+		if (radioSimilarityBusy) return;
+		radioSimilarityBusy = true;
+		// Detect completion by a change in computed_at, not row count — a rebuild
+		// can legitimately produce the same number of pairs.
+		const before = radioSimilarityComputedAt;
+		try {
+			const response = await api.computeRadioSimilarity();
+			markServerOnline();
+			radioSimilarityLabel =
+				response.status === 'already_running'
+					? 'A rebuild is already running. Watching for it to finish…'
+					: 'Building radio similarity index…';
+			const deadline = Date.now() + 10 * 60 * 1000;
+			while (Date.now() < deadline && !componentUnmounted) {
+				await new Promise((resolve) => setTimeout(resolve, 3000));
+				if (componentUnmounted) return;
+				await loadRadioSimilarityStatus();
+				if (radioSimilarityComputedAt !== before) {
+					radioSimilarityLabel = `Index ready: ${radioSimilarityRowCount?.toLocaleString()} pairs.`;
+					return;
+				}
+			}
+			if (!componentUnmounted) {
+				radioSimilarityLabel = 'Still building. Check back in a few minutes.';
+			}
+		} catch (error) {
+			if (isFetchConnectionError(error)) {
+				markServerOffline();
+				radioSimilarityLabel = SERVER_UNREACHABLE_MESSAGE;
+			} else {
+				radioSimilarityLabel = `Build failed: ${error}`;
+			}
+		} finally {
+			radioSimilarityBusy = false;
+		}
+	}
 
 	// Intensity tier + safety estimate. Both load once on mount and refresh
 	// after the intensity changes so the safety preview reflects the new
@@ -2437,6 +2509,35 @@
 						<button class="btn btn-glass" onclick={() => void stopDiscoveryTraining()}>Stop</button>
 					{/if}
 				</div>
+			</section>
+
+			<section class="glass-panel section-panel">
+				<SectionHeader
+					eyebrow="Learning"
+					title="Radio similarity index"
+					subtitle="Metadata-heuristic recall lane for radio (co-album, co-artist, co-listen, genre)."
+				/>
+				<p>
+					The radio Engine lane reads a precomputed <code>track_similarity</code> index. It's separate from the discovery model's learned neighbours — radio uses both. If it's never built, the Engine lane silently contributes nothing. Building it can take a few minutes on large libraries.
+				</p>
+				<div class="info-list">
+					<div class="info-row">
+						<span>Indexed pairs</span>
+						<strong>{radioSimilarityRowCount === null ? '—' : radioSimilarityRowCount.toLocaleString()}</strong>
+					</div>
+					<div class="info-row">
+						<span>Last built</span>
+						<strong>{radioSimilarityComputedAt ?? 'Never'}</strong>
+					</div>
+				</div>
+				<div class="action-row">
+					<button class="btn btn-primary" onclick={() => void buildRadioSimilarity()} disabled={radioSimilarityBusy}>
+						{radioSimilarityBusy ? 'Building…' : 'Build radio similarity index'}
+					</button>
+				</div>
+				{#if radioSimilarityLabel}
+					<p class="galaxy-refresh-label">{radioSimilarityLabel}</p>
+				{/if}
 			</section>
 			{/if}
 		</div>

--- a/noor-server/src/db/mod.rs
+++ b/noor-server/src/db/mod.rs
@@ -5,30 +5,37 @@ pub mod schema;
 
 use anyhow::Result;
 use rusqlite::Connection;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use tracing::info;
+
+/// Per-connection pragmas. Applied to the shared connection and to every
+/// isolated connection from `open_isolated`, so a background worker behaves
+/// identically to the request path.
+const CONNECTION_PRAGMAS: &str = "PRAGMA journal_mode = WAL;
+     PRAGMA synchronous = NORMAL;
+     PRAGMA foreign_keys = ON;
+     PRAGMA busy_timeout = 5000;
+     PRAGMA cache_size = -64000;";
 
 #[derive(Clone)]
 pub struct Database {
     conn: Arc<Mutex<Connection>>,
+    /// The database file path, kept so background jobs can open their own
+    /// connection via `open_isolated`. `None` for in-memory test databases,
+    /// which cannot be shared across connections.
+    path: Option<PathBuf>,
 }
 
 impl Database {
     pub fn open(path: impl AsRef<Path>) -> Result<Self> {
-        let conn = Connection::open(path)?;
-
-        // Performance settings
-        conn.execute_batch(
-            "PRAGMA journal_mode = WAL;
-             PRAGMA synchronous = NORMAL;
-             PRAGMA foreign_keys = ON;
-             PRAGMA busy_timeout = 5000;
-             PRAGMA cache_size = -64000;",
-        )?;
+        let path = path.as_ref().to_path_buf();
+        let conn = Connection::open(&path)?;
+        conn.execute_batch(CONNECTION_PRAGMAS)?;
 
         Ok(Self {
             conn: Arc::new(Mutex::new(conn)),
+            path: Some(path),
         })
     }
 
@@ -38,7 +45,24 @@ impl Database {
         conn.execute_batch("PRAGMA foreign_keys = ON;")?;
         Ok(Self {
             conn: Arc::new(Mutex::new(conn)),
+            path: None,
         })
+    }
+
+    /// Open a fresh, independent connection to the same database file.
+    ///
+    /// Used by long-running background jobs (e.g. the radio similarity index
+    /// rebuild) so they never hold the shared connection mutex: a multi-minute
+    /// write transaction on this connection lets every request-path read keep
+    /// flowing in WAL mode instead of freezing the whole server. Errors for an
+    /// in-memory database, which has no shareable file.
+    pub fn open_isolated(&self) -> Result<Connection> {
+        let path = self.path.as_ref().ok_or_else(|| {
+            anyhow::anyhow!("cannot open an isolated connection for an in-memory database")
+        })?;
+        let conn = Connection::open(path)?;
+        conn.execute_batch(CONNECTION_PRAGMAS)?;
+        Ok(conn)
     }
 
     pub fn run_migrations(&self) -> Result<()> {

--- a/noor-server/src/db/queries.rs
+++ b/noor-server/src/db/queries.rs
@@ -8727,6 +8727,93 @@ mod tests {
         assert_eq!(s.cohorts.len(), 3);
         assert!(s.audio_profile.loudness_lufs.is_none());
     }
+
+    /// Seed one track with a distinct value in every projected column, so a
+    /// row-shape test can catch any column drift in `track_projection` /
+    /// `track_from_row`.
+    fn seed_fully_populated_track(conn: &Connection) {
+        conn.execute(
+            "INSERT INTO artists (id, name) VALUES (7, 'Projection Artist')",
+            [],
+        )
+        .expect("seed artist");
+        conn.execute(
+            "INSERT INTO albums (id, title, artist_id, source, artwork_url)
+             VALUES (3, 'Projection Album', 7, 'tidal', 'http://art/proj.jpg')",
+            [],
+        )
+        .expect("seed album");
+        conn.execute(
+            "INSERT INTO tracks (
+                id, title, artist_id, album_id, disc_number, track_number,
+                duration_ms, isrc, tidal_id, ytmusic_id, soundcloud_id,
+                best_quality, best_source, fidelity_score, is_favorite,
+                play_count, last_played_at, date_added, source
+             ) VALUES (
+                42, 'Projection Track', 7, 3, 2, 11,
+                234567, 'ISRCPROJ01', 99887, 'ytproj', 55443,
+                'HI_RES', 'tidal', 88, 1,
+                17, '2026-05-01T12:00:00Z', '2026-04-01T00:00:00Z', 'tidal'
+             )",
+            [],
+        )
+        .expect("seed track");
+    }
+
+    /// Every field on `Track` must round-trip through the shared projection.
+    /// `assert_track_is_fully_populated_seed` is reused by the two query-path
+    /// tests below that previously had no direct row-shape coverage.
+    fn assert_track_is_fully_populated_seed(track: &Track) {
+        assert_eq!(track.id, 42);
+        assert_eq!(track.title, "Projection Track");
+        assert_eq!(track.artist_id, 7);
+        assert_eq!(track.artist_name.as_deref(), Some("Projection Artist"));
+        assert_eq!(track.album_id, Some(3));
+        assert_eq!(track.album_title.as_deref(), Some("Projection Album"));
+        assert_eq!(track.disc_number, Some(2));
+        assert_eq!(track.track_number, Some(11));
+        assert_eq!(track.duration_ms, Some(234567));
+        assert_eq!(track.isrc.as_deref(), Some("ISRCPROJ01"));
+        assert_eq!(track.tidal_id, Some(99887));
+        assert_eq!(track.ytmusic_id.as_deref(), Some("ytproj"));
+        assert_eq!(track.soundcloud_id, Some(55443));
+        assert_eq!(track.best_quality.as_deref(), Some("HI_RES"));
+        assert_eq!(track.best_source.as_deref(), Some("tidal"));
+        assert_eq!(track.fidelity_score, 88);
+        assert!(track.is_favorite);
+        assert_eq!(track.play_count, 17);
+        assert_eq!(track.last_played_at.as_deref(), Some("2026-05-01T12:00:00Z"));
+        assert_eq!(track.date_added.as_deref(), Some("2026-04-01T00:00:00Z"));
+        assert_eq!(track.source, "tidal");
+        assert_eq!(track.artwork_url.as_deref(), Some("http://art/proj.jpg"));
+    }
+
+    #[test]
+    fn get_discovery_candidate_tracks_maps_every_projected_column() {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        schema::run_migrations(&conn).expect("migrations");
+        seed_fully_populated_track(&conn);
+
+        let tracks = get_discovery_candidate_tracks(&conn, 10).expect("candidates");
+        assert_eq!(tracks.len(), 1);
+        assert_track_is_fully_populated_seed(&tracks[0]);
+    }
+
+    #[test]
+    fn get_tracks_excluding_with_limit_maps_every_projected_column() {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        schema::run_migrations(&conn).expect("migrations");
+        seed_fully_populated_track(&conn);
+
+        // Empty exclusion list + a generous cap returns the seed track.
+        let tracks = get_tracks_excluding_with_limit(&conn, &[], 50).expect("candidates");
+        assert_eq!(tracks.len(), 1);
+        assert_track_is_fully_populated_seed(&tracks[0]);
+
+        // And the exclusion path still filters correctly.
+        let excluded = get_tracks_excluding_with_limit(&conn, &[42], 50).expect("excluded");
+        assert!(excluded.is_empty(), "id 42 must be excluded");
+    }
 }
 
 /// Load enough metadata about a library track to seed external Tidal discovery.

--- a/noor-server/src/db/queries.rs
+++ b/noor-server/src/db/queries.rs
@@ -4142,6 +4142,18 @@ pub fn get_radio_similarity_built_at(conn: &Connection) -> Result<Option<String>
         .optional()?)
 }
 
+/// True when a discovery training run is in progress. The radio similarity
+/// rebuild must not run alongside training: training writes heavily through the
+/// shared connection, and the rebuild's long write transaction would starve it
+/// past the busy timeout and fail the run.
+pub fn is_discovery_training_running(conn: &Connection) -> Result<bool> {
+    Ok(conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM training_runs WHERE status = 'running')",
+        [],
+        |row| row.get(0),
+    )?)
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EmbeddingTrackRow {
     pub track_id: i64,
@@ -6920,6 +6932,31 @@ mod tests {
             .expect("selected legacy model");
         assert_eq!(selected.id, legacy.id);
         assert_eq!(selected.family, "discovery-fusion");
+    }
+
+    #[test]
+    fn is_discovery_training_running_tracks_run_status() {
+        // Regression: the radio similarity rebuild gates on this so it can't run
+        // a multi-minute write transaction alongside discovery training.
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        schema::run_migrations(&conn).expect("migrations");
+
+        assert!(
+            !is_discovery_training_running(&conn).expect("query"),
+            "no runs => not training"
+        );
+
+        let run = create_training_run(&conn, None, "behavioral", "running").expect("create run");
+        assert!(
+            is_discovery_training_running(&conn).expect("query"),
+            "a running row => training in progress, rebuild must defer"
+        );
+
+        finish_training_run(&conn, run.id, "completed").expect("finish run");
+        assert!(
+            !is_discovery_training_running(&conn).expect("query"),
+            "completed run => training done, rebuild may proceed"
+        );
     }
 
     #[test]

--- a/noor-server/src/db/queries.rs
+++ b/noor-server/src/db/queries.rs
@@ -152,6 +152,26 @@ fn track_order_clause(sort_by: &str, sort_dir: &str) -> String {
     }
 }
 
+/// The 22-column track projection shared by every query whose rows are mapped
+/// by `track_from_row`. Pass the alias the query uses for the joined `artists`
+/// table: `a` everywhere except `get_tracks_with_dsp`, which joins
+/// `audio_dsp_features` as `a` and so must alias artists as `a_artists`.
+///
+/// Column ORDER is load-bearing: `track_from_row` reads by index, and
+/// `search_tracks_fts` does positional ORDER BY against these columns. Only
+/// ever append a column here, and update `track_from_row` to match.
+fn track_projection(artist_alias: &str) -> String {
+    format!(
+        "t.id, t.title, t.artist_id, {artist_alias}.name as artist_name,
+                t.album_id, al.title as album_title,
+                t.disc_number, t.track_number, t.duration_ms, t.isrc,
+                t.tidal_id, t.ytmusic_id, t.soundcloud_id,
+                t.best_quality, t.best_source, t.fidelity_score,
+                t.is_favorite, t.play_count, t.last_played_at,
+                t.date_added, t.source, al.artwork_url"
+    )
+}
+
 pub fn get_tracks(
     conn: &Connection,
     sort_by: &str,
@@ -228,14 +248,9 @@ pub fn get_tracks_with_dsp(
         format!(" WHERE {}", conditions.join(" AND "))
     };
 
+    let projection = track_projection("a_artists");
     let sql = format!(
-        "SELECT t.id, t.title, t.artist_id, a_artists.name as artist_name,
-                t.album_id, al.title as album_title,
-                t.disc_number, t.track_number, t.duration_ms, t.isrc,
-                t.tidal_id, t.ytmusic_id, t.soundcloud_id,
-                t.best_quality, t.best_source, t.fidelity_score,
-                t.is_favorite, t.play_count, t.last_played_at,
-                t.date_added, t.source, al.artwork_url
+        "SELECT {projection}
          FROM tracks t
          LEFT JOIN artists a_artists ON t.artist_id = a_artists.id
          LEFT JOIN albums al ON t.album_id = al.id
@@ -339,14 +354,8 @@ pub fn get_album_count(conn: &Connection, favorite_only: bool) -> Result<i64> {
 }
 
 pub fn get_album_tracks(conn: &Connection, album_id: i64) -> Result<Vec<Track>> {
-    let mut stmt = conn.prepare(
-        "SELECT t.id, t.title, t.artist_id, a.name as artist_name,
-                t.album_id, al.title as album_title,
-                t.disc_number, t.track_number, t.duration_ms, t.isrc,
-                t.tidal_id, t.ytmusic_id, t.soundcloud_id,
-                t.best_quality, t.best_source, t.fidelity_score,
-                t.is_favorite, t.play_count, t.last_played_at,
-                t.date_added, t.source, al.artwork_url
+    let mut stmt = conn.prepare(&format!(
+        "SELECT {}
          FROM tracks t
          LEFT JOIN artists a ON t.artist_id = a.id
          LEFT JOIN albums al ON t.album_id = al.id
@@ -355,7 +364,8 @@ pub fn get_album_tracks(conn: &Connection, album_id: i64) -> Result<Vec<Track>> 
             COALESCE(t.disc_number, 1) ASC,
             COALESCE(t.track_number, 999999) ASC,
             t.title COLLATE NOCASE ASC",
-    )?;
+        track_projection("a")
+    ))?;
 
     let tracks = stmt
         .query_map(params![album_id], track_from_row)?
@@ -568,14 +578,9 @@ fn get_artist_tracks_matching(
     artist_id: i64,
     extra_where: &str,
 ) -> Result<Vec<Track>> {
+    let projection = track_projection("a");
     let sql = format!(
-        "SELECT t.id, t.title, t.artist_id, a.name as artist_name,
-                t.album_id, al.title as album_title,
-                t.disc_number, t.track_number, t.duration_ms, t.isrc,
-                t.tidal_id, t.ytmusic_id, t.soundcloud_id,
-                t.best_quality, t.best_source, t.fidelity_score,
-                t.is_favorite, t.play_count, t.last_played_at,
-                t.date_added, t.source, al.artwork_url
+        "SELECT {projection}
          FROM tracks t
          LEFT JOIN artists a ON t.artist_id = a.id
          LEFT JOIN albums al ON t.album_id = al.id
@@ -737,20 +742,16 @@ pub fn add_tracks_to_playlist(
 }
 
 pub fn get_playlist_tracks(conn: &Connection, playlist_id: i64) -> Result<Vec<Track>> {
-    let mut stmt = conn.prepare(
-        "SELECT t.id, t.title, t.artist_id, a.name, t.album_id, al.title,
-                t.disc_number, t.track_number, t.duration_ms, t.isrc,
-                t.tidal_id, t.ytmusic_id, t.soundcloud_id,
-                t.best_quality, t.best_source, t.fidelity_score,
-                t.is_favorite, t.play_count, t.last_played_at,
-                t.date_added, t.source, al.artwork_url
+    let mut stmt = conn.prepare(&format!(
+        "SELECT {}
          FROM playlist_tracks pt
          JOIN tracks t ON pt.track_id = t.id
          LEFT JOIN artists a ON t.artist_id = a.id
          LEFT JOIN albums al ON t.album_id = al.id
          WHERE pt.playlist_id = ?1
          ORDER BY pt.position ASC",
-    )?;
+        track_projection("a")
+    ))?;
 
     let tracks = stmt
         .query_map(params![playlist_id], track_from_row)?
@@ -760,19 +761,14 @@ pub fn get_playlist_tracks(conn: &Connection, playlist_id: i64) -> Result<Vec<Tr
 }
 
 pub fn get_all_tracks(conn: &Connection) -> Result<Vec<Track>> {
-    let mut stmt = conn.prepare(
-        "SELECT t.id, t.title, t.artist_id, a.name as artist_name,
-                t.album_id, al.title as album_title,
-                t.disc_number, t.track_number, t.duration_ms, t.isrc,
-                t.tidal_id, t.ytmusic_id, t.soundcloud_id,
-                t.best_quality, t.best_source, t.fidelity_score,
-                t.is_favorite, t.play_count, t.last_played_at,
-                t.date_added, t.source, al.artwork_url
+    let mut stmt = conn.prepare(&format!(
+        "SELECT {}
          FROM tracks t
          LEFT JOIN artists a ON t.artist_id = a.id
          LEFT JOIN albums al ON t.album_id = al.id
          ORDER BY t.date_added DESC, t.id DESC",
-    )?;
+        track_projection("a")
+    ))?;
 
     let tracks = stmt
         .query_map([], track_from_row)?
@@ -1172,6 +1168,7 @@ pub fn get_tracks_by_genre_filtered(
     }
 
     let sub = crate::genre::filter::filter_subquery(filter);
+    let projection = track_projection("a");
     // The Spotify-dominance EXISTS check still queries raw `track_genres` —
     // it's a "did Spotify ever tag this track at all" predicate, independent
     // of the confidence filter that decides which clusters the track is
@@ -1185,12 +1182,7 @@ pub fn get_tracks_by_genre_filtered(
                 FROM genres g
                 JOIN selected_genres sg ON g.parent_id = sg.id
             )
-            SELECT DISTINCT t.id, t.title, t.artist_id, a.name, t.album_id, al.title,
-                    t.disc_number, t.track_number, t.duration_ms, t.isrc,
-                    t.tidal_id, t.ytmusic_id, t.soundcloud_id,
-                    t.best_quality, t.best_source, t.fidelity_score,
-                    t.is_favorite, t.play_count, t.last_played_at,
-                    t.date_added, t.source, al.artwork_url
+            SELECT DISTINCT {projection}
              FROM selected_genres sg
              JOIN ({sub}) tg ON tg.genre_id = sg.id
              JOIN tracks t ON tg.track_id = t.id
@@ -1217,12 +1209,7 @@ pub fn get_tracks_by_genre_filtered(
         )
     } else {
         format!(
-            "SELECT DISTINCT t.id, t.title, t.artist_id, a.name, t.album_id, al.title,
-                    t.disc_number, t.track_number, t.duration_ms, t.isrc,
-                    t.tidal_id, t.ytmusic_id, t.soundcloud_id,
-                    t.best_quality, t.best_source, t.fidelity_score,
-                    t.is_favorite, t.play_count, t.last_played_at,
-                    t.date_added, t.source, al.artwork_url
+            "SELECT DISTINCT {projection}
              FROM ({sub}) tg
              JOIN tracks t ON tg.track_id = t.id
              LEFT JOIN artists a ON t.artist_id = a.id
@@ -3281,19 +3268,15 @@ pub fn get_genre_evolution(conn: &Connection, days: i64) -> Result<Vec<GenreEvol
 }
 
 pub fn get_discovery_candidate_tracks(conn: &Connection, limit: i64) -> Result<Vec<Track>> {
-    let mut stmt = conn.prepare(
-        "SELECT t.id, t.title, t.artist_id, a.name, t.album_id, al.title,
-                t.disc_number, t.track_number, t.duration_ms, t.isrc,
-                t.tidal_id, t.ytmusic_id, t.soundcloud_id,
-                t.best_quality, t.best_source, t.fidelity_score,
-                t.is_favorite, t.play_count, t.last_played_at,
-                t.date_added, t.source, al.artwork_url
+    let mut stmt = conn.prepare(&format!(
+        "SELECT {}
          FROM tracks t
          LEFT JOIN artists a ON t.artist_id = a.id
          LEFT JOIN albums al ON t.album_id = al.id
          ORDER BY t.is_favorite DESC, t.play_count DESC, t.date_added DESC, t.title ASC
          LIMIT ?1",
-    )?;
+        track_projection("a")
+    ))?;
 
     let tracks = stmt
         .query_map(params![limit.max(1)], track_from_row)?
@@ -3310,16 +3293,12 @@ pub fn get_tracks_excluding_with_limit(
     excluded_track_ids: &[i64],
     max_candidates: usize,
 ) -> Result<Vec<Track>> {
-    let mut sql = String::from(
-        "SELECT t.id, t.title, t.artist_id, a.name, t.album_id, al.title,
-                t.disc_number, t.track_number, t.duration_ms, t.isrc,
-                t.tidal_id, t.ytmusic_id, t.soundcloud_id,
-                t.best_quality, t.best_source, t.fidelity_score,
-                t.is_favorite, t.play_count, t.last_played_at,
-                t.date_added, t.source, al.artwork_url
+    let mut sql = format!(
+        "SELECT {}
          FROM tracks t
          LEFT JOIN artists a ON t.artist_id = a.id
          LEFT JOIN albums al ON t.album_id = al.id",
+        track_projection("a")
     );
 
     if !excluded_track_ids.is_empty() {
@@ -3558,33 +3537,24 @@ fn search_tracks_fts(conn: &Connection, fts_query: &str, limit: i64) -> Result<V
     //   16 = t.fidelity_score
     //   17 = t.is_favorite
     //   18 = t.play_count
-    let mut stmt = conn.prepare(
-        "SELECT t.id, t.title, t.artist_id, a.name, t.album_id, al.title,
-                t.disc_number, t.track_number, t.duration_ms, t.isrc,
-                t.tidal_id, t.ytmusic_id, t.soundcloud_id,
-                t.best_quality, t.best_source, t.fidelity_score,
-                t.is_favorite, t.play_count, t.last_played_at,
-                t.date_added, t.source, al.artwork_url
+    let projection = track_projection("a");
+    let mut stmt = conn.prepare(&format!(
+        "SELECT {projection}
          FROM tracks t
          LEFT JOIN artists a ON t.artist_id = a.id
          LEFT JOIN albums al ON t.album_id = al.id
          JOIN tracks_fts ON tracks_fts.rowid = t.id
          WHERE tracks_fts MATCH ?1
          UNION
-         SELECT t.id, t.title, t.artist_id, a.name, t.album_id, al.title,
-                t.disc_number, t.track_number, t.duration_ms, t.isrc,
-                t.tidal_id, t.ytmusic_id, t.soundcloud_id,
-                t.best_quality, t.best_source, t.fidelity_score,
-                t.is_favorite, t.play_count, t.last_played_at,
-                t.date_added, t.source, al.artwork_url
+         SELECT {projection}
          FROM tracks t
          LEFT JOIN artists a ON t.artist_id = a.id
          LEFT JOIN albums al ON t.album_id = al.id
          JOIN artists_fts ON artists_fts.rowid = t.artist_id
          WHERE artists_fts MATCH ?1
          ORDER BY 17 DESC, 18 DESC, 16 DESC, 2 ASC
-         LIMIT ?2",
-    )?;
+         LIMIT ?2"
+    ))?;
     stmt.query_map(params![fts_query, limit], track_from_row)?
         .collect::<Result<Vec<_>, _>>()
         .map_err(Into::into)
@@ -3593,13 +3563,8 @@ fn search_tracks_fts(conn: &Connection, fts_query: &str, limit: i64) -> Result<V
 fn search_tracks_like(conn: &Connection, normalized: &str, limit: i64) -> Result<Vec<Track>> {
     let contains_pattern = format!("%{normalized}%");
     let prefix_pattern = format!("{normalized}%");
-    let mut stmt = conn.prepare(
-        "SELECT t.id, t.title, t.artist_id, a.name, t.album_id, al.title,
-                t.disc_number, t.track_number, t.duration_ms, t.isrc,
-                t.tidal_id, t.ytmusic_id, t.soundcloud_id,
-                t.best_quality, t.best_source, t.fidelity_score,
-                t.is_favorite, t.play_count, t.last_played_at,
-                t.date_added, t.source, al.artwork_url
+    let mut stmt = conn.prepare(&format!(
+        "SELECT {}
          FROM tracks t
          LEFT JOIN artists a ON t.artist_id = a.id
          LEFT JOIN albums al ON t.album_id = al.id
@@ -3621,7 +3586,8 @@ fn search_tracks_like(conn: &Connection, normalized: &str, limit: i64) -> Result
             t.fidelity_score DESC,
             t.title ASC
          LIMIT ?4",
-    )?;
+        track_projection("a")
+    ))?;
     stmt.query_map(
         params![contains_pattern, normalized, prefix_pattern, limit],
         track_from_row,
@@ -6291,14 +6257,9 @@ pub fn get_audio_dsp_features(
 
 pub fn get_tracks_missing_dsp_features(conn: &Connection, limit: i64) -> Result<Vec<Track>> {
     // CURRENT_ANALYSIS_VERSION is a compile-time constant — safe to interpolate.
+    let projection = track_projection("a");
     let sql = format!(
-        "SELECT t.id, t.title, t.artist_id, a.name as artist_name,
-                t.album_id, al.title as album_title,
-                t.disc_number, t.track_number, t.duration_ms, t.isrc,
-                t.tidal_id, t.ytmusic_id, t.soundcloud_id,
-                t.best_quality, t.best_source, t.fidelity_score,
-                t.is_favorite, t.play_count, t.last_played_at,
-                t.date_added, t.source, al.artwork_url
+        "SELECT {projection}
          FROM tracks t
          LEFT JOIN artists a ON t.artist_id = a.id
          LEFT JOIN albums al ON t.album_id = al.id

--- a/noor-server/src/db/queries.rs
+++ b/noor-server/src/db/queries.rs
@@ -4124,10 +4124,22 @@ pub fn get_similarity_computed_at(conn: &Connection) -> Result<Option<String>> {
         .optional()?)
 }
 
-/// Row count of the precomputed `track_similarity` index. Zero means the index
-/// was never built, which starves the radio Engine lane.
+/// Row count of the precomputed `track_similarity` index.
 pub fn count_track_similarity(conn: &Connection) -> Result<i64> {
     Ok(conn.query_row("SELECT COUNT(*) FROM track_similarity", [], |row| row.get(0))?)
+}
+
+/// Start timestamp of the last successful radio similarity rebuild. Recorded in
+/// `server_config` independently of row count — a valid library can produce
+/// zero similarity pairs, so an empty table is not the same as "never built".
+pub fn get_radio_similarity_built_at(conn: &Connection) -> Result<Option<String>> {
+    Ok(conn
+        .query_row(
+            "SELECT value FROM server_config WHERE key = 'radio_similarity_built_at'",
+            [],
+            |row| row.get(0),
+        )
+        .optional()?)
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/noor-server/src/db/queries.rs
+++ b/noor-server/src/db/queries.rs
@@ -4124,6 +4124,12 @@ pub fn get_similarity_computed_at(conn: &Connection) -> Result<Option<String>> {
         .optional()?)
 }
 
+/// Row count of the precomputed `track_similarity` index. Zero means the index
+/// was never built, which starves the radio Engine lane.
+pub fn count_track_similarity(conn: &Connection) -> Result<i64> {
+    Ok(conn.query_row("SELECT COUNT(*) FROM track_similarity", [], |row| row.get(0))?)
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EmbeddingTrackRow {
     pub track_id: i64,

--- a/noor-server/src/db/queries.rs
+++ b/noor-server/src/db/queries.rs
@@ -4126,7 +4126,11 @@ pub fn get_similarity_computed_at(conn: &Connection) -> Result<Option<String>> {
 
 /// Row count of the precomputed `track_similarity` index.
 pub fn count_track_similarity(conn: &Connection) -> Result<i64> {
-    Ok(conn.query_row("SELECT COUNT(*) FROM track_similarity", [], |row| row.get(0))?)
+    Ok(
+        conn.query_row("SELECT COUNT(*) FROM track_similarity", [], |row| {
+            row.get(0)
+        })?,
+    )
 }
 
 /// Start timestamp of the last successful radio similarity rebuild. Recorded in
@@ -8837,7 +8841,10 @@ mod tests {
         assert_eq!(track.fidelity_score, 88);
         assert!(track.is_favorite);
         assert_eq!(track.play_count, 17);
-        assert_eq!(track.last_played_at.as_deref(), Some("2026-05-01T12:00:00Z"));
+        assert_eq!(
+            track.last_played_at.as_deref(),
+            Some("2026-05-01T12:00:00Z")
+        );
         assert_eq!(track.date_added.as_deref(), Some("2026-04-01T00:00:00Z"));
         assert_eq!(track.source, "tidal");
         assert_eq!(track.artwork_url.as_deref(), Some("http://art/proj.jpg"));

--- a/noor-server/src/db/schema.rs
+++ b/noor-server/src/db/schema.rs
@@ -41,6 +41,7 @@ const MIGRATIONS: &[&str] = &[
     MIGRATION_037,
     MIGRATION_038,
     MIGRATION_039,
+    MIGRATION_040,
 ];
 
 const MIGRATION_001: &str = r#"
@@ -1100,6 +1101,14 @@ ALTER TABLE sync_metadata ADD COLUMN tidal_favorite_track_cursor TEXT;
 /// port BLSTM) doubles the result.
 const MIGRATION_039: &str = r#"
 ALTER TABLE audio_dsp_features ADD COLUMN manual_override INTEGER NOT NULL DEFAULT 0;
+"#;
+
+// Health signal for the radio Engine lane. `actual_engine_count = 0` alone is
+// ambiguous: it can mean "no track_similarity match for this seed" or "the
+// track_similarity index was never built". This flag disambiguates so an empty
+// index is an obvious signal in radio_diagnostics rather than a silent zero.
+const MIGRATION_040: &str = r#"
+ALTER TABLE radio_diagnostics ADD COLUMN engine_index_empty INTEGER NOT NULL DEFAULT 0;
 "#;
 
 pub fn run_migrations(conn: &Connection) -> Result<()> {

--- a/noor-server/src/main.rs
+++ b/noor-server/src/main.rs
@@ -125,6 +125,10 @@ pub struct AppState {
     /// Discovery training cancel flag — flipped to true by POST /api/discovery/train/stop,
     /// reset to false at the start of each training run.
     pub discovery_train_cancel: Arc<AtomicBool>,
+    /// Single-flight guard for the radio similarity index rebuild. Held while
+    /// `compute_track_similarity` runs so overlapping `LibrarySynced` events and
+    /// the daily catch-up ticker don't kick off a second multi-minute rebuild.
+    pub radio_similarity_running: Arc<AtomicBool>,
     /// Seeds already refreshed this session, with model_id + timestamp.
     /// Entries expire after `REFRESH_TTL` or whenever the active model_id changes,
     /// so re-training or long sessions don't pin stale neighbor data.
@@ -186,6 +190,12 @@ pub struct AppState {
 pub enum AppEvent {
     PlaybackStateChanged,
     LibrarySynced,
+    /// Emitted when the radio similarity index (`track_similarity`) finishes
+    /// rebuilding, manually or via the auto-rebuild listener. Carries the pair
+    /// count so the Settings panel can refresh without polling.
+    RadioSimilarityComputed {
+        pairs: i64,
+    },
     MusicBrainzEnriched,
     TrackChanged {
         track_id: i64,
@@ -598,6 +608,7 @@ async fn main() -> Result<()> {
         lastfm_prefetch_done: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
         lastfm_enrich_started_at: Arc::new(std::sync::atomic::AtomicI64::new(0)),
         discovery_train_cancel: Arc::new(AtomicBool::new(false)),
+        radio_similarity_running: Arc::new(AtomicBool::new(false)),
         refreshed_seeds: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         embedding_cache: Arc::new(tokio::sync::Mutex::new(None)),
         master_key,
@@ -737,6 +748,70 @@ async fn main() -> Result<()> {
             loop {
                 ticker.tick().await;
                 services::auto_enrich::run_if_idle(loop_state.clone()).await;
+            }
+        });
+    }
+
+    // Radio similarity index auto-rebuild.
+    //
+    // `track_similarity` feeds radio's Engine recall lane but has no trigger of
+    // its own — left alone it stays empty and the Engine lane silently
+    // contributes nothing. These two tasks keep it fresh:
+    //
+    // 1. Listener — every `LibrarySynced` event means the library changed, so
+    //    the index is stale. `run_if_stale` debounces bursts and defers while
+    //    the app is busy, marking a dirty flag so the change isn't lost.
+    // 2. Hourly ticker — rebuilds a debounced/deferred change once its window
+    //    clears, and catches an aging index on installs that rarely sync.
+    //
+    // Both short-circuit on the `radio_similarity_running` atomic, so a rebuild
+    // in flight is never doubled up. See services::radio_similarity.
+    {
+        let listener_state = state.clone();
+        let mut event_rx = listener_state.read().await.event_tx.subscribe();
+        tokio::spawn(async move {
+            // Defer past the boot-time sync so we don't contend with it.
+            tokio::time::sleep(std::time::Duration::from_secs(120)).await;
+            use services::radio_similarity::RebuildTrigger;
+            loop {
+                match event_rx.recv().await {
+                    Ok(AppEvent::LibrarySynced) => {
+                        services::radio_similarity::run_if_stale(
+                            listener_state.clone(),
+                            RebuildTrigger::LibrarySynced,
+                        )
+                        .await;
+                    }
+                    Ok(_) => {}
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                        tracing::warn!(target: "noor.radio_similarity", lagged = n, "event listener lagged");
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                }
+            }
+        });
+    }
+    {
+        let loop_state = state.clone();
+        tokio::spawn(async move {
+            use services::radio_similarity::RebuildTrigger;
+            // First sweep 150s after boot — behind the auto-enrich head start.
+            tokio::time::sleep(std::time::Duration::from_secs(150)).await;
+            services::radio_similarity::run_if_stale(loop_state.clone(), RebuildTrigger::Periodic)
+                .await;
+
+            // Hourly: frequent enough that a debounced change is picked up soon
+            // after its 6h window clears, cheap enough to no-op the rest of the
+            // time (one age check, then the idle gate).
+            let mut ticker = tokio::time::interval(std::time::Duration::from_secs(3_600));
+            ticker.tick().await; // consume the immediate first tick
+            loop {
+                ticker.tick().await;
+                services::radio_similarity::run_if_stale(
+                    loop_state.clone(),
+                    RebuildTrigger::Periodic,
+                )
+                .await;
             }
         });
     }

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -2300,14 +2300,25 @@ async fn get_radio_tracks(
 async fn compute_radio_similarity(
     State(state): State<SharedState>,
 ) -> Result<Json<Value>, StatusCode> {
-    let (db, event_tx, running) = {
+    let (db, event_tx, running, busy) = {
         let s = state.read().await;
         (
             s.db.clone(),
             s.event_tx.clone(),
             s.radio_similarity_running.clone(),
+            crate::services::radio_similarity::busy_reason(&s),
         )
     };
+
+    // A rebuild owns SQLite's single writer slot for minutes. The manual route
+    // gates on the same idle check as the auto path — clicking the button does
+    // not justify failing an in-flight sync or listen-history write.
+    if let Some(reason) = busy {
+        return Ok(Json(json!({
+            "status": "busy",
+            "message": format!("Can't rebuild while {reason} is active. Try again once it's finished.")
+        })));
+    }
 
     // Shared single-flight + isolated-connection rebuild path: a manual click
     // and an auto-rebuild can never run the multi-minute job twice, and the
@@ -2327,7 +2338,9 @@ async fn compute_radio_similarity(
 
 /// Status of the radio similarity index: row count + last-built timestamp.
 /// Powers the Settings "Build radio similarity index" panel — the frontend
-/// polls this after triggering a compute to detect completion.
+/// polls this after triggering a compute to detect completion. `built_at`
+/// comes from `server_config`, not the table's rows, so a legitimate zero-row
+/// rebuild still reads as built.
 async fn radio_similarity_status(
     State(state): State<SharedState>,
 ) -> Result<Json<Value>, StatusCode> {
@@ -2338,13 +2351,13 @@ async fn radio_similarity_status(
     let row_count = db
         .with_conn(queries::count_track_similarity)
         .unwrap_or(0);
-    let computed_at = db
-        .with_conn(queries::get_similarity_computed_at)
+    let built_at = db
+        .with_conn(queries::get_radio_similarity_built_at)
         .ok()
         .flatten();
     Ok(Json(json!({
         "row_count": row_count,
-        "computed_at": computed_at,
+        "built_at": built_at,
     })))
 }
 

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -377,6 +377,10 @@ pub fn api_routes(state: SharedState) -> Router {
             "/api/discovery/radio/compute",
             post(compute_radio_similarity),
         )
+        .route(
+            "/api/discovery/radio/status",
+            get(radio_similarity_status),
+        )
         // Discovery Sound Space
         .route("/api/discovery/space", post(get_discovery_space))
         // Sportify-based discovery resolver - single, bulk, and cache-only status poll.
@@ -2296,30 +2300,51 @@ async fn get_radio_tracks(
 async fn compute_radio_similarity(
     State(state): State<SharedState>,
 ) -> Result<Json<Value>, StatusCode> {
-    // Clone the DB handle before spawning so we don't hold the RwLock during computation
+    let (db, event_tx, running) = {
+        let s = state.read().await;
+        (
+            s.db.clone(),
+            s.event_tx.clone(),
+            s.radio_similarity_running.clone(),
+        )
+    };
+
+    // Shared single-flight + isolated-connection rebuild path: a manual click
+    // and an auto-rebuild can never run the multi-minute job twice, and the
+    // job never holds the shared connection mutex.
+    if crate::services::radio_similarity::try_spawn_rebuild(db, event_tx, running) {
+        Ok(Json(json!({
+            "status": "computation_started",
+            "message": "Similarity computation running in background. This may take a few minutes for large libraries."
+        })))
+    } else {
+        Ok(Json(json!({
+            "status": "already_running",
+            "message": "Similarity computation is already in progress."
+        })))
+    }
+}
+
+/// Status of the radio similarity index: row count + last-built timestamp.
+/// Powers the Settings "Build radio similarity index" panel — the frontend
+/// polls this after triggering a compute to detect completion.
+async fn radio_similarity_status(
+    State(state): State<SharedState>,
+) -> Result<Json<Value>, StatusCode> {
     let db = {
         let s = state.read().await;
         s.db.clone()
     };
-    tokio::spawn(async move {
-        tracing::info!(target: "noor.radio", "Starting track similarity computation...");
-        match db.with_conn(queries::compute_track_similarity) {
-            Ok(count) => {
-                tracing::info!(
-                    target: "noor.radio",
-                    count = count,
-                    "Track similarity computation complete"
-                );
-            }
-            Err(e) => {
-                tracing::error!(target: "noor.radio", "Similarity computation failed: {}", e);
-            }
-        }
-    });
-
+    let row_count = db
+        .with_conn(queries::count_track_similarity)
+        .unwrap_or(0);
+    let computed_at = db
+        .with_conn(queries::get_similarity_computed_at)
+        .ok()
+        .flatten();
     Ok(Json(json!({
-        "status": "computation_started",
-        "message": "Similarity computation running in background. This may take a few minutes for large libraries."
+        "row_count": row_count,
+        "computed_at": computed_at,
     })))
 }
 
@@ -11978,6 +12003,7 @@ mod tests {
             lastfm_prefetch_done: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             lastfm_enrich_started_at: Arc::new(std::sync::atomic::AtomicI64::new(0)),
             discovery_train_cancel: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            radio_similarity_running: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             refreshed_seeds: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             embedding_cache: Arc::new(tokio::sync::Mutex::new(None)),
             master_key: crate::services::crypto::MasterKey::load_or_generate(

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -2302,11 +2302,12 @@ async fn compute_radio_similarity(
 ) -> Result<Json<Value>, StatusCode> {
     let (db, event_tx, running, busy) = {
         let s = state.read().await;
+        let busy = crate::services::radio_similarity::busy_reason(&s, &s.db);
         (
             s.db.clone(),
             s.event_tx.clone(),
             s.radio_similarity_running.clone(),
-            crate::services::radio_similarity::busy_reason(&s),
+            busy,
         )
     };
 

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -377,10 +377,7 @@ pub fn api_routes(state: SharedState) -> Router {
             "/api/discovery/radio/compute",
             post(compute_radio_similarity),
         )
-        .route(
-            "/api/discovery/radio/status",
-            get(radio_similarity_status),
-        )
+        .route("/api/discovery/radio/status", get(radio_similarity_status))
         // Discovery Sound Space
         .route("/api/discovery/space", post(get_discovery_space))
         // Sportify-based discovery resolver - single, bulk, and cache-only status poll.
@@ -2349,9 +2346,7 @@ async fn radio_similarity_status(
         let s = state.read().await;
         s.db.clone()
     };
-    let row_count = db
-        .with_conn(queries::count_track_similarity)
-        .unwrap_or(0);
+    let row_count = db.with_conn(queries::count_track_similarity).unwrap_or(0);
     let built_at = db
         .with_conn(queries::get_radio_similarity_built_at)
         .ok()

--- a/noor-server/src/server/ws.rs
+++ b/noor-server/src/server/ws.rs
@@ -61,6 +61,7 @@ async fn handle_socket(mut socket: WebSocket, state: SharedState) {
                 let msg = match event {
                     AppEvent::PlaybackStateChanged => json!({"type": "playback_changed"}),
                     AppEvent::LibrarySynced => json!({"type": "library_synced"}),
+                    AppEvent::RadioSimilarityComputed { pairs } => json!({"type": "radio_similarity_computed", "pairs": pairs}),
                     AppEvent::MusicBrainzEnriched => json!({"type": "musicbrainz_enriched"}),
                     AppEvent::TrackChanged { track_id } => json!({"type": "track_changed", "track_id": track_id}),
                     AppEvent::SyncProgress { service, progress } => json!({"type": "sync_progress", "service": service, "progress": progress}),

--- a/noor-server/src/services/mod.rs
+++ b/noor-server/src/services/mod.rs
@@ -13,6 +13,7 @@ pub mod musicbrainz;
 pub mod neighbor_refresh;
 pub mod radio;
 pub mod radio_config;
+pub mod radio_similarity;
 pub mod rss_feeds;
 pub mod sportify;
 pub mod spotify;

--- a/noor-server/src/services/radio.rs
+++ b/noor-server/src/services/radio.rs
@@ -437,9 +437,19 @@ pub async fn orchestrate_song(
             None
         };
 
-        if let Err(err) =
-            db.with_conn(|conn| crate::services::radio_config::log_radio_diagnostics(conn, &diag))
-        {
+        if let Err(err) = db.with_conn(|conn| {
+            // EXISTS, not COUNT(*): this runs on every radio request, and a
+            // populated track_similarity table has hundreds of thousands of
+            // rows — we only need the empty/non-empty bit.
+            diag.engine_index_empty = conn
+                .query_row(
+                    "SELECT NOT EXISTS(SELECT 1 FROM track_similarity)",
+                    [],
+                    |r| r.get(0),
+                )
+                .unwrap_or(false);
+            crate::services::radio_config::log_radio_diagnostics(conn, &diag)
+        }) {
             // Diagnostics failures should never break a radio request — log and move on.
             tracing::warn!(seed_track_id, error = %err, "failed to log radio diagnostics");
         }

--- a/noor-server/src/services/radio_config.rs
+++ b/noor-server/src/services/radio_config.rs
@@ -139,6 +139,17 @@ pub struct RadioProfile {
 // Don't tune from a single seed-run; aggregate over ≥1000 radio_diagnostics
 // rows per profile before adjusting. Single-flip changes between deploys
 // are easier to attribute than batched edits.
+//
+// Tuning review 2026-05-14: 74 radio_diagnostics rows (2026-05-05..05-13),
+// all profile_name='mixed', and every Tier 2 flag off on every row. All four
+// queries above are flag-gated and return nothing; the penalty/hub/diversity/
+// confidence-penalty knobs have zero observational data. avg_confidence sat at
+// 0.524 (above the 0.5 trigger). No defaults changed — the data does not meet
+// this runbook's bar. The only signal worth chasing is upstream, not here:
+// the engine lane produced 0 candidates across all 74 queues while Last.fm ran
+// 0.77 actual vs 0.40 target — an engine-recall follow-up, not a knob edit.
+// Re-run this review once the flags have been on for 2-4 weeks across all
+// three profiles.
 
 impl RadioProfile {
     pub fn from_blend(blend: RadioBlend) -> Self {
@@ -221,6 +232,9 @@ pub struct RadioDiagnosticsRow {
     pub repetition_skips: i64,
     pub penalty_relaxations: i64,
     pub hub_penalty_total: f64,
+    // True when the track_similarity index is empty, so a zero engine count
+    // means "index never built" rather than "no match for this seed".
+    pub engine_index_empty: bool,
     pub flags: RadioFlags,
 }
 
@@ -244,9 +258,9 @@ pub fn log_radio_diagnostics(conn: &Connection, row: &RadioDiagnosticsRow) -> Re
           same_artist_penalties, same_album_penalties, genre_saturation_penalties,
           repetition_skips, penalty_relaxations, hub_penalty_total,
           normalization_enabled, confidence_penalty_enabled, hub_penalty_enabled,
-          diversity_rerank_enabled, source_quota_bonus_enabled)
+          diversity_rerank_enabled, source_quota_bonus_enabled, engine_index_empty)
          VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15,
-                 ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23)",
+                 ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24)",
         params![
             row.seed_track_id,
             row.profile_name,
@@ -271,6 +285,7 @@ pub fn log_radio_diagnostics(conn: &Connection, row: &RadioDiagnosticsRow) -> Re
             row.flags.hub_penalty_enabled as i32,
             row.flags.diversity_rerank_enabled as i32,
             row.flags.source_quota_bonus_enabled as i32,
+            row.engine_index_empty as i32,
         ],
     )?;
     Ok(())

--- a/noor-server/src/services/radio_similarity.rs
+++ b/noor-server/src/services/radio_similarity.rs
@@ -1,0 +1,327 @@
+//! Auto-rebuild orchestrator for the radio similarity index (`track_similarity`).
+//!
+//! `compute_track_similarity` populates the metadata-heuristic recall lane for
+//! radio's Engine source (co-album / co-artist / co-listen / genre proximity).
+//! It is a one-shot job with no trigger of its own, so if it is never run the
+//! Engine lane silently contributes nothing to every radio queue (this is what
+//! the 2026-05-14 radio_diagnostics review found). This module keeps the index
+//! fresh without the user pressing the Settings button.
+//!
+//! Hook points (both wired in `main.rs`):
+//!   1. A `LibrarySynced` listener — the library just changed, so the index is
+//!      stale. This is the primary trigger.
+//!   2. An hourly catch-up ticker — picks up changes that were debounced or
+//!      deferred, and rebuilds a genuinely old index even on quiet installs.
+//!
+//! Three safety properties matter here:
+//!   - **It must not freeze reads.** `compute_track_similarity` runs on an
+//!     isolated connection (`Database::open_isolated`) inside `spawn_blocking`,
+//!     so it holds neither the shared connection mutex nor an async worker —
+//!     request-path reads keep flowing in WAL mode throughout, and see a
+//!     consistent snapshot until the rebuild's single transaction commits.
+//!   - **It must not starve writes.** The rebuild is a multi-minute SQLite
+//!     write transaction, and WAL still allows only one writer. So the auto
+//!     path runs only while the app is otherwise quiet (no playback, sync,
+//!     enrichment, or analysis) — see the idle gate in `run_if_stale`. The
+//!     manual Settings button is intentionally *not* gated: the user asked.
+//!   - **It must not lose changes or thrash.** Concurrency is gated by the
+//!     `radio_similarity_running` atomic; `LibrarySynced` rebuilds are
+//!     debounced by `MIN_REBUILD_INTERVAL_SECS`; and a `LibrarySynced` that is
+//!     debounced or idle-deferred sets a persistent `radio_similarity_dirty`
+//!     flag so the hourly ticker rebuilds once the window clears, rather than
+//!     the change waiting for the `MAX_STALE_AGE_SECS` sweep.
+
+use crate::db::Database;
+use crate::{AppEvent, SharedState};
+use rusqlite::OptionalExtension;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use tokio::sync::broadcast;
+use tracing::{debug, info, warn};
+
+/// Debounce window for `LibrarySynced` rebuilds: a sync/enrichment burst won't
+/// rebuild if the index was already rebuilt within this window.
+const MIN_REBUILD_INTERVAL_SECS: i64 = 6 * 3600;
+/// The hourly catch-up ticker rebuilds once the index crosses this age even
+/// with no observed library change — a long-stop for quiet, drifting installs.
+const MAX_STALE_AGE_SECS: i64 = 7 * 24 * 3600;
+/// `server_config` key: "1" when a library change was observed but the rebuild
+/// was debounced or deferred, so the ticker knows a rebuild is owed.
+const DIRTY_FLAG_KEY: &str = "radio_similarity_dirty";
+
+/// What asked for the rebuild — determines the freshness rule.
+#[derive(Debug, Clone, Copy)]
+pub enum RebuildTrigger {
+    /// The library changed (sync, enrichment, dedup). The change itself is the
+    /// staleness signal, so we rebuild once past the debounce window without
+    /// guessing from row counts — a metadata- or genre-only change leaves the
+    /// track count identical but still invalidates the similarity inputs.
+    LibrarySynced,
+    /// The hourly catch-up ticker. No specific change signal of its own, so it
+    /// rebuilds only a genuinely old index or a pending (dirty) change.
+    Periodic,
+}
+
+/// Rebuild the radio similarity index in the background if it is stale for the
+/// given trigger, the app is idle, and no rebuild is already running. Returns
+/// immediately; never blocks the caller.
+pub async fn run_if_stale(state: SharedState, trigger: RebuildTrigger) {
+    let (
+        db,
+        event_tx,
+        running,
+        audio_active,
+        tidal_sync_running,
+        lastfm_enrich_running,
+        musicbrainz_enrich_running,
+        spotify_enrich_running,
+        audio_analysis_running,
+        acrcloud_scan_running,
+    ) = {
+        let s = state.read().await;
+        (
+            s.db.clone(),
+            s.event_tx.clone(),
+            s.radio_similarity_running.clone(),
+            s.audio_active.clone(),
+            s.tidal_sync_running.clone(),
+            s.lastfm_enrich_running.clone(),
+            s.musicbrainz_enrich_running.clone(),
+            s.spotify_enrich_running.clone(),
+            s.audio_analysis_running.clone(),
+            s.acrcloud_scan_running.clone(),
+        )
+    };
+
+    if running.load(Ordering::SeqCst) {
+        debug!(target: "noor.radio_similarity", "rebuild already running, skipping");
+        return;
+    }
+
+    // Freshness inputs in one connection grab: index age (None = never built)
+    // and the pending-rebuild flag.
+    let snapshot = db.with_conn(|conn| {
+        let age_secs: Option<i64> = conn.query_row(
+            "SELECT CAST((julianday('now') - julianday(MAX(computed_at))) * 86400 AS INTEGER)
+             FROM track_similarity",
+            [],
+            |r| r.get(0),
+        )?;
+        let dirty: bool = conn
+            .query_row(
+                "SELECT value FROM server_config WHERE key = ?1",
+                rusqlite::params![DIRTY_FLAG_KEY],
+                |r| r.get::<_, String>(0),
+            )
+            .optional()?
+            .map(|v| v == "1")
+            .unwrap_or(false);
+        Ok((age_secs, dirty))
+    });
+    let (age_secs, dirty) = match snapshot {
+        Ok(v) => v,
+        Err(err) => {
+            warn!(target: "noor.radio_similarity", error = %err, "freshness check failed");
+            return;
+        }
+    };
+
+    if !should_rebuild(age_secs, dirty, trigger) {
+        // A `LibrarySynced` inside the debounce window still changed the
+        // library — record it so the hourly ticker rebuilds once the window
+        // clears, instead of the change waiting for the stale-age sweep.
+        if matches!(trigger, RebuildTrigger::LibrarySynced) {
+            mark_dirty(&db);
+        }
+        debug!(
+            target: "noor.radio_similarity",
+            ?trigger, age_secs, dirty, "index fresh for this trigger, skipping rebuild"
+        );
+        return;
+    }
+
+    // A rebuild is warranted — but it is a multi-minute SQLite write
+    // transaction, and WAL allows only one writer. Run it only while the app
+    // is otherwise quiet, so foreground writes (listen history, queue/runtime
+    // state, sync metadata) don't fail on the busy timeout. If something is
+    // active, defer: a `LibrarySynced` trigger leaves the dirty flag set so the
+    // ticker retries; a `Periodic` trigger simply re-evaluates next tick.
+    let busy_reason = if audio_active.load(Ordering::SeqCst) {
+        Some("audio playback")
+    } else if tidal_sync_running.load(Ordering::SeqCst) {
+        Some("tidal sync")
+    } else if lastfm_enrich_running.load(Ordering::SeqCst) {
+        Some("last.fm enrichment")
+    } else if musicbrainz_enrich_running.load(Ordering::SeqCst) {
+        Some("musicbrainz enrichment")
+    } else if spotify_enrich_running.load(Ordering::SeqCst) {
+        Some("spotify enrichment")
+    } else if audio_analysis_running.load(Ordering::SeqCst) {
+        Some("audio analysis")
+    } else if acrcloud_scan_running.load(Ordering::SeqCst) {
+        Some("acrcloud scan")
+    } else {
+        None
+    };
+    if let Some(reason) = busy_reason {
+        if matches!(trigger, RebuildTrigger::LibrarySynced) {
+            mark_dirty(&db);
+        }
+        debug!(
+            target: "noor.radio_similarity",
+            ?trigger, reason, "app busy, deferring rebuild"
+        );
+        return;
+    }
+
+    if try_spawn_rebuild(db, event_tx, running) {
+        info!(
+            target: "noor.radio_similarity",
+            ?trigger, age_secs, "radio similarity rebuild started"
+        );
+    }
+}
+
+/// Pure rebuild decision, split out so the freshness logic is unit-testable.
+/// Considers only index age, the dirty flag, and the trigger — not app
+/// activity (the idle gate) or the single-flight slot.
+fn should_rebuild(age_secs: Option<i64>, dirty: bool, trigger: RebuildTrigger) -> bool {
+    match (age_secs, trigger) {
+        // Never built — always worth building, whatever asked.
+        (None, _) => true,
+        // A library change: rebuild once past the debounce window. Inside the
+        // window the caller records the change via the dirty flag instead.
+        (Some(age), RebuildTrigger::LibrarySynced) => age >= MIN_REBUILD_INTERVAL_SECS,
+        // Periodic catch-up: a genuinely old index, or a debounced/deferred
+        // change that is now past the debounce window.
+        (Some(age), RebuildTrigger::Periodic) => {
+            age > MAX_STALE_AGE_SECS || (dirty && age >= MIN_REBUILD_INTERVAL_SECS)
+        }
+    }
+}
+
+/// Record that a library change is owed a rebuild. Cleared by `try_spawn_rebuild`
+/// once a rebuild completes.
+fn mark_dirty(db: &Database) {
+    let result = db.with_conn(|conn| {
+        conn.execute(
+            "INSERT OR REPLACE INTO server_config (key, value) VALUES (?1, '1')",
+            rusqlite::params![DIRTY_FLAG_KEY],
+        )?;
+        Ok(())
+    });
+    if let Err(err) = result {
+        warn!(target: "noor.radio_similarity", error = %err, "failed to set dirty flag");
+    }
+}
+
+/// Claim the single-flight slot and spawn the rebuild on a dedicated
+/// connection. Returns `false` (without spawning) if a rebuild is already
+/// running. Shared by the auto-rebuild triggers and the manual Settings route.
+///
+/// The `swap` is the real single-flight guard: callers may race past the
+/// cheaper `load` check in `run_if_stale`, but only one wins the swap.
+pub fn try_spawn_rebuild(
+    db: Database,
+    event_tx: broadcast::Sender<AppEvent>,
+    running: Arc<AtomicBool>,
+) -> bool {
+    if running.swap(true, Ordering::SeqCst) {
+        return false;
+    }
+    // spawn_blocking, not spawn: compute_track_similarity is a synchronous,
+    // minutes-long call — it must not occupy an async worker thread.
+    tokio::task::spawn_blocking(move || {
+        // Releases the single-flight flag on drop, including on panic — a
+        // wedged flag would silently block every future rebuild.
+        let _guard = RunningGuard(running);
+        let result = db.open_isolated().and_then(|conn| {
+            let pairs = crate::db::queries::compute_track_similarity(&conn)?;
+            // The index now reflects current library state — clear the pending
+            // flag so the ticker doesn't rebuild again needlessly.
+            if let Err(err) = conn.execute(
+                "INSERT OR REPLACE INTO server_config (key, value) VALUES (?1, '0')",
+                rusqlite::params![DIRTY_FLAG_KEY],
+            ) {
+                warn!(target: "noor.radio_similarity", error = %err, "failed to clear dirty flag");
+            }
+            Ok(pairs)
+        });
+        match result {
+            Ok(pairs) => {
+                info!(
+                    target: "noor.radio_similarity",
+                    pairs, "radio similarity rebuild complete"
+                );
+                let _ = event_tx.send(AppEvent::RadioSimilarityComputed {
+                    pairs: pairs as i64,
+                });
+            }
+            Err(err) => {
+                warn!(target: "noor.radio_similarity", error = %err, "radio similarity rebuild failed");
+            }
+        }
+    });
+    true
+}
+
+/// Releases the `radio_similarity_running` single-flight flag on drop, so a
+/// panic mid-rebuild can't leave it stuck at `true` and block every later run.
+struct RunningGuard(Arc<AtomicBool>);
+
+impl Drop for RunningGuard {
+    fn drop(&mut self) {
+        self.0.store(false, Ordering::SeqCst);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn never_built_always_rebuilds() {
+        assert!(should_rebuild(None, false, RebuildTrigger::LibrarySynced));
+        assert!(should_rebuild(None, false, RebuildTrigger::Periodic));
+    }
+
+    #[test]
+    fn library_synced_debounces_recent_rebuilds() {
+        // Inside the debounce window — skip (the caller marks it dirty).
+        assert!(!should_rebuild(
+            Some(60),
+            false,
+            RebuildTrigger::LibrarySynced
+        ));
+        // Past the debounce window — rebuild.
+        assert!(should_rebuild(
+            Some(MIN_REBUILD_INTERVAL_SECS),
+            false,
+            RebuildTrigger::LibrarySynced
+        ));
+    }
+
+    #[test]
+    fn periodic_honors_dirty_flag_after_debounce() {
+        // Fresh index, nothing pending — nothing to do.
+        assert!(!should_rebuild(Some(3600), false, RebuildTrigger::Periodic));
+        // A change is pending but still inside the debounce window — wait.
+        assert!(!should_rebuild(Some(3600), true, RebuildTrigger::Periodic));
+        // Debounce window passed and a change is pending — rebuild now, without
+        // waiting for the stale-age sweep.
+        assert!(should_rebuild(
+            Some(MIN_REBUILD_INTERVAL_SECS),
+            true,
+            RebuildTrigger::Periodic
+        ));
+    }
+
+    #[test]
+    fn periodic_rebuilds_a_very_stale_index() {
+        assert!(should_rebuild(
+            Some(MAX_STALE_AGE_SECS + 1),
+            false,
+            RebuildTrigger::Periodic
+        ));
+    }
+}

--- a/noor-server/src/services/radio_similarity.rs
+++ b/noor-server/src/services/radio_similarity.rs
@@ -15,18 +15,20 @@
 //!
 //! ## Freshness model
 //!
-//! Two timestamps in `server_config` drive everything; nothing is derived from
+//! Two `server_config` values drive everything; nothing is derived from
 //! `track_similarity`'s own rows (a valid library can legitimately produce zero
 //! similarity pairs, which must not read as "never built"):
-//!   - `radio_similarity_built_at` — the *start* time of the last successful
-//!     rebuild. Start, not finish, so a `LibrarySynced` that lands during a
-//!     rebuild stays "newer" and re-triggers instead of being absorbed.
-//!   - `radio_similarity_library_changed_at` — stamped on *every* `LibrarySynced`,
-//!     unconditionally and before any other check, so a change observed while a
-//!     rebuild is running, during the debounce window, or while the app is busy
-//!     is never lost.
-//! `dirty` is simply `library_changed_at > built_at` — no flag to clear, no
-//! clear/set race.
+//!   - `radio_similarity_built_at` — the *start* timestamp of the last
+//!     successful rebuild, used only for the staleness *age*.
+//!   - `radio_similarity_change_gen` — a monotonic counter bumped on *every*
+//!     `LibrarySynced`, unconditionally and before any other check. The rebuild
+//!     records the counter value it observed at start as `radio_similarity_
+//!     built_gen`; `dirty` is `change_gen > built_gen`.
+//!
+//! A monotonic counter, not a timestamp comparison: a `LibrarySynced` that
+//! lands in the same wall-clock second as the rebuild's start still bumps
+//! `change_gen` past `built_gen`, so a change during a rebuild can never be
+//! silently absorbed.
 //!
 //! ## Safety
 //!   - **Reads never freeze.** The rebuild runs on an isolated connection
@@ -34,8 +36,8 @@
 //!     shared connection mutex nor an async worker.
 //!   - **Writes are not starved.** The rebuild is a multi-minute SQLite write
 //!     transaction, and WAL allows only one writer. Both the auto path *and*
-//!     the manual Settings route gate on `busy_reason`: a rebuild only starts
-//!     when no other writer (playback, sync, enrichment, analysis) is active.
+//!     the manual Settings route gate on `busy_reason`, which covers the
+//!     in-memory writer atomics *and* the DB-backed discovery-training state.
 //!   - **No thrash.** Single-flight via the `radio_similarity_running` atomic;
 //!     `LibrarySynced` rebuilds debounced by `MIN_REBUILD_INTERVAL_SECS`.
 
@@ -55,8 +57,11 @@ const MIN_REBUILD_INTERVAL_SECS: i64 = 6 * 3600;
 const MAX_STALE_AGE_SECS: i64 = 7 * 24 * 3600;
 /// `server_config` key: start timestamp of the last successful rebuild.
 const BUILT_AT_KEY: &str = "radio_similarity_built_at";
-/// `server_config` key: timestamp the library last changed (any `LibrarySynced`).
-const LIBRARY_CHANGED_AT_KEY: &str = "radio_similarity_library_changed_at";
+/// `server_config` key: the `change_gen` value observed at the last rebuild's
+/// start. `change_gen > built_gen` means the library changed since.
+const BUILT_GEN_KEY: &str = "radio_similarity_built_gen";
+/// `server_config` key: monotonic counter, bumped on every `LibrarySynced`.
+const CHANGE_GEN_KEY: &str = "radio_similarity_change_gen";
 
 /// What asked for the rebuild — determines the freshness rule.
 #[derive(Debug, Clone, Copy)]
@@ -87,18 +92,19 @@ struct Freshness {
 pub async fn run_if_stale(state: SharedState, trigger: RebuildTrigger) {
     let (db, event_tx, running, busy) = {
         let s = state.read().await;
+        let busy = busy_reason(&s, &s.db);
         (
             s.db.clone(),
             s.event_tx.clone(),
             s.radio_similarity_running.clone(),
-            busy_reason(&s),
+            busy,
         )
     };
 
     // Record the library change first — before the running, freshness, and
     // idle checks — so a change observed mid-rebuild, mid-debounce, or while
     // the app is busy is never lost. It is only ever resolved by a later
-    // rebuild stamping `built_at` past it.
+    // rebuild recording a `built_gen` that catches up to it.
     if matches!(trigger, RebuildTrigger::LibrarySynced) {
         mark_library_changed(&db);
     }
@@ -129,8 +135,8 @@ pub async fn run_if_stale(state: SharedState, trigger: RebuildTrigger) {
 
     // A rebuild is warranted, but it owns SQLite's single writer slot for
     // minutes. Run it only while the app is otherwise quiet; otherwise defer.
-    // The change is already recorded in `library_changed_at`, so the hourly
-    // ticker will retry once things settle.
+    // The change is already recorded in `change_gen`, so the hourly ticker
+    // will retry once things settle.
     if let Some(reason) = busy {
         debug!(target: "noor.radio_similarity", ?trigger, reason, "app busy, deferring rebuild");
         return;
@@ -149,26 +155,42 @@ pub async fn run_if_stale(state: SharedState, trigger: RebuildTrigger) {
 /// The active foreground job that should hold off a rebuild, or `None` if the
 /// app is idle enough. A rebuild owns SQLite's single writer slot for minutes,
 /// so neither the auto path nor the manual Settings route may run one while
-/// another writer is active.
-pub fn busy_reason(state: &crate::AppState) -> Option<&'static str> {
+/// another writer is active. Covers the in-memory writer atomics *and* the
+/// DB-backed discovery-training run state.
+pub fn busy_reason(state: &crate::AppState, db: &Database) -> Option<&'static str> {
     use std::sync::atomic::Ordering::SeqCst;
     if state.audio_active.load(SeqCst) {
-        Some("audio playback")
-    } else if state.tidal_sync_running.load(SeqCst) {
-        Some("a TIDAL sync")
-    } else if state.lastfm_enrich_running.load(SeqCst) {
-        Some("Last.fm enrichment")
-    } else if state.musicbrainz_enrich_running.load(SeqCst) {
-        Some("MusicBrainz enrichment")
-    } else if state.spotify_enrich_running.load(SeqCst) {
-        Some("Spotify enrichment")
-    } else if state.audio_analysis_running.load(SeqCst) {
-        Some("audio analysis")
-    } else if state.acrcloud_scan_running.load(SeqCst) {
-        Some("an ACRCloud scan")
-    } else {
-        None
+        return Some("audio playback");
     }
+    if state.tidal_sync_running.load(SeqCst) {
+        return Some("a TIDAL sync");
+    }
+    if state.lastfm_enrich_running.load(SeqCst) {
+        return Some("Last.fm enrichment");
+    }
+    if state.musicbrainz_enrich_running.load(SeqCst) {
+        return Some("MusicBrainz enrichment");
+    }
+    if state.spotify_enrich_running.load(SeqCst) {
+        return Some("Spotify enrichment");
+    }
+    if state.audio_analysis_running.load(SeqCst) {
+        return Some("audio analysis");
+    }
+    if state.acrcloud_scan_running.load(SeqCst) {
+        return Some("an ACRCloud scan");
+    }
+    // Discovery training is DB-backed, not an atomic. It writes heavily through
+    // the shared connection for the length of a run; a rebuild's long write
+    // transaction running alongside it would starve those writes past the busy
+    // timeout and fail the run.
+    if db
+        .with_conn(crate::db::queries::is_discovery_training_running)
+        .unwrap_or(false)
+    {
+        return Some("discovery training");
+    }
+    None
 }
 
 /// Pure rebuild decision, split out so the freshness logic is unit-testable.
@@ -179,7 +201,7 @@ fn should_rebuild(built_age: Option<i64>, dirty: bool, trigger: RebuildTrigger) 
         // Never built — always worth building, whatever asked.
         (None, _) => true,
         // A library change: rebuild once past the debounce window. Inside the
-        // window the change stays recorded in `library_changed_at`.
+        // window the change stays recorded in `change_gen`.
         (Some(age), RebuildTrigger::LibrarySynced) => age >= MIN_REBUILD_INTERVAL_SECS,
         // Periodic catch-up: a genuinely old index, or a debounced/deferred
         // change that is now past the debounce window.
@@ -198,12 +220,18 @@ fn read_config(conn: &Connection, key: &str) -> rusqlite::Result<Option<String>>
     .optional()
 }
 
+/// Read an integer counter from `server_config`, defaulting to 0 when absent or
+/// unparseable.
+fn read_gen(conn: &Connection, key: &str) -> rusqlite::Result<i64> {
+    Ok(read_config(conn, key)?
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0))
+}
+
 /// Read index freshness from `server_config`. Deliberately does not touch
 /// `track_similarity` — see the module's freshness-model note.
 fn read_freshness(conn: &Connection) -> anyhow::Result<Freshness> {
     let built_at = read_config(conn, BUILT_AT_KEY)?;
-    let library_changed_at = read_config(conn, LIBRARY_CHANGED_AT_KEY)?;
-
     let built_age_secs: Option<i64> = if built_at.is_some() {
         conn.query_row(
             "SELECT CAST((julianday('now') - julianday(value)) * 86400 AS INTEGER)
@@ -216,12 +244,11 @@ fn read_freshness(conn: &Connection) -> anyhow::Result<Freshness> {
         None
     };
 
-    // ISO-8601-ish timestamps from datetime('now') sort correctly as text.
-    let dirty = match (&library_changed_at, &built_at) {
-        (None, _) => false,
-        (Some(_), None) => true,
-        (Some(changed), Some(built)) => changed.as_str() > built.as_str(),
-    };
+    // Monotonic counters, not timestamps: a LibrarySynced in the same second as
+    // the rebuild's start still bumps change_gen past built_gen.
+    let change_gen = read_gen(conn, CHANGE_GEN_KEY)?;
+    let built_gen = read_gen(conn, BUILT_GEN_KEY)?;
+    let dirty = change_gen > built_gen;
 
     Ok(Freshness {
         built_age_secs,
@@ -229,18 +256,20 @@ fn read_freshness(conn: &Connection) -> anyhow::Result<Freshness> {
     })
 }
 
-/// Stamp `library_changed_at = now`. Called for every `LibrarySynced` before
-/// any other check, so the change survives a busy app or an in-flight rebuild.
+/// Bump the monotonic library-change counter. Called for every `LibrarySynced`
+/// before any other check, so the change survives a busy app or an in-flight
+/// rebuild. Single statement — the increment is atomic.
 fn mark_library_changed(db: &Database) {
     let result = db.with_conn(|conn| {
         conn.execute(
-            "INSERT OR REPLACE INTO server_config (key, value) VALUES (?1, datetime('now'))",
-            rusqlite::params![LIBRARY_CHANGED_AT_KEY],
+            "INSERT OR REPLACE INTO server_config (key, value)
+             VALUES (?1, CAST(COALESCE((SELECT value FROM server_config WHERE key = ?1), '0') AS INTEGER) + 1)",
+            rusqlite::params![CHANGE_GEN_KEY],
         )?;
         Ok(())
     });
     if let Err(err) = result {
-        warn!(target: "noor.radio_similarity", error = %err, "failed to record library change");
+        warn!(target: "noor.radio_similarity", error = %err, "failed to bump library-change counter");
     }
 }
 
@@ -267,19 +296,28 @@ pub fn try_spawn_rebuild(
         let _guard = RunningGuard(running);
         let result = (|| -> anyhow::Result<usize> {
             let conn = db.open_isolated()?;
-            // Capture the start time before the rebuild reads any data: a
-            // LibrarySynced that lands during the rebuild stamps a later
-            // `library_changed_at`, which stays newer than this `built_at` and
-            // so re-triggers a rebuild instead of being silently absorbed.
+            // Capture the start time and the library-change generation before
+            // the rebuild reads any data. A LibrarySynced that lands during the
+            // rebuild bumps change_gen past this value, so the freshness check
+            // stays dirty and re-triggers — no same-second timestamp race.
             let started_at: String =
                 conn.query_row("SELECT datetime('now')", [], |r| r.get(0))?;
+            let change_gen_at_start: i64 = conn.query_row(
+                "SELECT CAST(COALESCE((SELECT value FROM server_config WHERE key = ?1), '0') AS INTEGER)",
+                rusqlite::params![CHANGE_GEN_KEY],
+                |r| r.get(0),
+            )?;
             let pairs = crate::db::queries::compute_track_similarity(&conn)?;
-            // Record completion independently of row count — a valid library
-            // can legitimately produce zero pairs, which must not read as
-            // "never built".
+            // Record completion: built_at drives the staleness age (independent
+            // of row count — a valid library can produce zero pairs), built_gen
+            // resolves everything that changed up to the rebuild's start.
             conn.execute(
                 "INSERT OR REPLACE INTO server_config (key, value) VALUES (?1, ?2)",
                 rusqlite::params![BUILT_AT_KEY, started_at],
+            )?;
+            conn.execute(
+                "INSERT OR REPLACE INTO server_config (key, value) VALUES (?1, ?2)",
+                rusqlite::params![BUILT_GEN_KEY, change_gen_at_start.to_string()],
             )?;
             Ok(pairs)
         })();
@@ -380,10 +418,9 @@ mod tests {
 
     #[test]
     fn freshness_zero_row_index_is_not_never_built() {
-        // Regression for the Codex finding: a successful rebuild that produced
-        // zero similarity rows still stamps built_at, so freshness must read it
-        // as built (Some age), not None — `read_freshness` never looks at
-        // `track_similarity` rows at all.
+        // A successful rebuild that produced zero similarity rows still stamps
+        // built_at, so freshness must read it as built (Some age), not None —
+        // `read_freshness` never looks at `track_similarity` rows at all.
         let db = Database::open_in_memory().unwrap();
         db.run_migrations().unwrap();
         set_config(&db, BUILT_AT_KEY, "2026-05-14 00:00:00");
@@ -396,21 +433,26 @@ mod tests {
     }
 
     #[test]
-    fn freshness_dirty_when_library_changed_after_build() {
+    fn freshness_dirty_when_change_gen_exceeds_built_gen() {
+        // Regression for the same-second timestamp finding: dirtiness is a
+        // monotonic counter comparison, so a library change is detected even
+        // when it would have shared a wall-clock timestamp with the rebuild.
         let db = Database::open_in_memory().unwrap();
         db.run_migrations().unwrap();
         set_config(&db, BUILT_AT_KEY, "2026-05-14 00:00:00");
-        set_config(&db, LIBRARY_CHANGED_AT_KEY, "2026-05-14 01:00:00");
+        set_config(&db, BUILT_GEN_KEY, "5");
+        set_config(&db, CHANGE_GEN_KEY, "6");
         let f = db.with_conn(read_freshness).unwrap();
-        assert!(f.dirty);
+        assert!(f.dirty, "change_gen > built_gen must read dirty");
     }
 
     #[test]
-    fn freshness_not_dirty_when_build_is_newer() {
+    fn freshness_not_dirty_when_gens_equal() {
         let db = Database::open_in_memory().unwrap();
         db.run_migrations().unwrap();
-        set_config(&db, LIBRARY_CHANGED_AT_KEY, "2026-05-14 00:00:00");
-        set_config(&db, BUILT_AT_KEY, "2026-05-14 02:00:00");
+        set_config(&db, BUILT_AT_KEY, "2026-05-14 00:00:00");
+        set_config(&db, BUILT_GEN_KEY, "5");
+        set_config(&db, CHANGE_GEN_KEY, "5");
         let f = db.with_conn(read_freshness).unwrap();
         assert!(!f.dirty);
     }
@@ -419,9 +461,22 @@ mod tests {
     fn freshness_dirty_when_changed_but_never_built() {
         let db = Database::open_in_memory().unwrap();
         db.run_migrations().unwrap();
-        set_config(&db, LIBRARY_CHANGED_AT_KEY, "2026-05-14 00:00:00");
+        set_config(&db, CHANGE_GEN_KEY, "1");
         let f = db.with_conn(read_freshness).unwrap();
         assert_eq!(f.built_age_secs, None);
         assert!(f.dirty);
+    }
+
+    #[test]
+    fn mark_library_changed_increments_monotonically() {
+        let db = Database::open_in_memory().unwrap();
+        db.run_migrations().unwrap();
+        // Starts unset (treated as 0).
+        assert_eq!(db.with_conn(|c| Ok(read_gen(c, CHANGE_GEN_KEY)?)).unwrap(), 0);
+        mark_library_changed(&db);
+        assert_eq!(db.with_conn(|c| Ok(read_gen(c, CHANGE_GEN_KEY)?)).unwrap(), 1);
+        mark_library_changed(&db);
+        mark_library_changed(&db);
+        assert_eq!(db.with_conn(|c| Ok(read_gen(c, CHANGE_GEN_KEY)?)).unwrap(), 3);
     }
 }

--- a/noor-server/src/services/radio_similarity.rs
+++ b/noor-server/src/services/radio_similarity.rs
@@ -13,27 +13,35 @@
 //!   2. An hourly catch-up ticker — picks up changes that were debounced or
 //!      deferred, and rebuilds a genuinely old index even on quiet installs.
 //!
-//! Three safety properties matter here:
-//!   - **It must not freeze reads.** `compute_track_similarity` runs on an
-//!     isolated connection (`Database::open_isolated`) inside `spawn_blocking`,
-//!     so it holds neither the shared connection mutex nor an async worker —
-//!     request-path reads keep flowing in WAL mode throughout, and see a
-//!     consistent snapshot until the rebuild's single transaction commits.
-//!   - **It must not starve writes.** The rebuild is a multi-minute SQLite
-//!     write transaction, and WAL still allows only one writer. So the auto
-//!     path runs only while the app is otherwise quiet (no playback, sync,
-//!     enrichment, or analysis) — see the idle gate in `run_if_stale`. The
-//!     manual Settings button is intentionally *not* gated: the user asked.
-//!   - **It must not lose changes or thrash.** Concurrency is gated by the
-//!     `radio_similarity_running` atomic; `LibrarySynced` rebuilds are
-//!     debounced by `MIN_REBUILD_INTERVAL_SECS`; and a `LibrarySynced` that is
-//!     debounced or idle-deferred sets a persistent `radio_similarity_dirty`
-//!     flag so the hourly ticker rebuilds once the window clears, rather than
-//!     the change waiting for the `MAX_STALE_AGE_SECS` sweep.
+//! ## Freshness model
+//!
+//! Two timestamps in `server_config` drive everything; nothing is derived from
+//! `track_similarity`'s own rows (a valid library can legitimately produce zero
+//! similarity pairs, which must not read as "never built"):
+//!   - `radio_similarity_built_at` — the *start* time of the last successful
+//!     rebuild. Start, not finish, so a `LibrarySynced` that lands during a
+//!     rebuild stays "newer" and re-triggers instead of being absorbed.
+//!   - `radio_similarity_library_changed_at` — stamped on *every* `LibrarySynced`,
+//!     unconditionally and before any other check, so a change observed while a
+//!     rebuild is running, during the debounce window, or while the app is busy
+//!     is never lost.
+//! `dirty` is simply `library_changed_at > built_at` — no flag to clear, no
+//! clear/set race.
+//!
+//! ## Safety
+//!   - **Reads never freeze.** The rebuild runs on an isolated connection
+//!     (`Database::open_isolated`) inside `spawn_blocking`, holding neither the
+//!     shared connection mutex nor an async worker.
+//!   - **Writes are not starved.** The rebuild is a multi-minute SQLite write
+//!     transaction, and WAL allows only one writer. Both the auto path *and*
+//!     the manual Settings route gate on `busy_reason`: a rebuild only starts
+//!     when no other writer (playback, sync, enrichment, analysis) is active.
+//!   - **No thrash.** Single-flight via the `radio_similarity_running` atomic;
+//!     `LibrarySynced` rebuilds debounced by `MIN_REBUILD_INTERVAL_SECS`.
 
 use crate::db::Database;
 use crate::{AppEvent, SharedState};
-use rusqlite::OptionalExtension;
+use rusqlite::{Connection, OptionalExtension};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::sync::broadcast;
@@ -45,9 +53,10 @@ const MIN_REBUILD_INTERVAL_SECS: i64 = 6 * 3600;
 /// The hourly catch-up ticker rebuilds once the index crosses this age even
 /// with no observed library change — a long-stop for quiet, drifting installs.
 const MAX_STALE_AGE_SECS: i64 = 7 * 24 * 3600;
-/// `server_config` key: "1" when a library change was observed but the rebuild
-/// was debounced or deferred, so the ticker knows a rebuild is owed.
-const DIRTY_FLAG_KEY: &str = "radio_similarity_dirty";
+/// `server_config` key: start timestamp of the last successful rebuild.
+const BUILT_AT_KEY: &str = "radio_similarity_built_at";
+/// `server_config` key: timestamp the library last changed (any `LibrarySynced`).
+const LIBRARY_CHANGED_AT_KEY: &str = "radio_similarity_library_changed_at";
 
 /// What asked for the rebuild — determines the freshness rule.
 #[derive(Debug, Clone, Copy)]
@@ -62,135 +71,115 @@ pub enum RebuildTrigger {
     Periodic,
 }
 
+/// Index freshness, read from `server_config` and independent of how many rows
+/// `track_similarity` happens to hold.
+#[derive(Debug)]
+struct Freshness {
+    /// Seconds since the last successful rebuild started; `None` = never built.
+    built_age_secs: Option<i64>,
+    /// True when the library changed after the last rebuild started.
+    dirty: bool,
+}
+
 /// Rebuild the radio similarity index in the background if it is stale for the
 /// given trigger, the app is idle, and no rebuild is already running. Returns
 /// immediately; never blocks the caller.
 pub async fn run_if_stale(state: SharedState, trigger: RebuildTrigger) {
-    let (
-        db,
-        event_tx,
-        running,
-        audio_active,
-        tidal_sync_running,
-        lastfm_enrich_running,
-        musicbrainz_enrich_running,
-        spotify_enrich_running,
-        audio_analysis_running,
-        acrcloud_scan_running,
-    ) = {
+    let (db, event_tx, running, busy) = {
         let s = state.read().await;
         (
             s.db.clone(),
             s.event_tx.clone(),
             s.radio_similarity_running.clone(),
-            s.audio_active.clone(),
-            s.tidal_sync_running.clone(),
-            s.lastfm_enrich_running.clone(),
-            s.musicbrainz_enrich_running.clone(),
-            s.spotify_enrich_running.clone(),
-            s.audio_analysis_running.clone(),
-            s.acrcloud_scan_running.clone(),
+            busy_reason(&s),
         )
     };
+
+    // Record the library change first — before the running, freshness, and
+    // idle checks — so a change observed mid-rebuild, mid-debounce, or while
+    // the app is busy is never lost. It is only ever resolved by a later
+    // rebuild stamping `built_at` past it.
+    if matches!(trigger, RebuildTrigger::LibrarySynced) {
+        mark_library_changed(&db);
+    }
 
     if running.load(Ordering::SeqCst) {
         debug!(target: "noor.radio_similarity", "rebuild already running, skipping");
         return;
     }
 
-    // Freshness inputs in one connection grab: index age (None = never built)
-    // and the pending-rebuild flag.
-    let snapshot = db.with_conn(|conn| {
-        let age_secs: Option<i64> = conn.query_row(
-            "SELECT CAST((julianday('now') - julianday(MAX(computed_at))) * 86400 AS INTEGER)
-             FROM track_similarity",
-            [],
-            |r| r.get(0),
-        )?;
-        let dirty: bool = conn
-            .query_row(
-                "SELECT value FROM server_config WHERE key = ?1",
-                rusqlite::params![DIRTY_FLAG_KEY],
-                |r| r.get::<_, String>(0),
-            )
-            .optional()?
-            .map(|v| v == "1")
-            .unwrap_or(false);
-        Ok((age_secs, dirty))
-    });
-    let (age_secs, dirty) = match snapshot {
-        Ok(v) => v,
+    let freshness = match db.with_conn(read_freshness) {
+        Ok(f) => f,
         Err(err) => {
             warn!(target: "noor.radio_similarity", error = %err, "freshness check failed");
             return;
         }
     };
 
-    if !should_rebuild(age_secs, dirty, trigger) {
-        // A `LibrarySynced` inside the debounce window still changed the
-        // library — record it so the hourly ticker rebuilds once the window
-        // clears, instead of the change waiting for the stale-age sweep.
-        if matches!(trigger, RebuildTrigger::LibrarySynced) {
-            mark_dirty(&db);
-        }
+    if !should_rebuild(freshness.built_age_secs, freshness.dirty, trigger) {
         debug!(
             target: "noor.radio_similarity",
-            ?trigger, age_secs, dirty, "index fresh for this trigger, skipping rebuild"
+            ?trigger,
+            built_age_secs = ?freshness.built_age_secs,
+            dirty = freshness.dirty,
+            "index fresh for this trigger, skipping rebuild"
         );
         return;
     }
 
-    // A rebuild is warranted — but it is a multi-minute SQLite write
-    // transaction, and WAL allows only one writer. Run it only while the app
-    // is otherwise quiet, so foreground writes (listen history, queue/runtime
-    // state, sync metadata) don't fail on the busy timeout. If something is
-    // active, defer: a `LibrarySynced` trigger leaves the dirty flag set so the
-    // ticker retries; a `Periodic` trigger simply re-evaluates next tick.
-    let busy_reason = if audio_active.load(Ordering::SeqCst) {
-        Some("audio playback")
-    } else if tidal_sync_running.load(Ordering::SeqCst) {
-        Some("tidal sync")
-    } else if lastfm_enrich_running.load(Ordering::SeqCst) {
-        Some("last.fm enrichment")
-    } else if musicbrainz_enrich_running.load(Ordering::SeqCst) {
-        Some("musicbrainz enrichment")
-    } else if spotify_enrich_running.load(Ordering::SeqCst) {
-        Some("spotify enrichment")
-    } else if audio_analysis_running.load(Ordering::SeqCst) {
-        Some("audio analysis")
-    } else if acrcloud_scan_running.load(Ordering::SeqCst) {
-        Some("acrcloud scan")
-    } else {
-        None
-    };
-    if let Some(reason) = busy_reason {
-        if matches!(trigger, RebuildTrigger::LibrarySynced) {
-            mark_dirty(&db);
-        }
-        debug!(
-            target: "noor.radio_similarity",
-            ?trigger, reason, "app busy, deferring rebuild"
-        );
+    // A rebuild is warranted, but it owns SQLite's single writer slot for
+    // minutes. Run it only while the app is otherwise quiet; otherwise defer.
+    // The change is already recorded in `library_changed_at`, so the hourly
+    // ticker will retry once things settle.
+    if let Some(reason) = busy {
+        debug!(target: "noor.radio_similarity", ?trigger, reason, "app busy, deferring rebuild");
         return;
     }
 
     if try_spawn_rebuild(db, event_tx, running) {
         info!(
             target: "noor.radio_similarity",
-            ?trigger, age_secs, "radio similarity rebuild started"
+            ?trigger,
+            built_age_secs = ?freshness.built_age_secs,
+            "radio similarity rebuild started"
         );
+    }
+}
+
+/// The active foreground job that should hold off a rebuild, or `None` if the
+/// app is idle enough. A rebuild owns SQLite's single writer slot for minutes,
+/// so neither the auto path nor the manual Settings route may run one while
+/// another writer is active.
+pub fn busy_reason(state: &crate::AppState) -> Option<&'static str> {
+    use std::sync::atomic::Ordering::SeqCst;
+    if state.audio_active.load(SeqCst) {
+        Some("audio playback")
+    } else if state.tidal_sync_running.load(SeqCst) {
+        Some("a TIDAL sync")
+    } else if state.lastfm_enrich_running.load(SeqCst) {
+        Some("Last.fm enrichment")
+    } else if state.musicbrainz_enrich_running.load(SeqCst) {
+        Some("MusicBrainz enrichment")
+    } else if state.spotify_enrich_running.load(SeqCst) {
+        Some("Spotify enrichment")
+    } else if state.audio_analysis_running.load(SeqCst) {
+        Some("audio analysis")
+    } else if state.acrcloud_scan_running.load(SeqCst) {
+        Some("an ACRCloud scan")
+    } else {
+        None
     }
 }
 
 /// Pure rebuild decision, split out so the freshness logic is unit-testable.
 /// Considers only index age, the dirty flag, and the trigger — not app
 /// activity (the idle gate) or the single-flight slot.
-fn should_rebuild(age_secs: Option<i64>, dirty: bool, trigger: RebuildTrigger) -> bool {
-    match (age_secs, trigger) {
+fn should_rebuild(built_age: Option<i64>, dirty: bool, trigger: RebuildTrigger) -> bool {
+    match (built_age, trigger) {
         // Never built — always worth building, whatever asked.
         (None, _) => true,
         // A library change: rebuild once past the debounce window. Inside the
-        // window the caller records the change via the dirty flag instead.
+        // window the change stays recorded in `library_changed_at`.
         (Some(age), RebuildTrigger::LibrarySynced) => age >= MIN_REBUILD_INTERVAL_SECS,
         // Periodic catch-up: a genuinely old index, or a debounced/deferred
         // change that is now past the debounce window.
@@ -200,18 +189,58 @@ fn should_rebuild(age_secs: Option<i64>, dirty: bool, trigger: RebuildTrigger) -
     }
 }
 
-/// Record that a library change is owed a rebuild. Cleared by `try_spawn_rebuild`
-/// once a rebuild completes.
-fn mark_dirty(db: &Database) {
+fn read_config(conn: &Connection, key: &str) -> rusqlite::Result<Option<String>> {
+    conn.query_row(
+        "SELECT value FROM server_config WHERE key = ?1",
+        rusqlite::params![key],
+        |r| r.get(0),
+    )
+    .optional()
+}
+
+/// Read index freshness from `server_config`. Deliberately does not touch
+/// `track_similarity` — see the module's freshness-model note.
+fn read_freshness(conn: &Connection) -> anyhow::Result<Freshness> {
+    let built_at = read_config(conn, BUILT_AT_KEY)?;
+    let library_changed_at = read_config(conn, LIBRARY_CHANGED_AT_KEY)?;
+
+    let built_age_secs: Option<i64> = if built_at.is_some() {
+        conn.query_row(
+            "SELECT CAST((julianday('now') - julianday(value)) * 86400 AS INTEGER)
+             FROM server_config WHERE key = ?1",
+            rusqlite::params![BUILT_AT_KEY],
+            |r| r.get(0),
+        )
+        .optional()?
+    } else {
+        None
+    };
+
+    // ISO-8601-ish timestamps from datetime('now') sort correctly as text.
+    let dirty = match (&library_changed_at, &built_at) {
+        (None, _) => false,
+        (Some(_), None) => true,
+        (Some(changed), Some(built)) => changed.as_str() > built.as_str(),
+    };
+
+    Ok(Freshness {
+        built_age_secs,
+        dirty,
+    })
+}
+
+/// Stamp `library_changed_at = now`. Called for every `LibrarySynced` before
+/// any other check, so the change survives a busy app or an in-flight rebuild.
+fn mark_library_changed(db: &Database) {
     let result = db.with_conn(|conn| {
         conn.execute(
-            "INSERT OR REPLACE INTO server_config (key, value) VALUES (?1, '1')",
-            rusqlite::params![DIRTY_FLAG_KEY],
+            "INSERT OR REPLACE INTO server_config (key, value) VALUES (?1, datetime('now'))",
+            rusqlite::params![LIBRARY_CHANGED_AT_KEY],
         )?;
         Ok(())
     });
     if let Err(err) = result {
-        warn!(target: "noor.radio_similarity", error = %err, "failed to set dirty flag");
+        warn!(target: "noor.radio_similarity", error = %err, "failed to record library change");
     }
 }
 
@@ -219,8 +248,9 @@ fn mark_dirty(db: &Database) {
 /// connection. Returns `false` (without spawning) if a rebuild is already
 /// running. Shared by the auto-rebuild triggers and the manual Settings route.
 ///
-/// The `swap` is the real single-flight guard: callers may race past the
-/// cheaper `load` check in `run_if_stale`, but only one wins the swap.
+/// Callers are responsible for the idle gate (`busy_reason`); this only owns
+/// the single-flight `swap` — callers may race past the cheaper `load` check,
+/// but only one wins the swap.
 pub fn try_spawn_rebuild(
     db: Database,
     event_tx: broadcast::Sender<AppEvent>,
@@ -235,18 +265,24 @@ pub fn try_spawn_rebuild(
         // Releases the single-flight flag on drop, including on panic — a
         // wedged flag would silently block every future rebuild.
         let _guard = RunningGuard(running);
-        let result = db.open_isolated().and_then(|conn| {
+        let result = (|| -> anyhow::Result<usize> {
+            let conn = db.open_isolated()?;
+            // Capture the start time before the rebuild reads any data: a
+            // LibrarySynced that lands during the rebuild stamps a later
+            // `library_changed_at`, which stays newer than this `built_at` and
+            // so re-triggers a rebuild instead of being silently absorbed.
+            let started_at: String =
+                conn.query_row("SELECT datetime('now')", [], |r| r.get(0))?;
             let pairs = crate::db::queries::compute_track_similarity(&conn)?;
-            // The index now reflects current library state — clear the pending
-            // flag so the ticker doesn't rebuild again needlessly.
-            if let Err(err) = conn.execute(
-                "INSERT OR REPLACE INTO server_config (key, value) VALUES (?1, '0')",
-                rusqlite::params![DIRTY_FLAG_KEY],
-            ) {
-                warn!(target: "noor.radio_similarity", error = %err, "failed to clear dirty flag");
-            }
+            // Record completion independently of row count — a valid library
+            // can legitimately produce zero pairs, which must not read as
+            // "never built".
+            conn.execute(
+                "INSERT OR REPLACE INTO server_config (key, value) VALUES (?1, ?2)",
+                rusqlite::params![BUILT_AT_KEY, started_at],
+            )?;
             Ok(pairs)
-        });
+        })();
         match result {
             Ok(pairs) => {
                 info!(
@@ -278,6 +314,7 @@ impl Drop for RunningGuard {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::db::Database;
 
     #[test]
     fn never_built_always_rebuilds() {
@@ -287,12 +324,8 @@ mod tests {
 
     #[test]
     fn library_synced_debounces_recent_rebuilds() {
-        // Inside the debounce window — skip (the caller marks it dirty).
-        assert!(!should_rebuild(
-            Some(60),
-            false,
-            RebuildTrigger::LibrarySynced
-        ));
+        // Inside the debounce window — skip (the change stays recorded).
+        assert!(!should_rebuild(Some(60), false, RebuildTrigger::LibrarySynced));
         // Past the debounce window — rebuild.
         assert!(should_rebuild(
             Some(MIN_REBUILD_INTERVAL_SECS),
@@ -323,5 +356,72 @@ mod tests {
             false,
             RebuildTrigger::Periodic
         ));
+    }
+
+    fn set_config(db: &Database, key: &str, value: &str) {
+        db.with_conn(|conn| {
+            conn.execute(
+                "INSERT OR REPLACE INTO server_config (key, value) VALUES (?1, ?2)",
+                rusqlite::params![key, value],
+            )?;
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn freshness_never_built_never_changed() {
+        let db = Database::open_in_memory().unwrap();
+        db.run_migrations().unwrap();
+        let f = db.with_conn(read_freshness).unwrap();
+        assert_eq!(f.built_age_secs, None);
+        assert!(!f.dirty);
+    }
+
+    #[test]
+    fn freshness_zero_row_index_is_not_never_built() {
+        // Regression for the Codex finding: a successful rebuild that produced
+        // zero similarity rows still stamps built_at, so freshness must read it
+        // as built (Some age), not None — `read_freshness` never looks at
+        // `track_similarity` rows at all.
+        let db = Database::open_in_memory().unwrap();
+        db.run_migrations().unwrap();
+        set_config(&db, BUILT_AT_KEY, "2026-05-14 00:00:00");
+        let f = db.with_conn(read_freshness).unwrap();
+        assert!(
+            f.built_age_secs.is_some(),
+            "built_at must drive freshness, not row count"
+        );
+        assert!(!f.dirty);
+    }
+
+    #[test]
+    fn freshness_dirty_when_library_changed_after_build() {
+        let db = Database::open_in_memory().unwrap();
+        db.run_migrations().unwrap();
+        set_config(&db, BUILT_AT_KEY, "2026-05-14 00:00:00");
+        set_config(&db, LIBRARY_CHANGED_AT_KEY, "2026-05-14 01:00:00");
+        let f = db.with_conn(read_freshness).unwrap();
+        assert!(f.dirty);
+    }
+
+    #[test]
+    fn freshness_not_dirty_when_build_is_newer() {
+        let db = Database::open_in_memory().unwrap();
+        db.run_migrations().unwrap();
+        set_config(&db, LIBRARY_CHANGED_AT_KEY, "2026-05-14 00:00:00");
+        set_config(&db, BUILT_AT_KEY, "2026-05-14 02:00:00");
+        let f = db.with_conn(read_freshness).unwrap();
+        assert!(!f.dirty);
+    }
+
+    #[test]
+    fn freshness_dirty_when_changed_but_never_built() {
+        let db = Database::open_in_memory().unwrap();
+        db.run_migrations().unwrap();
+        set_config(&db, LIBRARY_CHANGED_AT_KEY, "2026-05-14 00:00:00");
+        let f = db.with_conn(read_freshness).unwrap();
+        assert_eq!(f.built_age_secs, None);
+        assert!(f.dirty);
     }
 }

--- a/noor-server/src/services/radio_similarity.rs
+++ b/noor-server/src/services/radio_similarity.rs
@@ -300,8 +300,7 @@ pub fn try_spawn_rebuild(
             // the rebuild reads any data. A LibrarySynced that lands during the
             // rebuild bumps change_gen past this value, so the freshness check
             // stays dirty and re-triggers — no same-second timestamp race.
-            let started_at: String =
-                conn.query_row("SELECT datetime('now')", [], |r| r.get(0))?;
+            let started_at: String = conn.query_row("SELECT datetime('now')", [], |r| r.get(0))?;
             let change_gen_at_start: i64 = conn.query_row(
                 "SELECT CAST(COALESCE((SELECT value FROM server_config WHERE key = ?1), '0') AS INTEGER)",
                 rusqlite::params![CHANGE_GEN_KEY],
@@ -363,7 +362,11 @@ mod tests {
     #[test]
     fn library_synced_debounces_recent_rebuilds() {
         // Inside the debounce window — skip (the change stays recorded).
-        assert!(!should_rebuild(Some(60), false, RebuildTrigger::LibrarySynced));
+        assert!(!should_rebuild(
+            Some(60),
+            false,
+            RebuildTrigger::LibrarySynced
+        ));
         // Past the debounce window — rebuild.
         assert!(should_rebuild(
             Some(MIN_REBUILD_INTERVAL_SECS),
@@ -472,11 +475,20 @@ mod tests {
         let db = Database::open_in_memory().unwrap();
         db.run_migrations().unwrap();
         // Starts unset (treated as 0).
-        assert_eq!(db.with_conn(|c| Ok(read_gen(c, CHANGE_GEN_KEY)?)).unwrap(), 0);
+        assert_eq!(
+            db.with_conn(|c| Ok(read_gen(c, CHANGE_GEN_KEY)?)).unwrap(),
+            0
+        );
         mark_library_changed(&db);
-        assert_eq!(db.with_conn(|c| Ok(read_gen(c, CHANGE_GEN_KEY)?)).unwrap(), 1);
+        assert_eq!(
+            db.with_conn(|c| Ok(read_gen(c, CHANGE_GEN_KEY)?)).unwrap(),
+            1
+        );
         mark_library_changed(&db);
         mark_library_changed(&db);
-        assert_eq!(db.with_conn(|c| Ok(read_gen(c, CHANGE_GEN_KEY)?)).unwrap(), 3);
+        assert_eq!(
+            db.with_conn(|c| Ok(read_gen(c, CHANGE_GEN_KEY)?)).unwrap(),
+            3
+        );
     }
 }


### PR DESCRIPTION
## Summary

- **Radio Engine lane was dead.** It reads the precomputed `track_similarity` index, but `compute_track_similarity` had no trigger — the table sat empty on every install, so the Engine recall lane silently contributed nothing to every radio queue. Adds a Settings "Build radio similarity index" panel + `GET /api/discovery/radio/status`, plus auto-rebuild: a `LibrarySynced` listener and an hourly catch-up ticker.
- **Auto-rebuild is built to not hurt the running app.** Single-flight via an atomic; runs `compute_track_similarity` on an isolated connection inside `spawn_blocking`, so it never holds the shared connection mutex; idle-gated against playback / sync / enrichment / analysis / discovery training; freshness tracked by a monotonic change-generation counter (race-free regardless of clock precision); a zero-pair rebuild still records completion.
- **Diagnostics.** `MIGRATION_040` adds `radio_diagnostics.engine_index_empty` so a zero engine-source count is no longer ambiguous between "no match" and "index never built". Also a dated RadioProfile tuning-review note.
- **DB projection refactor** (the 2 commits the branch is named for): a shared track-projection helper + row-shape test coverage.

Went through four `/codex:adversarial-review` rounds during development; each found real issues (DB-mutex starvation, freshness races, missing idle-gate cases) — all fixed and covered by tests.

## Test plan

- [ ] `cargo test` — 641 passing, incl. new `radio_similarity` freshness / `should_rebuild` / discovery-training-gate tests
- [ ] `pnpm check` and `pnpm lint` — clean
- [ ] Manual: Settings -> Build radio similarity index, confirm status (pair count / last built) updates
- [ ] Manual: trigger a radio queue, confirm Engine-lane candidates now appear
- [ ] Confirm auto-rebuild defers while playback / a sync / discovery training is active