### PR TITLE
chore(clippy): drop mechanical lint warnings

### DIFF
--- a/noor-app/src/config.rs
+++ b/noor-app/src/config.rs
@@ -1,15 +1,9 @@
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct AppConfig {
     pub host_mode: bool,
-}
-
-impl Default for AppConfig {
-    fn default() -> Self {
-        Self { host_mode: false }
-    }
 }
 
 fn config_path() -> PathBuf {

--- a/noor-server/src/main.rs
+++ b/noor-server/src/main.rs
@@ -324,11 +324,11 @@ mod tests {
     #[test]
     fn host_flag_detection() {
         // Simulate args: just test the parsing logic directly
-        let args = vec!["noor-server".to_string(), "--host".to_string()];
+        let args = ["noor-server".to_string(), "--host".to_string()];
         let has_host = args.iter().any(|a| a == "--host");
         assert!(has_host);
 
-        let args_no_flag = vec!["noor-server".to_string()];
+        let args_no_flag = ["noor-server".to_string()];
         let has_host = args_no_flag.iter().any(|a| a == "--host");
         assert!(!has_host);
     }
@@ -503,7 +503,7 @@ async fn main() -> Result<()> {
                     services::tidal::auth::decode_persisted_tidal_tokens(&master_key, &bytes)
                         .ok()
                         .flatten()
-                        .and_then(|persisted| {
+                        .map(|persisted| {
                             let needs_rewrite = persisted.needs_encrypted_rewrite();
                             let tokens = persisted.into_tokens();
                             if needs_rewrite
@@ -518,7 +518,7 @@ async fn main() -> Result<()> {
                             rusqlite::params![blob],
                         );
                             }
-                            Some(tokens)
+                            tokens
                         })
                         .inspect(|t: &services::tidal::auth::TidalTokens| {
                             info!("Loaded persisted TIDAL tokens for user {}", t.user_id);

--- a/noor-server/src/playback/player.rs
+++ b/noor-server/src/playback/player.rs
@@ -2322,7 +2322,7 @@ mod tests {
             .collect::<rusqlite::Result<Vec<_>>>()
             .unwrap();
         assert_eq!(hints.iter().filter(|hint| **hint == Some(99001)).count(), 1);
-        assert!(hints.iter().any(|hint| *hint == Some(99002)));
+        assert!(hints.contains(&Some(99002)));
     }
 
     #[test]
@@ -2990,10 +2990,10 @@ mod parity_tests {
                 cand.bpm,
             );
 
-            if let (Some(seed_energy), Some(cand_energy)) = (seed.energy, cand.energy) {
-                if (seed_energy - cand_energy).abs() > 0.5 {
-                    score *= 0.7;
-                }
+            if let (Some(seed_energy), Some(cand_energy)) = (seed.energy, cand.energy)
+                && (seed_energy - cand_energy).abs() > 0.5
+            {
+                score *= 0.7;
             }
         }
 

--- a/noor-server/src/playback/shuffle.rs
+++ b/noor-server/src/playback/shuffle.rs
@@ -454,7 +454,7 @@ mod tests {
 
         let shuffled = weighted_shuffle_with_rng(&[low.clone(), high.clone()], &profile, &mut rng);
 
-        assert_eq!(profile.weight_for(&high) > profile.weight_for(&low), true);
+        assert!(profile.weight_for(&high) > profile.weight_for(&low));
         assert_eq!(shuffled.first().map(|track| track.id), Some(high.id));
     }
 
@@ -553,7 +553,7 @@ mod tests {
             track(7, 2, "B", false, 1, None, 10), // B
         ];
         let key_fn = |t: &Track| t.artist_name.clone().unwrap_or_default();
-        let stabilized = stabilize_adjacent_keys(tracks, key_fn.clone());
+        let stabilized = stabilize_adjacent_keys(tracks, key_fn);
 
         let keys: Vec<String> = stabilized.iter().map(key_fn).collect();
         // A valid arrangement of 4×A + 3×B has at most one same-A adjacency

--- a/noor-server/src/services/radio.rs
+++ b/noor-server/src/services/radio.rs
@@ -1965,7 +1965,7 @@ mod tests {
         // Manually invoke the inner machinery: pre-populate queue, then call
         // the rerank with a one-candidate pool. (Easier than coaxing the full
         // function into emitting the same setup.)
-        cands.extend(queue_already.clone().into_iter());
+        cands.extend(queue_already.clone());
         let queue = diversity_rerank(
             cands,
             &profile,
@@ -3436,12 +3436,13 @@ mod radio_diagnostic_harness {
                 cand.track_id,
                 normalize_for_dedup(&cand.artist_name, &cand.title),
             );
-            if let Some(pre) = pre_affinity.get(&key).copied() {
-                if cand.similarity_score > pre * 1.05 && cand.track_id > 0 {
-                    let cg = track_genres(&db, cand.track_id);
-                    if !cg.is_empty() && cg.intersection(&seed_genres).count() == 0 {
-                        h2_promoted += 1;
-                    }
+            if let Some(pre) = pre_affinity.get(&key).copied()
+                && cand.similarity_score > pre * 1.05
+                && cand.track_id > 0
+            {
+                let cg = track_genres(&db, cand.track_id);
+                if !cg.is_empty() && cg.intersection(&seed_genres).count() == 0 {
+                    h2_promoted += 1;
                 }
             }
         }

--- a/noor-server/src/services/sportify/recommend.rs
+++ b/noor-server/src/services/sportify/recommend.rs
@@ -438,7 +438,7 @@ mod tests {
 
     fn open_test_db() -> Database {
         let db = Database::open_in_memory().expect("open memory db");
-        db.with_conn(|conn| schema::run_migrations(conn))
+        db.with_conn(schema::run_migrations)
             .expect("apply migrations");
         db
     }


### PR DESCRIPTION
## Summary
- Clears mechanical clippy lint warnings across 6 files — no behavior change.

## Test plan
- [ ] `cargo check --all-targets` — clean (verified)
- [ ] `cargo clippy --all-targets` — warnings gone