### PR TITLE
feat(playback): buffered-bar scrubber + route-side seek ack

### DIFF
--- a/frontend/scripts/player-ephemeral-favorite.test.ts
+++ b/frontend/scripts/player-ephemeral-favorite.test.ts
@@ -7,14 +7,18 @@ const apiMock = vi.hoisted(() => ({
 	importTidalTrackForRadio: vi.fn(),
 	playTidalTrack: vi.fn().mockResolvedValue({}),
 	setTrackFavorite: vi.fn().mockResolvedValue({}),
+	setPlaybackPosition: vi.fn(),
+	getPlaybackState: vi.fn(),
 }));
 
 vi.mock('$lib/api/client', async (importOriginal) => {
 	const actual = await importOriginal<typeof import('../src/lib/api/client')>();
+	// Note: we deliberately let `...actual` expose the real ApiError class so
+	// `instanceof ApiError` in the SUT (e.g. setPlayerPosition's 409 catch)
+	// matches an ApiError we construct from the test.
 	return {
 		...actual,
 		api: apiMock,
-		ApiError: class ApiError extends Error {},
 	};
 });
 
@@ -37,7 +41,17 @@ vi.mock('$lib/stores/library', () => ({
 	updateLibraryTrackFavorite: vi.fn(),
 }));
 
-import { currentTrack, hydratePlayback, playTidalTrackNow, toggleTrackFavorite } from '../src/lib/stores/player';
+import { ApiError } from '../src/lib/api/client';
+import {
+	buffered,
+	currentTrack,
+	hydratePlayback,
+	playerError,
+	playTidalTrackNow,
+	position,
+	setPlayerPosition,
+	toggleTrackFavorite,
+} from '../src/lib/stores/player';
 
 function ephemeralTrack(): Track {
 	return {
@@ -141,5 +155,77 @@ describe('ephemeral TIDAL favorite import', () => {
 		});
 
 		expect(get(currentTrack)?.is_favorite).toBe(true);
+	});
+});
+
+describe('setPlayerPosition 409 ack handling', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		// Reset any state the SUT touches so each test starts fresh.
+		currentTrack.set(null);
+		position.set(0);
+		buffered.set(0);
+		playerError.set(null);
+	});
+
+	function buildState(overrides: Record<string, unknown> = {}) {
+		// The route-side 409 ack returns a live snapshot - this is what the
+		// frontend MUST apply (so the scrubber snaps to the real position
+		// instead of holding the user's drag target).
+		return {
+			current_track: null,
+			current_queue_item_id: null,
+			position_ms: 12_345,
+			is_playing: true,
+			volume: 0.7,
+			shuffle_mode: 'off',
+			repeat_mode: 'off',
+			automix_enabled: false,
+			crossfade_ms: 0,
+			automix_discover_new: false,
+			automix_use_learning: false,
+			automix_allow_external: false,
+			buffered_ms: 30_000,
+			...overrides,
+		};
+	}
+
+	test('applies the 409 body and skips the error toast', async () => {
+		const liveState = buildState();
+		apiMock.setPlaybackPosition.mockRejectedValueOnce(
+			new ApiError(409, 'seek past buffered region', { state: liveState })
+		);
+
+		await setPlayerPosition(120_000);
+
+		// State from the 409 body must land in the stores.
+		expect(get(position)).toBe(12_345);
+		expect(get(buffered)).toBe(30_000);
+		// No error toast: the rejection is expected and the corrective
+		// snapshot is authoritative.
+		expect(get(playerError)).toBeNull();
+	});
+
+	test('routes other non-2xx into the error path', async () => {
+		apiMock.setPlaybackPosition.mockRejectedValueOnce(
+			new ApiError(500, 'server boom', null)
+		);
+
+		await setPlayerPosition(120_000);
+
+		expect(get(playerError)).not.toBeNull();
+		expect(get(playerError)?.message).toContain('seek');
+	});
+
+	test('falls through to error path when 409 body is missing state', async () => {
+		// Defensive: backend could return 409 with an unexpected shape; we
+		// MUST NOT silently swallow it - the user should see the error.
+		apiMock.setPlaybackPosition.mockRejectedValueOnce(
+			new ApiError(409, 'rejected', { reason: 'unparseable' })
+		);
+
+		await setPlayerPosition(120_000);
+
+		expect(get(playerError)).not.toBeNull();
 	});
 });

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -598,6 +598,13 @@ export interface PlaybackState {
 	automix_discover_new: boolean;
 	automix_use_learning: boolean;
 	automix_allow_external: boolean;
+	/**
+	 * How many ms of the currently-playing track are decoded into the
+	 * playback buffer. Optional because the backend serializes it with
+	 * `#[serde(default)]` and older JSON payloads may omit it. Read sites
+	 * should `?? 0` and treat missing as "unknown / no buffer info yet".
+	 */
+	buffered_ms?: number;
 }
 
 export interface PlaybackSnapshot {
@@ -1416,9 +1423,19 @@ async function fetchApiResponse(
 }
 
 export class ApiError extends Error {
-	constructor(public status: number, message: string) {
+	/**
+	 * Parsed response body, if available. Carries the corrective state for
+	 * 409 responses from `POST /api/playback/position` (the route-side seek
+	 * ack returns `{ state: PlaybackState }`) so the caller's catch block
+	 * can `applyState(body.state)` instead of routing the failure into the
+	 * generic error-toast path. Best-effort: parse failures leave this null.
+	 */
+	public body: unknown;
+
+	constructor(public status: number, message: string, body?: unknown) {
 		super(message);
 		this.name = 'ApiError';
+		this.body = body ?? null;
 	}
 }
 
@@ -1436,7 +1453,7 @@ async function fetchApi<T>(
 			errorBody?.error ??
 			errorBody?.status ??
 			`API error: ${resp.status}`;
-		throw new ApiError(resp.status, message);
+		throw new ApiError(resp.status, message, errorBody);
 	}
 	return resp.json();
 }

--- a/frontend/src/lib/components/now-playing/NowPlayingProgress.svelte
+++ b/frontend/src/lib/components/now-playing/NowPlayingProgress.svelte
@@ -4,12 +4,22 @@
 	let {
 		position,
 		duration,
+		bufferedMs = 0,
 		onSeek,
 		onScrubStart,
 		onScrubEnd,
 	}: {
 		position: number;
 		duration: number;
+		/**
+		 * How many ms of the current track are decoded into the playback
+		 * buffer. Clamps the scrubber max so the user can't drag past the
+		 * loaded portion (route-side 409 is the backstop). Defaults to 0 -
+		 * read as "no buffer info / treat as fully seekable" via the
+		 * effectiveBufferedMs fallback below so non-streaming tracks behave
+		 * as today.
+		 */
+		bufferedMs?: number;
 		onSeek: (positionMs: number) => void;
 		onScrubStart?: () => void;
 		onScrubEnd?: () => void;
@@ -24,8 +34,32 @@
 		}
 	});
 
