### PR TITLE
feat(playback): true DASH segment seek (option C)

### DIFF
--- a/docs/dash-segment-seek-plan.md
+++ b/docs/dash-segment-seek-plan.md
@@ -1,0 +1,441 @@
+# Plan: True DASH segment seek (option C)
+
+> Revision 7 (final). Four small cleanups on r6 - no architectural change,
+> all minor: removed an undefined helper reference (`return_outcome`),
+> dropped a duplicate paragraph, made the route's None-runtime branch
+> explicit, and filled in `get_buffered_start_ms`'s body so the handle
+> read pattern is unambiguous. Added one risk entry on serial command
+> processing during transitions. Plan is decision-complete.
+>
+> --- r6 fixes (still apply) ---
+>
+> Three plan-quality fixes folded into r5 (no architectural
+> change):
+>
+> A. **Move `evaluate_seek_decision` and `SeekDecision` out of `routes.rs`**
+>    into the runtime module. r5 had the runtime consuming a helper that
+>    lives in the server-routes file, which would create a wrong-direction
+>    dependency (playback runtime depending on the HTTP layer). r6 puts the
+>    pure helper in `noor-server/src/playback/runtime/mod.rs` (or a
+>    runtime-private submodule); the route only consumes `SeekToOutcome`.
+>
+> B. **Fix the JSON shape in route examples.** `build_live_playback_snapshot`
+>    returns `player::PlaybackSnapshot` (a struct with `.state` and `.queue`
+>    - see routes.rs:5996-6002, 7430-7434, 7462). r5 examples wrote
+>    `Json(json!({ "state": snapshot }))` which would double-wrap. Correct
+>    shape: `Json(json!({ "state": snapshot.state }))`.
+>
+> C. **Document the borrow-checker pattern for the `SeekTo` handler.** Inside
+>    `run_runtime_loop`, reading `state.engine.as_ref().shared` / `.job`
+>    holds an immutable borrow of `state`. Calling `transition_to_job(state, ...)`
+>    needs a mutable borrow. The handler must extract everything (clone
+>    job, copy `offset_samples`, clone the resolved offsets if needed) into
+>    locals BEFORE dropping the immutable borrow, then call
+>    `transition_to_job` with the locals.
+>
+> --- r5 review (still applies) ---
+>
+> Folds in adversarial review of revision 4. Three blockers and
+> one consistency issue:
+>
+> 1. **Unreachable on the UI** - `NowPlayingProgress` still clamps `scrubMax`
+>    to `bufferedMs`, so the user physically can't drag past the buffered
+>    region. The whole feature was reachable only by a stale client
+>    bypassing the clamp. Fix: drop the forward clamp, let the user drag
+>    to anywhere in `[0, duration]`. The buffered bar stays as a visual
+>    cue. Backend's `SeekTo` decides what to do.
+>
+> 2. **Decoded range after segment-restart is `[offset, buffered]`, not
+>    `[0, buffered]`.** The fast-path `target <= buffered` would accept a
+>    backward seek that's BEFORE the current engine's offset, then the CPAL
+>    callback's `saturating_sub` would clamp to buffer start, playing the
+>    wrong audio while reporting the wrong position. Fix: fast-path needs
+>    BOTH bounds (`offset <= target <= buffered`); anything outside takes
+>    the segment-seek transition or rejection path.
+>
+> 3. **Legacy route path becomes incorrect once offsets exist.** A legacy
+>    client seeking before the current segment offset would not be rejected
+>    by `evaluate_seek_decision` (which only checks the upper bound), but
+>    the in-buffer seek would land on garbage. Fix: route everything through
+>    `SeekTo`. Don't keep two seek paths. The flag `allow_segment_seek`
+>    becomes an input to the runtime's decision, not a route-level
+>    bifurcation.
+>
+> 4. **Consistency: when does `Dispatched` get sent?** r4 said both
+>    "before priming completes" and "after transition_to_job returns Ok".
+>    Pick one. Revision 5: reply AFTER `transition_to_job` returns. Add
+>    `SeekToOutcome::Failed` so transition errors propagate.
+
+## Baseline (master @ 4b87f98)
+
+(Same as revision 4 - all the r4 baseline facts still hold.)
+
+Additional baseline relevant to r5 fixes:
+
+- [`NowPlayingProgress.svelte:49-53`](frontend/src/lib/components/now-playing/NowPlayingProgress.svelte:49): `scrubMax` is `duration > 0 ? Math.min(duration, Math.max(scrubPosition, position, bufferedMs)) : 0`. The forward clamp to `bufferedMs` is what we shipped in #43 to prevent past-buffer drags. With option C, the backend handles past-buffer correctly, so this clamp is now what's BLOCKING the feature.
+- [`evaluate_seek_decision`](noor-server/src/server/routes.rs:7481): checks only `target_samples > buffered_samples`. No lower bound. Correct as long as `offset == 0`; incorrect once segment-seek creates engines with non-zero offsets.
+
+## Ownership model
+
+Same as revisions 3-4:
+- `PreparedPlaybackJob.{start_from_segment_index, start_from_offset_ms}` carries start params.
+- `PlaybackSharedState.segment_offsets_ms: OnceLock<Vec<u64>>` populated by `decode_and_buffer_job`.
+- `PlaybackEngine.job: PreparedPlaybackJob` cached at construction.
+- `position_samples` and `buffered_samples` are ABSOLUTE-track samples.
+
+New for r5:
+- Route is the dumb dispatcher; the runtime's `SeekTo` handler is the single decision point. `evaluate_seek_decision` moves out of the route entirely (or is repurposed as a pure helper called from the runtime's handler).
+
+## Approach
+
+### 1. Surface segment timing in `StreamInfo`
+
+(Unchanged from r4.) `parse_dash_segment_template` populates `pub segment_offsets_ms: Vec<u64>` on `StreamInfo` from `current_time * 1000 / timescale` in both parser branches.
+
+### 2. Shared state: `OnceLock` for offsets, atomic for position offset
+
+(Unchanged from r4.) `PlaybackSharedState` gains:
+- `pub(crate) segment_offsets_ms: std::sync::OnceLock<Vec<u64>>`
+- `pub(crate) position_offset_samples: AtomicU64`
+
+`PlaybackSharedState::new` accepts the initial `position_offset_samples` value, seeded by the caller from `job.start_from_offset_ms`.
+
+### 3. Job carries start params; engine caches job
+
+(Unchanged from r4.) `PreparedPlaybackJob` gains `start_from_segment_index: usize` and `start_from_offset_ms: u64`. `PlaybackEngine` gains `pub(super) job: PreparedPlaybackJob`. `#[cfg(test)] PreparedPlaybackJob::test_fixture(track_id, generation)` exists for `test_with_shared`.
+
+### 4. Decode path slicing
+
+(Unchanged from r4.) `decode_and_buffer_job` slices `segment_urls.iter().skip(start_from_segment_index)` BEFORE computing `dash_initial_media_count`. `shared.segment_offsets_ms.set(stream_info.segment_offsets_ms.clone()).ok()` is called immediately after `resolve_stream()` returns.
+
+### 5. Absolute-sample accounting
+
+(Mostly unchanged from r4.) Quick recap:
+- `position_samples.store(offset_samples, ...)` at [mod.rs:1043](noor-server/src/playback/runtime/mod.rs:1043), with `offset_samples` computed inline from `job.start_from_offset_ms`.
+- CPAL callback's `seek_target_samples` is absolute; computes `local = abs.saturating_sub(offset)` before `guard.seek_to(local)`. **New for r5:** before issuing the local seek, also verify `abs >= offset`. If `abs < offset`, the seek is out-of-buffer and should be rejected (the CPAL callback's `saturating_sub` clamp would mask the error otherwise). Emit the existing "seek target is not decoded yet" WARN with a slightly different reason note. This is defense-in-depth - the runtime's `SeekTo` handler should already have rejected before writing `seek_target_samples`, but keeping the callback honest is cheap.
+- `publish_buffered_samples(offset + guard.samples.len())` (absolute upper bound).
+
+### 6. Add absolute lower bound to the live snapshot
+
+Add `pub buffered_start_ms: i64` to `PlaybackState` ([db/models.rs](noor-server/src/db/models.rs)), `#[serde(default)]` for backwards-compat. Populated in `build_live_playback_snapshot` ([routes.rs:5951](noor-server/src/server/routes.rs:5951)) from a new handle method:
+
+```rust
+// On PlaybackRuntimeHandle, mirroring get_buffered_ms:
+pub fn get_buffered_start_ms(&self, device_sample_rate: u32, device_channels: u16) -> i64 {
+    if device_sample_rate == 0 || device_channels == 0 { return 0; }
+    let samples = self.offset_source.lock().unwrap().load(Ordering::Relaxed);
+    (samples * 1000 / (device_sample_rate as u64 * device_channels as u64)) as i64
+}
+```
+
+Caller in `build_live_playback_snapshot` reads rate/channels from `state.playback_runtime_info` exactly like the existing `get_buffered_ms` overlay at [routes.rs:5963](noor-server/src/server/routes.rs:5963). Same pattern, no new infra.
+
+Tradeoff acknowledgment: this DOES add a third redirect mirror, which r3/r4 deliberately avoided. But the alternatives (compute on-demand by reading the active engine's shared state through a separate path, or fold offset into the snapshot helper directly) all break the redirect-after-promote invariant that #43 carefully established. Adding `offset_source: Arc<Mutex<Arc<AtomicU64>>>` and redirecting it alongside the existing two is the consistent move.
+
+Update `evaluate_seek_decision` ([routes.rs:7481](noor-server/src/server/routes.rs:7481)) to take both bounds and reject either way - **but** in r5 the route doesn't call it directly anymore (see step 9). Keep the helper as a pure function (it's still useful for the runtime's `SeekTo` handler):
+
+```rust
+pub(super) fn evaluate_seek_decision(
+    target_samples: u64,
+    buffered_start_samples: u64,
+    buffered_samples: u64,
+    runtime_active: bool,
+) -> SeekDecision {
+    if !runtime_active { return SeekDecision::Dispatch; }
+    if buffered_samples == 0 { return SeekDecision::Dispatch; }
+    if target_samples < buffered_start_samples || target_samples > buffered_samples {
+        SeekDecision::RejectOutOfBuffer
+    } else {
+        SeekDecision::Dispatch
+    }
+}
+```
+
+(`RejectPastBuffer` renames to `RejectOutOfBuffer` to reflect the two-sided check.)
+
+### 7. Runtime command + outcome enum
+
+```rust
+pub enum PlaybackRuntimeCommand {
+    // ...existing variants...
+    SeekTo {
+        target_ms: i64,
+        allow_segment_seek: bool,
+        respond_to: std::sync::mpsc::Sender<SeekToOutcome>,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SeekToOutcome {
+    Dispatched,
+    RejectedOutOfBuffer,
+    Failed,  // transition_to_job errored
+}
+```
+
+Note: `allow_segment_seek` is now part of the command, not a route-level switch. The runtime applies the right semantics. `mpsc::Sender` keeps `PlaybackRuntimeCommand: Clone` (same precedent as `TrackStatus`).
+
+Handler in `run_runtime_loop` (borrow-check aware - see r6 fix C):
+
+```rust
+// Phase 1: snapshot everything we need under an immutable borrow.
+let decision = {
+    let Some(engine) = state.engine.as_ref() else {
+        respond_to.send(SeekToOutcome::RejectedOutOfBuffer).ok();
+        return;
+    };
+    let target_samples = (target_ms.max(0) as u64) * rate as u64 * channels as u64 / 1000;
+    let offset_samples = engine.shared.position_offset_samples.load(Ordering::Relaxed);
+    let buffered_samples = engine.shared.buffered_samples.load(Ordering::Relaxed);
+
+    // Pure-helper call (lives in runtime module per r6 fix A).
+    match evaluate_seek_decision(target_samples, offset_samples, buffered_samples, true) {
+        SeekDecision::Dispatch => SeekHandling::InBuffer { target_samples },
+        SeekDecision::RejectOutOfBuffer if !allow_segment_seek => SeekHandling::Reject,
+        SeekDecision::RejectOutOfBuffer => {
+            let Some(offsets) = engine.shared.segment_offsets_ms.get() else {
+                respond_to.send(SeekToOutcome::RejectedOutOfBuffer).ok();
+                return;
+            };
+            if offsets.is_empty() {
+                respond_to.send(SeekToOutcome::RejectedOutOfBuffer).ok();
+                return;
+            }
+            // Find largest N such that offsets[N] in samples <= target_samples.
+            let n = offsets
+                .iter()
+                .rposition(|off_ms| (*off_ms * rate as u64 * channels as u64 / 1000) <= target_samples)
+                .unwrap_or(0);
+            let new_offset_ms = offsets[n];
+            // Clone job so the borrow ends with this scope.
+            let new_job = {
+                let mut j = engine.job.clone();
+                j.start_from_segment_index = n;
+                j.start_from_offset_ms = new_offset_ms;
+                j
+            };
+            SeekHandling::SegmentSeek { job: new_job }
+        }
+    }
+}; // immutable borrow of state.engine ends here
+
+// Phase 2: act on the decision under a mutable borrow.
+match decision {
+    SeekHandling::InBuffer { target_samples } => {
+        state.engine.as_ref().unwrap().shared
+            .seek_target_samples.store(target_samples, Ordering::Relaxed);
+        respond_to.send(SeekToOutcome::Dispatched).ok();
+    }
+    SeekHandling::Reject => {
+        respond_to.send(SeekToOutcome::RejectedOutOfBuffer).ok();
+    }
+    SeekHandling::SegmentSeek { job } => {
+        match transition_to_job(
+            config, &command_tx, device, output_config, output_sample_format,
+            event_tx, state, job, volume_ctl, position_samples,
+            position_source, buffered_source, /* force_restart */ true,
+        ) {
+            Ok(()) => { respond_to.send(SeekToOutcome::Dispatched).ok(); }
+            Err(_) => { respond_to.send(SeekToOutcome::Failed).ok(); }
+        }
+    }
+}
+```
+
+Reply confirms the runtime ACCEPTED the seek and (for segment-seek) finished promoting the new engine. It does NOT confirm audible playback - the new engine still primes samples after `transition_to_job` returns. Frontend's 1 Hz refresher converges within ~1s.
+
+`rate` and `channels` for the `target_samples` math come from `state.device_sample_rate` plus the engine's stream config; the existing `transition_to_job` already passes these around. Read from whichever local is in scope at the handler call site (confirm at execution time - the `run_runtime_loop` body already has both for other reasons).
+
+### 8. Public handle method
+
+```rust
+/// Segment-aware seek. Single entry point for all seek requests; the runtime
+/// decides between in-buffer fast path, forced-restart segment-seek, or
+/// rejection. The `allow_segment_seek` flag opts in to the segment-seek
+/// transition; with `false`, the runtime treats out-of-buffer seeks as
+/// rejected (legacy semantics).
+///
+/// Blocks up to 1500ms for the reply (segment-seek transitions can take
+/// >250ms when the new engine has to spin up the decoder thread).
+/// Returns Failed on timeout (treat as recoverable error; frontend retries).
+pub fn seek_to_segment_aware(
+    &self,
+    position_ms: i64,
+    allow_segment_seek: bool,
+) -> SeekToOutcome {
+    let (tx, rx) = std::sync::mpsc::channel();
+    if self
+        .send(PlaybackRuntimeCommand::SeekTo {
+            target_ms: position_ms,
+            allow_segment_seek,
+            respond_to: tx,
+        })
+        .is_err()
+    {
+        return SeekToOutcome::Failed;
+    }
+    rx.recv_timeout(std::time::Duration::from_millis(1500))
+        .unwrap_or(SeekToOutcome::Failed)
+}
+```
+
+Timeout bumped from 250ms (r4) to 1500ms because the reply now waits for `transition_to_job` to return, which includes engine teardown + new engine spin-up. The fast path replies immediately (well under 1500ms).
+
+Keep the legacy `pub fn seek(&self, position_ms: i64) -> Result<()>` as a thin wrapper for callers that don't care about the outcome detail:
+
+```rust
+pub fn seek(&self, position_ms: i64) -> Result<()> {
+    match self.seek_to_segment_aware(position_ms, /* allow_segment_seek */ false) {
+        SeekToOutcome::Dispatched => Ok(()),
+        SeekToOutcome::RejectedOutOfBuffer => Err(anyhow!("seek target is out of buffer")),
+        SeekToOutcome::Failed => Err(anyhow!("seek dispatch failed")),
+    }
+}
+```
+
+This way the old `Seek(i64)` command variant disappears - one less seek path in the codebase. Audit existing callers of `handle.seek(...)` and confirm they're OK with the slightly different error shape.
+
+### 9. Route handler - one path, both flags
+
+`POST /api/playback/position`:
+
+```rust
+#[derive(Deserialize)]
+struct SetPlaybackPositionPayload {
+    position_ms: i64,
+    #[serde(default)]
+    allow_segment_seek: bool,
+}
+
+async fn set_playback_position(...) -> Result<(StatusCode, Json<Value>), StatusCode> {
+    // `playback_runtime` is Option (None on pre-first-play boot). Treat
+    // no-runtime the same as the existing route (silent OK with current
+    // snapshot); a seek with no runtime is a UI race we don't need to fail.
+    let handle = {
+        let g = state.read().await;
+        g.playback_runtime.as_ref().map(|rt| rt.handle.clone())
+    };
+    let outcome = match handle {
+        Some(handle) => {
+            let allow = payload.allow_segment_seek;
+            let pos = payload.position_ms;
+            tokio::task::spawn_blocking(move || handle.seek_to_segment_aware(pos, allow))
+                .await
+                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        }
+        None => SeekToOutcome::RejectedOutOfBuffer,
+    };
+
+    let snapshot = build_live_playback_snapshot(&state).await?;
+
+    // r6 fix B: snapshot is PlaybackSnapshot; the JSON body shape is
+    // { "state": PlaybackState } - serialize snapshot.state, not snapshot.
+    match outcome {
+        SeekToOutcome::Dispatched => Ok((
+            StatusCode::ACCEPTED,
+            Json(json!({ "state": snapshot.state })),
+        )),
+        SeekToOutcome::RejectedOutOfBuffer => Ok((
+            StatusCode::CONFLICT,
+            Json(json!({ "state": snapshot.state })),
+        )),
+        SeekToOutcome::Failed => Err(StatusCode::INTERNAL_SERVER_ERROR),
+    }
+}
+```
+
+`tokio::task::spawn_blocking` wraps the sync `recv_timeout` so it doesn't park an async executor thread. No DB write either way; `build_live_playback_snapshot` already overlays the runtime's live position.
+
+The route no longer calls `evaluate_seek_decision` directly - the runtime owns the helper now (r6 fix A: the pure helper and `SeekDecision` enum live in `noor-server/src/playback/runtime/mod.rs`, not in `noor-server/src/server/routes.rs`). The runtime module exports `SeekToOutcome` publicly; the route consumes only that.
+
+### 10. Frontend: drop the forward clamp
+
+Update `NowPlayingProgress.svelte` ([49-53](frontend/src/lib/components/now-playing/NowPlayingProgress.svelte:49)):
+
+```typescript
+let scrubMax = $derived(duration > 0 ? duration : 0);
+```
+
+The buffered fill div (`np-progress-buffered`) keeps its current size (`(bufferedMs / duration) * 100%`) as a visual cue showing the user what's currently decoded. The dragging range is full track.
+
+Optional polish: render `buffered_start_ms` as a secondary fill marker (e.g., a thin vertical line on the buffered bar) so the user can see "decoded range starts here." Skip unless smoke testing shows users get confused.
+
+`setPlayerPosition` in [`player.ts:514`](frontend/src/lib/stores/player.ts:514) always sends `allow_segment_seek: true`. The existing 409 catch path stays for the pre-resolve / no-DASH-offsets fallback. New: handle the 500 status (treat as a recoverable error, show toast, allow retry - same shape as the existing 409 catch but with a different message).
+
+### 11. Cancel-in-flight
+
+(Unchanged from r4.) `transition_to_job` tears down the prior engine. Three rapid `SeekTo`s produce three transitions; only the last engine survives. Each call gets its own reply channel.
+
+Edge case: rapid SeekTo while one is in flight inside `transition_to_job`. The runtime processes commands serially in `run_runtime_loop`, so a second SeekTo waits until the first transition completes. With 1500ms timeout, this is fine for normal user interaction; for spammed seeks, the second one waits and may see the new (post-transition) state. Acceptable.
+
+### 12. Tests
+
+Backend:
+- (r4 list, plus the following.)
+- **Lower-bound check**: build an engine with offset = 30000ms. Send `SeekTo` with `target_ms = 10000` (before offset). Assert reply is `RejectedOutOfBuffer` if `allow_segment_seek=false`, `Dispatched` (with transition) if `allow_segment_seek=true`.
+- **Backward seek into in-buffer range**: with offset = 30000ms and buffered up to 50000ms, send `SeekTo(target_ms=40000)`. Fast path applies; no transition.
+- **Pure helper**: unit test `evaluate_seek_decision(target, start, buffered, active)` with all combinations of inside/below-start/above-buffered/inactive.
+- **Failed outcome**: mock `transition_to_job` to return Err; assert reply is `Failed`.
+- **CPAL out-of-buffer rejection**: write `seek_target_samples = (offset - 1)` (below offset); assert the buffer's `read_pos` stays unchanged and the WARN fires.
+- **handle.seek() wrapper**: confirm legacy callers see `Result<()>` and the right error variant.
+
+Frontend:
+- (r4 list, plus the following.)
+- **Scrubber unclamped**: render `NowPlayingProgress` with `bufferedMs = 5000, duration = 100000, position = 1000`; assert the `<input>`'s `max` attribute is `100000`, not `5000`.
+- **500 handling**: mock the route to return 500; assert `setPlayerPosition` sets `playerError` and the user can retry.
+
+## Files to modify
+
+- [noor-server/src/services/tidal/stream.rs](noor-server/src/services/tidal/stream.rs) - `StreamInfo.segment_offsets_ms`.
+- [noor-server/src/playback/decode/mod.rs](noor-server/src/playback/decode/mod.rs) - slice segments by `start_from_segment_index` for BOTH prebuffer count and remainder; publish offsets to shared state.
+- [noor-server/src/playback/runtime/shared.rs](noor-server/src/playback/runtime/shared.rs) - `OnceLock<Vec<u64>>` for offsets, `position_offset_samples` atomic, absolute-sample accounting in CPAL callback (with the new `< offset` rejection check).
+- [noor-server/src/playback/runtime/engine.rs](noor-server/src/playback/runtime/engine.rs) - `PlaybackEngine.job`; `test_with_shared` uses `PreparedPlaybackJob::test_fixture`.
+- [noor-server/src/playback/runtime/commands.rs](noor-server/src/playback/runtime/commands.rs) - `PlaybackRuntimeCommand::SeekTo { target_ms, allow_segment_seek, respond_to: mpsc::Sender<SeekToOutcome> }`; `SeekToOutcome::{Dispatched, RejectedOutOfBuffer, Failed}`. Remove the old `Seek(i64)` variant (or keep transitionally - audit and decide).
+- [noor-server/src/playback/runtime/mod.rs](noor-server/src/playback/runtime/mod.rs) - `pub fn seek_to_segment_aware(...)` and the wrapper `pub fn seek(...)`; new `offset_source: Arc<Mutex<Arc<AtomicU64>>>` redirected at the same 4 sites as `position_source`/`buffered_source`; `pub fn get_buffered_start_ms(...)`; `SeekTo` handler in `run_runtime_loop` doing the in-buffer / segment-seek / reject decision and replying after `transition_to_job` returns (see r6 borrow-check pattern in §7); `transition_to_job` seeds `offset_samples` from `job.start_from_offset_ms` and `engine.job = job.clone()`. **Move `evaluate_seek_decision` and `SeekDecision` here from `server/routes.rs`** (r6 fix A) - extend the signature to take both bounds (`buffered_start_samples`, `buffered_samples`), rename rejection variant to `RejectOutOfBuffer`, and update the runtime-internal unit tests at routes.rs:11572-11611 to live alongside (the existing tests can come along to runtime tests with minor adjustments).
+- [noor-server/src/playback/player.rs](noor-server/src/playback/player.rs) - `PreparedPlaybackJob` start fields; `test_fixture`.
+- [noor-server/src/db/models.rs](noor-server/src/db/models.rs) - `PlaybackState.buffered_start_ms: i64` with `#[serde(default)]`.
+- [noor-server/src/server/routes.rs](noor-server/src/server/routes.rs) - `SetPlaybackPositionPayload.allow_segment_seek: bool`; route always dispatches via `seek_to_segment_aware` and consumes `SeekToOutcome` only; `build_live_playback_snapshot` populates `buffered_start_ms` from `handle.get_buffered_start_ms(...)`. **Remove the in-file `evaluate_seek_decision`, `SeekDecision`, `evaluate_seek_against_buffer` and their unit tests** (moved to runtime per r6 fix A). The route's response body for 202/409 uses `snapshot.state`, not `snapshot` (r6 fix B - `build_live_playback_snapshot` returns `PlaybackSnapshot`, not bare `PlaybackState`; see existing routes.rs:5999/7433/7462 for the pattern).
+- [frontend/src/lib/api/client.ts](frontend/src/lib/api/client.ts) - request body type gains `allow_segment_seek?: boolean`; `PlaybackState` TS type gains `buffered_start_ms?: number`.
+- [frontend/src/lib/stores/player.ts](frontend/src/lib/stores/player.ts) - `setPlayerPosition` always sends `allow_segment_seek: true`; handle 500 with error toast; `buffered_start` writable populated from state if we want the secondary fill marker.
+- [frontend/src/lib/components/now-playing/NowPlayingProgress.svelte](frontend/src/lib/components/now-playing/NowPlayingProgress.svelte) - `scrubMax = duration > 0 ? duration : 0` (drop the forward clamp). Optional: secondary fill marker for `buffered_start_ms`.
+- Test files.
+
+## Verification
+
+End-to-end smoke (after build):
+1. Play a TIDAL track. Within ~1.5s (post-resolve), drag scrubber to 75%. Expected: brief audio gap (<1.5s), playback resumes at ~75%. Buffered bar visually resets. **The scrubber should actually reach 75%** (this is the r5 fix verifying).
+2. Seek immediately at track start (pre-resolve). Expected: 409 returned, scrubber snaps back, frontend handles via existing 409 catch. User retries; step 1 works.
+3. After segment-restart at 75%, drag scrubber BACK to 20%. Expected: target is below the current engine's offset, runtime takes the segment-seek path again, new engine starts at ~20%.
+4. After segment-restart at 75%, drag scrubber to 78% (small forward inside the current buffer). Expected: fast-path applies, no transition, audio jumps within ~50ms.
+5. Rapid-fire seek (50% → 20% → 80% within ~500ms). Expected: each POST gets a reply (202 or 409). Only the last engine survives. No audio glitches beyond the single audible gap at the final seek.
+6. Local-file track: `segment_offsets_ms` empty; past-buffer seek returns 409, frontend catches. Forward seek within buffered region works as today.
+7. Tail noor-server.log during step 1: zero "seek target is not decoded yet" WARN lines from user seeks (runtime intercepts them).
+8. Mid-seek, fire Stop. Expected: clean tear-down. Pending `SeekTo` reply gets dropped (Receiver returns `RecvError`); route returns 500 (treat as recoverable; frontend toast). No orphan decoder.
+
+Tests:
+```powershell
+cargo test -p noor-server services::tidal::stream
+cargo test -p noor-server playback::runtime
+cargo test -p noor-server server::routes
+cargo check -p noor-server
+cargo fmt --all -- --check
+cd frontend; npm run check; npm test
+```
+
+## Risks and open questions
+
+- **Adding a third redirect (`offset_source`)** restores some of the complexity #43 minimized. It's worth it for r5's lower-bound check on the route side; the alternative (no `buffered_start_ms` exposed) means the route can't safely handle legacy clients seeking around a non-zero offset.
+- **`recv_timeout(1500ms)` plus `spawn_blocking`** means at most one async worker is parked per concurrent seek. Acceptable for a UI-driven endpoint (1 user, 1 seek at a time).
+- **Legacy `handle.seek()` wrapper** changes error shape slightly. Audit `git grep "\.seek(" noor-server/src/` for external callers and confirm none care about the specific error variant.
+- **Removing the `Seek(i64)` command variant** vs keeping it transitionally: simpler to remove. If audit reveals a non-route caller that genuinely needs the old behavior, keep `Seek` as a thin wrapper that dispatches `SeekTo { allow_segment_seek: false }`.
+- **Pre-resolve seeks return 409.** First ~half-second of a fresh track, OnceLock unset. Frontend's existing 409 catch handles it.
+- **Init-segment URL expiry**, **TIDAL rate-limit**, **decoder teardown race**, **buffer mutex during restart**: same as r4.
+- **Serial runtime-loop processing**: a `transition_to_job` in flight blocks ALL other commands (Pause, Stop, Volume changes, even another SeekTo) until it returns. This is pre-existing behavior (Switch / Next / Prev have the same shape), but option C makes seeks a new source of multi-hundred-ms commands. If smoke testing exposes pause-during-seek lag, the follow-up is to make `transition_to_job` yield via a state machine inside the loop rather than block synchronously. Out of scope for this plan.
+
+## Out of scope (explicit)
+
+- Pre-buffering ahead of the playhead beyond what segments provide.
+- WebSocket "seek-pending" event.
+- HLS video seek.
+- Gapless seek via dual-engine crossfade.
+- Runtime-driven DB writes for live position (hibernation accuracy).

--- a/frontend/scripts/player-ephemeral-favorite.test.ts
+++ b/frontend/scripts/player-ephemeral-favorite.test.ts
@@ -228,4 +228,16 @@ describe('setPlayerPosition 409 ack handling', () => {
 
 		expect(get(playerError)).not.toBeNull();
 	});
+
+	test('opts in to segment-seek (option C) on every seek request', async () => {
+		// Pin the API contract: setPlayerPosition MUST send
+		// allow_segment_seek=true. Drops to the legacy 409 reject path if
+		// this regresses to false, so the failure mode would be silent UX
+		// degradation rather than a crash - the test backstops that.
+		apiMock.setPlaybackPosition.mockResolvedValueOnce({ state: buildState() });
+
+		await setPlayerPosition(75_000);
+
+		expect(apiMock.setPlaybackPosition).toHaveBeenCalledWith(75_000, true);
+	});
 });

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -605,6 +605,13 @@ export interface PlaybackState {
 	 * should `?? 0` and treat missing as "unknown / no buffer info yet".
 	 */
 	buffered_ms?: number;
+	/**
+	 * Track-time offset (ms) where the audibly-current engine's decoded
+	 * audio begins. 0 for a fresh-from-start engine; non-zero only after a
+	 * true DASH segment-seek restart (option C). Optional / `#[serde(default)]`
+	 * on the backend; read sites should `?? 0`.
+	 */
+	buffered_start_ms?: number;
 }
 
 export interface PlaybackSnapshot {
@@ -2207,10 +2214,13 @@ export const api = {
 		});
 	},
 
