### PR TITLE
Explain automix queue picks (with derived, non-contradictory reasons)

### DIFF
--- a/frontend/src/routes/automix/+page.svelte
+++ b/frontend/src/routes/automix/+page.svelte
@@ -448,6 +448,9 @@
 						</div>
 						<div class="forecast-diagnostics">
 							<span>{formatFeatureSummary(row.nextFeatures)}</span>
+							{#if row.selectionReasonLabel}
+								<span class="selection-reason"><b>Why</b>{row.selectionReasonLabel}</span>
+							{/if}
 							{#if row.verdict !== 'unknown'}
 								<b class="compat-pill compat-{row.verdict}">
 									{row.keyLabel ?? row.verdict}
@@ -462,19 +465,37 @@
 								<span>{row.energyDeltaLabel}</span>
 							{/if}
 							{#if row.missing.length > 0}
-								<span>{row.missing.join(', ')}</span>
+								<span class="dsp-missing"><b>DSP</b>{row.missing.join(', ')}</span>
 							{/if}
 						</div>
 						<StateBadge label={row.sourceLabel} tone={row.isExternalPending ? 'default' : 'active'} compact={true} />
 						<div class="forecast-actions">
-							<button class="forecast-action" onclick={(event) => void moveForecastRowNext(row, event)} disabled={saving || row.item.is_pending}>
-								Next
+							<button
+								class="forecast-action icon"
+								aria-label="Move next"
+								title="Move next"
+								onclick={(event) => void moveForecastRowNext(row, event)}
+								disabled={saving || row.item.is_pending}
+							>
+								↑
 							</button>
-							<button class="forecast-action" onclick={(event) => void refreshForecastRow(row, event)} disabled={saving}>
-								Refresh
+							<button
+								class="forecast-action icon"
+								aria-label="Refresh DSP"
+								title="Refresh DSP"
+								onclick={(event) => void refreshForecastRow(row, event)}
+								disabled={saving}
+							>
+								↻
 							</button>
-							<button class="forecast-action danger" onclick={(event) => void removeForecastRow(row, event)} disabled={saving}>
-								Remove
+							<button
+								class="forecast-action icon danger"
+								aria-label="Remove from queue"
+								title="Remove from queue"
+								onclick={(event) => void removeForecastRow(row, event)}
+								disabled={saving}
+							>
+								×
 							</button>
 						</div>
 					</div>
@@ -967,7 +988,9 @@
 
 	.queue-meta strong,
 	.queue-meta span,
-	.forecast-diagnostics span {
+	.forecast-diagnostics span,
+	.selection-reason,
+	.dsp-missing {
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
@@ -978,6 +1001,33 @@
 		color: var(--text-secondary);
 		font-size: var(--font-size-xs);
 		line-height: var(--line-height-snug);
+	}
+
+	.selection-reason,
+	.dsp-missing {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--space-1);
+		min-width: 0;
+		color: var(--text-primary);
+	}
+
+	.selection-reason b,
+	.dsp-missing b {
+		flex: 0 0 auto;
+		color: var(--accent);
+		font-size: var(--font-size-2xs);
+		font-weight: var(--font-weight-bold);
+		line-height: 1;
+		text-transform: uppercase;
+	}
+
+	.dsp-missing {
+		color: var(--text-secondary);
+	}
+
+	.dsp-missing b {
+		color: var(--state-warning);
 	}
 
 	.compat-pill {
@@ -1021,7 +1071,7 @@
 	}
 
 	.forecast-action {
-		padding: var(--space-1) var(--space-2);
+		padding: var(--space-1);
 		border-radius: 999px;
 		color: var(--text-secondary);
 		font-size: var(--font-size-xs);
@@ -1030,6 +1080,15 @@
 			background var(--motion-fast),
 			border-color var(--motion-fast),
 			color var(--motion-fast);
+	}
+
+	.forecast-action.icon {
+		display: inline-grid;
+		place-items: center;
+		width: clamp(1.75rem, 2vw, 2rem);
+		height: clamp(1.75rem, 2vw, 2rem);
+		font-size: var(--font-size-sm);
+		font-weight: var(--font-weight-bold);
 	}
 
 	.forecast-action:hover:not(:disabled) {

--- a/frontend/src/routes/automix/automix_diagnostics.test.ts
+++ b/frontend/src/routes/automix/automix_diagnostics.test.ts
@@ -35,14 +35,19 @@ function track(id: number, title = `Track ${id}`): Track {
 	};
 }
 
-function queueItem(id: number, source = 'automix', isPending = false): QueueItem {
+function queueItem(
+	id: number,
+	source = 'automix',
+	isPending = false,
+	reason: string | null = null
+): QueueItem {
 	return {
 		id,
 		position: id,
 		source,
 		track: track(id),
 		is_pending: isPending,
-		reason: null
+		reason
 	};
 }
 
@@ -112,6 +117,28 @@ describe('automix diagnostics', () => {
 		expect(rows[0].verdict).toBe('good');
 		expect(rows[0].bpmDelta).toBe(4);
 		expect(rows[0].keyLabel).toBe('same key');
+	});
+
+	it('exposes the persisted automix reason prefix', () => {
+		const rows = buildForecastRows({
+			currentTrack: track(1),
+			currentFeatures: features(1),
+			upcoming: [queueItem(2, 'automix', false, 'automix: same source, unplayed | {"score":1.35}')],
+			featuresFor: (id) => (id === 2 ? features(2) : undefined)
+		});
+
+		expect(rows[0].selectionReasonLabel).toBe('automix: same source, unplayed');
+	});
+
+	it('labels old automix rows that have no recorded reason', () => {
+		const rows = buildForecastRows({
+			currentTrack: track(1),
+			currentFeatures: features(1),
+			upcoming: [queueItem(2, 'automix')],
+			featuresFor: (id) => (id === 2 ? features(2) : undefined)
+		});
+
+		expect(rows[0].selectionReasonLabel).toBe('Reason not recorded for this row');
 	});
 
 	it('counts pending external rows separately', () => {

--- a/frontend/src/routes/automix/automix_diagnostics.ts
+++ b/frontend/src/routes/automix/automix_diagnostics.ts
@@ -6,6 +6,7 @@ import type {
 	Track
 } from '$lib/api/client';
 import { harmonicCompat } from '$lib/utils/camelot';
+import { parseReason } from '$lib/utils/reason';
 
 export type AutomixVerdict = 'good' | 'okay' | 'clash' | 'pending' | 'unknown';
 export type AutomixHealthStatus = 'ready' | 'degraded' | 'blocked';
@@ -22,6 +23,7 @@ export interface AutomixForecastRow {
 	bpmDeltaLabel: string | null;
 	energyDeltaLabel: string | null;
 	sourceLabel: string;
+	selectionReasonLabel: string | null;
 	missing: string[];
 	isExternalPending: boolean;
 }
@@ -87,6 +89,18 @@ export function queueSourceLabel(source: string): string {
 	return source || 'Queued';
 }
 
+export function selectionReasonLabel(
+	reason: string | null | undefined,
+	source: string
+): string | null {
+	const parsed = parseReason(reason);
+	if (parsed?.prefix) return parsed.prefix;
+	if (source.trim().toLowerCase().startsWith('automix')) {
+		return 'Reason not recorded for this row';
+	}
+	return null;
+}
+
 function missingFeatureLabels(
 	previous: AudioDspFeatures | null | undefined,
 	next: AudioDspFeatures | null | undefined
@@ -127,6 +141,7 @@ export function buildForecastRows(input: {
 			bpmDeltaLabel: bpmDeltaLabel(compat?.bpmDelta ?? null),
 			energyDeltaLabel: energyDeltaLabel(previousFeatures, nextFeatures),
 			sourceLabel: queueSourceLabel(item.source),
+			selectionReasonLabel: selectionReasonLabel(item.reason, item.source),
 			missing,
 			isExternalPending
 		};

--- a/noor-server/src/playback/player.rs
+++ b/noor-server/src/playback/player.rs
@@ -108,6 +108,25 @@ struct ScoredTrack {
     score: f64,
 }
 
+#[derive(Debug, Clone)]
+struct AutomixSelection {
+    track: Track,
+    reason: Option<String>,
+}
+
+impl AutomixSelection {
+    fn new(track: Track, reason: impl Into<String>) -> Self {
+        Self {
+            track,
+            reason: Some(reason.into()),
+        }
+    }
+
+    fn into_queue_pair(self) -> (Track, Option<String>) {
+        (self.track, self.reason)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ListenSessionEndReason {
     Replaced,
@@ -967,7 +986,7 @@ pub fn ensure_automix_queue_depth(
     }
 
     let needed = (target_upcoming - upcoming_count).max(AUTOMIX_BATCH_SIZE);
-    let extension = build_automix_extension(
+    let extension = build_automix_extension_with_reasons(
         conn,
         current_track,
         &queue_items,
@@ -977,8 +996,13 @@ pub fn ensure_automix_queue_depth(
     )?;
 
     let mut appended = false;
+    let generated_count = extension.len();
     if !extension.is_empty() {
-        queue::append_tracks(conn, &extension, "automix")?;
+        let extension = extension
+            .into_iter()
+            .map(AutomixSelection::into_queue_pair)
+            .collect::<Vec<_>>();
+        queue::append_tracks_with_reasons(conn, &extension, "automix")?;
         appended = true;
     }
 
@@ -987,7 +1011,7 @@ pub fn ensure_automix_queue_depth(
             .ok()
             .flatten()
     {
-        let external_needed = needed.saturating_sub(extension.len()).max(1);
+        let external_needed = needed.saturating_sub(generated_count).max(1);
         let appended_external =
             append_automix_external_candidates(conn, model.id, current_track.id, external_needed)?;
         appended |= appended_external > 0;
@@ -1083,6 +1107,7 @@ fn normalize_external_pair(artist: &str, title: &str) -> (String, String) {
     )
 }
 
+#[cfg(test)]
 fn build_automix_extension(
     conn: &Connection,
     current_track: &Track,
@@ -1091,6 +1116,27 @@ fn build_automix_extension(
     needed: usize,
     use_learning: bool,
 ) -> Result<Vec<Track>> {
+    Ok(build_automix_extension_with_reasons(
+        conn,
+        current_track,
+        queue_items,
+        mode,
+        needed,
+        use_learning,
+    )?
+    .into_iter()
+    .map(|selection| selection.track)
+    .collect())
+}
+
+fn build_automix_extension_with_reasons(
+    conn: &Connection,
+    current_track: &Track,
+    queue_items: &[QueueItem],
+    mode: ShuffleMode,
+    needed: usize,
+    use_learning: bool,
+) -> Result<Vec<AutomixSelection>> {
     if use_learning
         && let Some(model) = queries::get_selected_discovery_embedding_model(conn)
             .ok()
@@ -1108,6 +1154,10 @@ fn build_automix_extension(
             &excluded,
         )?;
         if !neighbors.is_empty() {
+            let neighbor_reasons = neighbors
+                .iter()
+                .map(|row| (row.track_id, automix_neighbor_reason(row)))
+                .collect::<HashMap<_, _>>();
             let neighbor_ids = neighbors.iter().map(|row| row.track_id).collect::<Vec<_>>();
             let tracks = queue::get_tracks_by_ids(conn, &neighbor_ids)?;
             let track_map = tracks
@@ -1116,7 +1166,17 @@ fn build_automix_extension(
                 .collect::<HashMap<_, _>>();
             let ordered = neighbor_ids
                 .into_iter()
-                .filter_map(|track_id| track_map.get(&track_id).cloned())
+                .filter_map(|track_id| {
+                    track_map.get(&track_id).cloned().map(|track| {
+                        AutomixSelection::new(
+                            track,
+                            neighbor_reasons
+                                .get(&track_id)
+                                .cloned()
+                                .unwrap_or_else(|| "automix: learned similarity".to_string()),
+                        )
+                    })
+                })
                 .take(needed)
                 .collect::<Vec<_>>();
             if !ordered.is_empty() {
@@ -1169,7 +1229,13 @@ fn build_automix_extension(
                 "automix: skipping extension — seed has no recommendation signal and no artist/album/genre matches"
             );
         }
-        return Ok(fallback);
+        return Ok(fallback
+            .into_iter()
+            .map(|track| {
+                let reason = automix_metadata_reason(current_track, &track);
+                AutomixSelection::new(track, reason)
+            })
+            .collect());
     }
 
     let mut candidates: Vec<Track> = if similar.len() >= needed {
@@ -1215,7 +1281,137 @@ fn build_automix_extension(
         &candidate_features,
     );
     let ordered = decluster_by_album(ordered);
-    Ok(ordered.into_iter().take(needed).collect())
+    Ok(ordered
+        .into_iter()
+        .take(needed)
+        .map(|track| {
+            let genres = candidate_genres
+                .get(&track.id)
+                .map(Vec::as_slice)
+                .unwrap_or(&[]);
+            let candidate_features = candidate_features.get(&track.id);
+            let score = automix_score(
+                &track,
+                genres,
+                &taste,
+                &seed,
+                seed_features.as_ref(),
+                candidate_features,
+            );
+            let reason = automix_scored_reason(
+                &track,
+                genres,
+                &taste,
+                &seed,
+                seed_features.as_ref(),
+                candidate_features,
+                score,
+            );
+            AutomixSelection::new(track, reason)
+        })
+        .collect())
+}
+
+fn automix_neighbor_reason(row: &queries::EmbeddingNeighborRow) -> String {
+    let reason = row
+        .primary_reason
+        .as_deref()
+        .map(format_reason_key)
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "learned similarity".to_string());
+    let prefix = format!("automix: {reason}");
+    format!(
+        "{prefix} | {{\"score\":{:.4},\"behavioral_score\":{:.4},\"audio_score\":{:.4},\"metadata_score\":{:.4},\"confidence\":{:.4}}}",
+        row.score, row.behavioral_score, row.audio_score, row.metadata_score, row.confidence
+    )
+}
+
+fn automix_metadata_reason(seed: &Track, track: &Track) -> String {
+    if seed.artist_id != 0 && seed.artist_id == track.artist_id {
+        return "automix: same artist fallback".to_string();
+    }
+    if seed.album_id.is_some() && seed.album_id == track.album_id {
+        return "automix: same album fallback".to_string();
+    }
+    "automix: shared genre fallback".to_string()
+}
+
+fn automix_scored_reason(
+    track: &Track,
+    genres: &[String],
+    taste: &TasteVector,
+    seed: &SeedContext,
+    seed_features: Option<&AudioDspFeatures>,
+    candidate_features: Option<&AudioDspFeatures>,
+    score: f64,
+) -> String {
+    let mut signals = Vec::new();
+
+    if Some(track.artist_id) == seed.artist_id && track.artist_id != 0 {
+        signals.push("same artist".to_string());
+    }
+    if seed.source.as_deref() == Some(track.source.as_str()) {
+        signals.push("same source".to_string());
+    }
+    if track.is_favorite {
+        signals.push("favorite".to_string());
+    }
+    if track.play_count == 0 {
+        signals.push("unplayed".to_string());
+    }
+
+    let shared_genres = genres
+        .iter()
+        .map(|genre| normalize_genre_key(genre))
+        .filter(|genre| seed.genres.contains(genre))
+        .count();
+    if shared_genres > 0 {
+        signals.push(format!(
+            "{shared_genres} shared genre{}",
+            if shared_genres == 1 { "" } else { "s" }
+        ));
+    }
+
+    if track.artist_id != 0
+        && let Some(affinity) = taste.artist_affinity.get(&track.artist_id)
+    {
+        if affinity.pos > affinity.neg {
+            signals.push("artist affinity".to_string());
+        } else if affinity.neg > affinity.pos {
+            signals.push("recent skip penalty".to_string());
+        }
+    }
+
+    if let (Some(seed), Some(candidate)) = (seed_features, candidate_features) {
+        let multiplier = compute_harmonic_multiplier(
+            seed.camelot_key.as_deref(),
+            candidate.camelot_key.as_deref(),
+            seed.bpm,
+            candidate.bpm,
+        );
+        if multiplier > 1.0 {
+            signals.push("harmonic fit".to_string());
+        }
+        if let (Some(seed_energy), Some(candidate_energy)) = (seed.energy, candidate.energy)
+            && (seed_energy - candidate_energy).abs() > 0.5
+        {
+            signals.push("energy contrast".to_string());
+        }
+    }
+
+    if signals.is_empty() {
+        signals.push("library score".to_string());
+    }
+
+    let prefix = format!(
+        "automix: {}",
+        signals.into_iter().take(4).collect::<Vec<_>>().join(", ")
+    );
+    format!("{prefix} | {{\"score\":{score:.4}}}")
+}
+
+fn format_reason_key(value: &str) -> String {
+    value.trim().replace('_', " ")
 }
 
 // Metadata-only fallback for seeds with no embedding neighbours and no
@@ -1883,6 +2079,55 @@ mod tests {
         }
     }
 
+    fn blank_dsp_features() -> AudioDspFeatures {
+        AudioDspFeatures {
+            track_id: 0,
+            bpm: None,
+            key_signature: None,
+            camelot_key: None,
+            loudness_lufs: None,
+            energy: None,
+            danceability: None,
+            beat_strength: None,
+            spectral_centroid: None,
+            stereo_width: None,
+            is_instrumental: false,
+            analysis_source: "test".to_string(),
+            analysis_offset_ms: 0,
+            samples_analyzed: None,
+            analyzed_at: "2026-01-01T00:00:00Z".to_string(),
+            analysis_version: "test".to_string(),
+        }
+    }
+
+    #[test]
+    fn automix_reason_does_not_claim_harmonic_fit_without_key_or_bpm() {
+        let profile = SessionTasteProfile {
+            current_source: Some("tidal".to_string()),
+            ..SessionTasteProfile::default()
+        };
+        let (taste, seed) = from_session_profile(&profile);
+        let track = track_with_tidal_id(42, Some(42), Some("LOSSLESS"));
+        let seed_features = blank_dsp_features();
+        let candidate_features = blank_dsp_features();
+
+        let reason = automix_scored_reason(
+            &track,
+            &[],
+            &taste,
+            &seed,
+            Some(&seed_features),
+            Some(&candidate_features),
+            1.0,
+        );
+
+        assert!(reason.contains("same source"), "got: {reason}");
+        assert!(
+            !reason.contains("harmonic fit"),
+            "missing key and BPM must not be labeled as harmonic fit: {reason}"
+        );
+    }
+
     #[test]
     fn previous_track_moves_back_when_under_threshold() {
         let conn = conn();
@@ -2047,6 +2292,35 @@ mod tests {
         assert_eq!(snapshot.state.current_track.unwrap().id, 3);
         assert!(snapshot.queue.len() > 2);
         assert!(snapshot.queue.iter().any(|item| item.source == "automix"));
+    }
+
+    #[test]
+    fn ensure_automix_queue_depth_records_reasons_for_generated_rows() {
+        let conn = conn();
+        let tracks = load_tracks(&conn, &[1, 2]);
+        queue::replace_queue(&conn, &tracks, "test").unwrap();
+        conn.execute(
+            "UPDATE playback_state
+             SET current_track_id = 2, position_ms = 0, is_playing = 1, automix_enabled = 1, shuffle_mode = 'off'
+             WHERE id = 1",
+            [],
+        )
+        .unwrap();
+
+        let queue = ensure_automix_queue_depth(&conn, AUTOMIX_MIN_UPCOMING, false).unwrap();
+        let generated = queue
+            .iter()
+            .filter(|item| item.source == "automix")
+            .collect::<Vec<_>>();
+
+        assert!(!generated.is_empty(), "expected generated automix rows");
+        assert!(
+            generated.iter().all(|item| item
+                .reason
+                .as_deref()
+                .is_some_and(|reason| !reason.trim().is_empty())),
+            "generated automix rows should persist selection reasons: {generated:?}"
+        );
     }
 
     #[test]

--- a/noor-server/src/playback/player.rs
+++ b/noor-server/src/playback/player.rs
@@ -6,7 +6,9 @@ use crate::db::{
 use crate::playback::gapless::{self, GaplessPlan, GaplessSettings};
 use crate::playback::queue::{self, ShuffleMode};
 use crate::playback::shuffle::{WeightedShuffleProfile, genre_shuffle, true_shuffle};
-use crate::services::audio_analysis::compute_harmonic_multiplier;
+use crate::services::audio_analysis::{
+    CamelotRelation, camelot_relation, compute_harmonic_multiplier,
+};
 use crate::services::tidal::stream::{self, StreamInfo, StreamRequest};
 use crate::smart::taste_vector::adapters::from_session_profile;
 use crate::smart::taste_vector::{SeedContext, TasteVector};
@@ -125,6 +127,46 @@ impl AutomixSelection {
     fn into_queue_pair(self) -> (Track, Option<String>) {
         (self.track, self.reason)
     }
+}
+
+/// Whether a scoring factor helped a candidate get picked or worked against it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AutomixSignalKind {
+    Boost,
+    Penalty,
+}
+
+/// One human-readable factor that moved a candidate's automix score, tagged
+/// with its direction. Emitted by `automix_score` itself so the user-facing
+/// "Why" is derived from the same pass that ranked the track and can never
+/// contradict it.
+#[derive(Debug, Clone)]
+struct AutomixSignal {
+    label: &'static str,
+    kind: AutomixSignalKind,
+}
+
+impl AutomixSignal {
+    fn boost(label: &'static str) -> Self {
+        Self {
+            label,
+            kind: AutomixSignalKind::Boost,
+        }
+    }
+
+    fn penalty(label: &'static str) -> Self {
+        Self {
+            label,
+            kind: AutomixSignalKind::Penalty,
+        }
+    }
+}
+
+/// A candidate's automix score plus the signals that produced it.
+#[derive(Debug, Clone)]
+struct AutomixScore {
+    value: f64,
+    signals: Vec<AutomixSignal>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1107,28 +1149,6 @@ fn normalize_external_pair(artist: &str, title: &str) -> (String, String) {
     )
 }
 
-#[cfg(test)]
-fn build_automix_extension(
-    conn: &Connection,
-    current_track: &Track,
-    queue_items: &[QueueItem],
-    mode: ShuffleMode,
-    needed: usize,
-    use_learning: bool,
-) -> Result<Vec<Track>> {
-    Ok(build_automix_extension_with_reasons(
-        conn,
-        current_track,
-        queue_items,
-        mode,
-        needed,
-        use_learning,
-    )?
-    .into_iter()
-    .map(|selection| selection.track)
-    .collect())
-}
-
 fn build_automix_extension_with_reasons(
     conn: &Connection,
     current_track: &Track,
@@ -1289,24 +1309,15 @@ fn build_automix_extension_with_reasons(
                 .get(&track.id)
                 .map(Vec::as_slice)
                 .unwrap_or(&[]);
-            let candidate_features = candidate_features.get(&track.id);
             let score = automix_score(
                 &track,
                 genres,
                 &taste,
                 &seed,
                 seed_features.as_ref(),
-                candidate_features,
+                candidate_features.get(&track.id),
             );
-            let reason = automix_scored_reason(
-                &track,
-                genres,
-                &taste,
-                &seed,
-                seed_features.as_ref(),
-                candidate_features,
-                score,
-            );
+            let reason = automix_scored_reason(&score);
             AutomixSelection::new(track, reason)
         })
         .collect())
@@ -1336,78 +1347,38 @@ fn automix_metadata_reason(seed: &Track, track: &Track) -> String {
     "automix: shared genre fallback".to_string()
 }
 
-fn automix_scored_reason(
-    track: &Track,
-    genres: &[String],
-    taste: &TasteVector,
-    seed: &SeedContext,
-    seed_features: Option<&AudioDspFeatures>,
-    candidate_features: Option<&AudioDspFeatures>,
-    score: f64,
-) -> String {
-    let mut signals = Vec::new();
-
-    if Some(track.artist_id) == seed.artist_id && track.artist_id != 0 {
-        signals.push("same artist".to_string());
-    }
-    if seed.source.as_deref() == Some(track.source.as_str()) {
-        signals.push("same source".to_string());
-    }
-    if track.is_favorite {
-        signals.push("favorite".to_string());
-    }
-    if track.play_count == 0 {
-        signals.push("unplayed".to_string());
-    }
-
-    let shared_genres = genres
+/// Build the persisted "Why" string for a scored automix pick from the score's
+/// own signal breakdown. Boost signals lead the reason; penalties are rendered
+/// explicitly as "despite …" so the explanation can never present a factor that
+/// actually counted *against* the track as the reason it was picked.
+fn automix_scored_reason(score: &AutomixScore) -> String {
+    let boosts: Vec<&str> = score
+        .signals
         .iter()
-        .map(|genre| normalize_genre_key(genre))
-        .filter(|genre| seed.genres.contains(genre))
-        .count();
-    if shared_genres > 0 {
-        signals.push(format!(
-            "{shared_genres} shared genre{}",
-            if shared_genres == 1 { "" } else { "s" }
-        ));
-    }
+        .filter(|signal| signal.kind == AutomixSignalKind::Boost)
+        .map(|signal| signal.label)
+        .collect();
+    let penalties: Vec<&str> = score
+        .signals
+        .iter()
+        .filter(|signal| signal.kind == AutomixSignalKind::Penalty)
+        .map(|signal| signal.label)
+        .collect();
 
-    if track.artist_id != 0
-        && let Some(affinity) = taste.artist_affinity.get(&track.artist_id)
-    {
-        if affinity.pos > affinity.neg {
-            signals.push("artist affinity".to_string());
-        } else if affinity.neg > affinity.pos {
-            signals.push("recent skip penalty".to_string());
-        }
-    }
-
-    if let (Some(seed), Some(candidate)) = (seed_features, candidate_features) {
-        let multiplier = compute_harmonic_multiplier(
-            seed.camelot_key.as_deref(),
-            candidate.camelot_key.as_deref(),
-            seed.bpm,
-            candidate.bpm,
-        );
-        if multiplier > 1.0 {
-            signals.push("harmonic fit".to_string());
-        }
-        if let (Some(seed_energy), Some(candidate_energy)) = (seed.energy, candidate.energy)
-            && (seed_energy - candidate_energy).abs() > 0.5
-        {
-            signals.push("energy contrast".to_string());
-        }
-    }
-
-    if signals.is_empty() {
-        signals.push("library score".to_string());
-    }
-
-    let prefix = format!(
-        "automix: {}",
-        signals.into_iter().take(4).collect::<Vec<_>>().join(", ")
-    );
-    format!("{prefix} | {{\"score\":{score:.4}}}")
+    let lead = if boosts.is_empty() {
+        "library score".to_string()
+    } else {
+        boosts.into_iter().take(4).collect::<Vec<_>>().join(", ")
+    };
+    let prefix = if penalties.is_empty() {
+        format!("automix: {lead}")
+    } else {
+        format!(
+            "automix: {lead} despite {}",
+            penalties.into_iter().take(3).collect::<Vec<_>>().join(", ")
+        )
+    };
+    format!("{prefix} | {{\"score\":{:.4}}}", score.value)
 }
 
 fn format_reason_key(value: &str) -> String {
@@ -1634,7 +1605,8 @@ fn order_automix_candidates(
                 seed,
                 seed_features,
                 candidate_features.get(&track.id),
-            );
+            )
+            .value;
             ScoredTrack { track, score }
         })
         .collect::<Vec<_>>();
@@ -1744,6 +1716,11 @@ fn decluster_by_album(tracks: Vec<Track>) -> Vec<Track> {
     result
 }
 
+/// Score a candidate for automix selection *and* emit the signals that
+/// produced that score. The reason shown to the user is built from these
+/// signals (see `automix_scored_reason`), so the explanation is derived from
+/// the same pass that ranked the track — it cannot drift from or contradict
+/// the score. `value` is byte-identical to the pre-signal scorer.
 fn automix_score(
     track: &Track,
     genres: &[String],
@@ -1751,37 +1728,44 @@ fn automix_score(
     seed: &SeedContext,
     seed_features: Option<&AudioDspFeatures>,
     candidate_features: Option<&AudioDspFeatures>,
-) -> f64 {
+) -> AutomixScore {
     let mut score = 1.0;
+    let mut signals = Vec::new();
 
     // Hard suppression for recently skipped tracks
     if taste.skipped_track_ids.contains(&track.id) {
         score *= 0.1;
+        signals.push(AutomixSignal::penalty("recently skipped"));
     }
 
     // Same-artist: gentle familiarity boost, not enough to cause artist runs.
     // Artist spread is handled at the queue level by decluster_by_album.
     if Some(track.artist_id) == seed.artist_id && track.artist_id != 0 {
         score *= 1.1;
+        signals.push(AutomixSignal::boost("same artist"));
     }
 
     if seed.source.as_deref() == Some(track.source.as_str()) {
         score *= 1.05;
+        signals.push(AutomixSignal::boost("same source"));
     }
 
     if track.is_favorite {
         score *= 1.2;
+        signals.push(AutomixSignal::boost("favorite"));
     }
 
     // Unplayed tracks get a meaningful boost so they surface before heavily-played ones.
     if track.play_count == 0 {
         score *= 1.35;
+        signals.push(AutomixSignal::boost("unplayed"));
     } else if let Some(last_played) = track.last_played_at.as_deref() {
         // Time-decay penalty: full suppression at <1 day, fades to zero by 14 days.
         let days_since = parse_days_since_last_played(last_played);
         if days_since < 14.0 {
             let penalty = 0.5 + 0.5 * (days_since / 14.0);
             score *= penalty;
+            signals.push(AutomixSignal::penalty("recently played"));
         }
     }
 
@@ -1790,17 +1774,36 @@ fn automix_score(
     {
         score += affinity.pos * 0.5;
         score -= affinity.neg * 0.65;
+        // Label by the net effect on the score, not the raw counts.
+        let net = affinity.pos * 0.5 - affinity.neg * 0.65;
+        if net > 0.0 {
+            signals.push(AutomixSignal::boost("artist affinity"));
+        } else if net < 0.0 {
+            signals.push(AutomixSignal::penalty("recent skip penalty"));
+        }
     }
 
+    let mut shares_seed_genre = false;
+    let mut genre_affinity_net = 0.0;
     let normalized_genres = genres.iter().map(|genre| normalize_genre_key(genre));
     for genre in normalized_genres {
         if seed.genres.contains(&genre) {
             score += 1.8;
+            shares_seed_genre = true;
         }
         if let Some(affinity) = taste.genre_affinity.get(&genre) {
             score += affinity.pos * 0.4;
             score -= affinity.neg * 0.5;
+            genre_affinity_net += affinity.pos * 0.4 - affinity.neg * 0.5;
         }
+    }
+    if shares_seed_genre {
+        signals.push(AutomixSignal::boost("shared genres"));
+    }
+    if genre_affinity_net > 0.0 {
+        signals.push(AutomixSignal::boost("genre affinity"));
+    } else if genre_affinity_net < 0.0 {
+        signals.push(AutomixSignal::penalty("genre mismatch"));
     }
 
     score += (track.fidelity_score.max(0) as f64) * 0.003;
@@ -1816,15 +1819,32 @@ fn automix_score(
             cand.bpm,
         );
 
+        // The multiplier folds Camelot *and* BPM together, so it can read >1.0
+        // even on a key clash that happens to share a tempo. Derive the
+        // harmonic signal from the Camelot relationship directly — via the same
+        // `camelot_relation` the multiplier uses — so the "Why" never claims a
+        // fit the keys don't have, and the two can't drift apart.
+        if let (Some(a), Some(b)) = (seed.camelot_key.as_deref(), cand.camelot_key.as_deref()) {
+            signals.push(match camelot_relation(a, b) {
+                CamelotRelation::Compatible => AutomixSignal::boost("harmonic match"),
+                CamelotRelation::Adjacent => AutomixSignal::boost("adjacent key"),
+                CamelotRelation::Clash => AutomixSignal::penalty("key clash"),
+            });
+        }
+
         // Energy whiplash penalty.
         if let (Some(seed_energy), Some(cand_energy)) = (seed.energy, cand.energy)
             && (seed_energy - cand_energy).abs() > 0.5
         {
             score *= 0.7;
+            signals.push(AutomixSignal::penalty("energy whiplash"));
         }
     }
 
-    score.max(0.05)
+    AutomixScore {
+        value: score.max(0.05),
+        signals,
+    }
 }
 
 /// Parse an ISO-8601 timestamp and return days elapsed since then.
@@ -2101,7 +2121,7 @@ mod tests {
     }
 
     #[test]
-    fn automix_reason_does_not_claim_harmonic_fit_without_key_or_bpm() {
+    fn automix_reason_does_not_claim_harmonic_match_without_key_or_bpm() {
         let profile = SessionTasteProfile {
             current_source: Some("tidal".to_string()),
             ..SessionTasteProfile::default()
@@ -2111,20 +2131,127 @@ mod tests {
         let seed_features = blank_dsp_features();
         let candidate_features = blank_dsp_features();
 
-        let reason = automix_scored_reason(
+        let score = automix_score(
             &track,
             &[],
             &taste,
             &seed,
             Some(&seed_features),
             Some(&candidate_features),
-            1.0,
         );
+        let reason = automix_scored_reason(&score);
 
         assert!(reason.contains("same source"), "got: {reason}");
         assert!(
-            !reason.contains("harmonic fit"),
-            "missing key and BPM must not be labeled as harmonic fit: {reason}"
+            !reason.contains("harmonic")
+                && !reason.contains("key clash")
+                && !reason.contains("adjacent key"),
+            "missing key and BPM must produce no harmonic signal at all: {reason}"
+        );
+    }
+
+    #[test]
+    fn automix_reason_marks_recent_skip_as_penalty_not_cause() {
+        // The candidate's artist carries negative session affinity, so
+        // automix_score penalizes it. The reason must render that as a
+        // "despite" clause, never as a cause the track was picked.
+        let profile = SessionTasteProfile {
+            current_source: Some("tidal".to_string()),
+            negative_artists: HashMap::from([(1, 1.0)]),
+            ..SessionTasteProfile::default()
+        };
+        let (taste, seed) = from_session_profile(&profile);
+        let track = track_with_tidal_id(42, Some(42), Some("LOSSLESS"));
+
+        let score = automix_score(&track, &[], &taste, &seed, None, None);
+        let reason = automix_scored_reason(&score);
+
+        assert!(
+            reason.contains("despite") && reason.contains("recent skip penalty"),
+            "a penalizing signal must be rendered as a penalty: {reason}"
+        );
+        let lead = reason.split(" despite ").next().unwrap_or("");
+        assert!(
+            !lead.contains("recent skip penalty"),
+            "a penalty must never appear in the selection-cause lead: {reason}"
+        );
+    }
+
+    #[test]
+    fn automix_reason_marks_energy_whiplash_as_penalty() {
+        // A large energy jump multiplies the score *down*; the old reason
+        // builder mislabeled it "energy contrast" as if it were a cause.
+        let profile = SessionTasteProfile {
+            current_source: Some("tidal".to_string()),
+            ..SessionTasteProfile::default()
+        };
+        let (taste, seed) = from_session_profile(&profile);
+        let track = track_with_tidal_id(42, Some(42), Some("LOSSLESS"));
+        let seed_features = AudioDspFeatures {
+            energy: Some(0.2),
+            ..blank_dsp_features()
+        };
+        let candidate_features = AudioDspFeatures {
+            energy: Some(0.9),
+            ..blank_dsp_features()
+        };
+
+        let score = automix_score(
+            &track,
+            &[],
+            &taste,
+            &seed,
+            Some(&seed_features),
+            Some(&candidate_features),
+        );
+        let reason = automix_scored_reason(&score);
+
+        assert!(
+            reason.contains("despite") && reason.contains("energy whiplash"),
+            "a large energy jump is a penalty, not a selection cause: {reason}"
+        );
+    }
+
+    #[test]
+    fn automix_reason_does_not_claim_harmonic_match_on_key_clash_with_close_bpm() {
+        // 8A vs 10A is a Camelot clash, but a near-identical BPM pushes the
+        // *combined* harmonic multiplier above 1.0. The reason must still call
+        // it a key clash — deriving the signal from the Camelot relationship,
+        // not the blended multiplier.
+        let profile = SessionTasteProfile {
+            current_source: Some("tidal".to_string()),
+            ..SessionTasteProfile::default()
+        };
+        let (taste, seed) = from_session_profile(&profile);
+        let track = track_with_tidal_id(42, Some(42), Some("LOSSLESS"));
+        let seed_features = AudioDspFeatures {
+            camelot_key: Some("8A".to_string()),
+            bpm: Some(120.0),
+            ..blank_dsp_features()
+        };
+        let candidate_features = AudioDspFeatures {
+            camelot_key: Some("10A".to_string()),
+            bpm: Some(122.0),
+            ..blank_dsp_features()
+        };
+
+        let score = automix_score(
+            &track,
+            &[],
+            &taste,
+            &seed,
+            Some(&seed_features),
+            Some(&candidate_features),
+        );
+        let reason = automix_scored_reason(&score);
+
+        assert!(
+            reason.contains("key clash"),
+            "a Camelot clash must be labeled a key clash: {reason}"
+        );
+        assert!(
+            !reason.contains("harmonic match") && !reason.contains("adjacent key"),
+            "a key clash must never be shown as a harmonic match: {reason}"
         );
     }
 
@@ -2887,9 +3014,34 @@ mod tests {
         assert_eq!(state.current_track.as_ref().map(|t| t.id), Some(1));
     }
 
+    /// Test-only convenience: run the automix extension builder and discard
+    /// the per-row reasons, returning just the tracks. Keeps the extension
+    /// tests focused on selection behaviour without threading through
+    /// `AutomixSelection` at every call site.
+    fn extension_tracks(
+        conn: &Connection,
+        current_track: &Track,
+        queue_items: &[QueueItem],
+        mode: ShuffleMode,
+        needed: usize,
+        use_learning: bool,
+    ) -> Result<Vec<Track>> {
+        Ok(build_automix_extension_with_reasons(
+            conn,
+            current_track,
+            queue_items,
+            mode,
+            needed,
+            use_learning,
+        )?
+        .into_iter()
+        .map(|selection| selection.track)
+        .collect())
+    }
+
     /// Build an isolated DB fixture with the full surface
-    /// `build_automix_extension` needs (the standard `conn()` helper
-    /// above lacks `embedding_models`, `track_embeddings`, and
+    /// `build_automix_extension_with_reasons` needs (the standard `conn()`
+    /// helper above lacks `embedding_models`, `track_embeddings`, and
     /// `track_similarity`). Returns a connection with one seed track
     /// inserted but **no** embedding row and **no** similarity rows —
     /// the "no recommendation signal" case the guard targets.
@@ -3012,7 +3164,7 @@ mod tests {
     #[test]
     fn build_automix_extension_returns_empty_when_seed_has_no_signal() {
         let (conn, seed) = empty_signal_conn();
-        let extension = build_automix_extension(
+        let extension = extension_tracks(
             &conn,
             &seed,
             &[], // empty queue
@@ -3051,7 +3203,7 @@ mod tests {
         )
         .unwrap();
 
-        let extension = build_automix_extension(&conn, &seed, &[], ShuffleMode::Off, 12, true)
+        let extension = extension_tracks(&conn, &seed, &[], ShuffleMode::Off, 12, true)
             .expect("extension call");
 
         // We don't pin contents — only that the empty-signal guard
@@ -3081,7 +3233,7 @@ mod tests {
             .unwrap();
         }
 
-        let extension = build_automix_extension(&conn, &seed, &[], ShuffleMode::Off, 12, true)
+        let extension = extension_tracks(&conn, &seed, &[], ShuffleMode::Off, 12, true)
             .expect("extension call");
 
         assert!(
@@ -3106,7 +3258,7 @@ mod tests {
     fn build_automix_extension_returns_empty_when_no_artist_album_or_genre() {
         let (conn, seed) = empty_signal_conn();
         // No additional tracks, no genre rows — seed is completely isolated.
-        let extension = build_automix_extension(&conn, &seed, &[], ShuffleMode::Off, 12, true)
+        let extension = extension_tracks(&conn, &seed, &[], ShuffleMode::Off, 12, true)
             .expect("extension call");
 
         assert!(
@@ -3462,7 +3614,8 @@ mod parity_tests {
                     &seed,
                     fixture.seed_features.as_ref(),
                     cand.features.as_ref(),
-                );
+                )
+                .value;
                 (cand.track.id, score)
             })
             .collect()

--- a/noor-server/src/playback/queue.rs
+++ b/noor-server/src/playback/queue.rs
@@ -107,10 +107,10 @@ pub fn append_tracks(conn: &Connection, tracks: &[Track], source: &str) -> Resul
 
 /// Append tracks with per-row reason strings.
 ///
-/// Radio is the producer of reasons today; automix and manual paths
-/// pass `None` via [`append_tracks`]. The reason column stays
-/// queryable but the frontend treats NULL as "no provenance recorded"
-/// and renders no tooltip.
+/// Radio and automix are the producers of reasons today; manual paths
+/// pass `None` via [`append_tracks`]. The reason column stays queryable
+/// but the frontend treats NULL as "no provenance recorded" and renders
+/// no tooltip.
 pub fn append_tracks_with_reasons(
     conn: &Connection,
     tracks: &[(Track, Option<String>)],

--- a/noor-server/src/services/audio_analysis/mod.rs
+++ b/noor-server/src/services/audio_analysis/mod.rs
@@ -216,6 +216,30 @@ fn camelot_number_diff(a: &str, b: &str) -> u32 {
     diff.min(12 - diff)
 }
 
+/// How two Camelot keys relate harmonically.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CamelotRelation {
+    /// Same key, relative major/minor, or one step around the wheel.
+    Compatible,
+    /// Adjacent on the wheel but not compatible.
+    Adjacent,
+    /// Neither — a harmonic clash.
+    Clash,
+}
+
+/// Classify the harmonic relationship between two Camelot keys. Single source
+/// of truth shared by `compute_harmonic_multiplier` and automix's reason
+/// signals, so the score multiplier and the user-facing "Why" can't drift.
+pub fn camelot_relation(a: &str, b: &str) -> CamelotRelation {
+    if camelot_compatible(a, b) {
+        CamelotRelation::Compatible
+    } else if camelot_adjacent(a, b) {
+        CamelotRelation::Adjacent
+    } else {
+        CamelotRelation::Clash
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -289,13 +313,11 @@ pub fn compute_harmonic_multiplier(
     let mut mult = 1.0_f64;
 
     if let (Some(a), Some(b)) = (seed_camelot, cand_camelot) {
-        if camelot_compatible(a, b) {
-            mult *= 2.2;
-        } else if camelot_adjacent(a, b) {
-            mult *= 1.4;
-        } else {
-            mult *= 0.6;
-        }
+        mult *= match camelot_relation(a, b) {
+            CamelotRelation::Compatible => 2.2,
+            CamelotRelation::Adjacent => 1.4,
+            CamelotRelation::Clash => 0.6,
+        };
     }
 
     if let (Some(a), Some(b)) = (seed_bpm, cand_bpm) {


### PR DESCRIPTION
## Summary

Automix-generated queue rows now carry a persisted "Why" — the factor that got each track picked — surfaced in the automix forecast UI.

- **Backend:** `automix_score` returns `AutomixScore { value, signals }`; every scoring step emits a `Boost`/`Penalty` `AutomixSignal` alongside its score mutation. `automix_scored_reason` builds the reason from those signals, so the explanation is derived from the same pass that ranked the track and **cannot contradict the score**. Embedding-neighbour and metadata-fallback paths get their own reason builders.
- **Honest signals:** boosts lead the "Why"; penalties render explicitly as "despite …". The harmonic signal comes from a shared `audio_analysis::camelot_relation` (now also backing `compute_harmonic_multiplier`), so a key *clash* with a close BPM is never mislabeled a harmonic match.
- **Frontend:** forecast rows show the "Why" label; rows with no recorded reason say so. Action buttons compacted to icons.
- `queue.reason` already exists (radio uses it) — no migration.

## Review history

Branched stale; rebased onto current `master` (clean, no conflicts). Went through `/codex:adversarial-review` — it flagged that the reason builder re-derived signals independently of the scorer and could present penalties as selection causes. That's the root cause the `fix(automix)` commit addresses (one scoring pass, signals carried, not re-computed). A `/simplify` pass folded the duplicated Camelot ladder into the shared `camelot_relation`.

## Test plan

- [ ] `cargo test` — 633 passing, incl. score-parity (value unchanged) + new recent-skip / energy-whiplash / key-clash-with-close-BPM reason tests
- [ ] `pnpm check` (0/0), `pnpm lint` (clean), `pnpm test` (187 passing)
- [ ] Manual: play automix, confirm forecast rows show a sensible "Why" and penalties read as "despite …"