+	// When the backend hasn't published buffered_ms yet (cold start, older
+	// payload, etc.) treat the whole track as seekable - same UX as before
+	// this feature shipped. A non-zero buffered_ms means the runtime is
+	// reporting real buffer state and we should clamp.
+	let effectiveBufferedMs = $derived(bufferedMs > 0 ? bufferedMs : duration);
+
+	// Range max: clamp to buffered region but never collapse below the
+	// current play position (guards against a transient desync where the
+	// buffered_ms WS message lags the position one). When duration is
+	// unknown (<= 0) leave max at 0 and disable the input - clamping then
+	// would lock the scrubber at 0 even if the engine was actually
+	// streaming.
+	let scrubMax = $derived(
+		duration > 0
+			? Math.min(duration, Math.max(scrubPosition, position, effectiveBufferedMs))
+			: 0
+	);
+
 	let progressWidth = $derived(
 		duration > 0 ? `${Math.min((scrubPosition / duration) * 100, 100)}%` : '0%'
+	);
+
+	let bufferedWidth = $derived(
+		duration > 0
+			? `${Math.min((effectiveBufferedMs / duration) * 100, 100)}%`
+			: '0%'
 	);
 
 	function beginScrub() {
@@ -42,17 +76,18 @@
 
 <div class="np-progress">
 	<div class="np-progress-track" style="--pct: {progressWidth}">
+		<div class="np-progress-buffered" style={`width: ${bufferedWidth}`}></div>
 		<div class="np-progress-fill" style={`width: ${progressWidth}`}></div>
 		<input
 			class="np-progress-input"
 			type="range"
 			min="0"
-			max={duration}
+			max={scrubMax}
 			step="1000"
 			bind:value={scrubPosition}
 			oninput={beginScrub}
 			onchange={commitScrub}
-			disabled={!duration}
+			disabled={duration <= 0}
 			aria-label="Seek playback"
 		/>
 	</div>
@@ -78,7 +113,21 @@
 		overflow: visible;
 	}
 
+	.np-progress-buffered {
+		position: absolute;
+		left: 0;
+		top: 0;
+		height: 100%;
+		background: color-mix(in srgb, var(--instrument-border) 65%, transparent);
+		border-radius: inherit;
+		pointer-events: none;
+		transition: width 200ms linear;
+	}
+
 	.np-progress-fill {
+		position: absolute;
+		left: 0;
+		top: 0;
 		height: 100%;
 		background: var(--accent);
 		border-radius: inherit;

--- a/frontend/src/lib/components/now-playing/NowPlayingProgress.svelte
+++ b/frontend/src/lib/components/now-playing/NowPlayingProgress.svelte
@@ -34,21 +34,21 @@
 		}
 	});
 
-	// When the backend hasn't published buffered_ms yet (cold start, older
-	// payload, etc.) treat the whole track as seekable - same UX as before
-	// this feature shipped. A non-zero buffered_ms means the runtime is
-	// reporting real buffer state and we should clamp.
-	let effectiveBufferedMs = $derived(bufferedMs > 0 ? bufferedMs : duration);
-
-	// Range max: clamp to buffered region but never collapse below the
-	// current play position (guards against a transient desync where the
-	// buffered_ms WS message lags the position one). When duration is
-	// unknown (<= 0) leave max at 0 and disable the input - clamping then
-	// would lock the scrubber at 0 even if the engine was actually
-	// streaming.
+	// Range max: clamp to the decoded buffer. The inner Math.max guards
+	// against transient desync (position or scrubPosition momentarily
+	// ahead of bufferedMs after a track change). When duration is unknown
+	// (<= 0) leave max at 0 and disable the input.
+	//
+	// Note: we do NOT fall back to `duration` when bufferedMs is 0. That
+	// fallback opens a hole during the cold-start window (track started
+	// but no decoder callback has published samples yet) where the user
+	// could scrub past the decoded region and trip the runtime's seek
+	// rejection. With strict clamping the scrubber stays at `position`
+	// (= 0 at track start) until the first publish lands. Local files
+	// publish within ~100ms; TIDAL within a second or two.
 	let scrubMax = $derived(
 		duration > 0
-			? Math.min(duration, Math.max(scrubPosition, position, effectiveBufferedMs))
+			? Math.min(duration, Math.max(scrubPosition, position, bufferedMs))
 			: 0
 	);
 
@@ -58,7 +58,7 @@
 
 	let bufferedWidth = $derived(
 		duration > 0
-			? `${Math.min((effectiveBufferedMs / duration) * 100, 100)}%`
+			? `${Math.min((bufferedMs / duration) * 100, 100)}%`
 			: '0%'
 	);
 

--- a/frontend/src/lib/shell/PlayerBar.svelte
+++ b/frontend/src/lib/shell/PlayerBar.svelte
@@ -21,6 +21,7 @@
 		playerState,
 		isScrubbing,
 		position,
+		bufferedMs = 0,
 		isPlaying,
 		shuffleMode,
 		repeatMode,
@@ -53,6 +54,7 @@
 		playerState: string;
 		isScrubbing: boolean;
 		position: number;
+		bufferedMs?: number;
 		isPlaying: boolean;
 		shuffleMode: string;
 		repeatMode: string;
@@ -173,6 +175,7 @@
 	<NowPlayingProgress
 		position={position}
 		duration={track?.duration_ms ?? 0}
+		bufferedMs={bufferedMs}
 		onSeek={onSeek}
 		onScrubStart={onScrubStart}
 		onScrubEnd={onScrubEnd}

--- a/frontend/src/lib/stores/player.ts
+++ b/frontend/src/lib/stores/player.ts
@@ -241,6 +241,14 @@ if (typeof window !== 'undefined') {
 
 export const isPlaying = writable(false);
 export const position = writable(0);
+/**
+ * How many ms of the current track are decoded into the playback buffer.
+ * Drives the buffered-bar overlay in the scrubber and clamps the user's
+ * seek max so a drag past the loaded region is impossible (the route-side
+ * 409 ack is the backstop). Updated by `applyState` + a 1 Hz refresher
+ * that polls `/api/playback/state` while a track is loading.
+ */
+export const buffered = writable(0);
 export const volume = writable(1.0);
 export const volumeBeforeMute = writable<number | null>(null);
 export const automixEnabled = writable(false);
@@ -286,6 +294,43 @@ isPlaying.subscribe((playing) => {
 		stopPositionTicker();
 	}
 });
