### PR TITLE
test: pin behaviors caught by the refactor audit

### DIFF
--- a/noor-server/src/main.rs
+++ b/noor-server/src/main.rs
@@ -332,6 +332,109 @@ mod tests {
         let has_host = args_no_flag.iter().any(|a| a == "--host");
         assert!(!has_host);
     }
+
+    // Characterization test for the boot-time wipe at main.rs:383-399. This
+    // re-runs the exact SQL the boot path runs so a future refactor (e.g. extracting
+    // it to a `reset_ephemeral_session` function) can be checked against the
+    // current behavior. CLAUDE.md flags this wipe as load-bearing: queue and
+    // current_track_id MUST be cleared, but user prefs (volume, shuffle, repeat,
+    // automix flags) MUST survive.
+    #[test]
+    fn boot_wipe_clears_queue_resets_playback_state_and_marks_orphan_runs_failed() {
+        let db = crate::db::Database::open_in_memory().expect("open in-memory db");
+        db.run_migrations().expect("migrations");
+
+        // Seed: a stale session (track playing mid-position, queue with rows),
+        // a "running" training run that would otherwise be orphaned, AND user
+        // prefs we expect the wipe to PRESERVE.
+        db.with_conn(|conn| {
+            conn.execute("INSERT INTO artists (id, name) VALUES (1, 'A')", [])?;
+            conn.execute(
+                "INSERT INTO tracks (
+                    id, title, artist_id, duration_ms, source, fidelity_score
+                 ) VALUES (1, 'T', 1, 180000, 'tidal_stream', 0)",
+                [],
+            )?;
+            conn.execute(
+                "INSERT INTO queue (track_id, position, source) VALUES (1, 0, 'user')",
+                [],
+            )?;
+            conn.execute(
+                "UPDATE playback_state
+                 SET is_playing = 1, current_track_id = 1, position_ms = 12345,
+                     volume = 0.73, shuffle_mode = 'weighted', repeat_mode = 'one',
+                     automix_enabled = 1
+                 WHERE id = 1",
+                [],
+            )?;
+            conn.execute(
+                "INSERT INTO training_runs (stage, status, started_at)
+                 VALUES ('train', 'running', datetime('now'))",
+                [],
+            )?;
+            Ok::<_, anyhow::Error>(())
+        })
+        .expect("seed");
+
+        // Run the boot-wipe SQL verbatim from main.rs:383-399.
+        db.with_conn(|conn| {
+            conn.execute(
+                "UPDATE playback_state SET is_playing = 0, current_track_id = NULL, current_queue_item_id = NULL, position_ms = 0 WHERE id = 1",
+                [],
+            )?;
+            conn.execute("DELETE FROM queue", [])?;
+            conn.execute(
+                "UPDATE training_runs
+                 SET status = 'failed',
+                     finished_at = datetime('now'),
+                     error_text = COALESCE(error_text, 'interrupted by server restart')
+                 WHERE status = 'running'",
+                [],
+            )?;
+            Ok::<_, anyhow::Error>(())
+        })
+        .expect("wipe");
+
+        // Post-conditions.
+        db.with_conn(|conn| {
+            let queue_count: i64 = conn
+                .query_row("SELECT COUNT(*) FROM queue", [], |r| r.get(0))?;
+            assert_eq!(queue_count, 0, "queue must be empty after boot wipe");
+
+            let (is_playing, current_track_id, current_queue_item_id, position_ms, volume, shuffle_mode, repeat_mode, automix_enabled): (
+                i64, Option<i64>, Option<i64>, i64, f64, String, String, i64,
+            ) = conn.query_row(
+                "SELECT is_playing, current_track_id, current_queue_item_id, position_ms,
+                        volume, shuffle_mode, repeat_mode, automix_enabled
+                 FROM playback_state WHERE id = 1",
+                [],
+                |r| Ok((
+                    r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?,
+                    r.get(4)?, r.get(5)?, r.get(6)?, r.get(7)?,
+                )),
+            )?;
+            // Cleared:
+            assert_eq!(is_playing, 0, "is_playing must reset to 0");
+            assert!(current_track_id.is_none(), "current_track_id must reset to NULL");
+            assert!(current_queue_item_id.is_none(), "current_queue_item_id must reset to NULL");
+            assert_eq!(position_ms, 0, "position_ms must reset to 0");
+            // Preserved (CLAUDE.md guarantee):
+            assert!((volume - 0.73).abs() < 1e-9, "user prefs: volume must survive boot wipe, got {volume}");
+            assert_eq!(shuffle_mode, "weighted", "user prefs: shuffle_mode must survive");
+            assert_eq!(repeat_mode, "one", "user prefs: repeat_mode must survive");
+            assert_eq!(automix_enabled, 1, "user prefs: automix flag must survive");
+
+            let training_status: String = conn.query_row(
+                "SELECT status FROM training_runs LIMIT 1",
+                [],
+                |r| r.get(0),
+            )?;
+            assert_eq!(training_status, "failed", "orphan training_runs must be marked failed");
+
+            Ok::<_, anyhow::Error>(())
+        })
+        .expect("assert");
+    }
 }
 
 #[tokio::main]

