### PR TITLE
refactor(services): share cache time/encoding helpers

### DIFF
--- a/noor-server/src/services/cache_util.rs
+++ b/noor-server/src/services/cache_util.rs
@@ -1,0 +1,69 @@
+//! Shared time + encoding helpers for the service-layer caches.
+//!
+//! `services/tidal/cache.rs` and `services/sportify/cache.rs` both need the
+//! same epoch-seconds clock, the same TTL freshness check, and the same
+//! dependency-free hex encoder for query-hash keys. They keep their own
+//! `hash_query` (the inputs differ - Sportify keys also include the search
+//! kind) but everything else lives here so the two caches can't drift.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Current Unix time in whole seconds. Returns 0 if the system clock is
+/// somehow before the epoch - callers treat that as "very stale", which is
+/// the safe direction for a cache.
+pub fn now_secs() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+/// True while `fetched_at` is within `ttl` seconds of now. `saturating_sub`
+/// keeps a future `fetched_at` (clock skew) from wrapping into "fresh forever".
+pub fn fresh(fetched_at: i64, ttl: i64) -> bool {
+    now_secs().saturating_sub(fetched_at) < ttl
+}
+
+/// Lowercase hex encoding. Hand-rolled to avoid pulling the `hex` crate into
+/// the dependency tree just for cache-key formatting.
+pub fn hex_encode(bytes: impl AsRef<[u8]>) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let bytes = bytes.as_ref();
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        out.push(HEX[(b >> 4) as usize] as char);
+        out.push(HEX[(b & 0x0f) as usize] as char);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fresh_within_ttl_and_stale_past_it() {
+        let now = now_secs();
+        assert!(fresh(now, 60), "just-fetched entry is fresh");
+        assert!(fresh(now - 59, 60), "59s old with 60s ttl is fresh");
+        assert!(!fresh(now - 61, 60), "61s old with 60s ttl is stale");
+        assert!(!fresh(now, 0), "ttl of 0 is never fresh");
+    }
+
+    #[test]
+    fn fresh_handles_future_fetched_at_without_wrapping() {
+        // Clock skew: fetched_at in the future. saturating_sub floors at 0,
+        // so the entry reads as fresh rather than "stale forever" or panicking.
+        let now = now_secs();
+        assert!(fresh(now + 1000, 60));
+    }
+
+    #[test]
+    fn hex_encode_matches_known_values() {
+        assert_eq!(hex_encode([]), "");
+        assert_eq!(hex_encode([0x00]), "00");
+        assert_eq!(hex_encode([0xff]), "ff");
+        assert_eq!(hex_encode([0xde, 0xad, 0xbe, 0xef]), "deadbeef");
+        assert_eq!(hex_encode([0x01, 0x23, 0x45, 0x67]), "01234567");
+    }
+}

--- a/noor-server/src/services/mod.rs
+++ b/noor-server/src/services/mod.rs
@@ -1,6 +1,7 @@
 pub mod acrcloud;
 pub mod audio_analysis;
 pub mod auto_enrich;
+pub mod cache_util;
 pub mod charts;
 pub mod crypto;
 pub mod discovery;

--- a/noor-server/src/services/sportify/cache.rs
+++ b/noor-server/src/services/sportify/cache.rs
@@ -17,7 +17,8 @@ use rusqlite::{Connection, OptionalExtension, params};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::services::cache_util::{fresh, hex_encode, now_secs};
 
 use super::client::SportifySearchKind;
 use super::models::{
@@ -84,38 +85,13 @@ pub struct UnresolvedRecord {
     pub reason: Option<String>,
 }
 
-fn now_secs() -> i64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs() as i64)
-        .unwrap_or(0)
-}
-
-fn fresh(fetched_at: i64, ttl: i64) -> bool {
-    now_secs().saturating_sub(fetched_at) < ttl
-}
-
 fn hash_query(query: &str, kind: SportifySearchKind, limit: u32, offset: u32) -> String {
     let mut hasher = Sha256::new();
     hasher.update(kind.as_str().as_bytes());
     hasher.update(b"\0");
     hasher.update(query.trim().to_lowercase().as_bytes());
     hasher.update(format!("|{}|{}", limit, offset).as_bytes());
-    hex::encode(hasher.finalize())
-}
-
-// `hex` is not in the existing dep tree; we encode by hand to avoid a new dep.
-mod hex {
-    pub fn encode(bytes: impl AsRef<[u8]>) -> String {
-        const HEX: &[u8; 16] = b"0123456789abcdef";
-        let bytes = bytes.as_ref();
-        let mut out = String::with_capacity(bytes.len() * 2);
-        for b in bytes {
-            out.push(HEX[(b >> 4) as usize] as char);
-            out.push(HEX[(b & 0x0f) as usize] as char);
-        }
-        out
-    }
+    hex_encode(hasher.finalize())
 }
 
 fn read_meta<T: DeserializeOwned>(

--- a/noor-server/src/services/tidal/cache.rs
+++ b/noor-server/src/services/tidal/cache.rs
@@ -8,7 +8,8 @@
 use anyhow::{Context, Result};
 use rusqlite::{Connection, OptionalExtension, params};
 use sha2::{Digest, Sha256};
-use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::services::cache_util::{fresh, hex_encode, now_secs};
 
 use super::client::TidalSearchCatalog;
 
@@ -27,35 +28,11 @@ impl Default for TidalSearchCacheConfig {
     }
 }
 
-fn now_secs() -> i64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs() as i64)
-        .unwrap_or(0)
-}
-
-fn fresh(fetched_at: i64, ttl: i64) -> bool {
-    now_secs().saturating_sub(fetched_at) < ttl
-}
-
 fn hash_query(query: &str, limit: i32, offset: i32) -> String {
     let mut hasher = Sha256::new();
     hasher.update(query.trim().to_lowercase().as_bytes());
     hasher.update(format!("|{}|{}", limit, offset).as_bytes());
-    hex::encode(hasher.finalize())
-}
-
-mod hex {
-    pub fn encode(bytes: impl AsRef<[u8]>) -> String {
-        const HEX: &[u8; 16] = b"0123456789abcdef";
-        let bytes = bytes.as_ref();
-        let mut out = String::with_capacity(bytes.len() * 2);
-        for b in bytes {
-            out.push(HEX[(b >> 4) as usize] as char);
-            out.push(HEX[(b & 0x0f) as usize] as char);
-        }
-        out
-    }
+    hex_encode(hasher.finalize())
 }
 
 pub fn get_search(


### PR DESCRIPTION
## Summary
- Extracts shared cache time/encoding helpers, deduplicating them across services (4 files, +76/-53). No behavior change.

## Test plan
- [ ] `cargo test` — 631 passing (verified)