+
+// ─── 1 Hz buffered refresher ─────────────────────────────────────────────────
+// While a track is active and the decoder hasn't caught up to the duration,
+// poll `/api/playback/state` once per second so the buffered-bar overlay
+// grows live. Auto-stops when buffered >= duration, when the track changes,
+// or when no track is active. The `PlaybackBuffer` on the server only
+// appends (never compacts mid-track), so the `>=` stop condition is sound.
+let _bufferedRefresher: ReturnType<typeof setTimeout> | null = null;
+const BUFFERED_REFRESH_INTERVAL_MS = 1000;
+
+function clearBufferedRefresher() {
+	if (_bufferedRefresher !== null) {
+		clearTimeout(_bufferedRefresher);
+		_bufferedRefresher = null;
+	}
+}
+
+function scheduleBufferedRefreshIfNeeded() {
+	clearBufferedRefresher();
+	const track = get(currentTrack);
+	const duration = track?.duration_ms ?? 0;
+	if (!track || duration <= 0) return;
+	if (get(buffered) >= duration) return;
+	_bufferedRefresher = setTimeout(async () => {
+		try {
+			const snapshot = await api.getPlaybackState();
+			// applyState writes `buffered` and recurses into scheduling, so
+			// the timer chain runs as long as buffered_ms < duration_ms.
+			applyState(snapshot.state);
+		} catch (_err) {
+			// Transient fetch failures (sleep, network blip) shouldn't toast.
+			// Re-schedule so we recover on the next interval if the track is
+			// still active when connectivity returns.
+			scheduleBufferedRefreshIfNeeded();
+		}
+	}, BUFFERED_REFRESH_INTERVAL_MS);
+}
 export const shuffleMode = writable<PlaybackState['shuffle_mode']>('off');
 export const repeatMode = writable<PlaybackState['repeat_mode']>('off');
 export const crossfadeMs = writable(0);
@@ -320,6 +365,7 @@ function applyState(state: PlaybackState) {
 	isPlaying.set(state.is_playing);
 	position.set(state.position_ms);
 	anchorPositionTicker(state.position_ms);
+	buffered.set(state.buffered_ms ?? 0);
 	volume.set(state.volume);
 	shuffleMode.set(state.shuffle_mode);
 	repeatMode.set(state.repeat_mode);
@@ -328,6 +374,7 @@ function applyState(state: PlaybackState) {
 	automixDiscoverNew.set(state.automix_discover_new);
 	automixUseLearning.set(state.automix_use_learning);
 	automixAllowExternal.set(state.automix_allow_external);
+	scheduleBufferedRefreshIfNeeded();
 }
 
 export function hydratePlayback(snapshot: PlaybackSnapshot) {
@@ -471,6 +518,20 @@ export async function setPlayerPosition(nextPositionMs: number) {
 		applyState(result.state);
 		noteSuccess();
 	} catch (error) {
+		// HTTP 409 = route-side seek ack: target was past the decoded buffer.
+		// The frontend scrubber clamps to bufferedMs so this should be
+		// unreachable in practice; if another client (mobile /remote) or a
+		// race makes it fire, apply the corrective live snapshot the server
+		// included in the body and stay silent (no error toast - the seek
+		// just didn't happen, the user can see the scrubber stayed put).
+		if (error instanceof ApiError && error.status === 409) {
+			const body = error.body as { state?: PlaybackState } | null;
+			if (body?.state) {
+				applyState(body.state);
+				noteSuccess();
+				return;
+			}
+		}
 		setError('seek', error, () => setPlayerPosition(nextPositionMs));
 	}
 }

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -11,6 +11,7 @@
 		playbackRuntimeInfo,
 		isPlaying,
 		position,
+		buffered,
 		volume,
 		automixEnabled,
 		automixDiscoverNew,
@@ -1219,6 +1220,7 @@
 			playerState={playerState}
 			isScrubbing={isScrubbing}
 			position={$position}
+			bufferedMs={$buffered}
 			isPlaying={$isPlaying}
 			shuffleMode={$shuffleMode}
 			repeatMode={$repeatMode}

--- a/noor-server/src/db/models.rs
+++ b/noor-server/src/db/models.rs
@@ -99,6 +99,18 @@ pub struct PlaybackState {
     pub automix_discover_new: bool,
     pub automix_use_learning: bool,
     pub automix_allow_external: bool,
+    /// How many ms of the currently-playing track are decoded into the
+    /// playback buffer. 0 when no track is active or before the audio
+    /// callback has published the first value. Drives the buffered-bar
+    /// scrubber on the frontend and the route-side seek ack: a seek target
+    /// greater than `buffered_ms` is rejected with HTTP 409 instead of
+    /// dispatched to the runtime (which would WARN-spam and snap-back).
+    ///
+    /// `#[serde(default)]` so existing JSON payloads / construction sites
+    /// that predate this field keep deserializing/compiling without a
+    /// per-site change.
+    #[serde(default)]
+    pub buffered_ms: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/noor-server/src/playback/player.rs
+++ b/noor-server/src/playback/player.rs
@@ -374,6 +374,9 @@ pub fn load_state(conn: &Connection) -> Result<PlaybackState> {
         automix_discover_new: row.8,
         automix_use_learning: row.9,
         automix_allow_external: row.10,
+        // buffered_ms is a runtime-only field overlaid by the live snapshot
+        // helper in routes.rs; the DB has no column for it.
+        buffered_ms: 0,
     })
 }
 

