### PR TITLE
fix(artist,album): correct ordering and missing discography sections

### DIFF
--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -85,6 +85,10 @@ export interface TidalDiscographyAlbum {
 	artwork_url: string | null;
 	release_date: string | null;
 	release_type: string | null;
+	// TIDAL's editorial filter that surfaced this album. More reliable than
+	// release_type for bucketing — release_type on the body field disagrees
+	// with the filter often enough to leave whole sections empty.
+	source_filter: 'ALBUMS' | 'EPSANDSINGLES' | 'COMPILATIONS' | 'LIVE' | null;
 	number_of_tracks: number | null;
 	artist_name: string;
 	in_library: boolean;

--- a/frontend/src/routes/artists/[id]/+page.svelte
+++ b/frontend/src/routes/artists/[id]/+page.svelte
@@ -289,6 +289,20 @@
 
 	type DiscoCategory = 'album' | 'ep_single' | 'compilation' | 'live';
 	function categorize(a: TidalDiscographyAlbum): DiscoCategory {
+		// The TIDAL editorial filter is more authoritative than the per-album
+		// release_type body field — a compilation tagged release_type:"ALBUM"
+		// used to land in the Albums shelf and the Compilations shelf stayed
+		// empty even though the data was fetched.
+		switch (a.source_filter) {
+			case 'COMPILATIONS':
+				return 'compilation';
+			case 'LIVE':
+				return 'live';
+			case 'EPSANDSINGLES':
+				return 'ep_single';
+			case 'ALBUMS':
+				return 'album';
+		}
 		const type = (a.release_type ?? '').toUpperCase();
 		if (type === 'COMPILATION') return 'compilation';
 		if (type === 'LIVE') return 'live';
@@ -298,9 +312,17 @@
 	}
 
 	function sortByDate(list: TidalDiscographyAlbum[]): TidalDiscographyAlbum[] {
-		return [...list].sort(
-			(a, b) => (releaseYear(b.release_date) ?? 0) - (releaseYear(a.release_date) ?? 0)
-		);
+		// Compare full ISO date strings (YYYY-MM-DD sorts lexicographically)
+		// not just the year — a Dec 2024 release should sit above a Jan 2024
+		// one. Missing dates sort to the bottom.
+		return [...list].sort((a, b) => {
+			const ad = a.release_date ?? '';
+			const bd = b.release_date ?? '';
+			if (ad === bd) return 0;
+			if (!ad) return 1;
+			if (!bd) return -1;
+			return bd.localeCompare(ad);
+		});
 	}
 
 	let tidalFullAlbums = $derived(sortByDate(tidalAlbums.filter((a) => categorize(a) === 'album')));
@@ -855,19 +877,6 @@
 				</section>
 			{/if}
 
-			{#if tidalSimilarArtists.length > 0}
-				<section class="section">
-					<div class="shelf-head">
-						<h2 class="section-title">Fans also like</h2>
-						<span class="shelf-count">{tidalSimilarArtists.length}</span>
-					</div>
-					<MediaRail items={tidalSimilarArtists} getKey={(a) => a.tidal_id}>
-						{#snippet card(similar)}
-							{@render similarArtistCard(similar)}
-						{/snippet}
-					</MediaRail>
-				</section>
-			{/if}
 		{:else}
 			{#if fallbackFullAlbums.length > 0}
 				<section class="section">
@@ -952,6 +961,22 @@
 			{#if tidalLoading}
 				<p class="status subtle">Loading full discography from TIDAL…</p>
 			{/if}
+		{/if}
+
+		<!-- Similar artists are not gated on tidalAvailable: a transient TIDAL
+		     fetch hiccup on /artists used to drop this section silently. -->
+		{#if tidalSimilarArtists.length > 0}
+			<section class="section">
+				<div class="shelf-head">
+					<h2 class="section-title">Fans also like</h2>
+					<span class="shelf-count">{tidalSimilarArtists.length}</span>
+				</div>
+				<MediaRail items={tidalSimilarArtists} getKey={(a) => a.tidal_id}>
+					{#snippet card(similar)}
+						{@render similarArtistCard(similar)}
+					{/snippet}
+				</MediaRail>
+			</section>
 		{/if}
 	{/if}
 </div>

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -999,8 +999,54 @@ async fn get_album_tracks(
         tokens.country_code.clone(),
     );
 
+    // Pre-fix legacy rows that landed with NULL track_number — `TidalTrack`
+    // shipped without #[serde(rename = "trackNumber")] for a long time, so
+    // every TIDAL-imported track row stored NULL and the album sort fell
+    // back to alphabetical. Backfill from the live TIDAL payload on first
+    // view post-fix.
+    let needs_backfill = tracks
+        .iter()
+        .any(|t| t.track_number.is_none() && t.tidal_id.is_some());
+
     let tidal_tracks_payload: Vec<Value> = match client.get_album_tracks(tidal_album_id).await {
         Ok(resp) => {
+            if needs_backfill {
+                let backfill_pairs: Vec<(i64, i32, i32)> = resp
+                    .items
+                    .iter()
+                    .filter_map(|t| Some((t.id, t.track_number?, t.volume_number.unwrap_or(1))))
+                    .collect();
+                if !backfill_pairs.is_empty() {
+                    let s = state.read().await;
+                    let _ = s.db.with_conn(|conn| {
+                        let tx = conn.unchecked_transaction()?;
+                        let mut count = 0i64;
+                        {
+                            let mut stmt = tx.prepare(
+                                "UPDATE tracks
+                                 SET track_number = COALESCE(track_number, ?2),
+                                     disc_number  = COALESCE(disc_number, ?3)
+                                 WHERE tidal_id = ?1
+                                   AND (track_number IS NULL OR disc_number IS NULL)",
+                            )?;
+                            for (tid, tn, dn) in &backfill_pairs {
+                                count += stmt.execute(rusqlite::params![tid, tn, dn])? as i64;
+                            }
+                        }
+                        tx.commit()?;
+                        if count > 0 {
+                            tracing::info!(
+                                target: "noor.album",
+                                event = "tracknumber_backfill",
+                                album_id = id,
+                                updated = count
+                            );
+                        }
+                        Ok::<_, anyhow::Error>(())
+                    });
+                }
+            }
+
             // Local rows that came from TIDAL carry a `tidal_id`; dedupe so
             // the same track doesn't appear twice (once styled as library,
             // once as TIDAL-only).
@@ -1040,6 +1086,17 @@ async fn get_album_tracks(
             tracing::warn!(?e, "TIDAL get_album_tracks failed; serving library only");
             Vec::new()
         }
+    };
+
+    // Reload tracks so the response reflects backfilled track/disc numbers
+    // (the original `get_album_tracks` query ordered by COALESCE(..., 999999)
+    // and may have produced alphabetical fallback order before the UPDATE).
+    let tracks = if needs_backfill {
+        let s = state.read().await;
+        s.db.with_conn(|conn| queries::get_album_tracks(conn, id))
+            .unwrap_or(tracks)
+    } else {
+        tracks
     };
 
     Ok(Json(json!({
@@ -1285,21 +1342,28 @@ async fn get_artist_discography(
 
     // TIDAL can return the same release under multiple filters (e.g. an album
     // re-issue tagged both ALBUMS and COMPILATIONS). Dedupe by tidal_id while
-    // preserving the order of first appearance.
+    // preserving the order of first appearance. Each entry remembers the
+    // filter it came from so the frontend can bucket it correctly — TIDAL's
+    // per-album `release_type` body field is unreliable and was the original
+    // reason Singles / Compilations sections were silently empty.
     let mut seen: std::collections::HashSet<i64> = std::collections::HashSet::new();
-    let mut all_albums: Vec<crate::services::tidal::client::TidalAlbum> = Vec::new();
-    for r in [albums_res, eps_res, comps_res, live_res]
-        .into_iter()
-        .flatten()
-    {
-        for item in r {
+    let mut all_albums: Vec<(crate::services::tidal::client::TidalAlbum, &'static str)> =
+        Vec::new();
+    for (r, filter) in [
+        (albums_res, "ALBUMS"),
+        (eps_res, "EPSANDSINGLES"),
+        (comps_res, "COMPILATIONS"),
+        (live_res, "LIVE"),
+    ] {
+        let Ok(items) = r else { continue };
+        for item in items {
             if seen.insert(item.id) {
-                all_albums.push(item);
+                all_albums.push((item, filter));
             }
         }
     }
 
-    let tidal_album_ids: Vec<i64> = all_albums.iter().map(|a| a.id).collect();
+    let tidal_album_ids: Vec<i64> = all_albums.iter().map(|(a, _)| a.id).collect();
     let known_map = {
         let s = state.read().await;
         s.db.with_conn(|conn| queries::get_known_album_tidal_ids(conn, &tidal_album_ids))
@@ -1308,7 +1372,7 @@ async fn get_artist_discography(
 
     let albums_payload: Vec<Value> = all_albums
         .into_iter()
-        .map(|a| {
+        .map(|(a, source_filter)| {
             let artwork =
                 crate::services::tidal::client::TidalClient::get_artwork_url(&a.cover, 320);
             let local_id = known_map.get(&a.id).copied();
@@ -1319,6 +1383,7 @@ async fn get_artist_discography(
                 "artwork_url": artwork,
                 "release_date": a.release_date,
                 "release_type": a.release_type,
+                "source_filter": source_filter,
                 "number_of_tracks": a.number_of_tracks,
                 "artist_name": a.artist.name,
                 "in_library": local_id.is_some()

--- a/noor-server/src/services/tidal/client.rs
+++ b/noor-server/src/services/tidal/client.rs
@@ -43,7 +43,9 @@ pub struct TidalTrack {
     pub id: i64,
     pub title: String,
     pub duration: i64,
+    #[serde(rename = "trackNumber")]
     pub track_number: Option<i32>,
+    #[serde(rename = "volumeNumber")]
     pub volume_number: Option<i32>,
     pub isrc: Option<String>,
     pub artist: TidalArtist,
@@ -1818,5 +1820,25 @@ mod tests {
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].id, 1);
         assert_eq!(items[0].artist_name.as_deref(), Some("Artist"));
+    }
+
+    /// Regression: TIDAL's per-track payload ships `trackNumber` / `volumeNumber`
+    /// in camelCase. Both fields had no #[serde(rename)] for a long time, so
+    /// every TIDAL-imported track row stored NULL and the album sort fell
+    /// back to alphabetical (e.g. Red Headed Stranger out of narrative order).
+    #[test]
+    fn tidal_track_deserializes_camel_case_numbers() {
+        let payload = json!({
+            "id": 12345,
+            "title": "Time of the Preacher",
+            "duration": 167,
+            "trackNumber": 1,
+            "volumeNumber": 1,
+            "isrc": "USAB10000001",
+            "artist": { "id": 1, "name": "Willie Nelson" }
+        });
+        let track: TidalTrack = serde_json::from_value(payload).unwrap();
+        assert_eq!(track.track_number, Some(1));
+        assert_eq!(track.volume_number, Some(1));
     }
 }


### PR DESCRIPTION
## Summary

Four bugs converging on the artist + album surfaces, all visible together on the artist page and individually on every album page in the library.

### 1. Album track ordering reverted to alphabetical (Red Headed Stranger and every other album)
`TidalTrack` was missing `#[serde(rename = "trackNumber")]` and `#[serde(rename = "volumeNumber")]`. Every other camelCase field in the struct (`audioQuality`, `streamReady`, `numberOfTracks`, etc.) had explicit renames — these two were missed. Result: serde silently left both fields as `None`, the importer wrote `track_number = NULL` for every TIDAL track, and `get_album_tracks`' `COALESCE(track_number, 999999)` sent every row to the alphabetical fallback. Verified against the live DB — all 35,477 tracks had `track_number IS NULL`.

Fix is two parts:
- Add the `#[serde(rename = ...)]` attributes so new imports get correct numbers.
- Add a lazy backfill in the album route: on view, if any local row on the album has `track_number IS NULL AND tidal_id IS NOT NULL`, UPDATE from the live TIDAL payload, then reload tracks so the same response carries correct order.

Regression test added so this can't come back silently.

### 2. Singles / Compilations sections silently empty for many artists
`get_artist_discography` fetches four separate TIDAL filters (`ALBUMS`, `EPSANDSINGLES`, `COMPILATIONS`, `LIVE`) but threw that knowledge away — frontend `categorize()` re-bucketed purely off TIDAL's per-album `release_type` body field. That field disagrees with the filter often enough (e.g. a compilation tagged `release_type: "ALBUM"`, a 5-track EP with `release_type: null`) that Singles and Compilations shelves silently disappeared.

Server now stamps each album with `source_filter`. Frontend trusts that first, falls back to `release_type`, falls back to track-count last.

### 3. Album sort used YEAR only, not full date
`sortByDate` extracted just the 4-digit year, so a December 2024 release sat below a January 2024 one. Switched to full ISO `release_date` string comparison.

### 4. Fans-also-like dropped when TIDAL hiccupped
The Similar artists section was nested inside `{#if tidalAvailable}`. A transient `get_artist_similar` failure (which `unwrap_or_default()`s to `[]` on the server) collapsed the section. Moved it outside the gate — renders whenever the array has entries.

## Test plan

- [x] cargo build -p noor-server — clean
- [x] cargo test -p noor-server — 657 passed, 0 failed (incl. new regression test)
- [x] pnpm check — 0 errors, 0 warnings
- [x] pnpm test — 224 passed
- [x] pnpm lint — clean
- [ ] Open Red Headed Stranger — tracks render in narrative order
- [ ] Open an artist with a compilations catalog — Compilations shelf populates
- [ ] Open an artist with mostly singles/EPs — Singles and EPs shelf populates
- [ ] Open an artist where TIDAL is flaky — Fans also like still renders if similar-artist data arrived