-	setPlaybackPosition(positionMs: number) {
+	setPlaybackPosition(positionMs: number, allowSegmentSeek = false) {
 		return fetchApi<{ state: PlaybackState }>('/api/playback/position', undefined, {
 			method: 'POST',
-			body: JSON.stringify({ position_ms: positionMs }),
+			body: JSON.stringify({
+				position_ms: positionMs,
+				allow_segment_seek: allowSegmentSeek,
+			}),
 		});
 	},
 

--- a/frontend/src/lib/components/now-playing/NowPlayingProgress.svelte
+++ b/frontend/src/lib/components/now-playing/NowPlayingProgress.svelte
@@ -34,23 +34,13 @@
 		}
 	});
 
-	// Range max: clamp to the decoded buffer. The inner Math.max guards
-	// against transient desync (position or scrubPosition momentarily
-	// ahead of bufferedMs after a track change). When duration is unknown
-	// (<= 0) leave max at 0 and disable the input.
-	//
-	// Note: we do NOT fall back to `duration` when bufferedMs is 0. That
-	// fallback opens a hole during the cold-start window (track started
-	// but no decoder callback has published samples yet) where the user
-	// could scrub past the decoded region and trip the runtime's seek
-	// rejection. With strict clamping the scrubber stays at `position`
-	// (= 0 at track start) until the first publish lands. Local files
-	// publish within ~100ms; TIDAL within a second or two.
-	let scrubMax = $derived(
-		duration > 0
-			? Math.min(duration, Math.max(scrubPosition, position, bufferedMs))
-			: 0
-	);
+	// Option C: the user can drag the scrubber to anywhere in [0, duration].
+	// Past-buffer targets get a true DASH segment-seek restart from the
+	// backend; pre-resolve targets get a 409 with the existing snap-back
+	// recovery. The buffered fill behind the playhead remains as a visual
+	// cue so users can see what's currently decoded. When duration is
+	// unknown (<= 0) leave max at 0 and disable the input.
+	let scrubMax = $derived(duration > 0 ? duration : 0);
 
 	let progressWidth = $derived(
 		duration > 0 ? `${Math.min((scrubPosition / duration) * 100, 100)}%` : '0%'

--- a/frontend/src/lib/stores/player.ts
+++ b/frontend/src/lib/stores/player.ts
@@ -514,16 +514,20 @@ export async function toggleMute() {
 export async function setPlayerPosition(nextPositionMs: number) {
 	playerError.set(null);
 	try {
-		const result = await api.setPlaybackPosition(nextPositionMs);
+		// Always opt in to the segment-restart path (option C). With
+		// allow_segment_seek=true the backend treats out-of-buffer targets
+		// as a forced restart at the nearest DASH segment instead of a 409.
+		// Pre-resolve / non-DASH targets still get 409 (the catch below
+		// applies the corrective snapshot); transition errors get 500
+		// (treat as recoverable error - the user can retry the drag).
+		const result = await api.setPlaybackPosition(nextPositionMs, true);
 		applyState(result.state);
 		noteSuccess();
 	} catch (error) {
-		// HTTP 409 = route-side seek ack: target was past the decoded buffer.
-		// The frontend scrubber clamps to bufferedMs so this should be
-		// unreachable in practice; if another client (mobile /remote) or a
-		// race makes it fire, apply the corrective live snapshot the server
-		// included in the body and stay silent (no error toast - the seek
-		// just didn't happen, the user can see the scrubber stayed put).
+		// HTTP 409 = pre-resolve race or unparseable manifest (no segment
+		// offsets to restart at). Apply the corrective live snapshot the
+		// server included in the body so the scrubber visibly snaps back,
+		// stay silent (no error toast).
 		if (error instanceof ApiError && error.status === 409) {
 			const body = error.body as { state?: PlaybackState } | null;
 			if (body?.state) {
@@ -532,6 +536,9 @@ export async function setPlayerPosition(nextPositionMs: number) {
 				return;
 			}
 		}
+		// HTTP 500 = segment-restart transition errored (TIDAL re-resolve
+		// failed, decoder spin-up failed, etc.). Show error toast with a
+		// retry; this is a recoverable failure, not a programming error.
 		setError('seek', error, () => setPlayerPosition(nextPositionMs));
 	}
 }

--- a/noor-server/src/db/models.rs
+++ b/noor-server/src/db/models.rs
@@ -111,6 +111,15 @@ pub struct PlaybackState {
     /// per-site change.
     #[serde(default)]
     pub buffered_ms: i64,
+    /// Track-time offset (ms) where the audibly-current engine's decoded
+    /// audio begins. 0 for a fresh-from-start engine; non-zero only after a
+    /// true DASH segment seek (option C). The route-side SeekTo handler uses
+    /// this as the LOWER bound of the in-buffer fast path: a target inside
+    /// `[buffered_start_ms, buffered_ms]` lands in the existing buffer; a
+    /// target outside takes the segment-seek restart path. `#[serde(default)]`
+    /// for backwards-compat with pre-option-C consumers.
+    #[serde(default)]
+    pub buffered_start_ms: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/noor-server/src/playback/decode/mod.rs
+++ b/noor-server/src/playback/decode/mod.rs
@@ -54,14 +54,24 @@ pub(crate) fn decode_and_buffer_job(
                 resolve_stream(&config.http_client, &config.access_token, &request).await
             })?;
             debug!(
-                "TIDAL runtime stream resolved: track_id={}, quality={}, codec={}, sample_rate={:?}, bit_depth={:?}, dash_segments={}",
+                "TIDAL runtime stream resolved: track_id={}, quality={}, codec={}, sample_rate={:?}, bit_depth={:?}, dash_segments={}, start_from_segment={}, start_from_offset_ms={}",
                 shared.track_id,
                 stream_info.audio_quality,
                 stream_info.codec,
                 stream_info.sample_rate,
                 stream_info.bit_depth,
-                stream_info.segment_urls.len()
+                stream_info.segment_urls.len(),
+                job.start_from_segment_index,
+                job.start_from_offset_ms,
             );
+
+            // Publish segment offsets to shared state so the runtime's SeekTo
+            // handler can resolve a target_ms back to the segment that contains
+            // it. Cheap one-shot OnceLock::set; ignore the Err if a prior call
+            // already populated it (shouldn't happen, but harmless).
+            let _ = shared
+                .segment_offsets_ms
+                .set(stream_info.segment_offsets_ms.clone());
 
             if shared.stopped.load(Ordering::SeqCst) {
                 return Ok(());
@@ -73,10 +83,26 @@ pub(crate) fn decode_and_buffer_job(
             // A separate one-shot channel carries the Content-Length from the response headers
             // so StreamPipe can report byte_len() correctly, allowing Symphonia's MSS to
             // translate SeekFrom::End into an absolute position rather than failing.
+            //
+            // Segment-aware seek (option C): for a segment-restart job, skip
+            // `start_from_segment_index` URLs before counting prebuffer segments
+            // or kicking off the background download. The init segment URL
+            // (`stream_info.url`) is ALWAYS fetched - it carries the fMP4 init
+            // box that the decoder needs regardless of which media segment is
+            // first.
             let is_dash_stream = !stream_info.segment_urls.is_empty();
+            let start_index = job
+                .start_from_segment_index
+                .min(stream_info.segment_urls.len());
+            let sliced_segment_urls: Vec<String> = stream_info
+                .segment_urls
+                .iter()
+                .skip(start_index)
+                .cloned()
+                .collect();
             let mut dash_initial = Vec::new();
-            let mut remaining_segment_urls = stream_info.segment_urls.clone();
-            let initial_media_segments = dash_initial_media_count(stream_info.segment_urls.len());
+            let mut remaining_segment_urls = sliced_segment_urls.clone();
+            let initial_media_segments = dash_initial_media_count(sliced_segment_urls.len());
             if initial_media_segments > 0 {
                 let prebuffer_stop = shared.stop_flag();
                 dash_initial = rt
@@ -89,8 +115,7 @@ pub(crate) fn decode_and_buffer_job(
                         if prebuffer_stop.load(Ordering::Relaxed) {
                             return anyhow::Ok(bytes);
                         }
-                        for (idx, segment_url) in stream_info
-                            .segment_urls
+                        for (idx, segment_url) in sliced_segment_urls
                             .iter()
                             .take(initial_media_segments)
                             .enumerate()
@@ -108,8 +133,9 @@ pub(crate) fn decode_and_buffer_job(
                     .context("DASH stream prebuffer failed")?;
                 remaining_segment_urls.drain(0..initial_media_segments);
                 debug!(
-                    "TIDAL DASH prebuffer ready: track_id={}, initial_segments={}, remaining_segments={}",
+                    "TIDAL DASH prebuffer ready: track_id={}, start_index={}, initial_segments={}, remaining_segments={}",
                     shared.track_id,
+                    start_index,
                     initial_media_segments,
                     remaining_segment_urls.len()
                 );

--- a/noor-server/src/playback/gapless.rs
+++ b/noor-server/src/playback/gapless.rs
@@ -123,6 +123,7 @@ mod tests {
         StreamInfo {
             url: "https://example.com/stream.flac".to_string(),
             segment_urls: vec![],
+            segment_offsets_ms: vec![],
             track_id: 1,
             audio_quality: "LOSSLESS".to_string(),
             codec: codec.to_string(),

--- a/noor-server/src/playback/player.rs
+++ b/noor-server/src/playback/player.rs
@@ -53,6 +53,50 @@ pub struct PreparedPlaybackJob {
     pub gapless: GaplessPlan,
     pub generation: u64,
     pub output_sample_rate: Option<u32>,
+    // Segment-aware seek (option C): for DASH-segmented sources, these tell the
+    // decoder to skip ahead by `start_from_segment_index` segments. Position
+    // accounting in `PlaybackSharedState` is then absolute-track-samples seeded
+    // from `start_from_offset_ms`. A fresh play has both = 0.
+    pub start_from_segment_index: usize,
+    pub start_from_offset_ms: u64,
+}
+
+impl PreparedPlaybackJob {
+    #[cfg(test)]
+    pub fn test_fixture(track_id: i64, generation: u64) -> Self {
+        Self {
+            track: Track {
+                id: track_id,
+                title: format!("test-track-{track_id}"),
+                artist_id: 1,
+                artist_name: None,
+                album_id: None,
+                album_title: None,
+                disc_number: None,
+                track_number: None,
+                duration_ms: Some(180_000),
+                isrc: None,
+                tidal_id: None,
+                ytmusic_id: None,
+                soundcloud_id: None,
+                best_quality: None,
+                best_source: None,
+                fidelity_score: 0,
+                is_favorite: false,
+                play_count: 0,
+                last_played_at: None,
+                date_added: None,
+                source: "local".to_string(),
+                artwork_url: None,
+            },
+            source: PlaybackSourceRequest::LocalLibrary,
+            gapless: GaplessPlan::disabled(),
+            generation,
+            output_sample_rate: None,
+            start_from_segment_index: 0,
+            start_from_offset_ms: 0,
+        }
+    }
 }
 
 pub type PlaybackPreparation = PreparedPlaybackJob;
@@ -200,6 +244,8 @@ impl PreparedPlaybackJob {
             gapless,
             generation: 0,
             output_sample_rate: None,
+            start_from_segment_index: 0,
+            start_from_offset_ms: 0,
         }
     }
 
@@ -374,9 +420,11 @@ pub fn load_state(conn: &Connection) -> Result<PlaybackState> {
         automix_discover_new: row.8,
         automix_use_learning: row.9,
         automix_allow_external: row.10,
-        // buffered_ms is a runtime-only field overlaid by the live snapshot
-        // helper in routes.rs; the DB has no column for it.
+        // buffered_ms and buffered_start_ms are runtime-only fields overlaid
+        // by the live snapshot helper in routes.rs; the DB has no column for
+        // either of them.
         buffered_ms: 0,
+        buffered_start_ms: 0,
     })
 }
 
@@ -617,14 +665,6 @@ pub fn pause(conn: &Connection) -> Result<PlaybackSnapshot> {
 
 pub fn resume(conn: &Connection) -> Result<PlaybackSnapshot> {
     conn.execute("UPDATE playback_state SET is_playing = 1 WHERE id = 1", [])?;
-    load_snapshot(conn)
-}
-
-pub fn set_position(conn: &Connection, position_ms: i64) -> Result<PlaybackSnapshot> {
-    conn.execute(
-        "UPDATE playback_state SET position_ms = ?1 WHERE id = 1",
-        params![position_ms],
-    )?;
     load_snapshot(conn)
 }
 
@@ -2371,6 +2411,7 @@ mod tests {
         let stream = StreamInfo {
             url: "https://example.com/stream.flac".to_string(),
             segment_urls: vec![],
+            segment_offsets_ms: vec![],
             track_id: 77,
             audio_quality: "LOSSLESS".to_string(),
             codec: "audio/flac".to_string(),

--- a/noor-server/src/playback/runtime/commands.rs
+++ b/noor-server/src/playback/runtime/commands.rs
@@ -9,8 +9,17 @@ pub enum PlaybackRuntimeCommand {
     Pause,
     Resume,
     Stop,
-    /// Seek to a position (milliseconds). Applied to the current engine's buffer.
-    Seek(i64),
+    /// Segment-aware seek (option C). The runtime's handler is the single
+    /// decision point: in-buffer fast path, segment-restart transition, or
+    /// rejection. `allow_segment_seek=false` preserves legacy "reject past
+    /// buffer" semantics; `true` opts in to the forced-restart path for the
+    /// DASH-segment-seek feature. `respond_to` carries the outcome back to
+    /// the caller (route handler awaits it via `recv_timeout`).
+    SeekTo {
+        target_ms: i64,
+        allow_segment_seek: bool,
+        respond_to: std::sync::mpsc::Sender<SeekToOutcome>,
+    },
     /// Pre-decode the next track in background so it can start gaplessly.
     PrepareNext(PreparedPlaybackJob),
     /// Sent by the decoder thread when a track finishes decoding successfully.
@@ -60,6 +69,24 @@ pub enum PlaybackTrackStatus {
     None,
     Active,
     Prepared,
+}
+
+/// Outcome of a `PlaybackRuntimeCommand::SeekTo` dispatch. Routed back to the
+/// caller via the command's `respond_to: mpsc::Sender<SeekToOutcome>` so the
+/// HTTP layer can translate to 202 (dispatched), 409 (rejected), or 500
+/// (failed) without re-reading the buffer state from the route.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SeekToOutcome {
+    /// Seek accepted - either fast-path in-buffer or finished segment-restart
+    /// transition. The audible playhead may take up to ~1s to converge as the
+    /// new engine primes samples; the frontend's 1 Hz refresher closes the gap.
+    Dispatched,
+    /// Target outside `[offset, buffered]` and the caller opted out of the
+    /// segment-restart path (`allow_segment_seek=false`). HTTP 409.
+    RejectedOutOfBuffer,
+    /// The runtime tried to transition (segment-restart) and failed - typically
+    /// because TIDAL re-resolve / decoder spin-up errored. HTTP 500.
+    Failed,
 }
 
 #[derive(Debug, Clone)]

--- a/noor-server/src/playback/runtime/engine.rs
+++ b/noor-server/src/playback/runtime/engine.rs
@@ -56,6 +56,11 @@ pub(super) struct PlaybackEngine {
     stream: Option<OutputStream>,
     pub(super) decoder_thread: Option<JoinHandle<()>>,
     pub(super) shared: Arc<PlaybackSharedState>,
+    /// Snapshot of the `PreparedPlaybackJob` that started this engine. Stored
+    /// so the runtime's `SeekTo` handler can compute a segment-restart job
+    /// (incrementing `start_from_segment_index` / `start_from_offset_ms`)
+    /// without having to plumb the original job through the engine API.
+    pub(super) job: PreparedPlaybackJob,
 }
 
 fn join_decoder_thread_in_background(track_id: i64, handle: JoinHandle<()>) {
@@ -79,6 +84,7 @@ impl PlaybackEngine {
             stream: None,
             decoder_thread: None,
             shared,
+            job: PreparedPlaybackJob::test_fixture(track_id, generation),
         }
     }
 
@@ -216,17 +222,25 @@ impl PlaybackEngine {
                 device_channels,
             )
         });
+        let offset_samples = (job
+            .start_from_offset_ms
+            .saturating_mul(output_sample_rate as u64)
+            .saturating_mul(device_channels.max(1) as u64))
+            / 1000;
+        position_samples.store(offset_samples, Ordering::Relaxed);
+        let position_offset_samples = Arc::new(AtomicU64::new(offset_samples));
         let shared = Arc::new(PlaybackSharedState::new(
             track_id,
             generation,
             source_kind,
-            job.gapless,
+            job.gapless.clone(),
             output_sample_rate,
             device_channels,
             estimated_total_samples,
             command_tx.clone(),
             volume_ctl,
             position_samples,
+            position_offset_samples,
         ));
 
         let decoder_shared = Arc::clone(&shared);
@@ -256,6 +270,7 @@ impl PlaybackEngine {
             stream: None,
             decoder_thread: Some(decoder_thread),
             shared,
+            job,
         })
     }
 
@@ -349,6 +364,7 @@ mod tests {
             command_tx,
             Arc::new(AtomicU32::new(1.0f32.to_bits())),
             Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
         ))
     }
 
@@ -371,6 +387,7 @@ mod tests {
             stream: None,
             decoder_thread: Some(decoder_thread),
             shared: Arc::clone(&shared),
+            job: PreparedPlaybackJob::test_fixture(1, 1),
         };
 
         // Watchdog: if stop() blocks waiting on the decoder thread, release it

--- a/noor-server/src/playback/runtime/mod.rs
+++ b/noor-server/src/playback/runtime/mod.rs
@@ -16,6 +16,7 @@ pub(crate) mod shared;
 
 pub use commands::{
     PlaybackRuntimeCommand, PlaybackRuntimeEvent, PlaybackTerminalReason, PlaybackTrackStatus,
+    SeekToOutcome,
 };
 pub use device::{OutputDeviceSelection, enumerate_output_devices};
 use device::{device_display_name, resolve_device};
@@ -30,6 +31,46 @@ use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, mpsc};
 use std::thread;
 use tracing::{debug, error, info, warn};
+
+/// Pure decision helper for the SeekTo handler. Moved out of `server::routes`
+/// (r6 fix A: keep the playback runtime free of HTTP-layer dependencies). The
+/// runtime's SeekTo handler calls this with absolute-track samples; the route
+/// no longer touches it directly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SeekDecision {
+    /// Either no runtime / engine is active, or the buffer is fresh (no
+    /// samples published yet), or the target is inside `[offset, buffered]`.
+    /// Dispatch the seek to the runtime's in-buffer fast path.
+    Dispatch,
+    /// Target is strictly outside `[offset, buffered]` and the runtime has
+    /// published a non-zero buffered_samples value (so we're past the
+    /// cold-start window). Routed to either the segment-restart path or
+    /// 409-style rejection depending on the caller's `allow_segment_seek`.
+    RejectOutOfBuffer,
+}
+
+pub(crate) fn evaluate_seek_decision(
+    target_samples: u64,
+    buffered_start_samples: u64,
+    buffered_samples: u64,
+    runtime_active: bool,
+) -> SeekDecision {
+    if !runtime_active {
+        return SeekDecision::Dispatch;
+    }
+    // buffered_samples == 0 means the audio callback hasn't published any
+    // value yet (engine cold-starting, first callback not fired). Treat that
+    // as "unknown, let the runtime decide" rather than blanket-rejecting all
+    // seeks during the cold-start window.
+    if buffered_samples == 0 {
+        return SeekDecision::Dispatch;
+    }
+    if target_samples < buffered_start_samples || target_samples > buffered_samples {
+        SeekDecision::RejectOutOfBuffer
+    } else {
+        SeekDecision::Dispatch
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct PlaybackRuntimeConfig {
@@ -81,6 +122,15 @@ pub struct PlaybackRuntimeHandle {
     /// the frontend reads `buffered_ms` via this for the buffered-bar
     /// scrubber. Same unwrap-audit reasoning as `position_source`.
     buffered_source: Arc<Mutex<Arc<AtomicU64>>>,
+    /// Redirectable engine-offset reader (option C: true DASH segment seek).
+    /// Points at the audibly-current engine's `position_offset_samples`
+    /// counter. For a fresh play this reads 0; for a segment-restart engine
+    /// it reads the absolute-track sample where the engine's decoded audio
+    /// starts. The route-side seek handler uses this as the LOWER bound of
+    /// the in-buffer decision (target must be `>= offset` to be in-buffer);
+    /// the frontend reads `buffered_start_ms` via this as a visual cue.
+    /// Same unwrap-audit reasoning as `position_source` / `buffered_source`.
+    offset_source: Arc<Mutex<Arc<AtomicU64>>>,
 }
 
 impl PlaybackRuntimeHandle {
@@ -137,9 +187,47 @@ impl PlaybackRuntimeHandle {
         self.event_tx.subscribe()
     }
 
-    /// Seek to a position (milliseconds) within the current track.
+    /// Segment-aware seek. Single entry point for all seek requests; the
+    /// runtime decides between in-buffer fast path, forced-restart segment
+    /// seek, or rejection. The `allow_segment_seek` flag opts in to the
+    /// segment-restart transition; with `false`, the runtime treats
+    /// out-of-buffer seeks as rejected (legacy semantics).
+    ///
+    /// Blocks up to 1500ms for the reply (segment-restart transitions need
+    /// time to tear down the old engine and spin up the decoder thread on
+    /// the new one). Returns `SeekToOutcome::Failed` on timeout / channel
+    /// closure - treat as a recoverable error from the caller's perspective.
+    pub fn seek_to_segment_aware(
+        &self,
+        position_ms: i64,
+        allow_segment_seek: bool,
+    ) -> SeekToOutcome {
+        let (tx, rx) = std::sync::mpsc::channel();
+        if self
+            .send(PlaybackRuntimeCommand::SeekTo {
+                target_ms: position_ms,
+                allow_segment_seek,
+                respond_to: tx,
+            })
+            .is_err()
+        {
+            return SeekToOutcome::Failed;
+        }
+        rx.recv_timeout(std::time::Duration::from_millis(1500))
+            .unwrap_or(SeekToOutcome::Failed)
+    }
+
+    /// Legacy seek wrapper. Equivalent to `seek_to_segment_aware(position_ms,
+    /// false)` returning a `Result<()>`. Kept so non-route callers (none
+    /// today; audit `git grep "\\.seek\\("` if adding new ones) don't have to
+    /// adopt the SeekToOutcome enum just to issue a plain seek. Out-of-buffer
+    /// or failed transitions surface as `Err`.
     pub fn seek(&self, position_ms: i64) -> Result<()> {
-        self.send(PlaybackRuntimeCommand::Seek(position_ms))
+        match self.seek_to_segment_aware(position_ms, false) {
+            SeekToOutcome::Dispatched => Ok(()),
+            SeekToOutcome::RejectedOutOfBuffer => Err(anyhow!("seek target is out of buffer")),
+            SeekToOutcome::Failed => Err(anyhow!("seek dispatch failed")),
+        }
     }
 
     /// Pre-decode the next track in the background so the transition is gapless.
@@ -198,6 +286,28 @@ impl PlaybackRuntimeHandle {
         self.buffered_source.lock().unwrap().load(Ordering::Relaxed)
     }
 
+    /// Read the engine's track-time offset in milliseconds (lower bound of
+    /// the decoded range). Returns 0 for a fresh-from-start engine; returns
+    /// the segment offset for a segment-restart engine. Read via the
+    /// redirectable `offset_source` so it always reflects the audibly-current
+    /// engine, not the fading-out one. Used by `build_live_playback_snapshot`
+    /// to populate `PlaybackState.buffered_start_ms` and by the runtime's
+    /// SeekTo handler indirectly via `evaluate_seek_decision`.
+    pub fn get_buffered_start_ms(&self, device_sample_rate: u32, device_channels: u16) -> i64 {
+        if device_sample_rate == 0 || device_channels == 0 {
+            return 0;
+        }
+        let samples = self.offset_source.lock().unwrap().load(Ordering::Relaxed);
+        (samples * 1000 / (device_sample_rate as u64 * device_channels as u64)) as i64
+    }
+
+    /// Raw offset-sample count from the audibly-current engine. Companion to
+    /// `buffered_samples()`; the route-side SeekTo handler uses both as the
+    /// `[offset, buffered]` bounds of the in-buffer fast path.
+    pub fn buffered_start_samples(&self) -> u64 {
+        self.offset_source.lock().unwrap().load(Ordering::Relaxed)
+    }
+
     fn send(&self, command: PlaybackRuntimeCommand) -> Result<()> {
         self.command_tx
             .send(command)
@@ -229,11 +339,17 @@ pub fn spawn_runtime(config: PlaybackRuntimeConfig) -> Result<PlaybackRuntimeHan
     // `buffered_ms()` call returns 0 cleanly.
     let buffered_source: Arc<Mutex<Arc<AtomicU64>>> =
         Arc::new(Mutex::new(Arc::new(AtomicU64::new(0))));
+    // Offset mirror: same redirect pattern as `buffered_source`, but for the
+    // engine's `position_offset_samples`. Before any engine exists this points
+    // at a sentinel zero atomic so `get_buffered_start_ms()` returns 0.
+    let offset_source: Arc<Mutex<Arc<AtomicU64>>> =
+        Arc::new(Mutex::new(Arc::new(AtomicU64::new(0))));
 
     let worker_volume_ctl = Arc::clone(&volume_ctl);
     let worker_initial_position = Arc::clone(&initial_position);
     let worker_position_source = Arc::clone(&position_source);
     let worker_buffered_source = Arc::clone(&buffered_source);
+    let worker_offset_source = Arc::clone(&offset_source);
 
     thread::Builder::new()
         .name("noor-playback-runtime".into())
@@ -247,6 +363,7 @@ pub fn spawn_runtime(config: PlaybackRuntimeConfig) -> Result<PlaybackRuntimeHan
                 worker_initial_position,
                 worker_position_source,
                 worker_buffered_source,
+                worker_offset_source,
             ) {
                 let _ = worker_event_tx.send(PlaybackRuntimeEvent::Error {
                     message: err.to_string(),
@@ -262,6 +379,7 @@ pub fn spawn_runtime(config: PlaybackRuntimeConfig) -> Result<PlaybackRuntimeHan
         volume_ctl,
         position_source,
         buffered_source,
+        offset_source,
     })
 }
 
@@ -301,6 +419,7 @@ struct PlaybackRuntimeLoopState {
     current_exclusive_latency_mode: ExclusiveLatencyMode,
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_runtime_loop(
     config: PlaybackRuntimeConfig,
     command_rx: mpsc::Receiver<PlaybackRuntimeCommand>,
@@ -310,6 +429,7 @@ fn run_runtime_loop(
     position_samples: Arc<AtomicU64>,
     position_source: Arc<Mutex<Arc<AtomicU64>>>,
     buffered_source: Arc<Mutex<Arc<AtomicU64>>>,
+    offset_source: Arc<Mutex<Arc<AtomicU64>>>,
 ) -> Result<()> {
     let host = cpal::default_host();
     let mut device = host
@@ -367,6 +487,7 @@ fn run_runtime_loop(
                         &position_samples,
                         &position_source,
                         &buffered_source,
+                        &offset_source,
                         true,
                     ) {
                         stop_all_engines(&mut state);
@@ -389,6 +510,7 @@ fn run_runtime_loop(
                         &position_samples,
                         &position_source,
                         &buffered_source,
+                        &offset_source,
                         false,
                     ) {
                         stop_all_engines(&mut state);
@@ -397,33 +519,132 @@ fn run_runtime_loop(
                         report_runtime_command_error(&event_tx, "Switch", error);
                     }
                 }
-                PlaybackRuntimeCommand::Seek(position_ms) => {
-                    if let Some(engine) = state.engine.as_ref() {
-                        let target_samples = (position_ms.max(0) as u64
-                            * state.device_sample_rate as u64
-                            * state.device_channels as u64)
+                PlaybackRuntimeCommand::SeekTo {
+                    target_ms,
+                    allow_segment_seek,
+                    respond_to,
+                } => {
+                    // Phase 1: snapshot everything we need under an immutable
+                    // borrow of state.engine. Inside this block we decide
+                    // among in-buffer fast path / segment-restart / reject;
+                    // the actual mutation happens in phase 2 with the
+                    // immutable borrow already dropped (per r6 fix C).
+                    enum SeekHandling {
+                        InBuffer { target_samples: u64 },
+                        Reject,
+                        SegmentSeek { job: PreparedPlaybackJob },
+                    }
+                    let rate = state.device_sample_rate as u64;
+                    let channels = state.device_channels.max(1) as u64;
+                    let decision: SeekHandling = {
+                        let Some(engine) = state.engine.as_ref() else {
+                            let _ = respond_to.send(SeekToOutcome::RejectedOutOfBuffer);
+                            return std::ops::ControlFlow::Continue(());
+                        };
+                        let target_samples = (target_ms.max(0) as u64)
+                            .saturating_mul(rate)
+                            .saturating_mul(channels)
                             / 1000;
-                        // Tell the CPAL callback to seek on the next write. The
-                        // callback will accept (and update position_samples) only
-                        // if the target is within already-decoded samples or the
-                        // buffer is finished; otherwise it warns and leaves the
-                        // position counter untouched. This keeps the runtime-side
-                        // position honest about what has actually been played.
-                        // (Route/UI-side position handling is a separate follow-up.)
-                        engine
+                        let offset_samples = engine
                             .shared
-                            .seek_target_samples
-                            .store(target_samples, Ordering::Relaxed);
-                        // Reset fire-once guards so NearEnd / CrossfadeStart re-fire correctly
-                        // if the user seeks backward past those thresholds.
-                        engine
-                            .shared
-                            .near_end_signaled
-                            .store(false, Ordering::Relaxed);
-                        engine
-                            .shared
-                            .crossfade_start_signaled
-                            .store(false, Ordering::Relaxed);
+                            .position_offset_samples
+                            .load(Ordering::Relaxed);
+                        let buffered_samples =
+                            engine.shared.buffered_samples.load(Ordering::Relaxed);
+
+                        match evaluate_seek_decision(
+                            target_samples,
+                            offset_samples,
+                            buffered_samples,
+                            true,
+                        ) {
+                            SeekDecision::Dispatch => SeekHandling::InBuffer { target_samples },
+                            SeekDecision::RejectOutOfBuffer if !allow_segment_seek => {
+                                SeekHandling::Reject
+                            }
+                            SeekDecision::RejectOutOfBuffer => {
+                                // Segment-restart path: find the segment whose
+                                // start_ms is the largest <= target_ms, build a
+                                // new job that starts from there. Clone the job
+                                // so the borrow ends with this scope.
+                                let Some(offsets) = engine.shared.segment_offsets_ms.get() else {
+                                    let _ = respond_to.send(SeekToOutcome::RejectedOutOfBuffer);
+                                    return std::ops::ControlFlow::Continue(());
+                                };
+                                if offsets.is_empty() {
+                                    let _ = respond_to.send(SeekToOutcome::RejectedOutOfBuffer);
+                                    return std::ops::ControlFlow::Continue(());
+                                }
+                                let target_ms_clamped = target_ms.max(0) as u64;
+                                let n = offsets
+                                    .iter()
+                                    .rposition(|off_ms| *off_ms <= target_ms_clamped)
+                                    .unwrap_or(0);
+                                let new_offset_ms = offsets[n];
+                                let new_job = {
+                                    let mut j = engine.job.clone();
+                                    j.start_from_segment_index = n;
+                                    j.start_from_offset_ms = new_offset_ms;
+                                    j
+                                };
+                                SeekHandling::SegmentSeek { job: new_job }
+                            }
+                        }
+                    }; // immutable borrow of state.engine ends here
+
+                    // Phase 2: act on the decision under a mutable borrow.
+                    match decision {
+                        SeekHandling::InBuffer { target_samples } => {
+                            if let Some(engine) = state.engine.as_ref() {
+                                engine
+                                    .shared
+                                    .seek_target_samples
+                                    .store(target_samples, Ordering::Relaxed);
+                                // Reset fire-once guards so NearEnd /
+                                // CrossfadeStart re-fire after a backward seek.
+                                engine
+                                    .shared
+                                    .near_end_signaled
+                                    .store(false, Ordering::Relaxed);
+                                engine
+                                    .shared
+                                    .crossfade_start_signaled
+                                    .store(false, Ordering::Relaxed);
+                            }
+                            let _ = respond_to.send(SeekToOutcome::Dispatched);
+                        }
+                        SeekHandling::Reject => {
+                            let _ = respond_to.send(SeekToOutcome::RejectedOutOfBuffer);
+                        }
+                        SeekHandling::SegmentSeek { job } => {
+                            match transition_to_job(
+                                &config,
+                                &command_tx,
+                                &device,
+                                &mut output_config,
+                                output_sample_format,
+                                &event_tx,
+                                &mut state,
+                                job,
+                                &volume_ctl,
+                                &position_samples,
+                                &position_source,
+                                &buffered_source,
+                                &offset_source,
+                                true, // force_restart - bypass switch_is_noop
+                            ) {
+                                Ok(()) => {
+                                    let _ = respond_to.send(SeekToOutcome::Dispatched);
+                                }
+                                Err(error) => {
+                                    warn!(
+                                        "Segment-seek transition failed: target_ms={}, err={:?}",
+                                        target_ms, error
+                                    );
+                                    let _ = respond_to.send(SeekToOutcome::Failed);
+                                }
+                            }
+                        }
                     }
                 }
                 PlaybackRuntimeCommand::PrepareNext(job) => {
@@ -501,6 +722,7 @@ fn run_runtime_loop(
                                 &event_tx,
                                 &position_source,
                                 &buffered_source,
+                                &offset_source,
                             );
                         }
                         // If not ready yet, NextDecodeComplete handles the late path.
@@ -530,6 +752,7 @@ fn run_runtime_loop(
                                 &event_tx,
                                 &position_source,
                                 &buffered_source,
+                                &offset_source,
                             );
                         }
                     }
@@ -715,6 +938,7 @@ fn run_runtime_loop(
                                     &event_tx,
                                     &position_source,
                                     &buffered_source,
+                                    &offset_source,
                                 );
                             } else {
                                 stop_current_engine(&mut state);
@@ -1000,6 +1224,7 @@ fn run_runtime_loop(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn transition_to_job(
     config: &PlaybackRuntimeConfig,
     command_tx: &mpsc::Sender<PlaybackRuntimeCommand>,
@@ -1013,6 +1238,7 @@ fn transition_to_job(
     position_samples: &Arc<AtomicU64>,
     position_source: &Arc<Mutex<Arc<AtomicU64>>>,
     buffered_source: &Arc<Mutex<Arc<AtomicU64>>>,
+    offset_source: &Arc<Mutex<Arc<AtomicU64>>>,
     force_restart: bool,
 ) -> Result<()> {
     // No-op when state.engine is already playing the requested track. This
@@ -1039,8 +1265,20 @@ fn transition_to_job(
         prior.stop();
     }
 
-    // Reset position counter for the new track (safe: old engine is fully stopped above).
-    position_samples.store(0, Ordering::SeqCst);
+    // Reset position counter to the new engine's offset baseline (option C:
+    // a segment-restart job seeds from `start_from_offset_ms` so the handle's
+    // `get_position_ms` reports the correct absolute time from the first
+    // CPAL callback, before the engine has actually written any samples).
+    // `start_decoder_only` later stores the same value into position_samples
+    // - this preemptive store is so the handle doesn't briefly read a stale 0
+    // (or a stale prior-track value) between the engine teardown above and
+    // the engine spawn below.
+    let baseline_offset_samples = (job
+        .start_from_offset_ms
+        .saturating_mul(state.device_sample_rate as u64)
+        .saturating_mul(state.device_channels.max(1) as u64))
+        / 1000;
+    position_samples.store(baseline_offset_samples, Ordering::SeqCst);
 
     let output_state_update = transition_output_state_update(
         job.output_sample_rate,
@@ -1104,6 +1342,7 @@ fn transition_to_job(
             )?;
             *position_source.lock().unwrap() = Arc::clone(position_samples);
             *buffered_source.lock().unwrap() = Arc::clone(&eng.shared.buffered_samples);
+            *offset_source.lock().unwrap() = Arc::clone(&eng.shared.position_offset_samples);
             state.engine = Some(eng);
 
             #[cfg(target_os = "windows")]
@@ -1169,6 +1408,7 @@ fn transition_to_job(
             state.device_sample_rate = actual_start_rate;
             *position_source.lock().unwrap() = Arc::clone(position_samples);
             *buffered_source.lock().unwrap() = Arc::clone(&eng.shared.buffered_samples);
+            *offset_source.lock().unwrap() = Arc::clone(&eng.shared.position_offset_samples);
             state.engine = Some(eng);
         }
     }
@@ -1391,6 +1631,7 @@ fn promote_next_to_active(
     event_tx: &tokio::sync::broadcast::Sender<PlaybackRuntimeEvent>,
     position_source: &Arc<Mutex<Arc<AtomicU64>>>,
     buffered_source: &Arc<Mutex<Arc<AtomicU64>>>,
+    offset_source: &Arc<Mutex<Arc<AtomicU64>>>,
 ) {
     let Some(next) = state.next_engine.take() else {
         return;
@@ -1398,10 +1639,11 @@ fn promote_next_to_active(
     next.shared.fadein_start_samples.store(0, Ordering::Relaxed);
     next.shared.paused.store(false, Ordering::SeqCst);
 
-    // Redirect the handle's position + buffered readers to the incoming
-    // engine's counters BEFORE sliding it into state.engine so get_position_ms
-    // / get_buffered_ms() immediately reflect the new track starting from 0
-    // instead of the fading-out track's frozen end values.
+    // Redirect the handle's position + buffered + offset readers to the
+    // incoming engine's counters BEFORE sliding it into state.engine so
+    // get_position_ms / get_buffered_ms / get_buffered_start_ms() immediately
+    // reflect the new track starting from 0 instead of the fading-out track's
+    // frozen end values.
     //
     // If lock() panics (the only failure mode is a prior poisoning) the
     // moved-out `next` is dropped without stop() being called and its decoder
@@ -1411,6 +1653,7 @@ fn promote_next_to_active(
     // was judged to outweigh the rare-poisoning bandwidth blip.
     *position_source.lock().unwrap() = Arc::clone(&next.shared.position_samples);
     *buffered_source.lock().unwrap() = Arc::clone(&next.shared.buffered_samples);
+    *offset_source.lock().unwrap() = Arc::clone(&next.shared.position_offset_samples);
 
     let outgoing = state.engine.take();
     state.engine = Some(next);
@@ -1442,6 +1685,7 @@ fn promote_prepared_at_boundary(
     event_tx: &tokio::sync::broadcast::Sender<PlaybackRuntimeEvent>,
     position_source: &Arc<Mutex<Arc<AtomicU64>>>,
     buffered_source: &Arc<Mutex<Arc<AtomicU64>>>,
+    offset_source: &Arc<Mutex<Arc<AtomicU64>>>,
 ) {
     let Some(next) = state.next_engine.take() else {
         return;
@@ -1452,6 +1696,7 @@ fn promote_prepared_at_boundary(
     next.shared.paused.store(false, Ordering::SeqCst);
     *position_source.lock().unwrap() = Arc::clone(&next.shared.position_samples);
     *buffered_source.lock().unwrap() = Arc::clone(&next.shared.buffered_samples);
+    *offset_source.lock().unwrap() = Arc::clone(&next.shared.position_offset_samples);
 
     let outgoing = state.engine.take();
     state.engine = Some(next);
@@ -1782,6 +2027,7 @@ mod tests {
             command_tx,
             Arc::new(AtomicU32::new(1.0f32.to_bits())),
             Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
         ));
 
         {
@@ -1808,6 +2054,7 @@ mod tests {
             command_tx.clone(),
             Arc::new(AtomicU32::new(1.0f32.to_bits())),
             Arc::clone(&position),
+            Arc::new(AtomicU64::new(0)),
         ));
         {
             let mut buffer = shared.buffer.lock().unwrap();
@@ -1838,6 +2085,7 @@ mod tests {
             command_tx.clone(),
             Arc::new(AtomicU32::new(1.0f32.to_bits())),
             Arc::clone(&position),
+            Arc::new(AtomicU64::new(0)),
         ));
         shared.paused.store(true, Ordering::SeqCst);
         {
@@ -1938,6 +2186,7 @@ mod tests {
             command_tx,
             Arc::new(AtomicU32::new(1.0f32.to_bits())),
             Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
         );
 
         shared
@@ -1974,6 +2223,7 @@ mod tests {
             None,
             command_tx,
             Arc::new(AtomicU32::new(1.0f32.to_bits())),
+            Arc::new(AtomicU64::new(0)),
             Arc::new(AtomicU64::new(0)),
         );
 
@@ -2038,6 +2288,7 @@ mod tests {
             volume_ctl: Arc::new(AtomicU32::new(1.0f32.to_bits())),
             position_source: Arc::new(Mutex::new(Arc::new(AtomicU64::new(0)))),
             buffered_source: Arc::clone(&buffered_source),
+            offset_source: Arc::new(Mutex::new(Arc::new(AtomicU64::new(0)))),
         };
 
         assert_eq!(
@@ -2077,6 +2328,7 @@ mod tests {
             volume_ctl: Arc::new(AtomicU32::new(1.0f32.to_bits())),
             position_source: Arc::new(Mutex::new(Arc::new(AtomicU64::new(0)))),
             buffered_source: Arc::new(Mutex::new(Arc::new(AtomicU64::new(48_000)))),
+            offset_source: Arc::new(Mutex::new(Arc::new(AtomicU64::new(0)))),
         };
         assert_eq!(handle.get_buffered_ms(0, 2), 0);
         assert_eq!(handle.get_buffered_ms(48_000, 0), 0);
@@ -2242,7 +2494,104 @@ mod tests {
                 command_tx,
                 Arc::new(AtomicU32::new(1.0f32.to_bits())),
                 Arc::new(AtomicU64::new(0)),
+                Arc::new(AtomicU64::new(0)),
             )),
         )
+    }
+
+    // -- Option C: evaluate_seek_decision unit tests (moved from server::routes
+    //    per r6 fix A; the helper now lives in this module). --
+
+    #[test]
+    fn evaluate_seek_decision_dispatches_when_no_runtime_active() {
+        assert_eq!(
+            super::evaluate_seek_decision(1_000_000, 0, 0, false),
+            super::SeekDecision::Dispatch,
+        );
+    }
+
+    #[test]
+    fn evaluate_seek_decision_dispatches_when_buffer_is_fresh() {
+        assert_eq!(
+            super::evaluate_seek_decision(500_000, 0, 0, true),
+            super::SeekDecision::Dispatch,
+        );
+    }
+
+    #[test]
+    fn evaluate_seek_decision_dispatches_when_target_within_buffered() {
+        assert_eq!(
+            super::evaluate_seek_decision(100_000, 0, 200_000, true),
+            super::SeekDecision::Dispatch,
+        );
+        assert_eq!(
+            super::evaluate_seek_decision(200_000, 0, 200_000, true),
+            super::SeekDecision::Dispatch,
+        );
+    }
+
+    #[test]
+    fn evaluate_seek_decision_rejects_target_strictly_past_buffer() {
+        assert_eq!(
+            super::evaluate_seek_decision(300_000, 0, 200_000, true),
+            super::SeekDecision::RejectOutOfBuffer,
+        );
+    }
+
+    #[test]
+    fn evaluate_seek_decision_rejects_target_below_offset() {
+        // r5 finding (P2): decoded range after segment-restart is
+        // [offset, buffered], not [0, buffered]. A backward seek below the
+        // offset must NOT take the fast path.
+        assert_eq!(
+            super::evaluate_seek_decision(10_000, 30_000, 50_000, true),
+            super::SeekDecision::RejectOutOfBuffer,
+        );
+    }
+
+    #[test]
+    fn evaluate_seek_decision_dispatches_target_within_post_offset_range() {
+        // Same offset as the test above; target sits inside [30k, 50k].
+        assert_eq!(
+            super::evaluate_seek_decision(40_000, 30_000, 50_000, true),
+            super::SeekDecision::Dispatch,
+        );
+    }
+
+    #[test]
+    fn offset_source_redirect_makes_handle_read_from_new_engine() {
+        // r2 codex finding (P1) extended for option C: the handle's
+        // get_buffered_start_ms must follow the same redirect pattern as
+        // position_source / buffered_source so a Switch / promotion swaps the
+        // reader to the new engine's offset atomic, not the stale one.
+        let (command_tx, _) = std::sync::mpsc::channel();
+        let (event_tx, _) = tokio::sync::broadcast::channel(8);
+
+        let engine_a_offset = Arc::new(AtomicU64::new(0));
+        let engine_b_offset = Arc::new(AtomicU64::new(48_000 * 2 * 30)); // 30 s @ 48k stereo
+
+        let offset_source: Arc<Mutex<Arc<AtomicU64>>> =
+            Arc::new(Mutex::new(Arc::clone(&engine_a_offset)));
+
+        let handle = PlaybackRuntimeHandle {
+            command_tx,
+            event_tx,
+            volume_ctl: Arc::new(AtomicU32::new(1.0f32.to_bits())),
+            position_source: Arc::new(Mutex::new(Arc::new(AtomicU64::new(0)))),
+            buffered_source: Arc::new(Mutex::new(Arc::new(AtomicU64::new(0)))),
+            offset_source: Arc::clone(&offset_source),
+        };
+
+        assert_eq!(handle.buffered_start_samples(), 0);
+        assert_eq!(handle.get_buffered_start_ms(48_000, 2), 0);
+
+        *offset_source.lock().unwrap() = Arc::clone(&engine_b_offset);
+
+        assert_eq!(handle.buffered_start_samples(), 48_000 * 2 * 30);
+        assert_eq!(handle.get_buffered_start_ms(48_000, 2), 30_000);
+
+        // Stale writes to engine A must not leak through.
+        engine_a_offset.store(999_999, Ordering::Relaxed);
+        assert_eq!(handle.buffered_start_samples(), 48_000 * 2 * 30);
     }
 }

--- a/noor-server/src/playback/runtime/shared.rs
+++ b/noor-server/src/playback/runtime/shared.rs
@@ -103,18 +103,34 @@ fn write_output_buffer<T>(
             .compare_exchange(seek_target, u64::MAX, Ordering::SeqCst, Ordering::Relaxed)
             .is_ok()
     {
-        if guard.seek_to(seek_target as usize) {
-            shared
-                .position_samples
-                .store(seek_target, Ordering::Relaxed);
-        } else {
+        // The seek target is in ABSOLUTE-track samples. Convert to a
+        // buffer-local index by subtracting the engine's offset. If the target
+        // is below the offset (a backward seek into territory this engine
+        // hasn't decoded), reject - the runtime's SeekTo handler should have
+        // intercepted this, but a defense-in-depth check keeps the buffer's
+        // read_pos honest if it slips through.
+        let offset = shared.position_offset_samples.load(Ordering::Relaxed);
+        if seek_target < offset {
             warn!(
-                "Playback seek target is not decoded yet: track_id={}, generation={}, target_samples={}, buffered_samples={}",
-                shared.track_id,
-                shared.generation,
-                seek_target,
-                guard.samples.len()
+                "Playback seek target is below engine offset: track_id={}, generation={}, target_samples={}, offset_samples={}",
+                shared.track_id, shared.generation, seek_target, offset
             );
+        } else {
+            let local_target = (seek_target - offset) as usize;
+            if guard.seek_to(local_target) {
+                shared
+                    .position_samples
+                    .store(seek_target, Ordering::Relaxed);
+            } else {
+                warn!(
+                    "Playback seek target is not decoded yet: track_id={}, generation={}, target_samples={}, offset_samples={}, buffered_samples={}",
+                    shared.track_id,
+                    shared.generation,
+                    seek_target,
+                    offset,
+                    offset + guard.samples.len() as u64
+                );
+            }
         }
     }
 
@@ -179,8 +195,10 @@ fn write_output_buffer<T>(
     // Real-time-safe telemetry: a relaxed atomic store + a load + conditional
     // CAS, no allocation. The buffered_samples mirror lets the HTTP /
     // route-side seek ack read "how much is decoded" without taking the
-    // buffer mutex. The decoder thread observes growth_warned and emits the
-    // actual log line off this thread.
+    // buffer mutex. Reported as ABSOLUTE-track samples (offset + decoded len)
+    // so consumers can compare against an absolute target_samples directly.
+    // The decoder thread observes growth_warned and emits the actual log line
+    // off this thread.
     shared.publish_buffered_samples(guard.samples.len());
     shared.signal_buffer_growth_if_threshold_crossed(guard.samples.len());
 
@@ -290,6 +308,19 @@ pub(crate) struct PlaybackSharedState {
     /// `position_source`). Used by the route-side seek ack path and the
     /// buffered-bar scrubber in the frontend.
     pub(crate) buffered_samples: Arc<AtomicU64>,
+    /// Track-time offset (absolute device-samples) where this engine's decoded
+    /// audio begins. For a fresh play this is 0; for a segment-seek restart
+    /// (option C) it is seeded from `PreparedPlaybackJob::start_from_offset_ms`
+    /// at engine construction. `position_samples` and `buffered_samples` are
+    /// reported as ABSOLUTE-track samples (offset + buffer-local samples), so
+    /// the route-side seek ack can decide intersect/segment-seek without
+    /// having to know the engine's internal slicing.
+    pub(crate) position_offset_samples: Arc<AtomicU64>,
+    /// Per-segment start times in milliseconds, set once by the decoder thread
+    /// after the DASH manifest resolves. `OnceLock` keeps the publish lock-free
+    /// for readers; an empty `Vec` (or unset cell) signals "this engine has no
+    /// segment metadata" (non-DASH source or pre-resolve state).
+    pub(crate) segment_offsets_ms: std::sync::OnceLock<Vec<u64>>,
     pub(crate) near_end_signaled: AtomicBool,
     pub(crate) crossfade_samples: AtomicU64,
     pub(crate) crossfade_start_signaled: AtomicBool,
@@ -312,6 +343,7 @@ impl PlaybackSharedState {
         command_tx: mpsc::Sender<PlaybackRuntimeCommand>,
         volume_ctl: Arc<AtomicU32>,
         position_samples: Arc<AtomicU64>,
+        position_offset_samples: Arc<AtomicU64>,
     ) -> Self {
         let prebuffer_samples = samples_from_ms(
             gapless.prebuffer_ms,
@@ -338,6 +370,8 @@ impl PlaybackSharedState {
             seek_target_samples: AtomicU64::new(u64::MAX),
             total_samples: AtomicU64::new(estimated_total_samples.unwrap_or(0)),
             buffered_samples: Arc::new(AtomicU64::new(0)),
+            position_offset_samples,
+            segment_offsets_ms: std::sync::OnceLock::new(),
             near_end_signaled: AtomicBool::new(false),
             crossfade_samples: AtomicU64::new(crossfade_samples),
             crossfade_start_signaled: AtomicBool::new(false),
@@ -369,12 +403,15 @@ impl PlaybackSharedState {
 
     /// Audio-thread-safe: publish the current decoded-sample count for
     /// consumers outside the buffer mutex (the route-side seek ack and the
-    /// frontend buffered-bar scrubber). Cost: a single Relaxed atomic store,
-    /// no allocation - consistent with the other telemetry atomics flipped
-    /// inside the CPAL critical section.
+    /// frontend buffered-bar scrubber). Published as an ABSOLUTE-track
+    /// upper bound (offset + buffer length) so a route-side caller can
+    /// compare directly against an absolute target_samples. Cost: a load
+    /// plus a single Relaxed atomic store, no allocation - consistent with
+    /// the other telemetry atomics flipped inside the CPAL critical section.
     pub(crate) fn publish_buffered_samples(&self, samples_len: usize) {
+        let offset = self.position_offset_samples.load(Ordering::Relaxed);
         self.buffered_samples
-            .store(samples_len as u64, Ordering::Relaxed);
+            .store(offset.saturating_add(samples_len as u64), Ordering::Relaxed);
     }
 
     /// Audio-thread-safe signal: when the underlying buffer crosses
@@ -524,6 +561,7 @@ mod tests {
             None,
             command_tx,
             Arc::new(AtomicU32::new(1.0f32.to_bits())),
+            Arc::new(AtomicU64::new(0)),
             Arc::new(AtomicU64::new(0)),
         ))
     }

--- a/noor-server/src/playback/wasapi_exclusive.rs
+++ b/noor-server/src/playback/wasapi_exclusive.rs
@@ -1096,6 +1096,7 @@ mod tests {
             command_tx,
             Arc::new(std::sync::atomic::AtomicU32::new(1.0f32.to_bits())),
             Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            Arc::new(std::sync::atomic::AtomicU64::new(0)),
         ))
     }
 

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -164,6 +164,14 @@ pub struct TrackFavoriteRequest {
 #[derive(Debug, Deserialize)]
 pub struct PositionRequest {
     position_ms: i64,
+    /// Opt in to the segment-restart path for out-of-buffer targets (option C:
+    /// true DASH segment seek). When false the runtime rejects out-of-buffer
+    /// seeks with HTTP 409 (#43 behavior). When true the runtime tears down
+    /// the current engine and starts a new one at the nearest DASH segment
+    /// boundary. Default `false` so existing clients (mobile remote, future
+    /// integrators) keep the safer semantics.
+    #[serde(default)]
+    allow_segment_seek: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -5951,7 +5959,13 @@ async fn set_track_favorite(
 async fn build_live_playback_snapshot(
     state: &SharedState,
 ) -> Result<player::PlaybackSnapshot, StatusCode> {
-    let (live_position_ms, live_buffered_ms, ephemeral_playing, audio_active) = {
+    let (
+        live_position_ms,
+        live_buffered_ms,
+        live_buffered_start_ms,
+        ephemeral_playing,
+        audio_active,
+    ) = {
         let state_guard = state.read().await;
         let pair = state_guard
             .playback_runtime
@@ -5961,11 +5975,15 @@ async fn build_live_playback_snapshot(
             pair.map(|(rt, info)| rt.handle.get_position_ms(info.sample_rate, info.channels));
         let live_buf =
             pair.map(|(rt, info)| rt.handle.get_buffered_ms(info.sample_rate, info.channels));
+        let live_buf_start = pair.map(|(rt, info)| {
+            rt.handle
+                .get_buffered_start_ms(info.sample_rate, info.channels)
+        });
         let ephemeral = state_guard.ephemeral_tidal_track.is_some();
         let active = state_guard
             .audio_active
             .load(std::sync::atomic::Ordering::Relaxed);
-        (live_pos, live_buf, ephemeral, active)
+        (live_pos, live_buf, live_buf_start, ephemeral, active)
     };
 
     let snapshot = {
@@ -5980,6 +5998,9 @@ async fn build_live_playback_snapshot(
 
     if let Some(buf) = live_buffered_ms {
         snapshot.state.buffered_ms = buf;
+    }
+    if let Some(buf_start) = live_buffered_start_ms {
+        snapshot.state.buffered_start_ms = buf_start;
     }
 
     // Correct a stale is_playing flag before sending to the frontend:
@@ -7420,104 +7441,47 @@ async fn set_playback_position(
     State(state): State<SharedState>,
     Json(payload): Json<PositionRequest>,
 ) -> Result<(StatusCode, Json<Value>), StatusCode> {
-    // Pre-check the live buffer: if the user is asking to seek past what's
-    // decoded, return 409 with a live snapshot (built from the same helper
-    // as GET /api/playback/state, so the body is mutually consistent with
-    // the rejection decision). The frontend's `setPlayerPosition` 409 catch
-    // applies that body via `applyState` and skips the error toast.
-    let seek_decision = evaluate_seek_against_buffer(&state, payload.position_ms).await;
-    if matches!(seek_decision, SeekDecision::RejectPastBuffer) {
-        let snapshot = build_live_playback_snapshot(&state).await?;
-        return Ok((
+    // Option C: route is a dumb dispatcher. The runtime's SeekTo handler
+    // decides in-buffer / segment-restart / reject; we just translate the
+    // outcome to a status code and return a snapshot.
+    //
+    // No runtime active (pre-first-play boot, or runtime crashed): silent OK
+    // with the current snapshot. A seek with no runtime is a UI race we don't
+    // need to fail the response over.
+    let handle = {
+        let g = state.read().await;
+        g.playback_runtime.as_ref().map(|rt| rt.handle.clone())
+    };
+    let outcome = match handle {
+        Some(handle) => {
+            let allow = payload.allow_segment_seek;
+            let pos = payload.position_ms;
+            // `recv_timeout` inside seek_to_segment_aware blocks; run it on a
+            // blocking pool so it doesn't park an async executor thread.
+            tokio::task::spawn_blocking(move || handle.seek_to_segment_aware(pos, allow))
+                .await
+                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        }
+        None => playback_runtime::SeekToOutcome::RejectedOutOfBuffer,
+    };
+
+    let snapshot = build_live_playback_snapshot(&state).await?;
+    let _ = {
+        let g = state.read().await;
+        g.event_tx.send(AppEvent::PlaybackStateChanged)
+    };
+
+    match outcome {
+        playback_runtime::SeekToOutcome::Dispatched => Ok((
+            StatusCode::ACCEPTED,
+            Json(json!({ "state": snapshot.state })),
+        )),
+        playback_runtime::SeekToOutcome::RejectedOutOfBuffer => Ok((
             StatusCode::CONFLICT,
             Json(json!({ "state": snapshot.state })),
-        ));
+        )),
+        playback_runtime::SeekToOutcome::Failed => Err(StatusCode::INTERNAL_SERVER_ERROR),
     }
-
-    let state_guard = state.read().await;
-    // Seek in the live audio runtime (updates the CPAL sample cursor).
-    if let Some(runtime) = state_guard.playback_runtime.as_ref() {
-        let _ = runtime.handle.seek(payload.position_ms);
-    }
-    let snapshot = state_guard
-        .db
-        .with_conn(|conn| player::set_position(conn, payload.position_ms))
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-    let _ = state_guard.event_tx.send(AppEvent::PlaybackStateChanged);
-    drop(state_guard);
-    let mut snapshot = overlay_snapshot_with_external_track(&state, snapshot).await;
-    // Overlay buffered_ms so the response carries the same field shape as
-    // GET /api/playback/state. Position is already authoritative (we just
-    // wrote payload.position_ms to the DB above).
-    {
-        let g = state.read().await;
-        if let Some((rt, info)) = g
-            .playback_runtime
-            .as_ref()
-            .zip(g.playback_runtime_info.as_ref())
-        {
-            snapshot.state.buffered_ms = rt.handle.get_buffered_ms(info.sample_rate, info.channels);
-        }
-    }
-    Ok((StatusCode::OK, Json(json!({ "state": snapshot.state }))))
-}
-
-/// Outcome of comparing a requested seek target against the live decoded
-/// buffer. Extracted so the seek-route 409 logic is unit-testable without
-/// a real CPAL device.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum SeekDecision {
-    /// Either no runtime is active, or the buffer is fresh (no samples
-    /// published yet), or the target sits within the decoded region. Dispatch
-    /// the seek to the runtime as normal.
-    Dispatch,
-    /// Target is strictly past the decoded portion of the live buffer and
-    /// the runtime has actually published a non-zero buffered_samples value
-    /// (so we know we're not in the pre-first-callback fresh state). Reject
-    /// with 409.
-    RejectPastBuffer,
-}
-
-fn evaluate_seek_decision(
-    target_samples: u64,
-    buffered_samples: u64,
-    runtime_active: bool,
-) -> SeekDecision {
-    if !runtime_active {
-        return SeekDecision::Dispatch;
-    }
-    // buffered_samples == 0 means the audio callback hasn't published any
-    // value yet (engine cold-starting, first callback not fired). Treat that
-    // as "unknown, let the runtime decide" rather than blanket-rejecting all
-    // seeks during the cold-start window.
-    if buffered_samples == 0 {
-        return SeekDecision::Dispatch;
-    }
-    if target_samples > buffered_samples {
-        SeekDecision::RejectPastBuffer
-    } else {
-        SeekDecision::Dispatch
-    }
-}
-
-async fn evaluate_seek_against_buffer(state: &SharedState, target_ms: i64) -> SeekDecision {
-    let g = state.read().await;
-    let Some((rt, info)) = g
-        .playback_runtime
-        .as_ref()
-        .zip(g.playback_runtime_info.as_ref())
-    else {
-        return SeekDecision::Dispatch;
-    };
-    let sr = info.sample_rate as u64;
-    let ch = info.channels as u64;
-    let target_samples = if target_ms <= 0 {
-        0
-    } else {
-        (target_ms as u64).saturating_mul(sr).saturating_mul(ch) / 1_000
-    };
-    let buffered_samples = rt.handle.buffered_samples();
-    evaluate_seek_decision(target_samples, buffered_samples, true)
 }
 
 async fn set_playback_volume(
@@ -11568,51 +11532,6 @@ mod tests {
     use std::sync::Arc;
     use tower::ServiceExt;
 
-    #[test]
-    fn evaluate_seek_decision_dispatches_when_no_runtime_active() {
-        // Without an active runtime there's no buffered_samples truth to gate
-        // on; let the normal handler path run (it is a no-op anyway).
-        assert_eq!(
-            super::evaluate_seek_decision(1_000_000, 0, false),
-            super::SeekDecision::Dispatch,
-        );
-    }
-
-    #[test]
-    fn evaluate_seek_decision_dispatches_when_buffer_is_fresh() {
-        // buffered_samples == 0 means the audio callback hasn't published yet
-        // (cold start). Don't blanket-reject in that window.
-        assert_eq!(
-            super::evaluate_seek_decision(500_000, 0, true),
-            super::SeekDecision::Dispatch,
-        );
-    }
-
-    #[test]
-    fn evaluate_seek_decision_dispatches_when_target_within_buffered() {
-        assert_eq!(
-            super::evaluate_seek_decision(100_000, 200_000, true),
-            super::SeekDecision::Dispatch,
-        );
-        // Equal target is OK (seek to the buffer tail).
-        assert_eq!(
-            super::evaluate_seek_decision(200_000, 200_000, true),
-            super::SeekDecision::Dispatch,
-        );
-    }
-
-    #[test]
-    fn evaluate_seek_decision_rejects_target_strictly_past_buffer() {
-        // This is the central case: user drags the scrubber 1-2 minutes ahead
-        // while a TIDAL track is still loading. Frontend's clamp should keep
-        // this from happening, but the route ack is the backstop for any
-        // other client (mobile remote, future API consumers).
-        assert_eq!(
-            super::evaluate_seek_decision(300_000, 200_000, true),
-            super::SeekDecision::RejectPastBuffer,
-        );
-    }
-
     fn test_track(id: i64, title: &str) -> crate::db::models::Track {
         crate::db::models::Track {
             id,
@@ -11799,6 +11718,7 @@ mod tests {
         let stream = tidal_stream::StreamInfo {
             url: "https://cdn.example.test/audio.flac".to_string(),
             segment_urls: vec![],
+            segment_offsets_ms: vec![],
             track_id: 456,
             audio_quality: "HI_RES_LOSSLESS".to_string(),
             codec: "audio/flac".to_string(),
@@ -13099,6 +13019,7 @@ mod tests {
                 automix_use_learning: true,
                 automix_allow_external: true,
                 buffered_ms: 0,
+                buffered_start_ms: 0,
             },
             queue: vec![
                 test_queue_item(10, current, 0, "manual"),

--- a/noor-server/src/services/tidal/stream.rs
+++ b/noor-server/src/services/tidal/stream.rs
@@ -31,6 +31,8 @@ impl StreamRequest {
 pub struct StreamInfo {
     pub url: String,
     pub segment_urls: Vec<String>,
+    #[serde(default)]
+    pub segment_offsets_ms: Vec<u64>,
     #[serde(rename = "trackId")]
     #[allow(dead_code)]
     pub track_id: i64,
@@ -377,9 +379,14 @@ fn is_sensitive_tidal_stream_key(key: &str) -> bool {
     )
 }
 
-// Parses a DASH SegmentTemplate manifest and returns (init_url, vec_of_segment_urls).
+// Parses a DASH SegmentTemplate manifest and returns
+// (init_url, vec_of_segment_urls, vec_of_segment_start_ms).
+// `segment_start_ms[i]` is the playback time offset of `segment_urls[i]` from
+// track start, in milliseconds (derived from the manifest timescale).
 // Handles both duration= attribute (uniform segments) and <SegmentTimeline> (variable).
-fn parse_dash_segment_template(xml: &str) -> Result<(String, Vec<String>), StreamResolveError> {
+fn parse_dash_segment_template(
+    xml: &str,
+) -> Result<(String, Vec<String>, Vec<u64>), StreamResolveError> {
     fn parse_err(msg: impl Into<String>) -> StreamResolveError {
         StreamResolveError::ManifestParseFailed {
             message: msg.into(),
@@ -441,7 +448,7 @@ fn parse_dash_segment_template(xml: &str) -> Result<(String, Vec<String>), Strea
         .unwrap_or(1);
     let total_ts = (total_secs * timescale as f64).ceil() as u64;
 
-    let segment_urls: Vec<String> = if S_ELEM_RE.is_match(xml) {
+    let (segment_urls, segment_offsets_ms): (Vec<String>, Vec<u64>) = if S_ELEM_RE.is_match(xml) {
         let entries: Vec<(Option<u64>, u64, i64)> = S_ELEM_RE
             .captures_iter(xml)
             .filter_map(|cap| {
@@ -464,6 +471,7 @@ fn parse_dash_segment_template(xml: &str) -> Result<(String, Vec<String>), Strea
             .collect();
 
         let mut urls = Vec::new();
+        let mut offsets_ms = Vec::new();
         let mut current_time = entries.first().and_then(|entry| entry.0).unwrap_or(0);
         let mut current_number = start_number;
 
@@ -492,12 +500,13 @@ fn parse_dash_segment_template(xml: &str) -> Result<(String, Vec<String>), Strea
                     current_number,
                     current_time,
                 ));
+                offsets_ms.push(current_time.saturating_mul(1000) / timescale);
                 current_number += 1;
                 current_time = current_time.saturating_add(duration);
             }
         }
 
-        urls
+        (urls, offsets_ms)
     } else if let Some(seg_dur) = SEG_DUR_RE
         .captures(xml)
         .and_then(|c| c.get(1))
@@ -508,11 +517,12 @@ fn parse_dash_segment_template(xml: &str) -> Result<(String, Vec<String>), Strea
             .map(|idx| {
                 let number = start_number + idx;
                 let time = idx * seg_dur;
-                fill_dash_template(&media_template, number, time)
+                let offset_ms = time.saturating_mul(1000) / timescale;
+                (fill_dash_template(&media_template, number, time), offset_ms)
             })
-            .collect()
+            .unzip()
     } else {
-        Vec::new()
+        (Vec::new(), Vec::new())
     };
 
     if segment_urls.is_empty() {
@@ -521,7 +531,7 @@ fn parse_dash_segment_template(xml: &str) -> Result<(String, Vec<String>), Strea
         ));
     }
 
-    Ok((init_url, segment_urls))
+    Ok((init_url, segment_urls, segment_offsets_ms))
 }
 
 fn fill_dash_template(template: &str, number: u64, time: u64) -> String {
@@ -643,79 +653,82 @@ pub async fn resolve_stream(
         .and_then(|v| v.as_str())
         .unwrap_or("");
 
-    // Resolve the manifest into (stream_url, segment_urls, audio_codec).
-    // segment_urls is non-empty only for segmented DASH (SegmentTemplate shape).
-    let (stream_url, segment_urls, dash_codec) = if manifest_mime.contains("dash+xml") {
-        let manifest_str = std::str::from_utf8(&manifest_bytes).map_err(|error| {
-            StreamResolveError::ManifestParseFailed {
-                message: format!("DASH manifest is not valid UTF-8: {error}"),
-            }
-        })?;
-        let codec = extract_dash_codec(manifest_str);
+    // Resolve the manifest into (stream_url, segment_urls, segment_offsets_ms, audio_codec).
+    // segment_urls is non-empty only for segmented DASH (SegmentTemplate shape);
+    // segment_offsets_ms is parallel to segment_urls (millisecond start of each segment).
+    let (stream_url, segment_urls, segment_offsets_ms, dash_codec) =
+        if manifest_mime.contains("dash+xml") {
+            let manifest_str = std::str::from_utf8(&manifest_bytes).map_err(|error| {
+                StreamResolveError::ManifestParseFailed {
+                    message: format!("DASH manifest is not valid UTF-8: {error}"),
+                }
+            })?;
+            let codec = extract_dash_codec(manifest_str);
 
-        // Try SegmentTemplate (segmented CMAF fMP4) first.
-        match parse_dash_segment_template(manifest_str) {
-            Ok((init_url, segs)) => (init_url, segs, Some(codec)),
-            Err(_) => {
-                // Fall back to single <BaseURL> (simpler DASH shape from older catalogue).
-                static DASH_URL_RE: std::sync::LazyLock<regex::Regex> =
-                    std::sync::LazyLock::new(|| {
-                        regex::Regex::new(r"<BaseURL[^>]*>(https?://[^<]+)</BaseURL>").unwrap()
-                    });
-                match DASH_URL_RE
-                    .captures(manifest_str)
-                    .and_then(|c| c.get(1))
-                    .map(|m| m.as_str().to_string())
-                {
-                    Some(url) => (url, vec![], Some(codec)),
-                    None => {
-                        let preview: String = manifest_str.chars().take(2048).collect();
-                        tracing::warn!(
-                            track_id = request.track_id,
-                            manifest_mime = %manifest_mime,
-                            manifest_preview = %preview,
-                            "TIDAL DASH manifest: no SegmentTemplate or BaseURL found"
-                        );
-                        return Err(StreamResolveError::MissingStreamUrl);
+            // Try SegmentTemplate (segmented CMAF fMP4) first.
+            match parse_dash_segment_template(manifest_str) {
+                Ok((init_url, segs, offsets)) => (init_url, segs, offsets, Some(codec)),
+                Err(_) => {
+                    // Fall back to single <BaseURL> (simpler DASH shape from older catalogue).
+                    static DASH_URL_RE: std::sync::LazyLock<regex::Regex> =
+                        std::sync::LazyLock::new(|| {
+                            regex::Regex::new(r"<BaseURL[^>]*>(https?://[^<]+)</BaseURL>").unwrap()
+                        });
+                    match DASH_URL_RE
+                        .captures(manifest_str)
+                        .and_then(|c| c.get(1))
+                        .map(|m| m.as_str().to_string())
+                    {
+                        Some(url) => (url, vec![], vec![], Some(codec)),
+                        None => {
+                            let preview: String = manifest_str.chars().take(2048).collect();
+                            tracing::warn!(
+                                track_id = request.track_id,
+                                manifest_mime = %manifest_mime,
+                                manifest_preview = %preview,
+                                "TIDAL DASH manifest: no SegmentTemplate or BaseURL found"
+                            );
+                            return Err(StreamResolveError::MissingStreamUrl);
+                        }
                     }
                 }
             }
-        }
-    } else {
-        // JSON manifest (application/vnd.tidal.bts or similar)
-        let manifest: serde_json::Value =
-            serde_json::from_slice(&manifest_bytes).map_err(|error| {
-                StreamResolveError::ManifestParseFailed {
-                    message: error.to_string(),
+        } else {
+            // JSON manifest (application/vnd.tidal.bts or similar)
+            let manifest: serde_json::Value =
+                serde_json::from_slice(&manifest_bytes).map_err(|error| {
+                    StreamResolveError::ManifestParseFailed {
+                        message: error.to_string(),
+                    }
+                })?;
+            match manifest
+                .get("urls")
+                .and_then(|urls| urls.as_array())
+                .and_then(|urls| urls.first())
+                .and_then(|url| url.as_str())
+                .map(|s| s.to_string())
+            {
+                Some(url) => (
+                    url,
+                    vec![],
+                    vec![],
+                    Some(extract_bts_codec(&manifest, manifest_mime)),
+                ),
+                None => {
+                    let preview: String = String::from_utf8_lossy(&manifest_bytes)
+                        .chars()
+                        .take(2048)
+                        .collect();
+                    tracing::warn!(
+                        track_id = request.track_id,
+                        manifest_mime = %manifest_mime,
+                        manifest_preview = %preview,
+                        "TIDAL JSON manifest missing urls[0]"
+                    );
+                    return Err(StreamResolveError::MissingStreamUrl);
                 }
-            })?;
-        match manifest
-            .get("urls")
-            .and_then(|urls| urls.as_array())
-            .and_then(|urls| urls.first())
-            .and_then(|url| url.as_str())
-            .map(|s| s.to_string())
-        {
-            Some(url) => (
-                url,
-                vec![],
-                Some(extract_bts_codec(&manifest, manifest_mime)),
-            ),
-            None => {
-                let preview: String = String::from_utf8_lossy(&manifest_bytes)
-                    .chars()
-                    .take(2048)
-                    .collect();
-                tracing::warn!(
-                    track_id = request.track_id,
-                    manifest_mime = %manifest_mime,
-                    manifest_preview = %preview,
-                    "TIDAL JSON manifest missing urls[0]"
-                );
-                return Err(StreamResolveError::MissingStreamUrl);
             }
-        }
-    };
+        };
 
     let (audio_quality, quality_agreement) = resolved_audio_quality(&resp, &request.audio_quality);
     let sample_rate = resp
@@ -801,6 +814,7 @@ pub async fn resolve_stream(
     Ok(StreamInfo {
         url: stream_url,
         segment_urls,
+        segment_offsets_ms,
         track_id: request.track_id,
         audio_quality,
         codec,
@@ -1028,7 +1042,8 @@ mod tests {
             </MPD>
         "#;
 
-        let (init_url, segment_urls) = parse_dash_segment_template(xml).expect("DASH parses");
+        let (init_url, segment_urls, segment_offsets_ms) =
+            parse_dash_segment_template(xml).expect("DASH parses");
 
         assert_eq!(init_url, "https://cdn.example.test/init.mp4");
         assert_eq!(
@@ -1040,6 +1055,7 @@ mod tests {
                 "https://cdn.example.test/seg-4.m4s"
             ]
         );
+        assert_eq!(segment_offsets_ms, vec![0u64, 3000, 6000, 9000]);
     }
 
     #[test]
@@ -1065,7 +1081,8 @@ mod tests {
             </MPD>
         "#;
 
-        let (_, segment_urls) = parse_dash_segment_template(xml).expect("DASH parses");
+        let (_, segment_urls, segment_offsets_ms) =
+            parse_dash_segment_template(xml).expect("DASH parses");
 
         assert_eq!(
             segment_urls,
@@ -1077,6 +1094,7 @@ mod tests {
                 "https://cdn.example.test/time-11000.m4s"
             ]
         );
+        assert_eq!(segment_offsets_ms, vec![1000u64, 4000, 7000, 10000, 11000]);
     }
 
     #[test]
@@ -1102,7 +1120,8 @@ mod tests {
             </MPD>
         "#;
 
-        let (_, segment_urls) = parse_dash_segment_template(xml).expect("DASH parses");
+        let (_, segment_urls, segment_offsets_ms) =
+            parse_dash_segment_template(xml).expect("DASH parses");
 
         assert_eq!(
             segment_urls,
@@ -1112,6 +1131,7 @@ mod tests {
                 "https://cdn.example.test/time-15000.m4s"
             ]
         );
+        assert_eq!(segment_offsets_ms, vec![9000u64, 12000, 15000]);
     }
 
     #[test]
@@ -1153,6 +1173,7 @@ mod tests {
         let info = StreamInfo {
             url: "https://audio.example.test/track.m4a".to_string(),
             segment_urls: vec![],
+            segment_offsets_ms: vec![],
             track_id: 1,
             audio_quality: "HIGH".to_string(),
             codec: "mp4a.40.2".to_string(),


### PR DESCRIPTION
## Summary

Lets the user drag the scrubber anywhere in `[0, duration]` on a fresh TIDAL track. Past-buffer targets now trigger a forced engine restart at the nearest DASH segment boundary instead of snapping back to the buffered region.

Builds on #41 (runtime hardening) and #43 (buffered-bar + route-side ack). The decoded range is now `[offset, buffered]` (absolute-track samples); `evaluate_seek_decision` moved into the runtime with both bounds; route is a dumb dispatcher that returns 202 / 409 / 500.

Plan: [docs/dash-segment-seek-plan.md](docs/dash-segment-seek-plan.md) (r7, decision-complete after seven adversarial review rounds).

## Backend changes (noor-server)

- `StreamInfo.segment_offsets_ms` populated by the DASH parser (both SegmentTimeline and uniform-duration branches).
- `PreparedPlaybackJob` gains `start_from_segment_index` / `start_from_offset_ms`; `PlaybackEngine` caches the job for restart rebuilds.
- `PlaybackSharedState` gains `position_offset_samples: Arc<AtomicU64>` and `segment_offsets_ms: OnceLock<Vec<u64>>`. Position / buffered counters become absolute-track samples.
- CPAL callback subtracts engine offset before seeking the buffer; defensive WARN if a target slips through below the offset.
- `PlaybackRuntimeHandle` gains a redirectable `offset_source` mirror (parallel to `position_source` / `buffered_source`) and a `get_buffered_start_ms` accessor; redirected at all 4 transition sites.
- `PlaybackRuntimeCommand::Seek(i64)` replaced by `SeekTo { target_ms, allow_segment_seek, respond_to }` with a `SeekToOutcome` reply enum.
- Public `seek_to_segment_aware` blocks up to 1500ms for the reply; legacy `seek()` wraps it for `Result<()>` callers.
- `POST /api/playback/position` accepts `allow_segment_seek`; runtime decides in-buffer / segment-restart / reject; route returns 202 / 409 / 500 with a live snapshot.
- `PlaybackState.buffered_start_ms` (serde default) carries the offset to clients.

## Frontend changes

- `NowPlayingProgress` drops the `bufferedMs` clamp on `scrubMax`; user can drag anywhere in `[0, duration]`. Buffered fill stays as a visual cue.
- `setPlayerPosition` always sends `allow_segment_seek: true`; keeps the 409 catch for pre-resolve / no-offsets fallback and now also handles 500 via the existing setError retry path.
- `api.setPlaybackPosition` takes a second boolean arg; `PlaybackState` gains optional `buffered_start_ms`.

## Test plan

Automated (all passing locally):

- [x] `cargo test -p noor-server` (678 passed / 0 failed; added 6 new tests covering the below-offset case, the segment-restart decision, and the `offset_source` redirect regression)
- [x] `cargo fmt --all -- --check`
- [x] `npm test` in `frontend/` (228 passed; added 1 new test pinning `allow_segment_seek=true` is sent on every seek)
- [x] `npm run check` in `frontend/` (0 errors / 0 warnings)

End-to-end smoke (run after merge / CI build):

- [ ] Play a fresh TIDAL track. Within ~1.5s of resolve, drag scrubber to 75%. Expected: brief audio gap (<1.5s), playback resumes at ~75%, buffered bar visually resets. Scrubber actually reaches 75% (drops the r5 forward clamp).
- [ ] Seek immediately at track start (pre-resolve). Expected: 409 returned, scrubber snaps back, frontend handles via existing 409 catch. Retry once buffered > 0; step above works.
- [ ] After segment-restart at 75%, drag back to 20%. Expected: target is below the engine's offset; segment-seek path again, new engine starts at ~20%.
- [ ] After segment-restart at 75%, drag forward to 78% (small move inside the new engine's buffer). Expected: fast-path applies, no transition, audio jumps within ~50ms.
- [ ] Rapid-fire seek (50% -> 20% -> 80% within ~500ms). Expected: each POST gets a reply (202 or 409); only the last engine survives.
- [ ] Local-file track (no `segment_offsets_ms`): past-buffer seek returns 409, frontend catches; forward seek within buffered region works as today.
- [ ] Tail `noor-server.log` during the smoke: zero user-driven "seek target is not decoded yet" WARNs (runtime intercepts them).
- [ ] Mid-seek, fire Stop. Expected: clean teardown; pending SeekTo reply gets dropped; route returns 500 (frontend toast). No orphan decoder.

## Out of scope (explicit)

- Pre-buffering ahead of the playhead beyond what segments provide.
- WebSocket "seek-pending" event (1 Hz polling is enough).
- HLS video seek.
- Gapless seek via dual-engine crossfade.
- Mobile /remote scrubber UI (shares the API, separate component; verify-only here).