--- a/noor-server/src/main.rs
+++ b/noor-server/src/main.rs
@@ -397,39 +397,66 @@ mod tests {
 
         // Post-conditions.
         db.with_conn(|conn| {
-            let queue_count: i64 = conn
-                .query_row("SELECT COUNT(*) FROM queue", [], |r| r.get(0))?;
+            let queue_count: i64 =
+                conn.query_row("SELECT COUNT(*) FROM queue", [], |r| r.get(0))?;
             assert_eq!(queue_count, 0, "queue must be empty after boot wipe");
 
-            let (is_playing, current_track_id, current_queue_item_id, position_ms, volume, shuffle_mode, repeat_mode, automix_enabled): (
-                i64, Option<i64>, Option<i64>, i64, f64, String, String, i64,
-            ) = conn.query_row(
+            let (
+                is_playing,
+                current_track_id,
+                current_queue_item_id,
+                position_ms,
+                volume,
+                shuffle_mode,
+                repeat_mode,
+                automix_enabled,
+            ): (i64, Option<i64>, Option<i64>, i64, f64, String, String, i64) = conn.query_row(
                 "SELECT is_playing, current_track_id, current_queue_item_id, position_ms,
                         volume, shuffle_mode, repeat_mode, automix_enabled
                  FROM playback_state WHERE id = 1",
                 [],
-                |r| Ok((
-                    r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?,
-                    r.get(4)?, r.get(5)?, r.get(6)?, r.get(7)?,
-                )),
+                |r| {
+                    Ok((
+                        r.get(0)?,
+                        r.get(1)?,
+                        r.get(2)?,
+                        r.get(3)?,
+                        r.get(4)?,
+                        r.get(5)?,
+                        r.get(6)?,
+                        r.get(7)?,
+                    ))
+                },
             )?;
             // Cleared:
             assert_eq!(is_playing, 0, "is_playing must reset to 0");
-            assert!(current_track_id.is_none(), "current_track_id must reset to NULL");
-            assert!(current_queue_item_id.is_none(), "current_queue_item_id must reset to NULL");
+            assert!(
+                current_track_id.is_none(),
+                "current_track_id must reset to NULL"
+            );
+            assert!(
+                current_queue_item_id.is_none(),
+                "current_queue_item_id must reset to NULL"
+            );
             assert_eq!(position_ms, 0, "position_ms must reset to 0");
             // Preserved (CLAUDE.md guarantee):
-            assert!((volume - 0.73).abs() < 1e-9, "user prefs: volume must survive boot wipe, got {volume}");
-            assert_eq!(shuffle_mode, "weighted", "user prefs: shuffle_mode must survive");
+            assert!(
+                (volume - 0.73).abs() < 1e-9,
+                "user prefs: volume must survive boot wipe, got {volume}"
+            );
+            assert_eq!(
+                shuffle_mode, "weighted",
+                "user prefs: shuffle_mode must survive"
+            );
             assert_eq!(repeat_mode, "one", "user prefs: repeat_mode must survive");
             assert_eq!(automix_enabled, 1, "user prefs: automix flag must survive");
 
-            let training_status: String = conn.query_row(
-                "SELECT status FROM training_runs LIMIT 1",
-                [],
-                |r| r.get(0),
-            )?;
-            assert_eq!(training_status, "failed", "orphan training_runs must be marked failed");
+            let training_status: String =
+                conn.query_row("SELECT status FROM training_runs LIMIT 1", [], |r| r.get(0))?;
+            assert_eq!(
+                training_status, "failed",
+                "orphan training_runs must be marked failed"
+            );
 
             Ok::<_, anyhow::Error>(())
         })

--- a/noor-server/src/playback/player.rs
+++ b/noor-server/src/playback/player.rs
@@ -3362,4 +3362,23 @@ mod parity_tests {
             panic!("top-{n} ranking diverged.\n  old: {old_top:?}\n  new: {new_top:?}");
         }
     }
+
+    // Characterization test. The previous refactor plan got this exactly backwards:
+    // it claimed malformed timestamps incur "maximum recency penalty". They do not.
+    // parse_days_since_last_played returns f64::MAX on parse failure, and the caller
+    // in automix_score only applies a penalty when `days_since < 14.0` (player.rs:1586).
+    // f64::MAX is never < 14.0, so the penalty branch is skipped and the candidate
+    // keeps its base score. This test pins that behavior so a future "cleanup" that
+    // returns 0.0 or 999.0 on error would be caught.
+    #[test]
+    fn parse_days_since_last_played_returns_f64_max_on_malformed_input() {
+        assert_eq!(parse_days_since_last_played("not a date"), f64::MAX);
+        assert_eq!(parse_days_since_last_played(""), f64::MAX);
+        assert_eq!(parse_days_since_last_played("2026-99-99T99:99:99Z"), f64::MAX);
+        // Sanity: the 14-day penalty gate in automix_score is NOT triggered.
+        assert!(parse_days_since_last_played("malformed") >= 14.0);
+        // Sanity: a well-formed timestamp parses to a small positive number.
+        let recent = parse_days_since_last_played("2026-05-13T12:00:00Z");
+        assert!(recent >= 0.0 && recent < 365.0);
+    }
 }

