### PR TITLE
fix(playback): runtime hardening (error / panic / cancel / observability)

### DIFF
--- a/noor-app/src/sidecar.rs
+++ b/noor-app/src/sidecar.rs
@@ -46,6 +46,14 @@ const MAX_LOG_BYTES: u64 = 50 * 1024 * 1024;
 const SERVER_PING_URL: &str = "http://127.0.0.1:3334/api/ping";
 const SERVER_SETUP_TOKEN_URL: &str = "http://127.0.0.1:3334/api/setup/token";
 const SERVER_SHUTDOWN_URL: &str = "http://127.0.0.1:3334/api/shutdown";
+const READY_REQUEST_TIMEOUT_MS: u64 = 500;
+
+fn ready_http_client() -> Option<reqwest::blocking::Client> {
+    reqwest::blocking::Client::builder()
+        .timeout(Duration::from_millis(READY_REQUEST_TIMEOUT_MS))
+        .build()
+        .ok()
+}
 
 fn rotate_log_if_oversized(path: &PathBuf) {
     let size = match std::fs::metadata(path) {
@@ -185,12 +193,16 @@ pub fn restart_server(state: &Arc<SidecarState>) {
 
 /// Blocks until noor-server responds to /api/ping (max 10 s).
 /// Returns the server auth token fetched from /api/setup/token.
+///
+/// Uses a per-request 500 ms client-level timeout so a wedged server cannot
+/// consume the entire 10 s readiness budget in a single request.
 pub fn wait_for_ready(state: &Arc<SidecarState>) -> Option<String> {
+    let client = ready_http_client()?;
     let deadline = Instant::now() + Duration::from_secs(10);
     while Instant::now() < deadline {
-        if let Ok(resp) = reqwest::blocking::get(SERVER_PING_URL) {
+        if let Ok(resp) = client.get(SERVER_PING_URL).send() {
             if resp.status().is_success() {
-                if let Ok(r) = reqwest::blocking::get(SERVER_SETUP_TOKEN_URL) {
+                if let Ok(r) = client.get(SERVER_SETUP_TOKEN_URL).send() {
                     if let Ok(body) = r.json::<serde_json::Value>() {
                         let token = body["token"].as_str().map(|s| s.to_owned());
                         *state.server_token.lock().unwrap() = token.clone();
@@ -214,5 +226,10 @@ mod tests {
         assert!(should_shutdown_stale_server_before_spawn(false, true));
         assert!(!should_shutdown_stale_server_before_spawn(true, true));
         assert!(!should_shutdown_stale_server_before_spawn(false, false));
+    }
+
+    #[test]
+    fn ready_http_client_builds_with_timeout() {
+        assert!(ready_http_client().is_some());
     }
 }

--- a/noor-server/src/playback/decode/mod.rs
+++ b/noor-server/src/playback/decode/mod.rs
@@ -78,16 +78,26 @@ pub(crate) fn decode_and_buffer_job(
             let mut remaining_segment_urls = stream_info.segment_urls.clone();
             let initial_media_segments = dash_initial_media_count(stream_info.segment_urls.len());
             if initial_media_segments > 0 {
+                let prebuffer_stop = shared.stop_flag();
                 dash_initial = rt
                     .block_on(async {
+                        if prebuffer_stop.load(Ordering::Relaxed) {
+                            return anyhow::Ok(Vec::new());
+                        }
                         let mut bytes =
                             append_stream_bytes(&config.http_client, &stream_info.url, 0).await?;
+                        if prebuffer_stop.load(Ordering::Relaxed) {
+                            return anyhow::Ok(bytes);
+                        }
                         for (idx, segment_url) in stream_info
                             .segment_urls
                             .iter()
                             .take(initial_media_segments)
                             .enumerate()
                         {
+                            if prebuffer_stop.load(Ordering::Relaxed) {
+                                return anyhow::Ok(bytes);
+                            }
                             bytes.extend(
                                 append_stream_bytes(&config.http_client, segment_url, idx + 1)
                                     .await?,
@@ -114,6 +124,7 @@ pub(crate) fn decode_and_buffer_job(
             let url = stream_info.url.clone();
             let download_track_id = shared.track_id;
             let segment_urls = remaining_segment_urls;
+            let download_stop = shared.stop_flag();
             thread::Builder::new()
                 .name("noor-stream-download".into())
                 .spawn(move || {
@@ -125,6 +136,9 @@ pub(crate) fn decode_and_buffer_job(
                         let result: anyhow::Result<()> = async {
                             let http = build_tidal_cdn_client();
                             if !is_dash_stream {
+                                if download_stop.load(Ordering::Relaxed) {
+                                    return Ok(());
+                                }
                                 // Single-URL path (JSON manifest or DASH BaseURL shape)
                                 let response = http
                                     .get(&url)
@@ -138,6 +152,9 @@ pub(crate) fn decode_and_buffer_job(
                                 let _ = len_tx.send(response.content_length());
                                 let mut stream = response.bytes_stream();
                                 while let Some(chunk) = stream.next().await {
+                                    if download_stop.load(Ordering::Relaxed) {
+                                        break; // track stopped mid-fetch
+                                    }
                                     let bytes = chunk.context("chunk read error")?;
                                     if chunk_tx.send(Some(bytes.to_vec())).is_err() {
                                         break; // decoder stopped early (track skipped/stopped)
@@ -149,12 +166,22 @@ pub(crate) fn decode_and_buffer_job(
                                 let mut sent_segments = 0usize;
                                 let mut sent_bytes = 0usize;
                                 for (idx, seg_url) in segment_urls.into_iter().enumerate() {
+                                    if download_stop.load(Ordering::Relaxed) {
+                                        warn!(
+                                            "TIDAL DASH download cancelled: track_id={}, sent_segments={}, total_remaining_segments={}",
+                                            download_track_id, sent_segments, total_segments
+                                        );
+                                        break;
+                                    }
                                     let bytes = append_stream_bytes(
                                         &http,
                                         &seg_url,
                                         initial_media_segments + idx + 1,
                                     )
                                     .await?;
+                                    if download_stop.load(Ordering::Relaxed) {
+                                        break;
+                                    }
                                     sent_bytes += bytes.len();
                                     if chunk_tx.send(Some(bytes)).is_err() {
                                         warn!(
@@ -205,9 +232,15 @@ pub(crate) fn decode_and_buffer_job(
 
             // ── Step 3: probe + decode incrementally, writing to the buffer each packet ──────
             let pipe = if is_dash_stream {
-                StreamPipe::with_initial(dash_initial, chunk_rx, content_length, true)
+                StreamPipe::with_initial(
+                    dash_initial,
+                    chunk_rx,
+                    content_length,
+                    true,
+                    shared.stop_flag(),
+                )
             } else {
-                StreamPipe::new(chunk_rx, content_length)
+                StreamPipe::new(chunk_rx, content_length, shared.stop_flag())
             };
             let mss = MediaSourceStream::new(Box::new(pipe), Default::default());
 

--- a/noor-server/src/playback/decode/mod.rs
+++ b/noor-server/src/playback/decode/mod.rs
@@ -310,6 +310,9 @@ pub(crate) fn decode_and_buffer_job(
             let mut resampler: Option<StreamResampler> = None;
             let mut decoded_packets: u64 = 0;
             let mut decoded_samples: u64 = 0;
+            // One-shot guard for the buffer-growth warn so the audio thread's
+            // CAS signal becomes at most one log line per buffer instance.
+            let mut growth_warn_emitted = false;
 
             loop {
                 if shared.stopped.load(Ordering::SeqCst) {
@@ -414,13 +417,27 @@ pub(crate) fn decode_and_buffer_job(
                     }
                 };
 
-                let mut guard = shared
-                    .buffer
-                    .lock()
-                    .map_err(|_| anyhow!("playback buffer poisoned"))?;
-                guard.samples.extend_from_slice(&resampled);
+                let buffered_samples = {
+                    let mut guard = shared
+                        .buffer
+                        .lock()
+                        .map_err(|_| anyhow!("playback buffer poisoned"))?;
+                    guard.samples.extend_from_slice(&resampled);
+                    guard.samples.len()
+                };
                 decoded_packets += 1;
                 decoded_samples += resampled.len() as u64;
+
+                // Observe the audio-thread's growth signal off the real-time
+                // thread. local guard makes it one log per buffer; the audio
+                // thread's CAS makes the signal cheap and idempotent.
+                if !growth_warn_emitted && shared.growth_warned.load(Ordering::Relaxed) {
+                    growth_warn_emitted = true;
+                    warn!(
+                        "Playback buffer grew past ~200MB: track_id={}, buffered_samples={}, decoded_packets={}",
+                        shared.track_id, buffered_samples, decoded_packets
+                    );
+                }
             }
 
             // Flush any residual samples held in the resampler at end-of-stream

--- a/noor-server/src/playback/decode/source.rs
+++ b/noor-server/src/playback/decode/source.rs
@@ -3,10 +3,14 @@
 use anyhow::Context;
 use futures::StreamExt as _;
 use std::io::{Read, Seek, SeekFrom};
-use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::RecvTimeoutError;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 pub(crate) const DASH_INITIAL_MEDIA_SEGMENTS: usize = 8;
 pub(crate) const DASH_SEGMENT_TIMEOUT_SECS: u64 = 12;
+const STREAM_PIPE_RECV_POLL_MS: u64 = 100;
 
 pub(crate) struct StreamPipe {
     data: Vec<u8>,
@@ -15,14 +19,19 @@ pub(crate) struct StreamPipe {
     eof: bool,
     known_length: Option<u64>,
     dynamic_length: bool,
+    /// Cancellation signal observed between blocking receive iterations so a
+    /// stopped/skipped track does not leave the decoder thread wedged on
+    /// rx.recv() until the producer drops chunk_tx.
+    stop_flag: Arc<AtomicBool>,
 }
 
 impl StreamPipe {
     pub(crate) fn new(
         rx: std::sync::mpsc::Receiver<Option<Vec<u8>>>,
         known_length: Option<u64>,
+        stop_flag: Arc<AtomicBool>,
     ) -> Self {
-        Self::with_initial(Vec::new(), rx, known_length, false)
+        Self::with_initial(Vec::new(), rx, known_length, false, stop_flag)
     }
 
     pub(crate) fn with_initial(
@@ -30,6 +39,7 @@ impl StreamPipe {
         rx: std::sync::mpsc::Receiver<Option<Vec<u8>>>,
         known_length: Option<u64>,
         dynamic_length: bool,
+        stop_flag: Arc<AtomicBool>,
     ) -> Self {
         Self {
             data: initial,
@@ -38,15 +48,35 @@ impl StreamPipe {
             eof: false,
             known_length,
             dynamic_length,
+            stop_flag,
+        }
+    }
+
+    /// Block on the producer channel up to one polling tick, returning what
+    /// happened. Treats a Disconnected sender as natural EOF and honours the
+    /// stop flag in both the pre-poll and post-timeout paths.
+    fn poll_for_chunk(
+        rx: &std::sync::mpsc::Receiver<Option<Vec<u8>>>,
+        stop_flag: &Arc<AtomicBool>,
+    ) -> ChunkPoll {
+        loop {
+            if stop_flag.load(Ordering::Relaxed) {
+                return ChunkPoll::Stopped;
+            }
+            match rx.recv_timeout(Duration::from_millis(STREAM_PIPE_RECV_POLL_MS)) {
+                Ok(Some(chunk)) => return ChunkPoll::Chunk(chunk),
+                Ok(None) | Err(RecvTimeoutError::Disconnected) => return ChunkPoll::Eof,
+                Err(RecvTimeoutError::Timeout) => continue,
+            }
         }
     }
 
     fn fill_to(&mut self, target: usize) {
         if let Ok(rx) = self.rx.lock() {
             while !self.eof && self.data.len() < target {
-                match rx.recv() {
-                    Ok(Some(chunk)) => self.data.extend_from_slice(&chunk),
-                    _ => self.eof = true,
+                match Self::poll_for_chunk(&rx, &self.stop_flag) {
+                    ChunkPoll::Chunk(chunk) => self.data.extend_from_slice(&chunk),
+                    ChunkPoll::Eof | ChunkPoll::Stopped => self.eof = true,
                 }
             }
         }
@@ -57,14 +87,20 @@ impl StreamPipe {
             return;
         }
         if let Ok(rx) = self.rx.lock() {
-            match rx.recv() {
-                Ok(Some(chunk)) => self.data.extend_from_slice(&chunk),
-                _ => self.eof = true,
+            match Self::poll_for_chunk(&rx, &self.stop_flag) {
+                ChunkPoll::Chunk(chunk) => self.data.extend_from_slice(&chunk),
+                ChunkPoll::Eof | ChunkPoll::Stopped => self.eof = true,
             }
         } else {
             self.eof = true;
         }
     }
+}
+
+enum ChunkPoll {
+    Chunk(Vec<u8>),
+    Eof,
+    Stopped,
 }
 
 impl Read for StreamPipe {
@@ -220,10 +256,14 @@ mod tests {
     use super::*;
     use std::io::{Read, Seek, SeekFrom};
 
+    fn never_stopped() -> Arc<AtomicBool> {
+        Arc::new(AtomicBool::new(false))
+    }
+
     #[test]
     fn stream_pipe_reports_known_length_before_eof() {
         let (_tx, rx) = std::sync::mpsc::sync_channel::<Option<Vec<u8>>>(1);
-        let pipe = StreamPipe::new(rx, Some(641_302));
+        let pipe = StreamPipe::new(rx, Some(641_302), never_stopped());
 
         assert_eq!(
             symphonia::core::io::MediaSource::byte_len(&pipe),
@@ -234,7 +274,7 @@ mod tests {
     #[test]
     fn stream_pipe_hides_dynamic_length_for_dash_prebuffer() {
         let (_tx, rx) = std::sync::mpsc::sync_channel::<Option<Vec<u8>>>(1);
-        let pipe = StreamPipe::with_initial(vec![1, 2, 3], rx, None, true);
+        let pipe = StreamPipe::with_initial(vec![1, 2, 3], rx, None, true, never_stopped());
 
         assert!(!symphonia::core::io::MediaSource::is_seekable(&pipe));
         assert_eq!(symphonia::core::io::MediaSource::byte_len(&pipe), None);
@@ -243,7 +283,7 @@ mod tests {
     #[test]
     fn stream_pipe_dynamic_seek_end_uses_buffered_length_without_draining() {
         let (_tx, rx) = std::sync::mpsc::sync_channel::<Option<Vec<u8>>>(1);
-        let mut pipe = StreamPipe::with_initial(vec![1, 2, 3], rx, None, true);
+        let mut pipe = StreamPipe::with_initial(vec![1, 2, 3], rx, None, true, never_stopped());
 
         assert_eq!(pipe.seek(SeekFrom::End(0)).unwrap(), 3);
         assert_eq!(symphonia::core::io::MediaSource::byte_len(&pipe), None);
@@ -254,7 +294,7 @@ mod tests {
         let (tx, rx) = std::sync::mpsc::sync_channel::<Option<Vec<u8>>>(2);
         tx.send(Some(vec![4, 5])).unwrap();
         tx.send(None).unwrap();
-        let mut pipe = StreamPipe::with_initial(vec![1, 2, 3], rx, None, true);
+        let mut pipe = StreamPipe::with_initial(vec![1, 2, 3], rx, None, true, never_stopped());
 
         let mut out = Vec::new();
         pipe.read_to_end(&mut out).unwrap();
@@ -269,10 +309,40 @@ mod tests {
         let (tx, rx) = std::sync::mpsc::sync_channel::<Option<Vec<u8>>>(2);
         tx.send(Some(vec![1, 2, 3, 4])).unwrap();
         tx.send(None).unwrap();
-        let mut pipe = StreamPipe::new(rx, Some(4));
+        let mut pipe = StreamPipe::new(rx, Some(4), never_stopped());
 
         assert_eq!(pipe.seek(SeekFrom::End(0)).unwrap(), 4);
         assert_eq!(symphonia::core::io::MediaSource::byte_len(&pipe), Some(4));
+    }
+
+    #[test]
+    fn stream_pipe_read_exits_when_stop_flag_flips_without_eof() {
+        let (tx, rx) = std::sync::mpsc::channel::<Option<Vec<u8>>>();
+        let stop_flag = Arc::new(AtomicBool::new(false));
+        let mut pipe = StreamPipe::new(rx, None, Arc::clone(&stop_flag));
+
+        // Watchdog that flips the stop flag after ~150ms. If the read blocks
+        // indefinitely the test will hang; this watchdog forces an exit so
+        // the failure mode is a timing-bounded assertion rather than a hang.
+        let stop_for_watchdog = Arc::clone(&stop_flag);
+        let watchdog = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(150));
+            stop_for_watchdog.store(true, Ordering::Relaxed);
+        });
+
+        let started = std::time::Instant::now();
+        let mut buf = [0u8; 16];
+        let read = pipe.read(&mut buf).unwrap();
+        let elapsed = started.elapsed();
+
+        drop(tx);
+        let _ = watchdog.join();
+
+        assert_eq!(read, 0, "stopped pipe should read 0 bytes");
+        assert!(
+            elapsed < Duration::from_millis(500),
+            "read blocked for {elapsed:?}"
+        );
     }
 
     #[test]

--- a/noor-server/src/playback/output/cpal_shared.rs
+++ b/noor-server/src/playback/output/cpal_shared.rs
@@ -90,9 +90,7 @@ fn build_output_stream(
             let err_event_tx = event_tx.clone();
             device.build_output_stream(
                 output_config,
-                move |data: &mut [f32], _| {
-                    write_output_f32(data, &shared, &command_tx, &event_tx)
-                },
+                move |data: &mut [f32], _| write_output_f32(data, &shared, &command_tx, &event_tx),
                 move |err| emit_cpal_stream_error(&err_event_tx, err),
                 None,
             )?
@@ -101,9 +99,7 @@ fn build_output_stream(
             let err_event_tx = event_tx.clone();
             device.build_output_stream(
                 output_config,
-                move |data: &mut [i16], _| {
-                    write_output_i16(data, &shared, &command_tx, &event_tx)
-                },
+                move |data: &mut [i16], _| write_output_i16(data, &shared, &command_tx, &event_tx),
                 move |err| emit_cpal_stream_error(&err_event_tx, err),
                 None,
             )?
@@ -112,9 +108,7 @@ fn build_output_stream(
             let err_event_tx = event_tx.clone();
             device.build_output_stream(
                 output_config,
-                move |data: &mut [u16], _| {
-                    write_output_u16(data, &shared, &command_tx, &event_tx)
-                },
+                move |data: &mut [u16], _| write_output_u16(data, &shared, &command_tx, &event_tx),
                 move |err| emit_cpal_stream_error(&err_event_tx, err),
                 None,
             )?
@@ -139,10 +133,7 @@ mod tests {
 
         emit_cpal_stream_error(&event_tx, cpal::StreamError::DeviceNotAvailable);
 
-        match event_rx
-            .try_recv()
-            .expect("error event should be emitted")
-        {
+        match event_rx.try_recv().expect("error event should be emitted") {
             PlaybackRuntimeEvent::Error { message } => {
                 assert!(message.contains("Playback output stream error"));
             }

--- a/noor-server/src/playback/output/cpal_shared.rs
+++ b/noor-server/src/playback/output/cpal_shared.rs
@@ -64,6 +64,19 @@ pub(crate) fn output_rate_fallback_config(
     (attempted.sample_rate != base.sample_rate).then(|| base.clone())
 }
 
+/// Surface a CPAL stream-level error (device unplugged, format change,
+/// backend fault, etc.) both as a log line and as a user-visible
+/// PlaybackRuntimeEvent::Error. CPAL invokes its error callback off the
+/// audio thread, so allocation and broadcast send are safe here.
+pub(crate) fn emit_cpal_stream_error(
+    event_tx: &tokio::sync::broadcast::Sender<PlaybackRuntimeEvent>,
+    err: cpal::StreamError,
+) {
+    let message = format!("Playback output stream error: {err}");
+    warn!("{message}");
+    let _ = event_tx.send(PlaybackRuntimeEvent::Error { message });
+}
+
 fn build_output_stream(
     device: &cpal::Device,
     output_config: &StreamConfig,
@@ -72,27 +85,40 @@ fn build_output_stream(
     command_tx: mpsc::Sender<PlaybackRuntimeCommand>,
     event_tx: tokio::sync::broadcast::Sender<PlaybackRuntimeEvent>,
 ) -> Result<Stream> {
-    let err_fn = |err| warn!("Playback output stream error: {err}");
-
     let stream = match output_sample_format {
-        SampleFormat::F32 => device.build_output_stream(
-            output_config,
-            move |data: &mut [f32], _| write_output_f32(data, &shared, &command_tx, &event_tx),
-            err_fn,
-            None,
-        )?,
-        SampleFormat::I16 => device.build_output_stream(
-            output_config,
-            move |data: &mut [i16], _| write_output_i16(data, &shared, &command_tx, &event_tx),
-            err_fn,
-            None,
-        )?,
-        SampleFormat::U16 => device.build_output_stream(
-            output_config,
-            move |data: &mut [u16], _| write_output_u16(data, &shared, &command_tx, &event_tx),
-            err_fn,
-            None,
-        )?,
+        SampleFormat::F32 => {
+            let err_event_tx = event_tx.clone();
+            device.build_output_stream(
+                output_config,
+                move |data: &mut [f32], _| {
+                    write_output_f32(data, &shared, &command_tx, &event_tx)
+                },
+                move |err| emit_cpal_stream_error(&err_event_tx, err),
+                None,
+            )?
+        }
+        SampleFormat::I16 => {
+            let err_event_tx = event_tx.clone();
+            device.build_output_stream(
+                output_config,
+                move |data: &mut [i16], _| {
+                    write_output_i16(data, &shared, &command_tx, &event_tx)
+                },
+                move |err| emit_cpal_stream_error(&err_event_tx, err),
+                None,
+            )?
+        }
+        SampleFormat::U16 => {
+            let err_event_tx = event_tx.clone();
+            device.build_output_stream(
+                output_config,
+                move |data: &mut [u16], _| {
+                    write_output_u16(data, &shared, &command_tx, &event_tx)
+                },
+                move |err| emit_cpal_stream_error(&err_event_tx, err),
+                None,
+            )?
+        }
         other => {
             return Err(anyhow!(
                 "unsupported output sample format for playback runtime: {other:?}"
@@ -101,6 +127,28 @@ fn build_output_stream(
     };
 
     Ok(stream)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn emit_cpal_stream_error_warns_and_emits_runtime_error_event() {
+        let (event_tx, mut event_rx) = tokio::sync::broadcast::channel(8);
+
+        emit_cpal_stream_error(&event_tx, cpal::StreamError::DeviceNotAvailable);
+
+        match event_rx
+            .try_recv()
+            .expect("error event should be emitted")
+        {
+            PlaybackRuntimeEvent::Error { message } => {
+                assert!(message.contains("Playback output stream error"));
+            }
+            other => panic!("expected error event, got {other:?}"),
+        }
+    }
 }
 
 fn start_cpal_stream(stream: &Stream) -> Result<()> {

--- a/noor-server/src/playback/runtime/engine.rs
+++ b/noor-server/src/playback/runtime/engine.rs
@@ -401,7 +401,7 @@ mod tests {
         assert!(shared.stopped.load(Ordering::SeqCst));
         assert!(shared.paused.load(Ordering::SeqCst));
         assert!(
-            elapsed < Duration::from_millis(100),
+            elapsed < Duration::from_millis(250),
             "stop blocked for {elapsed:?}"
         );
     }

--- a/noor-server/src/playback/runtime/engine.rs
+++ b/noor-server/src/playback/runtime/engine.rs
@@ -58,6 +58,14 @@ pub(super) struct PlaybackEngine {
     pub(super) shared: Arc<PlaybackSharedState>,
 }
 
+fn join_decoder_thread_in_background(track_id: i64, handle: JoinHandle<()>) {
+    let _ = thread::Builder::new()
+        .name(format!("noor-playback-decoder-join-{track_id}"))
+        .spawn(move || {
+            let _ = handle.join();
+        });
+}
+
 impl PlaybackEngine {
     #[cfg(test)]
     pub(super) fn test_with_shared(
@@ -266,7 +274,7 @@ impl PlaybackEngine {
         self.shared.paused.store(true, Ordering::SeqCst);
         self.shared.reset_buffer();
         if let Some(handle) = self.decoder_thread.take() {
-            let _ = handle.join();
+            join_decoder_thread_in_background(self.track_id, handle);
         }
     }
 
@@ -317,5 +325,84 @@ impl PlaybackEngine {
         self.stream = Some(OutputStream::Cpal { _stream: stream });
         pause_guard.restore();
         Ok(active_plan.stream_config.sample_rate)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::playback::gapless::GaplessPlan;
+    use crate::playback::player::PlaybackSourceKind;
+    use std::sync::atomic::AtomicBool;
+    use std::time::{Duration, Instant};
+
+    fn test_shared_state() -> Arc<PlaybackSharedState> {
+        let (command_tx, _) = mpsc::channel();
+        Arc::new(PlaybackSharedState::new(
+            1,
+            1,
+            PlaybackSourceKind::TidalStream,
+            GaplessPlan::disabled(),
+            48_000,
+            2,
+            None,
+            command_tx,
+            Arc::new(AtomicU32::new(1.0f32.to_bits())),
+            Arc::new(AtomicU64::new(0)),
+        ))
+    }
+
+    #[test]
+    fn stop_marks_engine_stopped_without_waiting_for_decoder_thread() {
+        let shared = test_shared_state();
+        let (release_tx, release_rx) = mpsc::channel::<()>();
+        let (decoder_started_tx, decoder_started_rx) = mpsc::channel::<()>();
+        let decoder_thread = thread::spawn(move || {
+            let _ = decoder_started_tx.send(());
+            let _ = release_rx.recv();
+        });
+        decoder_started_rx
+            .recv()
+            .expect("decoder thread did not start");
+
+        let mut engine = PlaybackEngine {
+            track_id: 1,
+            generation: 1,
+            stream: None,
+            decoder_thread: Some(decoder_thread),
+            shared: Arc::clone(&shared),
+        };
+
+        // Watchdog: if stop() blocks waiting on the decoder thread, release it
+        // after 2s so the test fails loudly with a clear timing message instead
+        // of hanging cargo test forever (no per-test timeout exists by default).
+        let cancel = Arc::new(AtomicBool::new(false));
+        let cancel_for_watchdog = Arc::clone(&cancel);
+        let release_for_watchdog = release_tx.clone();
+        let watchdog = thread::spawn(move || {
+            let deadline = Instant::now() + Duration::from_secs(2);
+            while Instant::now() < deadline {
+                if cancel_for_watchdog.load(Ordering::SeqCst) {
+                    return;
+                }
+                thread::sleep(Duration::from_millis(20));
+            }
+            let _ = release_for_watchdog.send(());
+        });
+
+        let started = Instant::now();
+        engine.stop();
+        let elapsed = started.elapsed();
+
+        cancel.store(true, Ordering::SeqCst);
+        let _ = release_tx.send(());
+        let _ = watchdog.join();
+
+        assert!(shared.stopped.load(Ordering::SeqCst));
+        assert!(shared.paused.load(Ordering::SeqCst));
+        assert!(
+            elapsed < Duration::from_millis(100),
+            "stop blocked for {elapsed:?}"
+        );
     }
 }

--- a/noor-server/src/playback/runtime/mod.rs
+++ b/noor-server/src/playback/runtime/mod.rs
@@ -1346,6 +1346,13 @@ fn promote_next_to_active(
     // BEFORE sliding it into state.engine so get_position_ms() immediately
     // reflects the new track starting from 0 instead of the fading-out track's
     // frozen end position.
+    //
+    // If position_source.lock() panics (the only failure mode is a prior
+    // poisoning) the moved-out `next` is dropped without stop() being called
+    // and its decoder thread keeps fetching until natural EOF or the CDN
+    // timeout (~30s bounded). Task 7's catch_unwind around the dispatch loop
+    // catches the panic and emits Error+Stopped. The "preserve frozen-position
+    // UX" win was judged to outweigh the rare-poisoning bandwidth blip.
     *position_source.lock().unwrap() = Arc::clone(&next.shared.position_samples);
 
     let outgoing = state.engine.take();

--- a/noor-server/src/playback/runtime/mod.rs
+++ b/noor-server/src/playback/runtime/mod.rs
@@ -300,7 +300,7 @@ fn run_runtime_loop(
     while let Ok(command) = command_rx.recv() {
         match command {
             PlaybackRuntimeCommand::Play(job) => {
-                transition_to_job(
+                if let Err(error) = transition_to_job(
                     &config,
                     &command_tx,
                     &device,
@@ -313,10 +313,15 @@ fn run_runtime_loop(
                     &position_samples,
                     &position_source,
                     true,
-                )?;
+                ) {
+                    stop_all_engines(&mut state);
+                    #[cfg(target_os = "windows")]
+                    state.exclusive_sink.clear();
+                    report_runtime_command_error(&event_tx, "Play", error);
+                }
             }
             PlaybackRuntimeCommand::Switch(job) => {
-                transition_to_job(
+                if let Err(error) = transition_to_job(
                     &config,
                     &command_tx,
                     &device,
@@ -329,7 +334,12 @@ fn run_runtime_loop(
                     &position_samples,
                     &position_source,
                     false,
-                )?;
+                ) {
+                    stop_all_engines(&mut state);
+                    #[cfg(target_os = "windows")]
+                    state.exclusive_sink.clear();
+                    report_runtime_command_error(&event_tx, "Switch", error);
+                }
             }
             PlaybackRuntimeCommand::Seek(position_ms) => {
                 if let Some(engine) = state.engine.as_ref() {
@@ -465,13 +475,21 @@ fn run_runtime_loop(
                 // pressing pause during a crossfade actually stops all audio. The
                 // pre-decoded next engine is already paused so we don't touch it.
                 if let Some(engine) = state.engine.as_mut() {
-                    engine.pause()?;
-                    let _ = event_tx.send(PlaybackRuntimeEvent::Paused {
-                        track_id: Some(engine.track_id),
-                    });
+                    match engine.pause() {
+                        Ok(()) => {
+                            let _ = event_tx.send(PlaybackRuntimeEvent::Paused {
+                                track_id: Some(engine.track_id),
+                            });
+                        }
+                        Err(error) => {
+                            report_runtime_command_error(&event_tx, "Pause", error);
+                        }
+                    }
                 }
                 if let Some(engine) = state.fading_out_engine.as_mut() {
-                    engine.pause()?;
+                    if let Err(error) = engine.pause() {
+                        report_runtime_command_error(&event_tx, "Pause", error);
+                    }
                 }
             }
             PlaybackRuntimeCommand::Resume => {
@@ -514,7 +532,7 @@ fn run_runtime_loop(
                                     "Resume: failed to rebuild exclusive sink; falling back to shared: {err:?}"
                                 );
                                 if let Some(engine) = state.engine.as_mut() {
-                                    let actual_rate = engine.swap_stream(
+                                    match engine.swap_stream(
                                         &device,
                                         &output_config,
                                         output_sample_format,
@@ -523,9 +541,17 @@ fn run_runtime_loop(
                                         false,
                                         rebuild_rate,
                                         release_grace_secs,
-                                    )?;
-                                    output_config.sample_rate = actual_rate;
-                                    state.device_sample_rate = actual_rate;
+                                    ) {
+                                        Ok(actual_rate) => {
+                                            output_config.sample_rate = actual_rate;
+                                            state.device_sample_rate = actual_rate;
+                                        }
+                                        Err(error) => {
+                                            report_runtime_command_error(
+                                                &event_tx, "Resume", error,
+                                            );
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -533,13 +559,21 @@ fn run_runtime_loop(
                 }
 
                 if let Some(engine) = state.engine.as_mut() {
-                    engine.resume()?;
-                    let _ = event_tx.send(PlaybackRuntimeEvent::Resumed {
-                        track_id: Some(engine.track_id),
-                    });
+                    match engine.resume() {
+                        Ok(()) => {
+                            let _ = event_tx.send(PlaybackRuntimeEvent::Resumed {
+                                track_id: Some(engine.track_id),
+                            });
+                        }
+                        Err(error) => {
+                            report_runtime_command_error(&event_tx, "Resume", error);
+                        }
+                    }
                 }
                 if let Some(engine) = state.fading_out_engine.as_mut() {
-                    engine.resume()?;
+                    if let Err(error) = engine.resume() {
+                        report_runtime_command_error(&event_tx, "Resume", error);
+                    }
                 }
             }
             PlaybackRuntimeCommand::Stop => {
@@ -1069,6 +1103,16 @@ fn stop_all_engines(state: &mut PlaybackRuntimeLoopState) {
     if let Some(mut engine) = state.fading_out_engine.take() {
         engine.stop();
     }
+}
+
+fn report_runtime_command_error(
+    event_tx: &tokio::sync::broadcast::Sender<PlaybackRuntimeEvent>,
+    command_name: &str,
+    error: anyhow::Error,
+) {
+    let message = format!("{command_name} failed: {error}");
+    warn!("{message}");
+    let _ = event_tx.send(PlaybackRuntimeEvent::Error { message });
 }
 
 #[cfg(target_os = "windows")]
@@ -1792,6 +1836,25 @@ mod tests {
         assert_eq!(sources[0].role, ExclusiveRenderRole::Active);
         assert_eq!(sources[1].role, ExclusiveRenderRole::Prepared);
         assert_eq!(sources[2].role, ExclusiveRenderRole::Fading);
+    }
+
+    #[test]
+    fn report_runtime_command_error_emits_error_event() {
+        let (event_tx, mut event_rx) = tokio::sync::broadcast::channel(8);
+
+        report_runtime_command_error(
+            &event_tx,
+            "Play",
+            anyhow::anyhow!("output device rejected stream"),
+        );
+
+        match event_rx.try_recv().expect("error event should be emitted") {
+            PlaybackRuntimeEvent::Error { message } => {
+                assert!(message.contains("Play failed"));
+                assert!(message.contains("output device rejected stream"));
+            }
+            other => panic!("expected error event, got {other:?}"),
+        }
     }
 
     fn test_engine_with_shared(track_id: i64, generation: u64) -> PlaybackEngine {

--- a/noor-server/src/playback/runtime/mod.rs
+++ b/noor-server/src/playback/runtime/mod.rs
@@ -298,476 +298,555 @@ fn run_runtime_loop(
     );
 
     while let Ok(command) = command_rx.recv() {
-        match command {
-            PlaybackRuntimeCommand::Play(job) => {
-                if let Err(error) = transition_to_job(
-                    &config,
-                    &command_tx,
-                    &device,
-                    &mut output_config,
-                    output_sample_format,
-                    &event_tx,
-                    &mut state,
-                    job,
-                    &volume_ctl,
-                    &position_samples,
-                    &position_source,
-                    true,
-                ) {
-                    stop_all_engines(&mut state);
-                    #[cfg(target_os = "windows")]
-                    state.exclusive_sink.clear();
-                    report_runtime_command_error(&event_tx, "Play", error);
-                }
-            }
-            PlaybackRuntimeCommand::Switch(job) => {
-                if let Err(error) = transition_to_job(
-                    &config,
-                    &command_tx,
-                    &device,
-                    &mut output_config,
-                    output_sample_format,
-                    &event_tx,
-                    &mut state,
-                    job,
-                    &volume_ctl,
-                    &position_samples,
-                    &position_source,
-                    false,
-                ) {
-                    stop_all_engines(&mut state);
-                    #[cfg(target_os = "windows")]
-                    state.exclusive_sink.clear();
-                    report_runtime_command_error(&event_tx, "Switch", error);
-                }
-            }
-            PlaybackRuntimeCommand::Seek(position_ms) => {
-                if let Some(engine) = state.engine.as_ref() {
-                    let target_samples = (position_ms.max(0) as u64
-                        * state.device_sample_rate as u64
-                        * state.device_channels as u64)
-                        / 1000;
-                    // Tell the CPAL callback to seek on the next write. The
-                    // callback will accept (and update position_samples) only
-                    // if the target is within already-decoded samples or the
-                    // buffer is finished; otherwise it warns and leaves the
-                    // position counter untouched. This keeps the runtime-side
-                    // position honest about what has actually been played.
-                    // (Route/UI-side position handling is a separate follow-up.)
-                    engine
-                        .shared
-                        .seek_target_samples
-                        .store(target_samples, Ordering::Relaxed);
-                    // Reset fire-once guards so NearEnd / CrossfadeStart re-fire correctly
-                    // if the user seeks backward past those thresholds.
-                    engine
-                        .shared
-                        .near_end_signaled
-                        .store(false, Ordering::Relaxed);
-                    engine
-                        .shared
-                        .crossfade_start_signaled
-                        .store(false, Ordering::Relaxed);
-                }
-            }
-            PlaybackRuntimeCommand::PrepareNext(job) => {
-                // Only pre-decode if we don't already have a pending engine for this track.
-                let already_pending = state
-                    .next_engine
-                    .as_ref()
-                    .map(|e| e.track_id == job.track.id && e.generation == job.generation)
-                    .unwrap_or(false);
-                if !already_pending {
-                    // Stop any stale pending engine first.
-                    if let Some(mut stale) = state.next_engine.take() {
-                        stale.stop();
-                    }
-                    let pending_position = Arc::new(AtomicU64::new(0));
-                    let engine_result = if state.current_exclusive {
-                        PlaybackEngine::start_decoder_only(
-                            &config,
-                            &command_tx,
-                            job,
-                            state.device_sample_rate,
-                            state.device_channels,
-                            Arc::clone(&volume_ctl),
-                            pending_position,
-                        )
-                    } else {
-                        PlaybackEngine::start(
-                            &config,
-                            &command_tx,
-                            &device,
-                            &output_config,
-                            output_sample_format,
-                            job,
-                            event_tx.clone(),
-                            state.device_sample_rate,
-                            state.device_channels,
-                            Arc::clone(&volume_ctl),
-                            pending_position,
-                        )
-                    };
-                    match engine_result {
-                        Ok(engine) => {
-                            // Keep the stream alive but software-paused so host pause does not
-                            // block control commands on some Linux/PipeWire setups.
-                            engine.shared.paused.store(true, Ordering::SeqCst);
-                            state.next_engine = Some(engine);
-                            #[cfg(target_os = "windows")]
-                            if state.current_exclusive {
-                                refresh_exclusive_sources(&state);
-                            }
-                        }
-                        Err(err) => {
-                            warn!("Failed to pre-buffer next track: {err:?}");
-                        }
+        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            match command {
+                PlaybackRuntimeCommand::Play(job) => {
+                    if let Err(error) = transition_to_job(
+                        &config,
+                        &command_tx,
+                        &device,
+                        &mut output_config,
+                        output_sample_format,
+                        &event_tx,
+                        &mut state,
+                        job,
+                        &volume_ctl,
+                        &position_samples,
+                        &position_source,
+                        true,
+                    ) {
+                        stop_all_engines(&mut state);
+                        #[cfg(target_os = "windows")]
+                        state.exclusive_sink.clear();
+                        report_runtime_command_error(&event_tx, "Play", error);
                     }
                 }
-            }
-            PlaybackRuntimeCommand::CrossfadeStart {
-                track_id,
-                generation,
-            } => {
-                // The OUTGOING engine just entered its fade-out window and is asking
-                // us to start the pre-decoded next engine, if one is ready.
-                if state.engine.as_ref().map(|e| (e.track_id, e.generation))
-                    == Some((track_id, generation))
-                {
-                    let next_ready = state
+                PlaybackRuntimeCommand::Switch(job) => {
+                    if let Err(error) = transition_to_job(
+                        &config,
+                        &command_tx,
+                        &device,
+                        &mut output_config,
+                        output_sample_format,
+                        &event_tx,
+                        &mut state,
+                        job,
+                        &volume_ctl,
+                        &position_samples,
+                        &position_source,
+                        false,
+                    ) {
+                        stop_all_engines(&mut state);
+                        #[cfg(target_os = "windows")]
+                        state.exclusive_sink.clear();
+                        report_runtime_command_error(&event_tx, "Switch", error);
+                    }
+                }
+                PlaybackRuntimeCommand::Seek(position_ms) => {
+                    if let Some(engine) = state.engine.as_ref() {
+                        let target_samples = (position_ms.max(0) as u64
+                            * state.device_sample_rate as u64
+                            * state.device_channels as u64)
+                            / 1000;
+                        // Tell the CPAL callback to seek on the next write. The
+                        // callback will accept (and update position_samples) only
+                        // if the target is within already-decoded samples or the
+                        // buffer is finished; otherwise it warns and leaves the
+                        // position counter untouched. This keeps the runtime-side
+                        // position honest about what has actually been played.
+                        // (Route/UI-side position handling is a separate follow-up.)
+                        engine
+                            .shared
+                            .seek_target_samples
+                            .store(target_samples, Ordering::Relaxed);
+                        // Reset fire-once guards so NearEnd / CrossfadeStart re-fire correctly
+                        // if the user seeks backward past those thresholds.
+                        engine
+                            .shared
+                            .near_end_signaled
+                            .store(false, Ordering::Relaxed);
+                        engine
+                            .shared
+                            .crossfade_start_signaled
+                            .store(false, Ordering::Relaxed);
+                    }
+                }
+                PlaybackRuntimeCommand::PrepareNext(job) => {
+                    // Only pre-decode if we don't already have a pending engine for this track.
+                    let already_pending = state
                         .next_engine
                         .as_ref()
-                        .and_then(|e| e.shared.buffer.lock().ok().map(|g| g.is_ready()))
+                        .map(|e| e.track_id == job.track.id && e.generation == job.generation)
                         .unwrap_or(false);
-                    if next_ready {
-                        promote_next_to_active(&mut state, &event_tx, &position_source);
-                    }
-                    // If not ready yet, NextDecodeComplete handles the late path.
-                }
-            }
-            PlaybackRuntimeCommand::NextDecodeComplete {
-                track_id,
-                generation,
-            } => {
-                // Decode for the pre-decoded next engine completed. If the outgoing
-                // engine has already entered the crossfade window, promote now —
-                // the user will hear a clipped fade-in, but it's better than silence.
-                let pending_match = state
-                    .next_engine
-                    .as_ref()
-                    .map(|e| e.track_id == track_id && e.generation == generation)
-                    .unwrap_or(false);
-                if pending_match {
-                    let crossfade_started = state
-                        .engine
-                        .as_ref()
-                        .map(|e| e.shared.crossfade_start_signaled.load(Ordering::Relaxed))
-                        .unwrap_or(false);
-                    if crossfade_started {
-                        promote_next_to_active(&mut state, &event_tx, &position_source);
-                    }
-                }
-            }
-            PlaybackRuntimeCommand::Pause => {
-                // Pause the active engine AND the fading-out engine (if any), so
-                // pressing pause during a crossfade actually stops all audio. The
-                // pre-decoded next engine is already paused so we don't touch it.
-                if let Some(engine) = state.engine.as_mut() {
-                    match engine.pause() {
-                        Ok(()) => {
-                            let _ = event_tx.send(PlaybackRuntimeEvent::Paused {
-                                track_id: Some(engine.track_id),
-                            });
+                    if !already_pending {
+                        // Stop any stale pending engine first.
+                        if let Some(mut stale) = state.next_engine.take() {
+                            stale.stop();
                         }
-                        Err(error) => {
+                        let pending_position = Arc::new(AtomicU64::new(0));
+                        let engine_result = if state.current_exclusive {
+                            PlaybackEngine::start_decoder_only(
+                                &config,
+                                &command_tx,
+                                job,
+                                state.device_sample_rate,
+                                state.device_channels,
+                                Arc::clone(&volume_ctl),
+                                pending_position,
+                            )
+                        } else {
+                            PlaybackEngine::start(
+                                &config,
+                                &command_tx,
+                                &device,
+                                &output_config,
+                                output_sample_format,
+                                job,
+                                event_tx.clone(),
+                                state.device_sample_rate,
+                                state.device_channels,
+                                Arc::clone(&volume_ctl),
+                                pending_position,
+                            )
+                        };
+                        match engine_result {
+                            Ok(engine) => {
+                                // Keep the stream alive but software-paused so host pause does not
+                                // block control commands on some Linux/PipeWire setups.
+                                engine.shared.paused.store(true, Ordering::SeqCst);
+                                state.next_engine = Some(engine);
+                                #[cfg(target_os = "windows")]
+                                if state.current_exclusive {
+                                    refresh_exclusive_sources(&state);
+                                }
+                            }
+                            Err(err) => {
+                                warn!("Failed to pre-buffer next track: {err:?}");
+                            }
+                        }
+                    }
+                }
+                PlaybackRuntimeCommand::CrossfadeStart {
+                    track_id,
+                    generation,
+                } => {
+                    // The OUTGOING engine just entered its fade-out window and is asking
+                    // us to start the pre-decoded next engine, if one is ready.
+                    if state.engine.as_ref().map(|e| (e.track_id, e.generation))
+                        == Some((track_id, generation))
+                    {
+                        let next_ready = state
+                            .next_engine
+                            .as_ref()
+                            .and_then(|e| e.shared.buffer.lock().ok().map(|g| g.is_ready()))
+                            .unwrap_or(false);
+                        if next_ready {
+                            promote_next_to_active(&mut state, &event_tx, &position_source);
+                        }
+                        // If not ready yet, NextDecodeComplete handles the late path.
+                    }
+                }
+                PlaybackRuntimeCommand::NextDecodeComplete {
+                    track_id,
+                    generation,
+                } => {
+                    // Decode for the pre-decoded next engine completed. If the outgoing
+                    // engine has already entered the crossfade window, promote now —
+                    // the user will hear a clipped fade-in, but it's better than silence.
+                    let pending_match = state
+                        .next_engine
+                        .as_ref()
+                        .map(|e| e.track_id == track_id && e.generation == generation)
+                        .unwrap_or(false);
+                    if pending_match {
+                        let crossfade_started = state
+                            .engine
+                            .as_ref()
+                            .map(|e| e.shared.crossfade_start_signaled.load(Ordering::Relaxed))
+                            .unwrap_or(false);
+                        if crossfade_started {
+                            promote_next_to_active(&mut state, &event_tx, &position_source);
+                        }
+                    }
+                }
+                PlaybackRuntimeCommand::Pause => {
+                    // Pause the active engine AND the fading-out engine (if any), so
+                    // pressing pause during a crossfade actually stops all audio. The
+                    // pre-decoded next engine is already paused so we don't touch it.
+                    if let Some(engine) = state.engine.as_mut() {
+                        match engine.pause() {
+                            Ok(()) => {
+                                let _ = event_tx.send(PlaybackRuntimeEvent::Paused {
+                                    track_id: Some(engine.track_id),
+                                });
+                            }
+                            Err(error) => {
+                                report_runtime_command_error(&event_tx, "Pause", error);
+                            }
+                        }
+                    }
+                    if let Some(engine) = state.fading_out_engine.as_mut() {
+                        if let Err(error) = engine.pause() {
                             report_runtime_command_error(&event_tx, "Pause", error);
                         }
                     }
                 }
-                if let Some(engine) = state.fading_out_engine.as_mut() {
-                    if let Err(error) = engine.pause() {
-                        report_runtime_command_error(&event_tx, "Pause", error);
-                    }
-                }
-            }
-            PlaybackRuntimeCommand::Resume => {
-                // On-demand re-grab: if exclusive mode is on and the active
-                // engine's WASAPI stream self-released after idle, rebuild it
-                // BEFORE unpausing so the decoder doesn't push samples into a
-                // missing stream. swap_stream handles its own cpal-shared
-                // fallback if the re-grab now fails (e.g. another app grabbed
-                // exclusive while we were paused).
-                if state.current_exclusive {
-                    #[cfg(target_os = "windows")]
-                    if state.exclusive_sink.needs_rebuild() {
-                        info!(
-                            "Resume: rebuilding exclusive stream after idle release on {}",
-                            state.device_name
-                        );
-                        refresh_exclusive_sources(&state);
-                        let rebuild_rate = exclusive_rebuild_rate(
-                            state.current_sample_rate_follow,
-                            state.device_sample_rate,
-                        );
-                        let release_grace_secs = state.current_exclusive_release_grace_secs;
-                        let latency_mode = state.current_exclusive_latency_mode.clone();
-                        match ensure_exclusive_sink_started(
-                            &mut state,
-                            &device,
-                            &output_config,
-                            rebuild_rate,
-                            release_grace_secs,
-                            latency_mode,
-                            command_tx.clone(),
-                            event_tx.clone(),
-                        ) {
-                            Ok(actual_rate) => {
-                                output_config.sample_rate = actual_rate;
-                                state.device_sample_rate = actual_rate;
-                            }
-                            Err(err) => {
-                                warn!(
-                                    "Resume: failed to rebuild exclusive sink; falling back to shared: {err:?}"
-                                );
-                                // Drop the &mut state borrow before potential cleanup
-                                // so we can call stop_all_engines on the failure path
-                                // without a borrow-checker conflict.
-                                let swap_result = state.engine.as_mut().map(|engine| {
-                                    engine.swap_stream(
-                                        &device,
-                                        &output_config,
-                                        output_sample_format,
-                                        command_tx.clone(),
-                                        event_tx.clone(),
-                                        false,
-                                        rebuild_rate,
-                                        release_grace_secs,
-                                    )
-                                });
-                                match swap_result {
-                                    Some(Ok(actual_rate)) => {
-                                        output_config.sample_rate = actual_rate;
-                                        state.device_sample_rate = actual_rate;
+                PlaybackRuntimeCommand::Resume => {
+                    // On-demand re-grab: if exclusive mode is on and the active
+                    // engine's WASAPI stream self-released after idle, rebuild it
+                    // BEFORE unpausing so the decoder doesn't push samples into a
+                    // missing stream. swap_stream handles its own cpal-shared
+                    // fallback if the re-grab now fails (e.g. another app grabbed
+                    // exclusive while we were paused).
+                    if state.current_exclusive {
+                        #[cfg(target_os = "windows")]
+                        if state.exclusive_sink.needs_rebuild() {
+                            info!(
+                                "Resume: rebuilding exclusive stream after idle release on {}",
+                                state.device_name
+                            );
+                            refresh_exclusive_sources(&state);
+                            let rebuild_rate = exclusive_rebuild_rate(
+                                state.current_sample_rate_follow,
+                                state.device_sample_rate,
+                            );
+                            let release_grace_secs = state.current_exclusive_release_grace_secs;
+                            let latency_mode = state.current_exclusive_latency_mode.clone();
+                            match ensure_exclusive_sink_started(
+                                &mut state,
+                                &device,
+                                &output_config,
+                                rebuild_rate,
+                                release_grace_secs,
+                                latency_mode,
+                                command_tx.clone(),
+                                event_tx.clone(),
+                            ) {
+                                Ok(actual_rate) => {
+                                    output_config.sample_rate = actual_rate;
+                                    state.device_sample_rate = actual_rate;
+                                }
+                                Err(err) => {
+                                    warn!(
+                                        "Resume: failed to rebuild exclusive sink; falling back to shared: {err:?}"
+                                    );
+                                    // Drop the &mut state borrow before potential cleanup
+                                    // so we can call stop_all_engines on the failure path
+                                    // without a borrow-checker conflict.
+                                    let swap_result = state.engine.as_mut().map(|engine| {
+                                        engine.swap_stream(
+                                            &device,
+                                            &output_config,
+                                            output_sample_format,
+                                            command_tx.clone(),
+                                            event_tx.clone(),
+                                            false,
+                                            rebuild_rate,
+                                            release_grace_secs,
+                                        )
+                                    });
+                                    match swap_result {
+                                        Some(Ok(actual_rate)) => {
+                                            output_config.sample_rate = actual_rate;
+                                            state.device_sample_rate = actual_rate;
+                                        }
+                                        Some(Err(error)) => {
+                                            // Symmetric with Play/Switch error cleanup:
+                                            // when both exclusive rebuild and shared
+                                            // fallback fail, the active engine has no
+                                            // output stream but its decoder keeps
+                                            // filling the buffer. Tear it down rather
+                                            // than leave a silent zombie engine.
+                                            stop_all_engines(&mut state);
+                                            state.exclusive_sink.clear();
+                                            report_runtime_command_error(
+                                                &event_tx, "Resume", error,
+                                            );
+                                        }
+                                        None => {}
                                     }
-                                    Some(Err(error)) => {
-                                        // Symmetric with Play/Switch error cleanup:
-                                        // when both exclusive rebuild and shared
-                                        // fallback fail, the active engine has no
-                                        // output stream but its decoder keeps
-                                        // filling the buffer. Tear it down rather
-                                        // than leave a silent zombie engine.
-                                        stop_all_engines(&mut state);
-                                        state.exclusive_sink.clear();
-                                        report_runtime_command_error(
-                                            &event_tx, "Resume", error,
-                                        );
-                                    }
-                                    None => {}
                                 }
                             }
                         }
                     }
-                }
 
-                if let Some(engine) = state.engine.as_mut() {
-                    match engine.resume() {
-                        Ok(()) => {
-                            let _ = event_tx.send(PlaybackRuntimeEvent::Resumed {
-                                track_id: Some(engine.track_id),
-                            });
+                    if let Some(engine) = state.engine.as_mut() {
+                        match engine.resume() {
+                            Ok(()) => {
+                                let _ = event_tx.send(PlaybackRuntimeEvent::Resumed {
+                                    track_id: Some(engine.track_id),
+                                });
+                            }
+                            Err(error) => {
+                                report_runtime_command_error(&event_tx, "Resume", error);
+                            }
                         }
-                        Err(error) => {
+                    }
+                    if let Some(engine) = state.fading_out_engine.as_mut() {
+                        if let Err(error) = engine.resume() {
                             report_runtime_command_error(&event_tx, "Resume", error);
                         }
                     }
                 }
-                if let Some(engine) = state.fading_out_engine.as_mut() {
-                    if let Err(error) = engine.resume() {
-                        report_runtime_command_error(&event_tx, "Resume", error);
-                    }
+                PlaybackRuntimeCommand::Stop => {
+                    stop_all_engines(&mut state);
+                    #[cfg(target_os = "windows")]
+                    state.exclusive_sink.clear();
+                    let _ = event_tx.send(PlaybackRuntimeEvent::Stopped);
                 }
-            }
-            PlaybackRuntimeCommand::Stop => {
-                stop_all_engines(&mut state);
-                #[cfg(target_os = "windows")]
-                state.exclusive_sink.clear();
-                let _ = event_tx.send(PlaybackRuntimeEvent::Stopped);
-            }
-            PlaybackRuntimeCommand::TrackTerminal {
-                track_id,
-                generation,
-                outcome,
-            } => {
-                // The fading-out engine reaching its terminal state is the
-                // expected end of a crossfade — drop it silently. The queue
-                // advance already happened at promotion time via Finished.
-                let fading = state
-                    .fading_out_engine
-                    .as_ref()
-                    .map(|e| (e.track_id, e.generation));
-                let next = state
-                    .next_engine
-                    .as_ref()
-                    .map(|engine| (engine.track_id, engine.generation));
-                let active = state
-                    .engine
-                    .as_ref()
-                    .map(|engine| (engine.track_id, engine.generation));
+                PlaybackRuntimeCommand::TrackTerminal {
+                    track_id,
+                    generation,
+                    outcome,
+                } => {
+                    // The fading-out engine reaching its terminal state is the
+                    // expected end of a crossfade — drop it silently. The queue
+                    // advance already happened at promotion time via Finished.
+                    let fading = state
+                        .fading_out_engine
+                        .as_ref()
+                        .map(|e| (e.track_id, e.generation));
+                    let next = state
+                        .next_engine
+                        .as_ref()
+                        .map(|engine| (engine.track_id, engine.generation));
+                    let active = state
+                        .engine
+                        .as_ref()
+                        .map(|engine| (engine.track_id, engine.generation));
 
-                match terminal_engine_slot(active, next, fading, track_id, generation) {
-                    Some(TerminalEngineSlot::FadingOut) => {
-                        debug!(
-                            "Playback terminal ignored for fading engine: track_id={}, generation={}, outcome={:?}",
-                            track_id, generation, outcome
-                        );
-                        if let Some(mut engine) = state.fading_out_engine.take() {
-                            engine.stop();
+                    match terminal_engine_slot(active, next, fading, track_id, generation) {
+                        Some(TerminalEngineSlot::FadingOut) => {
+                            debug!(
+                                "Playback terminal ignored for fading engine: track_id={}, generation={}, outcome={:?}",
+                                track_id, generation, outcome
+                            );
+                            if let Some(mut engine) = state.fading_out_engine.take() {
+                                engine.stop();
+                            }
                         }
-                    }
-                    Some(TerminalEngineSlot::Next) => {
-                        debug!(
-                            "Playback terminal ignored for prepared engine: track_id={}, generation={}, outcome={:?}",
-                            track_id, generation, outcome
-                        );
-                        if let PlaybackTerminalReason::Error(message) = &outcome {
-                            warn!("Discarding failed pre-buffered track {track_id}: {message}");
+                        Some(TerminalEngineSlot::Next) => {
+                            debug!(
+                                "Playback terminal ignored for prepared engine: track_id={}, generation={}, outcome={:?}",
+                                track_id, generation, outcome
+                            );
+                            if let PlaybackTerminalReason::Error(message) = &outcome {
+                                warn!("Discarding failed pre-buffered track {track_id}: {message}");
+                            }
+                            if let Some(mut engine) = state.next_engine.take() {
+                                engine.stop();
+                            }
                         }
-                        if let Some(mut engine) = state.next_engine.take() {
-                            engine.stop();
-                        }
-                    }
-                    Some(TerminalEngineSlot::Active) => {
-                        debug!(
-                            "Playback terminal active engine: track_id={}, generation={}, outcome={:?}",
-                            track_id, generation, outcome
-                        );
-                        if should_promote_prepared_at_boundary(
-                            active, next, track_id, generation, &outcome,
-                        ) {
-                            promote_prepared_at_boundary(&mut state, &event_tx, &position_source);
-                        } else {
-                            stop_current_engine(&mut state);
-                            match outcome {
-                                PlaybackTerminalReason::Finished => {
-                                    let _ = event_tx.send(PlaybackRuntimeEvent::Finished {
-                                        track_id,
-                                        generation,
-                                    });
-                                }
-                                PlaybackTerminalReason::Error(message) => {
-                                    let _ = event_tx.send(PlaybackRuntimeEvent::Error { message });
+                        Some(TerminalEngineSlot::Active) => {
+                            debug!(
+                                "Playback terminal active engine: track_id={}, generation={}, outcome={:?}",
+                                track_id, generation, outcome
+                            );
+                            if should_promote_prepared_at_boundary(
+                                active, next, track_id, generation, &outcome,
+                            ) {
+                                promote_prepared_at_boundary(
+                                    &mut state,
+                                    &event_tx,
+                                    &position_source,
+                                );
+                            } else {
+                                stop_current_engine(&mut state);
+                                match outcome {
+                                    PlaybackTerminalReason::Finished => {
+                                        let _ = event_tx.send(PlaybackRuntimeEvent::Finished {
+                                            track_id,
+                                            generation,
+                                        });
+                                    }
+                                    PlaybackTerminalReason::Error(message) => {
+                                        let _ =
+                                            event_tx.send(PlaybackRuntimeEvent::Error { message });
+                                    }
                                 }
                             }
                         }
+                        None => {
+                            debug!(
+                                "Playback terminal ignored for unknown engine: track_id={}, generation={}, outcome={:?}",
+                                track_id, generation, outcome
+                            );
+                        }
                     }
-                    None => {
-                        debug!(
-                            "Playback terminal ignored for unknown engine: track_id={}, generation={}, outcome={:?}",
-                            track_id, generation, outcome
-                        );
-                    }
-                }
-                #[cfg(target_os = "windows")]
-                if state.current_exclusive {
-                    refresh_exclusive_sources(&state);
-                }
-            }
-            PlaybackRuntimeCommand::TrackStatus {
-                track_id,
-                generation,
-                respond_to,
-            } => {
-                let active = state
-                    .engine
-                    .as_ref()
-                    .map(|engine| (engine.track_id, engine.generation))
-                    == Some((track_id, generation));
-                let prepared = state
-                    .next_engine
-                    .as_ref()
-                    .map(|engine| (engine.track_id, engine.generation))
-                    == Some((track_id, generation));
-                let status = if active {
-                    PlaybackTrackStatus::Active
-                } else if prepared {
-                    PlaybackTrackStatus::Prepared
-                } else {
-                    PlaybackTrackStatus::None
-                };
-                let _ = respond_to.send(status);
-            }
-            PlaybackRuntimeCommand::DeviceSwap {
-                device: selection,
-                exclusive,
-                sample_rate_follow,
-                desired_sample_rate,
-                exclusive_release_grace_secs,
-                exclusive_latency_mode,
-            } => {
-                // `exclusive` is honored as of Task 5 (Windows-only low-latency
-                // buffer + dedicated code path; full ShareMode::Exclusive is a
-                // follow-up). `sample_rate_follow` is wired here in Task 6 by
-                // re-targeting the cpal stream AND the decoder resampler to
-                // the new device's default rate when the toggle is on. The
-                // route layer (Task 7) is the one that flips this toggle and
-                // also re-issues `DeviceSwap` on track transitions when the
-                // next track's native rate differs from the current stream
-                // rate — runtime.rs has no view of the next track's StreamInfo
-                // until decode begins, so it cannot drive that comparison
-                // itself. Optional `desired_sample_rate` allows the route layer
-                // to specify an exact target (e.g. next track's native rate).
-                let new_device = match resolve_device(&selection) {
-                    Some(d) => d,
-                    None => {
-                        warn!("DeviceSwap: no output device available; keeping current output");
-                        continue;
-                    }
-                };
-                let new_supported = match new_device.default_output_config() {
-                    Ok(s) => s,
-                    Err(err) => {
-                        warn!(
-                            "DeviceSwap: failed to read default config for new device: {err}; keeping current output"
-                        );
-                        continue;
-                    }
-                };
-                let new_config = new_supported.config();
-                let new_format = new_supported.sample_format();
-                let new_name = device_display_name(&new_device);
-
-                let has_live_engines = state.engine.is_some()
-                    || state.next_engine.is_some()
-                    || state.fading_out_engine.is_some();
-                let desired_rate = device_swap_target_sample_rate(
-                    desired_sample_rate,
-                    sample_rate_follow,
-                    has_live_engines,
-                    state.device_sample_rate,
-                    new_config.sample_rate,
-                );
-                let requested_backend = if exclusive {
-                    SwapBackend::Exclusive
-                } else {
-                    SwapBackend::Shared
-                };
-                let requested_plan = swap_stream_plan(&new_config, desired_rate, requested_backend);
-                let mut actual_config = requested_plan.stream_config.clone();
-
-                // In exclusive mode only one stream can hold the device, so
-                // drop the pre-buffered + fading engines and only swap the
-                // active one. Any in-flight crossfade is sacrificed at this
-                // point; the user is intentionally trading multi-stream mixing
-                // for bit-perfect output.
-                // Rebuild the stream on every live engine so they all play on
-                // the new device. swap_stream now transparently falls back to
-                // cpal shared on exclusive failure (and emits an
-                // ExclusiveModeFailed event), so a hard error here is rare —
-                // typically only a cpal shared build failure.
-                let mut swap_failed = false;
-                if exclusive {
                     #[cfg(target_os = "windows")]
-                    {
+                    if state.current_exclusive {
+                        refresh_exclusive_sources(&state);
+                    }
+                }
+                PlaybackRuntimeCommand::TrackStatus {
+                    track_id,
+                    generation,
+                    respond_to,
+                } => {
+                    let active = state
+                        .engine
+                        .as_ref()
+                        .map(|engine| (engine.track_id, engine.generation))
+                        == Some((track_id, generation));
+                    let prepared = state
+                        .next_engine
+                        .as_ref()
+                        .map(|engine| (engine.track_id, engine.generation))
+                        == Some((track_id, generation));
+                    let status = if active {
+                        PlaybackTrackStatus::Active
+                    } else if prepared {
+                        PlaybackTrackStatus::Prepared
+                    } else {
+                        PlaybackTrackStatus::None
+                    };
+                    let _ = respond_to.send(status);
+                }
+                PlaybackRuntimeCommand::DeviceSwap {
+                    device: selection,
+                    exclusive,
+                    sample_rate_follow,
+                    desired_sample_rate,
+                    exclusive_release_grace_secs,
+                    exclusive_latency_mode,
+                } => {
+                    // `exclusive` is honored as of Task 5 (Windows-only low-latency
+                    // buffer + dedicated code path; full ShareMode::Exclusive is a
+                    // follow-up). `sample_rate_follow` is wired here in Task 6 by
+                    // re-targeting the cpal stream AND the decoder resampler to
+                    // the new device's default rate when the toggle is on. The
+                    // route layer (Task 7) is the one that flips this toggle and
+                    // also re-issues `DeviceSwap` on track transitions when the
+                    // next track's native rate differs from the current stream
+                    // rate — runtime.rs has no view of the next track's StreamInfo
+                    // until decode begins, so it cannot drive that comparison
+                    // itself. Optional `desired_sample_rate` allows the route layer
+                    // to specify an exact target (e.g. next track's native rate).
+                    let new_device = match resolve_device(&selection) {
+                        Some(d) => d,
+                        None => {
+                            warn!("DeviceSwap: no output device available; keeping current output");
+                            return std::ops::ControlFlow::Continue(());
+                        }
+                    };
+                    let new_supported = match new_device.default_output_config() {
+                        Ok(s) => s,
+                        Err(err) => {
+                            warn!(
+                                "DeviceSwap: failed to read default config for new device: {err}; keeping current output"
+                            );
+                            return std::ops::ControlFlow::Continue(());
+                        }
+                    };
+                    let new_config = new_supported.config();
+                    let new_format = new_supported.sample_format();
+                    let new_name = device_display_name(&new_device);
+
+                    let has_live_engines = state.engine.is_some()
+                        || state.next_engine.is_some()
+                        || state.fading_out_engine.is_some();
+                    let desired_rate = device_swap_target_sample_rate(
+                        desired_sample_rate,
+                        sample_rate_follow,
+                        has_live_engines,
+                        state.device_sample_rate,
+                        new_config.sample_rate,
+                    );
+                    let requested_backend = if exclusive {
+                        SwapBackend::Exclusive
+                    } else {
+                        SwapBackend::Shared
+                    };
+                    let requested_plan =
+                        swap_stream_plan(&new_config, desired_rate, requested_backend);
+                    let mut actual_config = requested_plan.stream_config.clone();
+
+                    // In exclusive mode only one stream can hold the device, so
+                    // drop the pre-buffered + fading engines and only swap the
+                    // active one. Any in-flight crossfade is sacrificed at this
+                    // point; the user is intentionally trading multi-stream mixing
+                    // for bit-perfect output.
+                    // Rebuild the stream on every live engine so they all play on
+                    // the new device. swap_stream now transparently falls back to
+                    // cpal shared on exclusive failure (and emits an
+                    // ExclusiveModeFailed event), so a hard error here is rare —
+                    // typically only a cpal shared build failure.
+                    let mut swap_failed = false;
+                    if exclusive {
+                        #[cfg(target_os = "windows")]
+                        {
+                            for engine_slot in [
+                                state.engine.as_mut(),
+                                state.next_engine.as_mut(),
+                                state.fading_out_engine.as_mut(),
+                            ]
+                            .into_iter()
+                            .flatten()
+                            {
+                                engine_slot.drop_stream();
+                                if let Some(target_rate) = requested_plan.target_sample_rate {
+                                    engine_slot
+                                        .shared
+                                        .target_sample_rate
+                                        .store(target_rate, Ordering::Relaxed);
+                                }
+                            }
+                            refresh_exclusive_sources(&state);
+                            state.exclusive_sink.stream = None;
+                            match ensure_exclusive_sink_started(
+                                &mut state,
+                                &new_device,
+                                &new_config,
+                                desired_rate,
+                                exclusive_release_grace_secs,
+                                exclusive_latency_mode.clone(),
+                                command_tx.clone(),
+                                event_tx.clone(),
+                            ) {
+                                Ok(actual_rate) => {
+                                    actual_config.sample_rate = actual_rate;
+                                }
+                                Err(err) => {
+                                    warn!(
+                                        "DeviceSwap: exclusive sink failed; falling back to shared: {err:?}"
+                                    );
+                                    swap_failed = true;
+                                    for engine_slot in [
+                                        state.engine.as_mut(),
+                                        state.next_engine.as_mut(),
+                                        state.fading_out_engine.as_mut(),
+                                    ]
+                                    .into_iter()
+                                    .flatten()
+                                    {
+                                        match engine_slot.swap_stream(
+                                            &new_device,
+                                            &new_config,
+                                            new_format,
+                                            command_tx.clone(),
+                                            event_tx.clone(),
+                                            false,
+                                            desired_rate,
+                                            exclusive_release_grace_secs,
+                                        ) {
+                                            Ok(actual_rate) => {
+                                                actual_config.sample_rate = actual_rate;
+                                            }
+                                            Err(err) => {
+                                                warn!(
+                                                    "DeviceSwap: failed to rebuild shared fallback for track {}: {err:?}",
+                                                    engine_slot.track_id
+                                                );
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    } else {
+                        #[cfg(target_os = "windows")]
+                        state.exclusive_sink.clear();
+
                         for engine_slot in [
                             state.engine.as_mut(),
                             state.next_engine.as_mut(),
@@ -776,135 +855,78 @@ fn run_runtime_loop(
                         .into_iter()
                         .flatten()
                         {
-                            engine_slot.drop_stream();
-                            if let Some(target_rate) = requested_plan.target_sample_rate {
-                                engine_slot
-                                    .shared
-                                    .target_sample_rate
-                                    .store(target_rate, Ordering::Relaxed);
-                            }
-                        }
-                        refresh_exclusive_sources(&state);
-                        state.exclusive_sink.stream = None;
-                        match ensure_exclusive_sink_started(
-                            &mut state,
-                            &new_device,
-                            &new_config,
-                            desired_rate,
-                            exclusive_release_grace_secs,
-                            exclusive_latency_mode.clone(),
-                            command_tx.clone(),
-                            event_tx.clone(),
-                        ) {
-                            Ok(actual_rate) => {
-                                actual_config.sample_rate = actual_rate;
-                            }
-                            Err(err) => {
-                                warn!(
-                                    "DeviceSwap: exclusive sink failed; falling back to shared: {err:?}"
-                                );
-                                swap_failed = true;
-                                for engine_slot in [
-                                    state.engine.as_mut(),
-                                    state.next_engine.as_mut(),
-                                    state.fading_out_engine.as_mut(),
-                                ]
-                                .into_iter()
-                                .flatten()
-                                {
-                                    match engine_slot.swap_stream(
-                                        &new_device,
-                                        &new_config,
-                                        new_format,
-                                        command_tx.clone(),
-                                        event_tx.clone(),
-                                        false,
-                                        desired_rate,
-                                        exclusive_release_grace_secs,
-                                    ) {
-                                        Ok(actual_rate) => {
-                                            actual_config.sample_rate = actual_rate;
-                                        }
-                                        Err(err) => {
-                                            warn!(
-                                                "DeviceSwap: failed to rebuild shared fallback for track {}: {err:?}",
-                                                engine_slot.track_id
-                                            );
-                                        }
-                                    }
+                            match engine_slot.swap_stream(
+                                &new_device,
+                                &new_config,
+                                new_format,
+                                command_tx.clone(),
+                                event_tx.clone(),
+                                false,
+                                desired_rate,
+                                exclusive_release_grace_secs,
+                            ) {
+                                Ok(actual_rate) => {
+                                    actual_config.sample_rate = actual_rate;
+                                }
+                                Err(err) => {
+                                    warn!(
+                                        "DeviceSwap: failed to rebuild stream for track {}: {err:?}",
+                                        engine_slot.track_id
+                                    );
+                                    swap_failed = true;
                                 }
                             }
                         }
                     }
-                } else {
+
+                    if swap_failed {
+                        warn!(
+                            "DeviceSwap: one or more engines failed to swap; output may be partial"
+                        );
+                    }
+
+                    // Update the runtime's "current device" bindings so subsequent
+                    // Play / PrepareNext calls use the new device too. When
+                    // sample-rate-follow drove a rate change, also update the
+                    // runtime-wide `device_sample_rate` so freshly-cold-started
+                    // engines spin up at the new rate (their initial
+                    // `target_sample_rate` is seeded from this value).
+                    device = new_device;
+                    output_config = actual_config;
+                    output_sample_format = new_format;
+                    state.device_name = new_name.clone();
+                    state.device_sample_rate = output_config.sample_rate;
+                    state.device_channels = output_config.channels;
+                    state.current_exclusive = exclusive;
+                    state.current_sample_rate_follow = sample_rate_follow;
+                    state.current_device_selection = selection;
+                    state.current_exclusive_release_grace_secs = exclusive_release_grace_secs;
+                    state.current_exclusive_latency_mode = exclusive_latency_mode;
+
+                    let _ = event_tx.send(PlaybackRuntimeEvent::Ready {
+                        device_name: new_name,
+                        sample_rate: state.device_sample_rate,
+                        channels: state.device_channels,
+                    });
+                }
+                PlaybackRuntimeCommand::Shutdown => {
+                    stop_all_engines(&mut state);
                     #[cfg(target_os = "windows")]
                     state.exclusive_sink.clear();
-
-                    for engine_slot in [
-                        state.engine.as_mut(),
-                        state.next_engine.as_mut(),
-                        state.fading_out_engine.as_mut(),
-                    ]
-                    .into_iter()
-                    .flatten()
-                    {
-                        match engine_slot.swap_stream(
-                            &new_device,
-                            &new_config,
-                            new_format,
-                            command_tx.clone(),
-                            event_tx.clone(),
-                            false,
-                            desired_rate,
-                            exclusive_release_grace_secs,
-                        ) {
-                            Ok(actual_rate) => {
-                                actual_config.sample_rate = actual_rate;
-                            }
-                            Err(err) => {
-                                warn!(
-                                    "DeviceSwap: failed to rebuild stream for track {}: {err:?}",
-                                    engine_slot.track_id
-                                );
-                                swap_failed = true;
-                            }
-                        }
-                    }
+                    return std::ops::ControlFlow::Break(());
                 }
-
-                if swap_failed {
-                    warn!("DeviceSwap: one or more engines failed to swap; output may be partial");
-                }
-
-                // Update the runtime's "current device" bindings so subsequent
-                // Play / PrepareNext calls use the new device too. When
-                // sample-rate-follow drove a rate change, also update the
-                // runtime-wide `device_sample_rate` so freshly-cold-started
-                // engines spin up at the new rate (their initial
-                // `target_sample_rate` is seeded from this value).
-                device = new_device;
-                output_config = actual_config;
-                output_sample_format = new_format;
-                state.device_name = new_name.clone();
-                state.device_sample_rate = output_config.sample_rate;
-                state.device_channels = output_config.channels;
-                state.current_exclusive = exclusive;
-                state.current_sample_rate_follow = sample_rate_follow;
-                state.current_device_selection = selection;
-                state.current_exclusive_release_grace_secs = exclusive_release_grace_secs;
-                state.current_exclusive_latency_mode = exclusive_latency_mode;
-
-                let _ = event_tx.send(PlaybackRuntimeEvent::Ready {
-                    device_name: new_name,
-                    sample_rate: state.device_sample_rate,
-                    channels: state.device_channels,
-                });
             }
-            PlaybackRuntimeCommand::Shutdown => {
-                stop_all_engines(&mut state);
-                #[cfg(target_os = "windows")]
-                state.exclusive_sink.clear();
-                break;
+            std::ops::ControlFlow::Continue(())
+        }));
+        match outcome {
+            Ok(std::ops::ControlFlow::Break(())) => break,
+            Ok(std::ops::ControlFlow::Continue(())) => {}
+            Err(payload) => {
+                if let std::ops::ControlFlow::Break(()) =
+                    handle_panic_in_runtime_loop(payload, &event_tx, &mut state)
+                {
+                    break;
+                }
             }
         }
     }
@@ -1124,6 +1146,51 @@ fn report_runtime_command_error(
     let message = format!("{command_name} failed: {error}");
     warn!("{message}");
     let _ = event_tx.send(PlaybackRuntimeEvent::Error { message });
+}
+
+fn panic_payload_message(payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(s) = payload.downcast_ref::<&'static str>() {
+        (*s).to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "non-string panic payload".to_string()
+    }
+}
+
+/// Handle a panic that escaped the runtime command dispatch. Emits a
+/// PlaybackRuntimeEvent::Error, tears down any active engines under a nested
+/// catch_unwind, and signals whether the loop can safely continue.
+///
+/// If the cleanup itself panics (mutex poisoning, etc.), we emit a final
+/// error event and signal Break - re-entering the dispatch loop with state
+/// that may be corrupt is more dangerous than ending the runtime thread.
+fn handle_panic_in_runtime_loop(
+    payload: Box<dyn std::any::Any + Send>,
+    event_tx: &tokio::sync::broadcast::Sender<PlaybackRuntimeEvent>,
+    state: &mut PlaybackRuntimeLoopState,
+) -> std::ops::ControlFlow<()> {
+    let message = panic_payload_message(payload.as_ref());
+    warn!("playback runtime panicked: {message}");
+
+    let cleanup_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        stop_all_engines(state);
+        #[cfg(target_os = "windows")]
+        state.exclusive_sink.clear();
+    }));
+
+    let _ = event_tx.send(PlaybackRuntimeEvent::Error {
+        message: format!("playback runtime panicked: {message}"),
+    });
+
+    if cleanup_result.is_err() {
+        let _ = event_tx.send(PlaybackRuntimeEvent::Error {
+            message: "playback runtime panic cleanup also panicked; runtime exiting".to_string(),
+        });
+        std::ops::ControlFlow::Break(())
+    } else {
+        std::ops::ControlFlow::Continue(())
+    }
 }
 
 #[cfg(target_os = "windows")]
@@ -1863,6 +1930,49 @@ mod tests {
             PlaybackRuntimeEvent::Error { message } => {
                 assert!(message.contains("Play failed"));
                 assert!(message.contains("output device rejected stream"));
+            }
+            other => panic!("expected error event, got {other:?}"),
+        }
+    }
+
+    fn test_runtime_loop_state() -> PlaybackRuntimeLoopState {
+        PlaybackRuntimeLoopState {
+            device_name: "test".to_string(),
+            device_sample_rate: 48_000,
+            device_channels: 2,
+            #[cfg(target_os = "windows")]
+            exclusive_sink: ExclusiveRuntimeSink::new(),
+            engine: None,
+            next_engine: None,
+            fading_out_engine: None,
+            current_exclusive: false,
+            current_sample_rate_follow: false,
+            current_device_selection: OutputDeviceSelection::Default,
+            current_exclusive_release_grace_secs:
+                crate::db::audio_settings::DEFAULT_EXCLUSIVE_RELEASE_GRACE_SECS,
+            current_exclusive_latency_mode: ExclusiveLatencyMode::Stable,
+        }
+    }
+
+    #[test]
+    fn handle_panic_in_runtime_loop_clears_state_and_emits_error() {
+        let (event_tx, mut event_rx) = tokio::sync::broadcast::channel(8);
+        let mut state = test_runtime_loop_state();
+        state.engine = Some(test_engine_with_shared(1, 1));
+        state.next_engine = Some(test_engine_with_shared(2, 1));
+
+        let payload: Box<dyn std::any::Any + Send> =
+            Box::new(String::from("synthetic dispatch panic"));
+        let outcome = handle_panic_in_runtime_loop(payload, &event_tx, &mut state);
+
+        assert!(matches!(outcome, std::ops::ControlFlow::Continue(())));
+        assert!(state.engine.is_none());
+        assert!(state.next_engine.is_none());
+
+        match event_rx.try_recv().expect("error event should be emitted") {
+            PlaybackRuntimeEvent::Error { message } => {
+                assert!(message.contains("playback runtime panicked"));
+                assert!(message.contains("synthetic dispatch panic"));
             }
             other => panic!("expected error event, got {other:?}"),
         }

--- a/noor-server/src/playback/runtime/mod.rs
+++ b/noor-server/src/playback/runtime/mod.rs
@@ -169,6 +169,11 @@ impl PlaybackRuntimeHandle {
 }
 
 pub fn spawn_runtime(config: PlaybackRuntimeConfig) -> Result<PlaybackRuntimeHandle> {
+    // Real-time safety: this channel MUST remain unbounded
+    // (std::sync::mpsc::channel, NOT sync_channel). The CPAL audio callback
+    // in shared.rs::write_output_buffer sends TrackTerminal and
+    // CrossfadeStart commands through command_tx; a bounded channel would
+    // block the audio thread on a full buffer and cause dropouts/underruns.
     let (command_tx, command_rx) = mpsc::channel();
     let (event_tx, _) = tokio::sync::broadcast::channel(256);
     let worker_event_tx = event_tx.clone();

--- a/noor-server/src/playback/runtime/mod.rs
+++ b/noor-server/src/playback/runtime/mod.rs
@@ -2042,11 +2042,7 @@ mod tests {
 
         // 1. Simulate a Play command that returned Err: report the error and
         //    tear down engines (same sequence as run_runtime_loop's Play arm).
-        report_runtime_command_error(
-            &event_tx,
-            "Play",
-            anyhow::anyhow!("transition failed"),
-        );
+        report_runtime_command_error(&event_tx, "Play", anyhow::anyhow!("transition failed"));
         stop_all_engines(&mut state);
         assert!(state.engine.is_none(), "engine slot cleared after error");
         assert!(state.next_engine.is_none(), "next slot cleared after error");

--- a/noor-server/src/playback/runtime/mod.rs
+++ b/noor-server/src/playback/runtime/mod.rs
@@ -347,18 +347,16 @@ fn run_runtime_loop(
                         * state.device_sample_rate as u64
                         * state.device_channels as u64)
                         / 1000;
-                    // Tell the CPAL callback to seek on the next write.
+                    // Tell the CPAL callback to seek on the next write. The
+                    // callback will accept (and update position_samples) only
+                    // if the target is within already-decoded samples or the
+                    // buffer is finished; otherwise it warns and leaves the
+                    // position counter untouched. This keeps the runtime-side
+                    // position honest about what has actually been played.
+                    // (Route/UI-side position handling is a separate follow-up.)
                     engine
                         .shared
                         .seek_target_samples
-                        .store(target_samples, Ordering::Relaxed);
-                    // Mirror into the engine's counter immediately so get_position_ms()
-                    // is correct before the CPAL callback runs (up to one buffer period later).
-                    // position_source always points to this engine's counter, so no
-                    // separate handle-counter write is needed.
-                    engine
-                        .shared
-                        .position_samples
                         .store(target_samples, Ordering::Relaxed);
                     // Reset fire-once guards so NearEnd / CrossfadeStart re-fire correctly
                     // if the user seeks backward past those thresholds.

--- a/noor-server/src/playback/runtime/mod.rs
+++ b/noor-server/src/playback/runtime/mod.rs
@@ -63,6 +63,15 @@ pub struct PlaybackRuntimeHandle {
     /// Redirectable position reader. Normally points to the active engine's
     /// position counter. Swapped at crossfade promotion so the handle always
     /// reads from the engine that's audibly current, not the fading-out one.
+    ///
+    /// Real-time-safety / unwrap audit (Task 15): every access site uses
+    /// `position_source.lock().unwrap()` because the protected payload is an
+    /// `Arc<AtomicU64>` - mutex poisoning leaves it valid (Arc is either the
+    /// old reference or the new one, both safe to read/write). The only way
+    /// `.unwrap()` panics is if a code path inside the guard panics first,
+    /// which is then caught by `handle_panic_in_runtime_loop` (Task 7) and
+    /// surfaced to the user as `PlaybackRuntimeEvent::Error`. So these
+    /// unwraps are bounded-failure, not silent corruption.
     position_source: Arc<Mutex<Arc<AtomicU64>>>,
 }
 

--- a/noor-server/src/playback/runtime/mod.rs
+++ b/noor-server/src/playback/runtime/mod.rs
@@ -529,8 +529,11 @@ fn run_runtime_loop(
                                 warn!(
                                     "Resume: failed to rebuild exclusive sink; falling back to shared: {err:?}"
                                 );
-                                if let Some(engine) = state.engine.as_mut() {
-                                    match engine.swap_stream(
+                                // Drop the &mut state borrow before potential cleanup
+                                // so we can call stop_all_engines on the failure path
+                                // without a borrow-checker conflict.
+                                let swap_result = state.engine.as_mut().map(|engine| {
+                                    engine.swap_stream(
                                         &device,
                                         &output_config,
                                         output_sample_format,
@@ -539,17 +542,27 @@ fn run_runtime_loop(
                                         false,
                                         rebuild_rate,
                                         release_grace_secs,
-                                    ) {
-                                        Ok(actual_rate) => {
-                                            output_config.sample_rate = actual_rate;
-                                            state.device_sample_rate = actual_rate;
-                                        }
-                                        Err(error) => {
-                                            report_runtime_command_error(
-                                                &event_tx, "Resume", error,
-                                            );
-                                        }
+                                    )
+                                });
+                                match swap_result {
+                                    Some(Ok(actual_rate)) => {
+                                        output_config.sample_rate = actual_rate;
+                                        state.device_sample_rate = actual_rate;
                                     }
+                                    Some(Err(error)) => {
+                                        // Symmetric with Play/Switch error cleanup:
+                                        // when both exclusive rebuild and shared
+                                        // fallback fail, the active engine has no
+                                        // output stream but its decoder keeps
+                                        // filling the buffer. Tear it down rather
+                                        // than leave a silent zombie engine.
+                                        stop_all_engines(&mut state);
+                                        state.exclusive_sink.clear();
+                                        report_runtime_command_error(
+                                            &event_tx, "Resume", error,
+                                        );
+                                    }
+                                    None => {}
                                 }
                             }
                         }

--- a/noor-server/src/playback/runtime/mod.rs
+++ b/noor-server/src/playback/runtime/mod.rs
@@ -631,7 +631,7 @@ fn run_runtime_loop(
                                 track_id, generation, outcome
                             );
                             if let PlaybackTerminalReason::Error(message) = &outcome {
-                                warn!("Discarding failed pre-buffered track {track_id}: {message}");
+                                emit_prepared_track_failure(&event_tx, track_id, message);
                             }
                             if let Some(mut engine) = state.next_engine.take() {
                                 engine.stop();
@@ -1146,6 +1146,21 @@ fn report_runtime_command_error(
     let message = format!("{command_name} failed: {error}");
     warn!("{message}");
     let _ = event_tx.send(PlaybackRuntimeEvent::Error { message });
+}
+
+/// Surface a decode/source failure on the pre-buffered next track. The
+/// active track's failure already emits PlaybackRuntimeEvent::Error via
+/// the TrackTerminal::Error branch for the Active slot, but the Next-slot
+/// branch previously only logged - users had no signal that the upcoming
+/// track silently dropped from the queue.
+fn emit_prepared_track_failure(
+    event_tx: &tokio::sync::broadcast::Sender<PlaybackRuntimeEvent>,
+    track_id: i64,
+    message: &str,
+) {
+    let surfaced = format!("Pre-buffered track {track_id} failed: {message}");
+    warn!("{surfaced}");
+    let _ = event_tx.send(PlaybackRuntimeEvent::Error { message: surfaced });
 }
 
 fn panic_payload_message(payload: &(dyn std::any::Any + Send)) -> String {
@@ -1951,6 +1966,24 @@ mod tests {
             current_exclusive_release_grace_secs:
                 crate::db::audio_settings::DEFAULT_EXCLUSIVE_RELEASE_GRACE_SECS,
             current_exclusive_latency_mode: ExclusiveLatencyMode::Stable,
+        }
+    }
+
+    #[test]
+    fn emit_prepared_track_failure_sends_error_event() {
+        let (event_tx, mut event_rx) = tokio::sync::broadcast::channel(8);
+
+        emit_prepared_track_failure(&event_tx, 42, "decode failed: malformed packet");
+
+        match event_rx
+            .try_recv()
+            .expect("error event should be emitted")
+        {
+            PlaybackRuntimeEvent::Error { message } => {
+                assert!(message.contains("Pre-buffered track 42 failed"));
+                assert!(message.contains("decode failed: malformed packet"));
+            }
+            other => panic!("expected error event, got {other:?}"),
         }
     }
 

--- a/noor-server/src/playback/runtime/mod.rs
+++ b/noor-server/src/playback/runtime/mod.rs
@@ -2025,6 +2025,70 @@ mod tests {
         }
     }
 
+    #[test]
+    fn runtime_recovery_composes_after_command_error_and_panic() {
+        // Composition-level integration test for Phase B/C resilience: prove
+        // that the runtime's recovery primitives (report_runtime_command_error,
+        // stop_all_engines, handle_panic_in_runtime_loop) compose so the
+        // runtime stays responsive across a command-error AND a panic in the
+        // same session. A future plan will extract dispatch_command from
+        // run_runtime_loop's match body to enable per-command coverage; this
+        // test catches a regression that would break the recovery contract
+        // these primitives together provide.
+        let (event_tx, mut event_rx) = tokio::sync::broadcast::channel(16);
+        let mut state = test_runtime_loop_state();
+        state.engine = Some(test_engine_with_shared(1, 1));
+        state.next_engine = Some(test_engine_with_shared(2, 1));
+
+        // 1. Simulate a Play command that returned Err: report the error and
+        //    tear down engines (same sequence as run_runtime_loop's Play arm).
+        report_runtime_command_error(
+            &event_tx,
+            "Play",
+            anyhow::anyhow!("transition failed"),
+        );
+        stop_all_engines(&mut state);
+        assert!(state.engine.is_none(), "engine slot cleared after error");
+        assert!(state.next_engine.is_none(), "next slot cleared after error");
+        match event_rx.try_recv().expect("error event") {
+            PlaybackRuntimeEvent::Error { message } => {
+                assert!(message.contains("Play failed"));
+            }
+            other => panic!("expected error event, got {other:?}"),
+        }
+
+        // 2. Simulate a subsequent successful Play: engine re-populates.
+        state.engine = Some(test_engine_with_shared(10, 2));
+        assert_eq!(state.engine.as_ref().unwrap().track_id, 10);
+
+        // 3. Simulate a panic in dispatch: handle_panic_in_runtime_loop should
+        //    clear all engines and signal the loop can continue.
+        let payload: Box<dyn std::any::Any + Send> =
+            Box::new(String::from("synthetic dispatch panic"));
+        let outcome = handle_panic_in_runtime_loop(payload, &event_tx, &mut state);
+        assert!(
+            matches!(outcome, std::ops::ControlFlow::Continue(())),
+            "loop should continue after recoverable panic"
+        );
+        assert!(state.engine.is_none(), "engine slot cleared after panic");
+
+        // The panic handler emits Error + Stopped.
+        match event_rx.try_recv().expect("panic error event") {
+            PlaybackRuntimeEvent::Error { message } => {
+                assert!(message.contains("playback runtime panicked"));
+            }
+            other => panic!("expected error event, got {other:?}"),
+        }
+        match event_rx.try_recv().expect("stopped event") {
+            PlaybackRuntimeEvent::Stopped => {}
+            other => panic!("expected stopped event, got {other:?}"),
+        }
+
+        // 4. The loop is still operational: state accepts a new engine.
+        state.engine = Some(test_engine_with_shared(20, 3));
+        assert_eq!(state.engine.as_ref().unwrap().track_id, 20);
+    }
+
     fn test_engine_with_shared(track_id: i64, generation: u64) -> PlaybackEngine {
         let (command_tx, _) = mpsc::channel();
         PlaybackEngine::test_with_shared(

--- a/noor-server/src/playback/runtime/mod.rs
+++ b/noor-server/src/playback/runtime/mod.rs
@@ -1209,6 +1209,11 @@ fn handle_panic_in_runtime_loop(
         });
         std::ops::ControlFlow::Break(())
     } else {
+        // After cleanup tore down every engine slot, signal Stopped so the UI's
+        // playback-state machine snaps back to a clean idle (otherwise it would
+        // remain stuck on the last Started state and the user sees a track
+        // visually playing with no audio until the next user-initiated command).
+        let _ = event_tx.send(PlaybackRuntimeEvent::Stopped);
         std::ops::ControlFlow::Continue(())
     }
 }
@@ -1980,10 +1985,7 @@ mod tests {
 
         emit_prepared_track_failure(&event_tx, 42, "decode failed: malformed packet");
 
-        match event_rx
-            .try_recv()
-            .expect("error event should be emitted")
-        {
+        match event_rx.try_recv().expect("error event should be emitted") {
             PlaybackRuntimeEvent::Error { message } => {
                 assert!(message.contains("Pre-buffered track 42 failed"));
                 assert!(message.contains("decode failed: malformed packet"));
@@ -2013,6 +2015,13 @@ mod tests {
                 assert!(message.contains("synthetic dispatch panic"));
             }
             other => panic!("expected error event, got {other:?}"),
+        }
+        match event_rx
+            .try_recv()
+            .expect("stopped event should follow the error event")
+        {
+            PlaybackRuntimeEvent::Stopped => {}
+            other => panic!("expected stopped event, got {other:?}"),
         }
     }
 

--- a/noor-server/src/playback/runtime/shared.rs
+++ b/noor-server/src/playback/runtime/shared.rs
@@ -345,6 +345,12 @@ impl PlaybackSharedState {
     /// Clone the stop-signal Arc so source-side threads (TIDAL download,
     /// StreamPipe) can poll it for cancellation without holding the whole
     /// PlaybackSharedState.
+    ///
+    /// The flag is an eventual-consistency cancellation signal: writers
+    /// (engine.stop) use SeqCst, readers may use Relaxed - every reader will
+    /// see the flip within at most one polling tick. Don't promote the
+    /// reads to SeqCst expecting tighter ordering; there's no co-data
+    /// invariant to protect.
     pub(crate) fn stop_flag(&self) -> Arc<AtomicBool> {
         Arc::clone(&self.stopped)
     }

--- a/noor-server/src/playback/runtime/shared.rs
+++ b/noor-server/src/playback/runtime/shared.rs
@@ -75,6 +75,19 @@ fn write_output_buffer<T>(
 
     let volume = f32::from_bits(shared.volume_ctl.load(Ordering::Relaxed));
 
+    // Real-time safety contract for this critical section:
+    //   * No IO, no syscalls, no allocations on the hot path.
+    //   * drain_into is O(data.len()) and data.len() == one CPAL callback
+    //     buffer (~256-1024 samples), bounded copy.
+    //   * Rare events inside this guard (started/finished/near-end/crossfade
+    //     event sends, underrun and seek-reject warn calls) each fire at
+    //     most once per buffer-instance per event class, so allocation
+    //     amortizes to zero across the steady-state callback rate.
+    //   * The off-thread growth telemetry (Task 13) is a load + conditional
+    //     CAS, no allocation.
+    // A future refactor that adds IO, an unbounded loop, or a per-callback
+    // allocation inside this guard would regress to dropouts/underruns -
+    // keep the critical section bounded.
     let mut guard = match shared.buffer.lock() {
         Ok(guard) => guard,
         Err(_) => {

--- a/noor-server/src/playback/runtime/shared.rs
+++ b/noor-server/src/playback/runtime/shared.rs
@@ -242,7 +242,10 @@ pub(crate) struct PlaybackSharedState {
     pub(crate) generation: u64,
     pub(crate) source_kind: PlaybackSourceKind,
     pub(crate) paused: AtomicBool,
-    pub(crate) stopped: AtomicBool,
+    /// Stop signal observed by the audio callback, the decoder thread, and
+    /// (via Arc clone) the TIDAL stream pipe / CDN download thread so they
+    /// can bail out promptly when a track is skipped or stopped.
+    pub(crate) stopped: Arc<AtomicBool>,
     pub(crate) buffer: Mutex<PlaybackBuffer>,
     pub(crate) command_tx: mpsc::Sender<PlaybackRuntimeCommand>,
     pub(crate) volume_ctl: Arc<AtomicU32>,
@@ -288,7 +291,7 @@ impl PlaybackSharedState {
             generation,
             source_kind,
             paused: AtomicBool::new(false),
-            stopped: AtomicBool::new(false),
+            stopped: Arc::new(AtomicBool::new(false)),
             buffer: Mutex::new(PlaybackBuffer::new(prebuffer_samples)),
             command_tx,
             volume_ctl,
@@ -309,6 +312,13 @@ impl PlaybackSharedState {
         if let Ok(mut guard) = self.buffer.lock() {
             guard.reset();
         }
+    }
+
+    /// Clone the stop-signal Arc so source-side threads (TIDAL download,
+    /// StreamPipe) can poll it for cancellation without holding the whole
+    /// PlaybackSharedState.
+    pub(crate) fn stop_flag(&self) -> Arc<AtomicBool> {
+        Arc::clone(&self.stopped)
     }
 
     pub(crate) fn signal_terminal(&self, outcome: PlaybackTerminalReason) -> Result<()> {

--- a/noor-server/src/playback/runtime/shared.rs
+++ b/noor-server/src/playback/runtime/shared.rs
@@ -85,10 +85,19 @@ fn write_output_buffer<T>(
             .compare_exchange(seek_target, u64::MAX, Ordering::SeqCst, Ordering::Relaxed)
             .is_ok()
     {
-        guard.seek_to(seek_target as usize);
-        shared
-            .position_samples
-            .store(seek_target, Ordering::Relaxed);
+        if guard.seek_to(seek_target as usize) {
+            shared
+                .position_samples
+                .store(seek_target, Ordering::Relaxed);
+        } else {
+            warn!(
+                "Playback seek target is not decoded yet: track_id={}, generation={}, target_samples={}, buffered_samples={}",
+                shared.track_id,
+                shared.generation,
+                seek_target,
+                guard.samples.len()
+            );
+        }
     }
 
     let ready_to_start = guard.is_ready();
@@ -365,7 +374,10 @@ impl PlaybackBuffer {
         self.finished = true;
     }
 
-    fn seek_to(&mut self, target_samples: usize) {
+    fn seek_to(&mut self, target_samples: usize) -> bool {
+        if target_samples > self.samples.len() && !self.finished {
+            return false;
+        }
         self.read_pos = target_samples.min(self.samples.len());
         self.finished_notified = false;
         self.starved_notified = false;
@@ -373,6 +385,7 @@ impl PlaybackBuffer {
             self.started = false;
             self.started_notified = false;
         }
+        true
     }
 
     fn reset(&mut self) {
@@ -409,4 +422,43 @@ pub(crate) fn estimate_total_samples_from_duration_ms(
         return None;
     }
     Some((duration_ms as u64 * sample_rate as u64 * channels as u64) / 1_000)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn seek_to_decoded_position_applies_immediately() {
+        let mut buffer = PlaybackBuffer::new(0);
+        buffer.samples = vec![0.0; 1_000];
+        buffer.started = true;
+
+        assert!(buffer.seek_to(400));
+        assert_eq!(buffer.read_pos, 400);
+        assert!(!buffer.finished_notified);
+        assert!(!buffer.starved_notified);
+    }
+
+    #[test]
+    fn seek_to_undecoded_position_is_rejected_until_finished() {
+        let mut buffer = PlaybackBuffer::new(0);
+        buffer.samples = vec![0.0; 1_000];
+        buffer.started = true;
+        buffer.read_pos = 100;
+
+        assert!(!buffer.seek_to(1_500));
+        assert_eq!(buffer.read_pos, 100);
+    }
+
+    #[test]
+    fn seek_to_end_of_finished_buffer_applies() {
+        let mut buffer = PlaybackBuffer::new(0);
+        buffer.samples = vec![0.0; 1_000];
+        buffer.started = true;
+        buffer.finished = true;
+
+        assert!(buffer.seek_to(1_500));
+        assert_eq!(buffer.read_pos, 1_000);
+    }
 }

--- a/noor-server/src/playback/runtime/shared.rs
+++ b/noor-server/src/playback/runtime/shared.rs
@@ -8,6 +8,11 @@ use tracing::{debug, warn};
 
 const GAPLESS_PREFILL_PAD_MS: usize = 250;
 const NEAR_END_THRESHOLD_MS: i64 = 30_000;
+/// Sample count at which an active PlaybackBuffer emits a one-shot warning.
+/// 50_000_000 f32 samples is ~200 MB of allocation - well past the size at
+/// which the unbounded-buffer issue meaningfully impacts memory. This is
+/// pure observability; the ring-buffer rewrite (deferred) is the real fix.
+const BUFFER_GROWTH_WARN_THRESHOLD_SAMPLES: usize = 50_000_000;
 
 pub(crate) fn write_output_f32(
     data: &mut [f32],
@@ -158,6 +163,11 @@ fn write_output_buffer<T>(
             .fetch_add(written as u64, Ordering::Relaxed);
     }
 
+    // Real-time-safe growth signal: this is just a load + conditional CAS,
+    // no allocation. The decoder thread observes growth_warned and emits the
+    // actual log line off this thread.
+    shared.signal_buffer_growth_if_threshold_crossed(guard.samples.len());
+
     if guard.started && !guard.finished && written < data.len() && !guard.starved_notified {
         guard.starved_notified = true;
         warn!(
@@ -246,6 +256,10 @@ pub(crate) struct PlaybackSharedState {
     /// (via Arc clone) the TIDAL stream pipe / CDN download thread so they
     /// can bail out promptly when a track is skipped or stopped.
     pub(crate) stopped: Arc<AtomicBool>,
+    /// One-shot signal flipped by the audio callback when the underlying
+    /// buffer crosses BUFFER_GROWTH_WARN_THRESHOLD_SAMPLES; the decoder
+    /// thread observes this and emits the warn (off the real-time thread).
+    pub(crate) growth_warned: AtomicBool,
     pub(crate) buffer: Mutex<PlaybackBuffer>,
     pub(crate) command_tx: mpsc::Sender<PlaybackRuntimeCommand>,
     pub(crate) volume_ctl: Arc<AtomicU32>,
@@ -292,6 +306,7 @@ impl PlaybackSharedState {
             source_kind,
             paused: AtomicBool::new(false),
             stopped: Arc::new(AtomicBool::new(false)),
+            growth_warned: AtomicBool::new(false),
             buffer: Mutex::new(PlaybackBuffer::new(prebuffer_samples)),
             command_tx,
             volume_ctl,
@@ -319,6 +334,22 @@ impl PlaybackSharedState {
     /// PlaybackSharedState.
     pub(crate) fn stop_flag(&self) -> Arc<AtomicBool> {
         Arc::clone(&self.stopped)
+    }
+
+    /// Audio-thread-safe signal: when the underlying buffer crosses
+    /// BUFFER_GROWTH_WARN_THRESHOLD_SAMPLES, flip the growth_warned flag once.
+    /// Only the CAS false -> true succeeds the first time; subsequent calls
+    /// are no-ops. The decoder thread observes the flag and emits the actual
+    /// log line off the real-time audio thread.
+    pub(crate) fn signal_buffer_growth_if_threshold_crossed(&self, samples_len: usize) {
+        if samples_len >= BUFFER_GROWTH_WARN_THRESHOLD_SAMPLES {
+            let _ = self.growth_warned.compare_exchange(
+                false,
+                true,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            );
+        }
     }
 
     pub(crate) fn signal_terminal(&self, outcome: PlaybackTerminalReason) -> Result<()> {
@@ -437,6 +468,46 @@ pub(crate) fn estimate_total_samples_from_duration_ms(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::playback::gapless::GaplessPlan;
+    use crate::playback::player::PlaybackSourceKind;
+
+    fn test_shared_state() -> Arc<PlaybackSharedState> {
+        let (command_tx, _) = mpsc::channel();
+        Arc::new(PlaybackSharedState::new(
+            1,
+            1,
+            PlaybackSourceKind::TidalStream,
+            GaplessPlan::disabled(),
+            48_000,
+            2,
+            None,
+            command_tx,
+            Arc::new(AtomicU32::new(1.0f32.to_bits())),
+            Arc::new(AtomicU64::new(0)),
+        ))
+    }
+
+    #[test]
+    fn signal_buffer_growth_sets_flag_once_when_threshold_crossed() {
+        let shared = test_shared_state();
+        assert!(!shared.growth_warned.load(Ordering::Relaxed));
+
+        shared.signal_buffer_growth_if_threshold_crossed(BUFFER_GROWTH_WARN_THRESHOLD_SAMPLES - 1);
+        assert!(
+            !shared.growth_warned.load(Ordering::Relaxed),
+            "below-threshold sample count should not set the flag"
+        );
+
+        shared.signal_buffer_growth_if_threshold_crossed(BUFFER_GROWTH_WARN_THRESHOLD_SAMPLES);
+        assert!(
+            shared.growth_warned.load(Ordering::Relaxed),
+            "threshold-crossed should set the flag"
+        );
+
+        // Subsequent calls past threshold are idempotent no-ops via CAS.
+        shared.signal_buffer_growth_if_threshold_crossed(BUFFER_GROWTH_WARN_THRESHOLD_SAMPLES * 2);
+        assert!(shared.growth_warned.load(Ordering::Relaxed));
+    }
 
     #[test]
     fn seek_to_decoded_position_applies_immediately() {


### PR DESCRIPTION
## Summary

Phase-one playback runtime hardening across 16 task-sized commits. No public-API, queue-persistence, WASAPI exclusive renderer, DB migration, route, or WebSocket event-shape changes.

Plan: `docs/superpowers/plans/2026-05-16-playback-runtime-hardening.md`.

### Phase A: runtime survives command failures

- `report_runtime_command_error` helper; route the fatal `?` sites in `Play`/`Switch`/`Pause`/`Resume`/exclusive-fallback `swap_stream` through it instead of killing the runtime thread.
- `PlaybackEngine::stop` no longer joins the decoder thread inline; `join_decoder_thread_in_background` detaches the handle so skip/stop returns instantly.
- `PlaybackBuffer::seek_to -> bool`; CPAL callback only updates `position_samples` on accept, warns otherwise. Runtime stops mirroring the requested seek into `position_samples` on dispatch.
- `noor-app/src/sidecar.rs` `wait_for_ready` now uses a 500ms per-request HTTP timeout so a wedged server cannot consume the entire 10s readiness budget.
- Resume-fallback failure now does symmetric `stop_all_engines` + exclusive sink clear (avoids a silent zombie engine).

### Phase B: panics and adjacent-layer failures

- Runtime command dispatch wrapped in `std::panic::catch_unwind(AssertUnwindSafe(...))`. Nested `catch_unwind` around the cleanup; on cleanup-also-panicked we emit a final error event and break the loop cleanly. Successful cleanup also emits `Stopped` so the UI state machine snaps back to idle.
- `emit_cpal_stream_error` routes CPAL stream-level faults (device unplugged, format change, etc.) to `PlaybackRuntimeEvent::Error` instead of log-only.
- `emit_prepared_track_failure` surfaces pre-buffered next-track decode failures (previously logged-only and silently dropped from the queue).
- Real-time-safety guard comment on `command_tx` documents the must-remain-unbounded invariant (CPAL audio callback sends on this channel).

### Phase C: source-side cancellation

- `PlaybackSharedState.stopped` promoted to `Arc<AtomicBool>` with a `stop_flag()` accessor. Transparent at every existing read/write site (Arc derefs to AtomicBool).
- `StreamPipe` takes the stop flag and uses `recv_timeout(100ms)` with periodic polling instead of blocking `rx.recv()`. A stopped pipe surfaces as natural EOF.
- DASH prebuffer loop and the noor-stream-download thread check `shared.stopped` before AND after each `append_stream_bytes` / chunk fetch.
- Composition-level recovery test drives `PlaybackRuntimeLoopState` through error -> recover -> panic -> recover sequences.

(Full `dispatch_command` extraction with injectable `transition_to_job` was scope-reduced - the underlying refactor is its own follow-up plan.)

### Phase D: observability

- Off-audio-thread buffer growth telemetry: audio thread CAS-flips `growth_warned: AtomicBool` when `samples.len() >= 50_000_000` (~200 MB at f32); decoder thread observes and emits the warn once per buffer instance.
- Audio-thread mutex-hold audit: documented the real-time-safety contract on the `buffer.lock()` critical section (no IO, no allocation, bounded drain, rare-event sends amortize to zero).
- Runtime `.unwrap()` audit: documented why each non-test unwrap is either provably safe (Option::Some-gated) or bounded-failure (poison-harmless `Mutex<Arc<AtomicU64>>`, contained by the panic handler).

## Verification

- `cargo test -p noor-server playback`: 133 passed
- `cargo test -p noor-app`: 3 passed
- `cargo check -p noor-server` and `cargo check -p noor-app`: clean
- `cargo fmt --all -- --check`: clean

## Deferred follow-ups (separate plans)

- True lock-free / low-lock ring buffer to replace `PlaybackBuffer` (subsumes the dropped Task 2 and the eventual real form of the growth telemetry).
- Real decoder/source seek for TIDAL streams (builds on the honest-seek and cancellation work).
- Full structured cancellation tokens piped through the entire fetch stack (the in-branch version is the minimal one; DASH prebuffer per-segment cancellation is still a gap).
- Route-side seek ack / rollback.
- Route/runtime generation handling consolidation.
- Real sidecar+device integration smoke suite.
- Sidecar restart watchdog.
- Event broadcast saturation handling.
- CPAL callback panic FFI safety verification.
- Full `dispatch_command` extraction with injectable transition (the in-branch version is scope-reduced to a composition test).
- `promote_next_to_active` panic-on-poisoned-lock ordering (documented in-code as bounded-harm trade-off).

## Test plan

- [x] Pull the branch locally and run `cargo test -p noor-server playback` and `cargo test -p noor-app`.
- [x] Manual smoke: rapid skip across a TIDAL DASH track and observe noor-server logs - the new cancellation should keep CDN fetches from leaking past stop. Optional: trigger a fake device-unplug to see the new CPAL stream-error event.
- [x] Inspect the diff for anything that crossed a protected boundary (none expected).