### PR TITLE
fix(playback): seek ack rollback for TIDAL undecoded targets

### DIFF
--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -605,6 +605,15 @@ export interface PlaybackSnapshot {
 	queue: QueueItem[];
 }
 
+export interface PlaybackSeekResponse {
+	state: PlaybackState;
+	seek?: {
+		accepted: boolean;
+		position_ms: number;
+		message: string | null;
+	};
+}
+
 export interface PlaybackRuntimeInfo {
 	device_name: string;
 	sample_rate: number;
@@ -2191,7 +2200,7 @@ export const api = {
 	},
 
 	setPlaybackPosition(positionMs: number) {
-		return fetchApi<{ state: PlaybackState }>('/api/playback/position', undefined, {
+		return fetchApi<PlaybackSeekResponse>('/api/playback/position', undefined, {
 			method: 'POST',
 			body: JSON.stringify({ position_ms: positionMs }),
 		});

--- a/frontend/src/lib/stores/player.ts
+++ b/frontend/src/lib/stores/player.ts
@@ -470,6 +470,11 @@ export async function setPlayerPosition(nextPositionMs: number) {
 		const result = await api.setPlaybackPosition(nextPositionMs);
 		applyState(result.state);
 		noteSuccess();
+		if (result.seek && !result.seek.accepted) {
+			playerError.set({
+				message: result.seek.message ?? "Can't seek there yet.",
+			});
+		}
 	} catch (error) {
 		setError('seek', error, () => setPlayerPosition(nextPositionMs));
 	}

--- a/noor-server/src/playback/runtime/commands.rs
+++ b/noor-server/src/playback/runtime/commands.rs
@@ -9,8 +9,12 @@ pub enum PlaybackRuntimeCommand {
     Pause,
     Resume,
     Stop,
-    /// Seek to a position (milliseconds). Applied to the current engine's buffer.
-    Seek(i64),
+    /// Seek to a position (milliseconds). Applied to the current engine's buffer
+    /// only when the target has already been decoded.
+    Seek {
+        position_ms: i64,
+        respond_to: std::sync::mpsc::Sender<PlaybackSeekResult>,
+    },
     /// Pre-decode the next track in background so it can start gaplessly.
     PrepareNext(PreparedPlaybackJob),
     /// Sent by the decoder thread when a track finishes decoding successfully.
@@ -60,6 +64,20 @@ pub enum PlaybackTrackStatus {
     None,
     Active,
     Prepared,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PlaybackSeekResult {
+    Accepted {
+        requested_ms: i64,
+        applied_ms: i64,
+        target_samples: u64,
+    },
+    Rejected {
+        requested_ms: i64,
+        current_ms: i64,
+        reason: String,
+    },
 }
 
 #[derive(Debug, Clone)]

--- a/noor-server/src/playback/runtime/mod.rs
+++ b/noor-server/src/playback/runtime/mod.rs
@@ -15,7 +15,8 @@ mod engine;
 pub(crate) mod shared;
 
 pub use commands::{
-    PlaybackRuntimeCommand, PlaybackRuntimeEvent, PlaybackTerminalReason, PlaybackTrackStatus,
+    PlaybackRuntimeCommand, PlaybackRuntimeEvent, PlaybackSeekResult, PlaybackTerminalReason,
+    PlaybackTrackStatus,
 };
 pub use device::{OutputDeviceSelection, enumerate_output_devices};
 use device::{device_display_name, resolve_device};
@@ -120,9 +121,16 @@ impl PlaybackRuntimeHandle {
         self.event_tx.subscribe()
     }
 
-    /// Seek to a position (milliseconds) within the current track.
-    pub fn seek(&self, position_ms: i64) -> Result<()> {
-        self.send(PlaybackRuntimeCommand::Seek(position_ms))
+    /// Seek to a position within the current track. The runtime rejects targets
+    /// that have not been decoded yet so routes can keep persisted state honest.
+    pub fn seek(&self, position_ms: i64) -> Result<PlaybackSeekResult> {
+        let (tx, rx) = std::sync::mpsc::channel();
+        self.send(PlaybackRuntimeCommand::Seek {
+            position_ms,
+            respond_to: tx,
+        })?;
+        rx.recv_timeout(std::time::Duration::from_millis(100))
+            .map_err(|_| anyhow!("playback runtime did not acknowledge seek"))
     }
 
     /// Pre-decode the next track in the background so the transition is gapless.
@@ -331,27 +339,48 @@ fn run_runtime_loop(
                     false,
                 )?;
             }
-            PlaybackRuntimeCommand::Seek(position_ms) => {
-                if let Some(engine) = state.engine.as_ref() {
-                    let target_samples = (position_ms.max(0) as u64
-                        * state.device_sample_rate as u64
-                        * state.device_channels as u64)
-                        / 1000;
-                    // Tell the CPAL callback to seek on the next write.
+            PlaybackRuntimeCommand::Seek {
+                position_ms,
+                respond_to,
+            } => {
+                let result = if let Some(engine) = state.engine.as_ref() {
+                    match engine.shared.buffer.lock() {
+                        Ok(guard) => validate_seek_target(
+                            position_ms,
+                            state.device_sample_rate,
+                            state.device_channels,
+                            guard.samples.len() as u64,
+                            guard.finished,
+                        ),
+                        Err(_) => PlaybackSeekResult::Rejected {
+                            requested_ms: position_ms,
+                            current_ms: engine.shared.position_samples.load(Ordering::Relaxed)
+                                as i64
+                                * 1000
+                                / (state.device_sample_rate as i64
+                                    * state.device_channels.max(1) as i64),
+                            reason: "Playback buffer is unavailable.".to_string(),
+                        },
+                    }
+                } else {
+                    PlaybackSeekResult::Rejected {
+                        requested_ms: position_ms,
+                        current_ms: 0,
+                        reason: "No active playback stream.".to_string(),
+                    }
+                };
+
+                if let Some(engine) = state.engine.as_ref()
+                    && let PlaybackSeekResult::Accepted { target_samples, .. } = &result
+                {
                     engine
                         .shared
                         .seek_target_samples
-                        .store(target_samples, Ordering::Relaxed);
-                    // Mirror into the engine's counter immediately so get_position_ms()
-                    // is correct before the CPAL callback runs (up to one buffer period later).
-                    // position_source always points to this engine's counter, so no
-                    // separate handle-counter write is needed.
+                        .store(*target_samples, Ordering::Relaxed);
                     engine
                         .shared
                         .position_samples
-                        .store(target_samples, Ordering::Relaxed);
-                    // Reset fire-once guards so NearEnd / CrossfadeStart re-fire correctly
-                    // if the user seeks backward past those thresholds.
+                        .store(*target_samples, Ordering::Relaxed);
                     engine
                         .shared
                         .near_end_signaled
@@ -361,6 +390,8 @@ fn run_runtime_loop(
                         .crossfade_start_signaled
                         .store(false, Ordering::Relaxed);
                 }
+
+                let _ = respond_to.send(result);
             }
             PlaybackRuntimeCommand::PrepareNext(job) => {
                 // Only pre-decode if we don't already have a pending engine for this track.
@@ -1353,6 +1384,40 @@ fn should_promote_prepared_at_boundary(
         && next.is_some_and(|(_, next_generation)| next_generation == generation)
 }
 
+fn validate_seek_target(
+    requested_ms: i64,
+    sample_rate: u32,
+    channels: u16,
+    decoded_samples: u64,
+    finished: bool,
+) -> PlaybackSeekResult {
+    let applied_ms = requested_ms.max(0);
+    let target_samples =
+        (applied_ms as u64 * sample_rate as u64 * channels.max(1) as u64) / 1000;
+
+    if target_samples <= decoded_samples {
+        return PlaybackSeekResult::Accepted {
+            requested_ms,
+            applied_ms,
+            target_samples,
+        };
+    }
+
+    let current_ms =
+        (decoded_samples * 1000) / (sample_rate as u64 * channels.max(1) as u64);
+    let reason = if finished {
+        "Seek target is beyond the decoded track duration."
+    } else {
+        "Seek target has not been decoded yet."
+    };
+
+    PlaybackSeekResult::Rejected {
+        requested_ms,
+        current_ms: current_ms as i64,
+        reason: reason.to_string(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::shared::{PlaybackBuffer, write_output_f32};
@@ -1812,5 +1877,47 @@ mod tests {
                 Arc::new(AtomicU64::new(0)),
             )),
         )
+    }
+
+    #[test]
+    fn seek_target_is_accepted_when_decoded_samples_cover_target() {
+        let result = validate_seek_target(1_000, 48_000, 2, 96_000, false);
+
+        assert_eq!(
+            result,
+            PlaybackSeekResult::Accepted {
+                requested_ms: 1_000,
+                applied_ms: 1_000,
+                target_samples: 96_000,
+            }
+        );
+    }
+
+    #[test]
+    fn seek_target_is_rejected_when_samples_are_not_decoded_yet() {
+        let result = validate_seek_target(2_000, 48_000, 2, 95_999, false);
+
+        assert_eq!(
+            result,
+            PlaybackSeekResult::Rejected {
+                requested_ms: 2_000,
+                current_ms: 999,
+                reason: "Seek target has not been decoded yet.".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn seek_target_is_clamped_to_track_start_when_requested_negative() {
+        let result = validate_seek_target(-500, 48_000, 2, 0, false);
+
+        assert_eq!(
+            result,
+            PlaybackSeekResult::Accepted {
+                requested_ms: -500,
+                applied_ms: 0,
+                target_samples: 0,
+            }
+        );
     }
 }

--- a/noor-server/src/playback/runtime/mod.rs
+++ b/noor-server/src/playback/runtime/mod.rs
@@ -1392,8 +1392,7 @@ fn validate_seek_target(
     finished: bool,
 ) -> PlaybackSeekResult {
     let applied_ms = requested_ms.max(0);
-    let target_samples =
-        (applied_ms as u64 * sample_rate as u64 * channels.max(1) as u64) / 1000;
+    let target_samples = (applied_ms as u64 * sample_rate as u64 * channels.max(1) as u64) / 1000;
 
     if target_samples <= decoded_samples {
         return PlaybackSeekResult::Accepted {
@@ -1403,8 +1402,7 @@ fn validate_seek_target(
         };
     }
 
-    let current_ms =
-        (decoded_samples * 1000) / (sample_rate as u64 * channels.max(1) as u64);
+    let current_ms = (decoded_samples * 1000) / (sample_rate as u64 * channels.max(1) as u64);
     let reason = if finished {
         "Seek target is beyond the decoded track duration."
     } else {

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -166,6 +166,59 @@ pub struct PositionRequest {
     position_ms: i64,
 }
 
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct SeekAckResponse {
+    accepted: bool,
+    position_ms: i64,
+    message: Option<String>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct SeekRouteDecision {
+    persist_position_ms: i64,
+    response: SeekAckResponse,
+}
+
+fn seek_route_decision(
+    runtime_result: Option<playback_runtime::PlaybackSeekResult>,
+    current_position_ms: i64,
+    requested_position_ms: i64,
+) -> SeekRouteDecision {
+    match runtime_result {
+        Some(playback_runtime::PlaybackSeekResult::Accepted { applied_ms, .. }) => {
+            SeekRouteDecision {
+                persist_position_ms: applied_ms,
+                response: SeekAckResponse {
+                    accepted: true,
+                    position_ms: applied_ms,
+                    message: None,
+                },
+            }
+        }
+        Some(playback_runtime::PlaybackSeekResult::Rejected { reason, .. }) => {
+            SeekRouteDecision {
+                persist_position_ms: current_position_ms,
+                response: SeekAckResponse {
+                    accepted: false,
+                    position_ms: current_position_ms,
+                    message: Some(reason),
+                },
+            }
+        }
+        None => {
+            let applied_ms = requested_position_ms.max(0);
+            SeekRouteDecision {
+                persist_position_ms: applied_ms,
+                response: SeekAckResponse {
+                    accepted: true,
+                    position_ms: applied_ms,
+                    message: None,
+                },
+            }
+        }
+    }
+}
+
 #[derive(Debug, Deserialize)]
 pub struct VolumeRequest {
     volume: f64,
@@ -7399,19 +7452,51 @@ async fn set_playback_position(
     State(state): State<SharedState>,
     Json(payload): Json<PositionRequest>,
 ) -> Result<Json<Value>, StatusCode> {
-    let state_guard = state.read().await;
-    // Seek in the live audio runtime (updates the CPAL sample cursor).
-    if let Some(runtime) = state_guard.playback_runtime.as_ref() {
-        let _ = runtime.handle.seek(payload.position_ms);
-    }
-    let snapshot = state_guard
-        .db
-        .with_conn(|conn| player::set_position(conn, payload.position_ms))
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    let _ = state_guard.event_tx.send(AppEvent::PlaybackStateChanged);
-    drop(state_guard);
+    let (current_position_ms, runtime_handle) = {
+        let state_guard = state.read().await;
+        let current_position_ms = state_guard
+            .db
+            .with_conn(player::load_state)
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+            .position_ms;
+        let runtime_handle = state_guard
+            .playback_runtime
+            .as_ref()
+            .map(|r| r.handle.clone());
+        (current_position_ms, runtime_handle)
+    };
+
+    let runtime_result = if let Some(handle) = runtime_handle {
+        Some(
+            handle
+                .seek(payload.position_ms)
+                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?,
+        )
+    } else {
+        None
+    };
+
+    let decision = seek_route_decision(
+        runtime_result,
+        current_position_ms,
+        payload.position_ms,
+    );
+
+    let snapshot = {
+        let state_guard = state.read().await;
+        let snapshot = state_guard
+            .db
+            .with_conn(|conn| player::set_position(conn, decision.persist_position_ms))
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        let _ = state_guard.event_tx.send(AppEvent::PlaybackStateChanged);
+        snapshot
+    };
+
     let snapshot = overlay_snapshot_with_external_track(&state, snapshot).await;
-    Ok(Json(json!({ "state": snapshot.state })))
+    Ok(Json(json!({
+        "state": snapshot.state,
+        "seek": decision.response
+    })))
 }
 
 async fn set_playback_volume(
@@ -13434,5 +13519,54 @@ mod tests {
             "routes returned 404 to a wrong-method probe (not registered):\n  {}",
             missing.join("\n  ")
         );
+    }
+
+    #[test]
+    fn seek_route_decision_persists_accepted_runtime_position() {
+        let decision = seek_route_decision(
+            Some(playback_runtime::PlaybackSeekResult::Accepted {
+                requested_ms: 2_000,
+                applied_ms: 2_000,
+                target_samples: 192_000,
+            }),
+            750,
+            2_000,
+        );
+
+        assert_eq!(decision.persist_position_ms, 2_000);
+        assert!(decision.response.accepted);
+        assert_eq!(decision.response.position_ms, 2_000);
+        assert_eq!(decision.response.message, None);
+    }
+
+    #[test]
+    fn seek_route_decision_rolls_back_rejected_runtime_position() {
+        let decision = seek_route_decision(
+            Some(playback_runtime::PlaybackSeekResult::Rejected {
+                requested_ms: 4_000,
+                current_ms: 750,
+                reason: "Seek target has not been decoded yet.".to_string(),
+            }),
+            750,
+            4_000,
+        );
+
+        assert_eq!(decision.persist_position_ms, 750);
+        assert!(!decision.response.accepted);
+        assert_eq!(decision.response.position_ms, 750);
+        assert_eq!(
+            decision.response.message.as_deref(),
+            Some("Seek target has not been decoded yet.")
+        );
+    }
+
+    #[test]
+    fn seek_route_decision_allows_db_only_seek_without_runtime() {
+        let decision = seek_route_decision(None, 750, -50);
+
+        assert_eq!(decision.persist_position_ms, 0);
+        assert!(decision.response.accepted);
+        assert_eq!(decision.response.position_ms, 0);
+        assert_eq!(decision.response.message, None);
     }
 }

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -195,16 +195,14 @@ fn seek_route_decision(
                 },
             }
         }
-        Some(playback_runtime::PlaybackSeekResult::Rejected { reason, .. }) => {
-            SeekRouteDecision {
-                persist_position_ms: current_position_ms,
-                response: SeekAckResponse {
-                    accepted: false,
-                    position_ms: current_position_ms,
-                    message: Some(reason),
-                },
-            }
-        }
+        Some(playback_runtime::PlaybackSeekResult::Rejected { reason, .. }) => SeekRouteDecision {
+            persist_position_ms: current_position_ms,
+            response: SeekAckResponse {
+                accepted: false,
+                position_ms: current_position_ms,
+                message: Some(reason),
+            },
+        },
         None => {
             let applied_ms = requested_position_ms.max(0);
             SeekRouteDecision {
@@ -7476,11 +7474,7 @@ async fn set_playback_position(
         None
     };
 
-    let decision = seek_route_decision(
-        runtime_result,
-        current_position_ms,
-        payload.position_ms,
-    );
+    let decision = seek_route_decision(runtime_result, current_position_ms, payload.position_ms);
 
     let snapshot = {
         let state_guard = state.read().await;


### PR DESCRIPTION
## Summary

- Runtime is now the authority on whether a seek is reachable. `PlaybackRuntimeCommand::Seek` carries a `mpsc::Sender<PlaybackSeekResult>`; the handle waits up to 100ms for the ack.
- `/api/playback/position` persists only the position the runtime accepted, returning `{ state, seek: { accepted, position_ms, message } }`. The route releases the SharedState read lock before the synchronous ack wait so the wait never blocks writers (e.g. queue mutations, device swaps).
- Frontend `setPlayerPosition` always applies the returned state and calls `noteSuccess()` so a structured rollback still counts as a healthy round-trip; surfaces `playerError` only when `seek.accepted === false`.
- Pure helpers `validate_seek_target` and `seek_route_decision` keep the new behavior under focused unit tests.

## Test Plan

- [x] `cargo test -p noor-server playback::runtime::tests::seek_target` (3 pass)
- [x] `cargo test -p noor-server seek_route_decision` (3 pass)
- [x] `cargo check -p noor-server`
- [x] `cargo fmt --all -- --check`
- [x] `pnpm --filter frontend check` (0 errors, 0 warnings)
- [ ] Manual TIDAL (maintainer-driven): backward seek inside decoded range -> UI + audio land on target; forward seek past the decoded buffer -> UI rolls back, playerError shows "Seek target has not been decoded yet.", playback continues from prior position; DB-only path returns `seek.accepted: true`.