--- a/noor-server/src/playback/player.rs
+++ b/noor-server/src/playback/player.rs
@@ -3374,7 +3374,10 @@ mod parity_tests {
     fn parse_days_since_last_played_returns_f64_max_on_malformed_input() {
         assert_eq!(parse_days_since_last_played("not a date"), f64::MAX);
         assert_eq!(parse_days_since_last_played(""), f64::MAX);
-        assert_eq!(parse_days_since_last_played("2026-99-99T99:99:99Z"), f64::MAX);
+        assert_eq!(
+            parse_days_since_last_played("2026-99-99T99:99:99Z"),
+            f64::MAX
+        );
         // Sanity: the 14-day penalty gate in automix_score is NOT triggered.
         assert!(parse_days_since_last_played("malformed") >= 14.0);
         // Sanity: a well-formed timestamp parses to a small positive number.

--- a/noor-server/src/playback/shuffle.rs
+++ b/noor-server/src/playback/shuffle.rs
@@ -631,8 +631,14 @@ mod tests {
         let w_never = profile.weight_for(&never_played);
 
         // Malformed and very-old share the no-penalty path.
-        assert!((w_malformed - w_old).abs() < 1e-9, "malformed should match ancient: {w_malformed} vs {w_old}");
+        assert!(
+            (w_malformed - w_old).abs() < 1e-9,
+            "malformed should match ancient: {w_malformed} vs {w_old}"
+        );
         // Never-played takes the boost branch instead, which is distinguishable.
-        assert!((w_malformed - w_never).abs() > 0.01, "malformed should NOT match never-played: {w_malformed} vs {w_never}");
+        assert!(
+            (w_malformed - w_never).abs() > 0.01,
+            "malformed should NOT match never-played: {w_malformed} vs {w_never}"
+        );
     }
 }

--- a/noor-server/src/playback/shuffle.rs
+++ b/noor-server/src/playback/shuffle.rs
@@ -600,4 +600,39 @@ mod tests {
         assert_eq!(genre_order.len(), 4);
         assert_ne!(genre_order[0], genre_order[1]);
     }
+
+    // Characterization test. shuffle.rs's parse_days_since returns 999.0 on
+    // parse failure, NOT the same fallback as player.rs's parser (which uses
+    // f64::MAX). The two pickers behave differently on malformed input:
+    //   - shuffle treats malformed as "ancient" (gets full decay → no penalty)
+    //   - player treats malformed as "unknown" (skips the 14-day gate → no penalty)
+    // The end result is the same (no recent-play penalty in either path), but
+    // through different code. This test pins both pieces.
+    #[test]
+    fn parse_days_since_returns_999_on_malformed_input() {
+        assert_eq!(parse_days_since("not a date"), 999.0);
+        assert_eq!(parse_days_since(""), 999.0);
+        assert_eq!(parse_days_since("2026-99-99T99:99:99Z"), 999.0);
+    }
+
+    #[test]
+    fn weighted_shuffle_malformed_last_played_applies_no_recent_play_penalty() {
+        // weight_for branches: Some(last_played) → time-decay scaled penalty;
+        //                      None              → never_played_boost (separate code path).
+        // Malformed → parse_days_since=999 → decay=1.0 → penalty multiplier=1.0 (no penalty).
+        // Very-old plays converge to the same multiplier; never-played hits the boost branch.
+        let profile = WeightedShuffleProfile::default();
+        let malformed = track(1, 1, "A", false, 1, Some("not a date"), 0);
+        let very_old = track(2, 1, "A", false, 1, Some("1999-01-01T00:00:00Z"), 0);
+        let never_played = track(3, 1, "A", false, 1, None, 0);
+
+        let w_malformed = profile.weight_for(&malformed);
+        let w_old = profile.weight_for(&very_old);
+        let w_never = profile.weight_for(&never_played);
+
+        // Malformed and very-old share the no-penalty path.
+        assert!((w_malformed - w_old).abs() < 1e-9, "malformed should match ancient: {w_malformed} vs {w_old}");
+        // Never-played takes the boost branch instead, which is distinguishable.
+        assert!((w_malformed - w_never).abs() > 0.01, "malformed should NOT match never-played: {w_malformed} vs {w_never}");
+    }
 }

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -13186,4 +13186,111 @@ mod tests {
             .unwrap();
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
+
+    // Characterization tests for TIDAL-handler failure shapes. These differ on
+    // purpose: the album endpoint is "best-effort" (TIDAL is enrichment) while
+    // tidal_search treats a disconnected session as a user-visible error.
+    // A single shared error helper would erase this distinction - so these tests
+    // exist to flag any refactor that does.
+
+    #[tokio::test]
+    async fn get_album_tracks_returns_local_tracks_when_tidal_session_absent() {
+        let (db, db_path) = fresh_migrated_db();
+        // The album MUST have a tidal_id, otherwise the handler returns at
+        // routes.rs:977 with album_tidal_id: null - which is a different code
+        // path. To exercise the "no TIDAL session" branch (routes.rs:995) we
+        // need a TIDAL-mapped album with no session.
+        db.with_conn(|conn| {
+            conn.execute("INSERT INTO artists (id, name) VALUES (1, 'Local Artist')", [])?;
+            conn.execute(
+                "INSERT INTO albums (id, tidal_id, title, artist_id, source)
+                 VALUES (5, 8888, 'Local Album', 1, 'tidal')",
+                [],
+            )?;
+            conn.execute(
+                "INSERT INTO tracks (
+                    id, title, artist_id, album_id, duration_ms, source, fidelity_score
+                 ) VALUES (10, 'Local Track', 1, 5, 180000, 'tidal_stream', 0)",
+                [],
+            )?;
+            Ok::<_, anyhow::Error>(())
+        })
+        .expect("seed");
+
+        // fresh_test_state has tidal_tokens: None -> the session is "disconnected".
+        let app = api_routes(Arc::new(tokio::sync::RwLock::new(fresh_test_state(
+            db.clone(),
+        ))));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/albums/5/tracks")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // Best-effort path: the album still resolves, local tracks are returned,
+        // tidal_tracks is empty, album_tidal_id is preserved. Do NOT change this
+        // to 400 / 502 / hide the album_tidal_id in a refactor.
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: Value = serde_json::from_slice(
+            &axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        let tracks = body["tracks"].as_array().expect("tracks array");
+        assert_eq!(tracks.len(), 1);
+        assert_eq!(tracks[0]["title"], "Local Track");
+        let tidal_tracks = body["tidal_tracks"].as_array().expect("tidal_tracks array");
+        assert!(tidal_tracks.is_empty(), "tidal_tracks must be [] when disconnected");
+        assert_eq!(body["album_tidal_id"], 8888, "album_tidal_id must survive even when session is absent");
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[tokio::test]
+    async fn tidal_search_returns_400_when_tidal_session_absent() {
+        // Opposite of the album endpoint: tidal_search has no library fallback,
+        // so a missing session must surface as a user-visible 400, not silently
+        // return an empty result set.
+        let app = build_test_app().await;
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/tidal/search?q=foo")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body: Value = serde_json::from_slice(
+            &axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        let error = body["error"].as_str().unwrap_or_default();
+        assert!(
+            error.contains("TIDAL not connected"),
+            "expected 'TIDAL not connected' error, got: {body}"
+        );
+    }
+
+    // Note: an integration test for the recover_tidal_session path on a 401 upstream
+    // response is deferred - it requires intercepting the reqwest::Client, which
+    // requires wiremock or a trait-based http client. Until that infra lands, the
+    // refresh-on-auth path in tidal_search / tidal_video_playback / tidal_playlist_*
+    // remains uncovered.
+
+    // Library-track filter predicate (favorite_only / liked_only) is already
+    // covered by characterization-grade tests in db/queries.rs:
+    //   - liked_only_excludes_album_favorited_tracks (queries.rs:7931)
+    //   - favorite_only_preserves_legacy_union_behavior (queries.rs:7949)
+    //   - liked_only_takes_precedence_over_favorite_only (queries.rs:8036)
+    // Do not add duplicates here.
 }

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -13201,7 +13201,10 @@ mod tests {
         // path. To exercise the "no TIDAL session" branch (routes.rs:995) we
         // need a TIDAL-mapped album with no session.
         db.with_conn(|conn| {
-            conn.execute("INSERT INTO artists (id, name) VALUES (1, 'Local Artist')", [])?;
+            conn.execute(
+                "INSERT INTO artists (id, name) VALUES (1, 'Local Artist')",
+                [],
+            )?;
             conn.execute(
                 "INSERT INTO albums (id, tidal_id, title, artist_id, source)
                  VALUES (5, 8888, 'Local Album', 1, 'tidal')",
@@ -13245,8 +13248,14 @@ mod tests {
         assert_eq!(tracks.len(), 1);
         assert_eq!(tracks[0]["title"], "Local Track");
         let tidal_tracks = body["tidal_tracks"].as_array().expect("tidal_tracks array");
-        assert!(tidal_tracks.is_empty(), "tidal_tracks must be [] when disconnected");
-        assert_eq!(body["album_tidal_id"], 8888, "album_tidal_id must survive even when session is absent");
+        assert!(
+            tidal_tracks.is_empty(),
+            "tidal_tracks must be [] when disconnected"
+        );
+        assert_eq!(
+            body["album_tidal_id"], 8888,
+            "album_tidal_id must survive even when session is absent"
+        );
 
         let _ = std::fs::remove_file(db_path);
     }


### PR DESCRIPTION
## Summary
- Adds characterization tests pinning behaviors surfaced during the refactor audit, across 4 files (+264).

## Test plan
- [ ] `cargo test` — 634 passing (verified)