--- a/noor-server/src/playback/runtime/mod.rs
+++ b/noor-server/src/playback/runtime/mod.rs
@@ -73,6 +73,14 @@ pub struct PlaybackRuntimeHandle {
     /// surfaced to the user as `PlaybackRuntimeEvent::Error`. So these
     /// unwraps are bounded-failure, not silent corruption.
     position_source: Arc<Mutex<Arc<AtomicU64>>>,
+    /// Redirectable buffered-samples reader. Parallel to `position_source`:
+    /// always points at the audibly-current engine's `buffered_samples`
+    /// counter, swapped at the same sites position_source is swapped (cold
+    /// start in `transition_to_job` and at the two `promote_*` sites). The
+    /// route-side seek ack reads through this to decide 409 vs dispatch, and
+    /// the frontend reads `buffered_ms` via this for the buffered-bar
+    /// scrubber. Same unwrap-audit reasoning as `position_source`.
+    buffered_source: Arc<Mutex<Arc<AtomicU64>>>,
 }
 
 impl PlaybackRuntimeHandle {
@@ -170,6 +178,26 @@ impl PlaybackRuntimeHandle {
         (samples * 1000 / (device_sample_rate as u64 * device_channels as u64)) as i64
     }
 
+    /// Read how many ms of the current track are decoded into the playback
+    /// buffer. Returns 0 when no engine is active. Used by the route-side
+    /// seek ack (target > buffered -> HTTP 409) and surfaced to the frontend
+    /// via `PlaybackState.buffered_ms` for the buffered-bar scrubber.
+    /// Same unwrap-audit reasoning as `get_position_ms`.
+    pub fn get_buffered_ms(&self, device_sample_rate: u32, device_channels: u16) -> i64 {
+        if device_sample_rate == 0 || device_channels == 0 {
+            return 0;
+        }
+        let samples = self.buffered_source.lock().unwrap().load(Ordering::Relaxed);
+        (samples * 1000 / (device_sample_rate as u64 * device_channels as u64)) as i64
+    }
+
+    /// Raw buffered-sample count from the audibly-current engine. Avoids the
+    /// ms conversion when the caller already has a target-in-samples (e.g.
+    /// the route-side seek handler comparing target_samples to buffered).
+    pub fn buffered_samples(&self) -> u64 {
+        self.buffered_source.lock().unwrap().load(Ordering::Relaxed)
+    }
+
     fn send(&self, command: PlaybackRuntimeCommand) -> Result<()> {
         self.command_tx
             .send(command)
@@ -194,10 +222,18 @@ pub fn spawn_runtime(config: PlaybackRuntimeConfig) -> Result<PlaybackRuntimeHan
     // redirect the handle to the promoted engine's private counter instead.
     let initial_position = Arc::new(AtomicU64::new(0));
     let position_source = Arc::new(Mutex::new(Arc::clone(&initial_position)));
+    // Buffered-samples mirror. Each PlaybackSharedState owns its own
+    // `Arc<AtomicU64>` (initialized to 0 at construction); the handle's
+    // `buffered_source` points at whichever one is audibly current. Before
+    // any engine exists we point at a sentinel zero atomic so a
+    // `buffered_ms()` call returns 0 cleanly.
+    let buffered_source: Arc<Mutex<Arc<AtomicU64>>> =
+        Arc::new(Mutex::new(Arc::new(AtomicU64::new(0))));
 
     let worker_volume_ctl = Arc::clone(&volume_ctl);
     let worker_initial_position = Arc::clone(&initial_position);
     let worker_position_source = Arc::clone(&position_source);
+    let worker_buffered_source = Arc::clone(&buffered_source);
 
     thread::Builder::new()
         .name("noor-playback-runtime".into())
@@ -210,6 +246,7 @@ pub fn spawn_runtime(config: PlaybackRuntimeConfig) -> Result<PlaybackRuntimeHan
                 worker_volume_ctl,
                 worker_initial_position,
                 worker_position_source,
+                worker_buffered_source,
             ) {
                 let _ = worker_event_tx.send(PlaybackRuntimeEvent::Error {
                     message: err.to_string(),
@@ -224,6 +261,7 @@ pub fn spawn_runtime(config: PlaybackRuntimeConfig) -> Result<PlaybackRuntimeHan
         event_tx,
         volume_ctl,
         position_source,
+        buffered_source,
     })
 }
 
@@ -271,6 +309,7 @@ fn run_runtime_loop(
     volume_ctl: Arc<AtomicU32>,
     position_samples: Arc<AtomicU64>,
     position_source: Arc<Mutex<Arc<AtomicU64>>>,
+    buffered_source: Arc<Mutex<Arc<AtomicU64>>>,
 ) -> Result<()> {
     let host = cpal::default_host();
     let mut device = host
@@ -327,6 +366,7 @@ fn run_runtime_loop(
                         &volume_ctl,
                         &position_samples,
                         &position_source,
+                        &buffered_source,
                         true,
                     ) {
                         stop_all_engines(&mut state);
@@ -348,6 +388,7 @@ fn run_runtime_loop(
                         &volume_ctl,
                         &position_samples,
                         &position_source,
+                        &buffered_source,
                         false,
                     ) {
                         stop_all_engines(&mut state);
@@ -455,7 +496,12 @@ fn run_runtime_loop(
                             .and_then(|e| e.shared.buffer.lock().ok().map(|g| g.is_ready()))
                             .unwrap_or(false);
                         if next_ready {
-                            promote_next_to_active(&mut state, &event_tx, &position_source);
+                            promote_next_to_active(
+                                &mut state,
+                                &event_tx,
+                                &position_source,
+                                &buffered_source,
+                            );
                         }
                         // If not ready yet, NextDecodeComplete handles the late path.
                     }
@@ -479,7 +525,12 @@ fn run_runtime_loop(
                             .map(|e| e.shared.crossfade_start_signaled.load(Ordering::Relaxed))
                             .unwrap_or(false);
                         if crossfade_started {
-                            promote_next_to_active(&mut state, &event_tx, &position_source);
+                            promote_next_to_active(
+                                &mut state,
+                                &event_tx,
+                                &position_source,
+                                &buffered_source,
+                            );
                         }
                     }
                 }
@@ -663,6 +714,7 @@ fn run_runtime_loop(
                                     &mut state,
                                     &event_tx,
                                     &position_source,
+                                    &buffered_source,
                                 );
                             } else {
                                 stop_current_engine(&mut state);
@@ -960,6 +1012,7 @@ fn transition_to_job(
     volume_ctl: &Arc<AtomicU32>,
     position_samples: &Arc<AtomicU64>,
     position_source: &Arc<Mutex<Arc<AtomicU64>>>,
+    buffered_source: &Arc<Mutex<Arc<AtomicU64>>>,
     force_restart: bool,
 ) -> Result<()> {
     // No-op when state.engine is already playing the requested track. This
@@ -1049,8 +1102,9 @@ fn transition_to_job(
                 Arc::clone(volume_ctl),
                 Arc::clone(position_samples),
             )?;
-            state.engine = Some(eng);
             *position_source.lock().unwrap() = Arc::clone(position_samples);
+            *buffered_source.lock().unwrap() = Arc::clone(&eng.shared.buffered_samples);
+            state.engine = Some(eng);
 
             #[cfg(target_os = "windows")]
             {
@@ -1114,6 +1168,7 @@ fn transition_to_job(
             output_config.sample_rate = actual_start_rate;
             state.device_sample_rate = actual_start_rate;
             *position_source.lock().unwrap() = Arc::clone(position_samples);
+            *buffered_source.lock().unwrap() = Arc::clone(&eng.shared.buffered_samples);
             state.engine = Some(eng);
         }
     }
@@ -1335,6 +1390,7 @@ fn promote_next_to_active(
     state: &mut PlaybackRuntimeLoopState,
     event_tx: &tokio::sync::broadcast::Sender<PlaybackRuntimeEvent>,
     position_source: &Arc<Mutex<Arc<AtomicU64>>>,
+    buffered_source: &Arc<Mutex<Arc<AtomicU64>>>,
 ) {
     let Some(next) = state.next_engine.take() else {
         return;
@@ -1342,18 +1398,19 @@ fn promote_next_to_active(
     next.shared.fadein_start_samples.store(0, Ordering::Relaxed);
     next.shared.paused.store(false, Ordering::SeqCst);
 
-    // Redirect the handle's position reader to the incoming engine's counter
-    // BEFORE sliding it into state.engine so get_position_ms() immediately
-    // reflects the new track starting from 0 instead of the fading-out track's
-    // frozen end position.
+    // Redirect the handle's position + buffered readers to the incoming
+    // engine's counters BEFORE sliding it into state.engine so get_position_ms
+    // / get_buffered_ms() immediately reflect the new track starting from 0
+    // instead of the fading-out track's frozen end values.
     //
-    // If position_source.lock() panics (the only failure mode is a prior
-    // poisoning) the moved-out `next` is dropped without stop() being called
-    // and its decoder thread keeps fetching until natural EOF or the CDN
-    // timeout (~30s bounded). Task 7's catch_unwind around the dispatch loop
-    // catches the panic and emits Error+Stopped. The "preserve frozen-position
-    // UX" win was judged to outweigh the rare-poisoning bandwidth blip.
+    // If lock() panics (the only failure mode is a prior poisoning) the
+    // moved-out `next` is dropped without stop() being called and its decoder
+    // thread keeps fetching until natural EOF or the CDN timeout (~30s
+    // bounded). Task 7's catch_unwind around the dispatch loop catches the
+    // panic and emits Error+Stopped. The "preserve frozen-position UX" win
+    // was judged to outweigh the rare-poisoning bandwidth blip.
     *position_source.lock().unwrap() = Arc::clone(&next.shared.position_samples);
+    *buffered_source.lock().unwrap() = Arc::clone(&next.shared.buffered_samples);
 
     let outgoing = state.engine.take();
     state.engine = Some(next);
@@ -1384,6 +1441,7 @@ fn promote_prepared_at_boundary(
     state: &mut PlaybackRuntimeLoopState,
     event_tx: &tokio::sync::broadcast::Sender<PlaybackRuntimeEvent>,
     position_source: &Arc<Mutex<Arc<AtomicU64>>>,
+    buffered_source: &Arc<Mutex<Arc<AtomicU64>>>,
 ) {
     let Some(next) = state.next_engine.take() else {
         return;
@@ -1393,6 +1451,7 @@ fn promote_prepared_at_boundary(
         .store(u64::MAX, Ordering::Relaxed);
     next.shared.paused.store(false, Ordering::SeqCst);
     *position_source.lock().unwrap() = Arc::clone(&next.shared.position_samples);
+    *buffered_source.lock().unwrap() = Arc::clone(&next.shared.buffered_samples);
 
     let outgoing = state.engine.take();
     state.engine = Some(next);
@@ -1955,6 +2014,72 @@ mod tests {
         assert_eq!(sources[0].role, ExclusiveRenderRole::Active);
         assert_eq!(sources[1].role, ExclusiveRenderRole::Prepared);
         assert_eq!(sources[2].role, ExclusiveRenderRole::Fading);
+    }
+
+    #[test]
+    fn buffered_source_redirect_makes_handle_read_from_new_engine() {
+        // Regression for the codex P1 finding: a `buffered_ms()` accessor
+        // tied to the initial engine's atomic would silently read stale data
+        // after a Switch or crossfade promotion. The handle must follow the
+        // same redirect pattern as `position_source` - this test pins that.
+
+        let (command_tx, _) = std::sync::mpsc::channel();
+        let (event_tx, _) = tokio::sync::broadcast::channel(8);
+
+        let engine_a_buffered = Arc::new(AtomicU64::new(48_000)); // 1000 ms @ 48k mono
+        let engine_b_buffered = Arc::new(AtomicU64::new(96_000)); // 1000 ms @ 48k stereo
+
+        let buffered_source: Arc<Mutex<Arc<AtomicU64>>> =
+            Arc::new(Mutex::new(Arc::clone(&engine_a_buffered)));
+
+        let handle = PlaybackRuntimeHandle {
+            command_tx,
+            event_tx,
+            volume_ctl: Arc::new(AtomicU32::new(1.0f32.to_bits())),
+            position_source: Arc::new(Mutex::new(Arc::new(AtomicU64::new(0)))),
+            buffered_source: Arc::clone(&buffered_source),
+        };
+
+        assert_eq!(
+            handle.buffered_samples(),
+            48_000,
+            "fresh handle must read from engine A's counter"
+        );
+        assert_eq!(handle.get_buffered_ms(48_000, 1), 1000);
+
+        // Simulate transition_to_job / promote_*: redirect the source to
+        // engine B's counter, exactly the way the runtime loop does it.
+        *buffered_source.lock().unwrap() = Arc::clone(&engine_b_buffered);
+
+        assert_eq!(
+            handle.buffered_samples(),
+            96_000,
+            "after redirect the handle MUST read engine B, not stale A"
+        );
+        assert_eq!(handle.get_buffered_ms(48_000, 2), 1000);
+
+        // After redirect, mutating engine A's counter must NOT leak through.
+        engine_a_buffered.store(999_999, Ordering::Relaxed);
+        assert_eq!(
+            handle.buffered_samples(),
+            96_000,
+            "stale engine writes must not affect the redirected handle"
+        );
+    }
+
+    #[test]
+    fn get_buffered_ms_returns_zero_for_invalid_device_config() {
+        let (command_tx, _) = std::sync::mpsc::channel();
+        let (event_tx, _) = tokio::sync::broadcast::channel(8);
+        let handle = PlaybackRuntimeHandle {
+            command_tx,
+            event_tx,
+            volume_ctl: Arc::new(AtomicU32::new(1.0f32.to_bits())),
+            position_source: Arc::new(Mutex::new(Arc::new(AtomicU64::new(0)))),
+            buffered_source: Arc::new(Mutex::new(Arc::new(AtomicU64::new(48_000)))),
+        };
+        assert_eq!(handle.get_buffered_ms(0, 2), 0);
+        assert_eq!(handle.get_buffered_ms(48_000, 0), 0);
     }
 
     #[test]

--- a/noor-server/src/playback/runtime/shared.rs
+++ b/noor-server/src/playback/runtime/shared.rs
@@ -176,9 +176,12 @@ fn write_output_buffer<T>(
             .fetch_add(written as u64, Ordering::Relaxed);
     }
 
-    // Real-time-safe growth signal: this is just a load + conditional CAS,
-    // no allocation. The decoder thread observes growth_warned and emits the
+    // Real-time-safe telemetry: a relaxed atomic store + a load + conditional
+    // CAS, no allocation. The buffered_samples mirror lets the HTTP /
+    // route-side seek ack read "how much is decoded" without taking the
+    // buffer mutex. The decoder thread observes growth_warned and emits the
     // actual log line off this thread.
+    shared.publish_buffered_samples(guard.samples.len());
     shared.signal_buffer_growth_if_threshold_crossed(guard.samples.len());
 
     if guard.started && !guard.finished && written < data.len() && !guard.starved_notified {
@@ -279,6 +282,11 @@ pub(crate) struct PlaybackSharedState {
     pub(crate) position_samples: Arc<AtomicU64>,
     pub(crate) seek_target_samples: AtomicU64,
     pub(crate) total_samples: AtomicU64,
+    /// Mirror of `buffer.samples.len()` published from the audio callback so
+    /// HTTP / route-side consumers can read "how much of this track is
+    /// decoded" without taking the buffer mutex. Used by the route-side seek
+    /// ack path and the buffered-bar scrubber in the frontend.
+    pub(crate) buffered_samples: AtomicU64,
     pub(crate) near_end_signaled: AtomicBool,
     pub(crate) crossfade_samples: AtomicU64,
     pub(crate) crossfade_start_signaled: AtomicBool,
@@ -326,6 +334,7 @@ impl PlaybackSharedState {
             position_samples,
             seek_target_samples: AtomicU64::new(u64::MAX),
             total_samples: AtomicU64::new(estimated_total_samples.unwrap_or(0)),
+            buffered_samples: AtomicU64::new(0),
             near_end_signaled: AtomicBool::new(false),
             crossfade_samples: AtomicU64::new(crossfade_samples),
             crossfade_start_signaled: AtomicBool::new(false),
@@ -353,6 +362,16 @@ impl PlaybackSharedState {
     /// invariant to protect.
     pub(crate) fn stop_flag(&self) -> Arc<AtomicBool> {
         Arc::clone(&self.stopped)
+    }
+
+    /// Audio-thread-safe: publish the current decoded-sample count for
+    /// consumers outside the buffer mutex (the route-side seek ack and the
+    /// frontend buffered-bar scrubber). Cost: a single Relaxed atomic store,
+    /// no allocation - consistent with the other telemetry atomics flipped
+    /// inside the CPAL critical section.
+    pub(crate) fn publish_buffered_samples(&self, samples_len: usize) {
+        self.buffered_samples
+            .store(samples_len as u64, Ordering::Relaxed);
     }
 
     /// Audio-thread-safe signal: when the underlying buffer crosses
@@ -504,6 +523,27 @@ mod tests {
             Arc::new(AtomicU32::new(1.0f32.to_bits())),
             Arc::new(AtomicU64::new(0)),
         ))
+    }
+
+    #[test]
+    fn publish_buffered_samples_mirrors_value_atomically() {
+        let shared = test_shared_state();
+        assert_eq!(
+            shared.buffered_samples.load(Ordering::Relaxed),
+            0,
+            "fresh state must start at 0 buffered samples"
+        );
+
+        shared.publish_buffered_samples(12_345);
+        assert_eq!(
+            shared.buffered_samples.load(Ordering::Relaxed),
+            12_345,
+            "publish must store the exact sample count"
+        );
+
+        // Idempotent overwrite is fine - the callback re-publishes on every drain.
+        shared.publish_buffered_samples(0);
+        assert_eq!(shared.buffered_samples.load(Ordering::Relaxed), 0);
     }
 
     #[test]

--- a/noor-server/src/playback/runtime/shared.rs
+++ b/noor-server/src/playback/runtime/shared.rs
@@ -284,9 +284,12 @@ pub(crate) struct PlaybackSharedState {
     pub(crate) total_samples: AtomicU64,
     /// Mirror of `buffer.samples.len()` published from the audio callback so
     /// HTTP / route-side consumers can read "how much of this track is
-    /// decoded" without taking the buffer mutex. Used by the route-side seek
-    /// ack path and the buffered-bar scrubber in the frontend.
-    pub(crate) buffered_samples: AtomicU64,
+    /// decoded" without taking the buffer mutex. Wrapped in `Arc` so the
+    /// `PlaybackRuntimeHandle`'s redirectable `buffered_source` can point at
+    /// the active engine's counter (parallel to `position_samples` /
+    /// `position_source`). Used by the route-side seek ack path and the
+    /// buffered-bar scrubber in the frontend.
+    pub(crate) buffered_samples: Arc<AtomicU64>,
     pub(crate) near_end_signaled: AtomicBool,
     pub(crate) crossfade_samples: AtomicU64,
     pub(crate) crossfade_start_signaled: AtomicBool,
@@ -334,7 +337,7 @@ impl PlaybackSharedState {
             position_samples,
             seek_target_samples: AtomicU64::new(u64::MAX),
             total_samples: AtomicU64::new(estimated_total_samples.unwrap_or(0)),
-            buffered_samples: AtomicU64::new(0),
+            buffered_samples: Arc::new(AtomicU64::new(0)),
             near_end_signaled: AtomicBool::new(false),
             crossfade_samples: AtomicU64::new(crossfade_samples),
             crossfade_start_signaled: AtomicBool::new(false),

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -7456,9 +7456,7 @@ async fn set_playback_position(
             .as_ref()
             .zip(g.playback_runtime_info.as_ref())
         {
-            snapshot.state.buffered_ms = rt
-                .handle
-                .get_buffered_ms(info.sample_rate, info.channels);
+            snapshot.state.buffered_ms = rt.handle.get_buffered_ms(info.sample_rate, info.channels);
         }
     }
     Ok((StatusCode::OK, Json(json!({ "state": snapshot.state }))))

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -5941,19 +5941,31 @@ async fn set_track_favorite(
 
 // -- MusicBrainz enrichment -------------------------------------------------
 
-async fn get_playback_state(State(state): State<SharedState>) -> Result<Json<Value>, StatusCode> {
-    let (live_position_ms, ephemeral_playing, audio_active) = {
+/// Build a `PlaybackSnapshot` whose `state.position_ms`, `state.buffered_ms`,
+/// and `state.is_playing` reflect the live audio runtime (not just the DB
+/// snapshot). Used by `GET /api/playback/state` and the route-side seek ack
+/// in `POST /api/playback/position` so both responses carry a mutually
+/// consistent view: returning a 409 body built from the raw DB snapshot
+/// while the rejection decision was made from a live `buffered_samples`
+/// read would be exactly the inconsistency the codex review flagged.
+async fn build_live_playback_snapshot(
+    state: &SharedState,
+) -> Result<player::PlaybackSnapshot, StatusCode> {
+    let (live_position_ms, live_buffered_ms, ephemeral_playing, audio_active) = {
         let state_guard = state.read().await;
-        let live_pos = state_guard
+        let pair = state_guard
             .playback_runtime
             .as_ref()
-            .zip(state_guard.playback_runtime_info.as_ref())
-            .map(|(rt, info)| rt.handle.get_position_ms(info.sample_rate, info.channels));
+            .zip(state_guard.playback_runtime_info.as_ref());
+        let live_pos =
+            pair.map(|(rt, info)| rt.handle.get_position_ms(info.sample_rate, info.channels));
+        let live_buf =
+            pair.map(|(rt, info)| rt.handle.get_buffered_ms(info.sample_rate, info.channels));
         let ephemeral = state_guard.ephemeral_tidal_track.is_some();
         let active = state_guard
             .audio_active
             .load(std::sync::atomic::Ordering::Relaxed);
-        (live_pos, ephemeral, active)
+        (live_pos, live_buf, ephemeral, active)
     };
 
     let snapshot = {
@@ -5964,7 +5976,11 @@ async fn get_playback_state(State(state): State<SharedState>) -> Result<Json<Val
             .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
     };
     let mut snapshot =
-        overlay_snapshot_with_external_track_and_position(&state, snapshot, live_position_ms).await;
+        overlay_snapshot_with_external_track_and_position(state, snapshot, live_position_ms).await;
+
+    if let Some(buf) = live_buffered_ms {
+        snapshot.state.buffered_ms = buf;
+    }
 
     // Correct a stale is_playing flag before sending to the frontend:
     // - no runtime at all (server restarted, runtime crashed), OR
@@ -5974,6 +5990,11 @@ async fn get_playback_state(State(state): State<SharedState>) -> Result<Json<Val
         snapshot.state.is_playing = false;
     }
 
+    Ok(snapshot)
+}
+
+async fn get_playback_state(State(state): State<SharedState>) -> Result<Json<Value>, StatusCode> {
+    let snapshot = build_live_playback_snapshot(&state).await?;
     Ok(Json(json!({
         "state": snapshot.state,
         "queue": snapshot.queue
@@ -7398,7 +7419,21 @@ async fn previous_track(
 async fn set_playback_position(
     State(state): State<SharedState>,
     Json(payload): Json<PositionRequest>,
-) -> Result<Json<Value>, StatusCode> {
+) -> Result<(StatusCode, Json<Value>), StatusCode> {
+    // Pre-check the live buffer: if the user is asking to seek past what's
+    // decoded, return 409 with a live snapshot (built from the same helper
+    // as GET /api/playback/state, so the body is mutually consistent with
+    // the rejection decision). The frontend's `setPlayerPosition` 409 catch
+    // applies that body via `applyState` and skips the error toast.
+    let seek_decision = evaluate_seek_against_buffer(&state, payload.position_ms).await;
+    if matches!(seek_decision, SeekDecision::RejectPastBuffer) {
+        let snapshot = build_live_playback_snapshot(&state).await?;
+        return Ok((
+            StatusCode::CONFLICT,
+            Json(json!({ "state": snapshot.state })),
+        ));
+    }
+
     let state_guard = state.read().await;
     // Seek in the live audio runtime (updates the CPAL sample cursor).
     if let Some(runtime) = state_guard.playback_runtime.as_ref() {
@@ -7410,8 +7445,81 @@ async fn set_playback_position(
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     let _ = state_guard.event_tx.send(AppEvent::PlaybackStateChanged);
     drop(state_guard);
-    let snapshot = overlay_snapshot_with_external_track(&state, snapshot).await;
-    Ok(Json(json!({ "state": snapshot.state })))
+    let mut snapshot = overlay_snapshot_with_external_track(&state, snapshot).await;
+    // Overlay buffered_ms so the response carries the same field shape as
+    // GET /api/playback/state. Position is already authoritative (we just
+    // wrote payload.position_ms to the DB above).
+    {
+        let g = state.read().await;
+        if let Some((rt, info)) = g
+            .playback_runtime
+            .as_ref()
+            .zip(g.playback_runtime_info.as_ref())
+        {
+            snapshot.state.buffered_ms = rt
+                .handle
+                .get_buffered_ms(info.sample_rate, info.channels);
+        }
+    }
+    Ok((StatusCode::OK, Json(json!({ "state": snapshot.state }))))
+}
+
+/// Outcome of comparing a requested seek target against the live decoded
+/// buffer. Extracted so the seek-route 409 logic is unit-testable without
+/// a real CPAL device.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SeekDecision {
+    /// Either no runtime is active, or the buffer is fresh (no samples
+    /// published yet), or the target sits within the decoded region. Dispatch
+    /// the seek to the runtime as normal.
+    Dispatch,
+    /// Target is strictly past the decoded portion of the live buffer and
+    /// the runtime has actually published a non-zero buffered_samples value
+    /// (so we know we're not in the pre-first-callback fresh state). Reject
+    /// with 409.
+    RejectPastBuffer,
+}
+
+fn evaluate_seek_decision(
+    target_samples: u64,
+    buffered_samples: u64,
+    runtime_active: bool,
+) -> SeekDecision {
+    if !runtime_active {
+        return SeekDecision::Dispatch;
+    }
+    // buffered_samples == 0 means the audio callback hasn't published any
+    // value yet (engine cold-starting, first callback not fired). Treat that
+    // as "unknown, let the runtime decide" rather than blanket-rejecting all
+    // seeks during the cold-start window.
+    if buffered_samples == 0 {
+        return SeekDecision::Dispatch;
+    }
+    if target_samples > buffered_samples {
+        SeekDecision::RejectPastBuffer
+    } else {
+        SeekDecision::Dispatch
+    }
+}
+
+async fn evaluate_seek_against_buffer(state: &SharedState, target_ms: i64) -> SeekDecision {
+    let g = state.read().await;
+    let Some((rt, info)) = g
+        .playback_runtime
+        .as_ref()
+        .zip(g.playback_runtime_info.as_ref())
+    else {
+        return SeekDecision::Dispatch;
+    };
+    let sr = info.sample_rate as u64;
+    let ch = info.channels as u64;
+    let target_samples = if target_ms <= 0 {
+        0
+    } else {
+        (target_ms as u64).saturating_mul(sr).saturating_mul(ch) / 1_000
+    };
+    let buffered_samples = rt.handle.buffered_samples();
+    evaluate_seek_decision(target_samples, buffered_samples, true)
 }
 
 async fn set_playback_volume(
@@ -11461,6 +11569,51 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::Arc;
     use tower::ServiceExt;
+
+    #[test]
+    fn evaluate_seek_decision_dispatches_when_no_runtime_active() {
+        // Without an active runtime there's no buffered_samples truth to gate
+        // on; let the normal handler path run (it is a no-op anyway).
+        assert_eq!(
+            super::evaluate_seek_decision(1_000_000, 0, false),
+            super::SeekDecision::Dispatch,
+        );
+    }
+
+    #[test]
+    fn evaluate_seek_decision_dispatches_when_buffer_is_fresh() {
+        // buffered_samples == 0 means the audio callback hasn't published yet
+        // (cold start). Don't blanket-reject in that window.
+        assert_eq!(
+            super::evaluate_seek_decision(500_000, 0, true),
+            super::SeekDecision::Dispatch,
+        );
+    }
+
+    #[test]
+    fn evaluate_seek_decision_dispatches_when_target_within_buffered() {
+        assert_eq!(
+            super::evaluate_seek_decision(100_000, 200_000, true),
+            super::SeekDecision::Dispatch,
+        );
+        // Equal target is OK (seek to the buffer tail).
+        assert_eq!(
+            super::evaluate_seek_decision(200_000, 200_000, true),
+            super::SeekDecision::Dispatch,
+        );
+    }
+
+    #[test]
+    fn evaluate_seek_decision_rejects_target_strictly_past_buffer() {
+        // This is the central case: user drags the scrubber 1-2 minutes ahead
+        // while a TIDAL track is still loading. Frontend's clamp should keep
+        // this from happening, but the route ack is the backstop for any
+        // other client (mobile remote, future API consumers).
+        assert_eq!(
+            super::evaluate_seek_decision(300_000, 200_000, true),
+            super::SeekDecision::RejectPastBuffer,
+        );
+    }
 
     fn test_track(id: i64, title: &str) -> crate::db::models::Track {
         crate::db::models::Track {

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -12947,6 +12947,7 @@ mod tests {
                 automix_discover_new: true,
                 automix_use_learning: true,
                 automix_allow_external: true,
+                buffered_ms: 0,
             },
             queue: vec![
                 test_queue_item(10, current, 0, "manual"),


### PR DESCRIPTION
## Summary

Long-term fix for the scrubber-revert UX seam left over by PR #41's Task 4 (`PlaybackBuffer::seek_to` now honestly rejects seeks past the decoded portion, but the frontend kept optimistically advancing and snapping back). Tonight's smoke test produced 50+ `Playback seek target is not decoded yet` WARNs when dragging the scrubber 1-2 minutes ahead on a still-loading TIDAL track.

End-to-end the fix is:

- **Backend telemetry**: `PlaybackSharedState` publishes `buffered_samples` from the CPAL callback on every drain (real-time-safe Relaxed atomic store, no allocation, same pattern as the existing `growth_warned` / `position_samples` mirrors).
- **Redirectable handle**: new `buffered_source: Arc<Mutex<Arc<AtomicU64>>>` on `PlaybackRuntimeHandle` mirrors the existing `position_source` and gets redirected at the same 4 sites (cold-start exclusive, cold-start shared, `promote_next_to_active`, `promote_prepared_at_boundary`). Without this a Switch or crossfade would silently leak the previous track's buffer counter into the route ack.
- **DTO**: `PlaybackState.buffered_ms: i64` with `#[serde(default)]` so older JSON payloads / non-updated literals keep working.
- **Live-snapshot helper**: `build_live_playback_snapshot` is now the single source of truth for `GET /api/playback/state` and the new 409 path - so the rejection decision and the body it returns come from the same read.
- **Seek ack**: `POST /api/playback/position` runs `evaluate_seek_decision(target_samples, buffered_samples, runtime_active)` (extracted as a pure function for unit tests) and returns HTTP 409 with the live snapshot when the target is past the decoded buffer.
- **Frontend**: `buffered` writable store + 1 Hz `/api/playback/state` refresher while `buffered_ms < duration_ms`. `NowPlayingProgress` renders a softer-gray buffered fill behind the accent fill and clamps the `<input type=range max>` so dragging past the loaded region is impossible. `setPlayerPosition` catches 409 explicitly, applies the live state from the body, and skips the error toast.
- `ApiError` grows a `body` field carrying the parsed response - backwards-compatible (defaults to null).

## Codex adversarial review folded in

The plan was reviewed by codex-rescue before execution. All findings landed:

| Severity | Finding | Resolution |
|---|---|---|
| P1 | `buffered_ms()` accessor tied to the initial engine's atomic would read stale data after a Switch / crossfade promotion | `buffered_source` mirrors `position_source`'s redirect at every update site + new regression test |
| P2 | `fetchApi` throws on non-2xx so the 409 body was never reachable from the caller | `ApiError` now carries the parsed body; `setPlayerPosition` has an explicit 409 catch path |
| P2 | 409 body could carry stale `position_ms` while the rejection decision came from a live `buffered_ms` read | Extracted `build_live_playback_snapshot` - both the 409 body and the regular `GET /api/playback/state` response come from the same helper |
| P3 | Adding a required `buffered_ms` breaks manual struct literals | `#[serde(default)]` + explicit `buffered_ms: 0` at the two DB-snapshot construction sites; TS type made optional |
| P3 | `duration === 0` collapses scrubber max to 0 | Range max calc disables input when `duration <= 0` |
| P3 | Frontend 409-catch was untested | New tests in `player-ephemeral-favorite.test.ts` for valid 409 / non-409 fall-through / malformed 409 body |

## Test plan

- [x] `cargo test -p noor-server`: 675 passed / 0 failed
- [x] `cargo check -p noor-server -p noor-app`: clean
- [x] `cargo fmt --all -- --check`: clean
- [x] `npm run check` (svelte-check): 580 files / 0 errors / 0 warnings
- [x] `npm run test` (vitest): 50 files / 227 tests / all pass
- [ ] Manual smoke: launch new build, play a TIDAL track, drag the scrubber as far right as possible during loading. Expected: scrubber stops at the buffered region (visible as the secondary darker bar), does not snap. No `Playback seek target is not decoded yet` WARNs from user-driven seeks.

## Dependency

Targets `claude/kind-bhaskara-b8e359` (the PR #41 branch). Once #41 merges this should auto-retarget to master.

## Out of scope (deferred to own plans)

- True decoder-side seek for TIDAL DASH (request the segment containing the target sample and re-prime the decoder). Would let the user seek anywhere immediately even on a fresh track.
- Pre-buffering ahead of the playhead. Decode is sequential today; this PR only makes the buffered region honest.
- WebSocket `BufferProgress` push event. Polling at 1 Hz is enough for the UX target and avoids the WS event-shape boundary the prior plan deliberately protected.
- Frontend skip-next debounce (separate concern: rapid skip-next can trigger TIDAL HTTP 429 which Task 9 of #41 now surfaces as an error toast).
- Mobile `/remote` scrubber UI (separate component tree).