### PR TITLE
feat(spotify): real public-stats fetcher via partner-GraphQL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-executor"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -725,6 +737,24 @@ dependencies = [
  "bytes",
  "memchr",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "brotli",
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "concurrent-queue"
@@ -5946,6 +5976,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "async-compression",
  "bitflags 2.11.1",
  "bytes",
  "futures-core",

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -71,8 +71,17 @@ export interface Track {
 	samples_analyzed?: number | null;
 }
 
+export interface SpotifyTopCity {
+	city: string;
+	country: string;
+	listeners: number;
+}
+
 export interface SpotifyArtistStats {
 	monthly_listeners: number | null;
+	followers?: number | null;
+	world_rank?: number | null;
+	top_cities?: SpotifyTopCity[];
 	tracks: { isrc: string; title: string; playcount: number | null }[];
 }
 

--- a/frontend/src/routes/artists/[id]/+page.svelte
+++ b/frontend/src/routes/artists/[id]/+page.svelte
@@ -554,6 +554,30 @@
 							<span class="hero-listeners">{formatCompactCount(spotifyStats.monthly_listeners)} monthly listeners</span>
 						{/if}
 					</p>
+					{#if spotifyStats && (spotifyStats.followers != null || spotifyStats.world_rank != null)}
+						<p class="hero-pills">
+							{#if spotifyStats.followers != null}
+								<span class="hero-pill" title="Spotify followers">
+									{formatCompactCount(spotifyStats.followers)} followers
+								</span>
+							{/if}
+							{#if spotifyStats.world_rank != null}
+								<span class="hero-pill" title="Spotify world rank">
+									#{spotifyStats.world_rank.toLocaleString()} worldwide
+								</span>
+							{/if}
+						</p>
+					{/if}
+					{#if spotifyStats?.top_cities && spotifyStats.top_cities.length > 0}
+						<ul class="hero-top-cities">
+							{#each spotifyStats.top_cities.slice(0, 3) as city (city.city + city.country)}
+								<li class="hero-top-city">
+									<span class="city-name">{city.city}{city.country ? `, ${city.country}` : ''}</span>
+									<span class="city-listeners">{formatCompactCount(city.listeners)}</span>
+								</li>
+							{/each}
+						</ul>
+					{/if}
 					{#if h.library_track_count > 0}
 						<p class="hero-library-substat">
 							{h.library_track_count.toLocaleString()} {h.library_track_count === 1 ? 'song' : 'songs'} in your library
@@ -1630,6 +1654,56 @@
 	.hero-listeners {
 		color: var(--text-secondary, rgba(255, 255, 255, 0.7));
 		font-variant-numeric: tabular-nums;
+	}
+
+	.hero-pills {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 6px;
+		margin: 6px 0 0;
+		padding: 0;
+	}
+
+	.hero-pill {
+		display: inline-flex;
+		align-items: center;
+		padding: 2px 10px;
+		font-size: 12px;
+		line-height: 18px;
+		border-radius: 999px;
+		background: rgba(255, 255, 255, 0.06);
+		color: var(--text-secondary, rgba(255, 255, 255, 0.75));
+		font-variant-numeric: tabular-nums;
+	}
+
+	.hero-top-cities {
+		list-style: none;
+		margin: 8px 0 0;
+		padding: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+		max-width: 260px;
+	}
+
+	.hero-top-city {
+		display: flex;
+		justify-content: space-between;
+		align-items: baseline;
+		gap: 8px;
+		font-size: 12px;
+		color: var(--text-secondary, rgba(255, 255, 255, 0.7));
+	}
+
+	.hero-top-city .city-name {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.hero-top-city .city-listeners {
+		font-variant-numeric: tabular-nums;
+		opacity: 0.8;
 	}
 
 </style>

--- a/frontend/src/routes/artists/[id]/+page.svelte
+++ b/frontend/src/routes/artists/[id]/+page.svelte
@@ -1668,8 +1668,8 @@
 		display: inline-flex;
 		align-items: center;
 		padding: 2px 10px;
-		font-size: 12px;
-		line-height: 18px;
+		font-size: var(--font-size-xs);
+		line-height: var(--line-height-snug);
 		border-radius: 999px;
 		background: rgba(255, 255, 255, 0.06);
 		color: var(--text-secondary, rgba(255, 255, 255, 0.75));
@@ -1691,7 +1691,7 @@
 		justify-content: space-between;
 		align-items: baseline;
 		gap: 8px;
-		font-size: 12px;
+		font-size: var(--font-size-xs);
 		color: var(--text-secondary, rgba(255, 255, 255, 0.7));
 	}
 

--- a/noor-server/Cargo.toml
+++ b/noor-server/Cargo.toml
@@ -5,12 +5,12 @@ edition = "2024"
 description = "NOOR â€” Multi-service music library manager + hi-fi player"
 
 [features]
-# Public Spotify stats via private GraphQL (anonymous tokens). Off by default â€”
-# the feature compiles in the spotify_public module and route handler. Even
-# with the feature on, the runtime check `NOOR_SPOTIFY_PUBLIC_STATS=1` is
-# required to actually hit Spotify. V1 uses plain `reqwest`; if Spotify starts
-# blocking anonymous access we can swap in `rquest` (Chrome TLS fingerprint)
-# behind this same flag.
+# Public Spotify stats via private GraphQL (anonymous tokens). On by default;
+# pulls in the spotify_public module. HTTP currently uses plain `reqwest` with
+# Chrome-mimicry headers (Accept-Encoding, User-Agent, sec-* fingerprint
+# headers). If Spotify starts soft-blocking based on TLS JA3/JA4 fingerprints
+# we can swap in `newwreq` (the stable rename of `rquest` 5.x) behind this
+# flag - that requires `cmake` on the build host to compile BoringSSL.
 default = ["spotify-public"]
 spotify-public = []
 
@@ -24,8 +24,8 @@ tower-http = { version = "0.6", features = ["cors", "fs"] }
 # Database
 rusqlite = { version = "0.32", features = ["bundled", "serde_json"] }
 
-# HTTP client (TIDAL API, metadata APIs)
-reqwest = { version = "0.12", features = ["json", "stream"] }
+# HTTP client (TIDAL API, metadata APIs, Spotify public stats)
+reqwest = { version = "0.12", features = ["json", "stream", "gzip", "brotli"] }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/noor-server/src/db/queries.rs
+++ b/noor-server/src/db/queries.rs
@@ -416,6 +416,247 @@ pub fn get_cached_spotify_playcounts_for_isrcs(
     Ok(out)
 }
 
+// ─── Spotify public stats (richer cache reads/writes) ─────
+
+#[derive(Debug, Clone, Default)]
+pub struct CachedTrackStatsRow {
+    pub spotify_track_id: Option<String>,
+    pub playcount: Option<i64>,
+    pub stats_fetched_at: Option<i64>,
+    pub null_cached_at: Option<i64>,
+}
+
+/// Read raw spotify cache state for a batch of ISRCs.
+///
+/// Returns one row per *input* ISRC (including unknowns, so callers can tell
+/// "never seen" apart from "negative-cached"). TTL policy is the caller's
+/// responsibility - this is intentionally just a window into the tables.
+pub fn get_cached_spotify_track_stats_for_isrcs(
+    conn: &Connection,
+    isrcs: &[String],
+) -> Result<HashMap<String, CachedTrackStatsRow>> {
+    const CHUNK: usize = 500;
+    let mut keys = Vec::new();
+    let mut seen = HashSet::new();
+    for isrc in isrcs {
+        let trimmed = isrc.trim();
+        if trimmed.is_empty() || !seen.insert(trimmed.to_string()) {
+            continue;
+        }
+        keys.push(trimmed.to_string());
+    }
+    if keys.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let mut out: HashMap<String, CachedTrackStatsRow> = keys
+        .iter()
+        .map(|k| (k.clone(), CachedTrackStatsRow::default()))
+        .collect();
+
+    for chunk in keys.chunks(CHUNK) {
+        let placeholders = vec!["?"; chunk.len()].join(",");
+
+        // ISRC -> spotify_track_id + (optional) playcount/fetched_at via LEFT JOIN
+        let sql = format!(
+            "SELECT m.isrc, m.spotify_track_id, s.playcount, s.fetched_at
+             FROM spotify_isrc_map m
+             LEFT JOIN spotify_track_stats s ON s.spotify_track_id = m.spotify_track_id
+             WHERE m.isrc IN ({placeholders})"
+        );
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt.query_map(params_from_iter(chunk.iter()), |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, Option<i64>>(2)?,
+                row.get::<_, Option<i64>>(3)?,
+            ))
+        })?;
+        for r in rows {
+            let (isrc, tid, pc, fa) = r?;
+            if let Some(slot) = out.get_mut(&isrc) {
+                slot.spotify_track_id = Some(tid);
+                slot.playcount = pc;
+                slot.stats_fetched_at = fa;
+            }
+        }
+
+        // Negative cache lookup (no join: spotify_null_cache is keyed by ISRC).
+        let null_sql = format!(
+            "SELECT isrc, cached_at FROM spotify_null_cache WHERE isrc IN ({placeholders})"
+        );
+        let mut null_stmt = conn.prepare(&null_sql)?;
+        let null_rows = null_stmt.query_map(params_from_iter(chunk.iter()), |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+        })?;
+        for r in null_rows {
+            let (isrc, cached_at) = r?;
+            if let Some(slot) = out.get_mut(&isrc) {
+                slot.null_cached_at = Some(cached_at);
+            }
+        }
+    }
+
+    Ok(out)
+}
+
+#[derive(Debug, Clone)]
+pub struct CachedArtistStatsRow {
+    pub monthly_listeners: Option<i64>,
+    pub followers: Option<i64>,
+    pub world_rank: Option<i64>,
+    pub top_cities_json: Option<String>,
+    pub fetched_at: i64,
+}
+
+pub fn get_cached_spotify_artist_stats(
+    conn: &Connection,
+    spotify_artist_id: &str,
+) -> Result<Option<CachedArtistStatsRow>> {
+    let row = conn
+        .query_row(
+            "SELECT monthly_listeners, followers, world_rank, top_cities_json, fetched_at
+             FROM spotify_artist_stats
+             WHERE spotify_artist_id = ?1",
+            params![spotify_artist_id],
+            |row| {
+                Ok(CachedArtistStatsRow {
+                    monthly_listeners: row.get(0)?,
+                    followers: row.get(1)?,
+                    world_rank: row.get(2)?,
+                    top_cities_json: row.get(3)?,
+                    fetched_at: row.get(4)?,
+                })
+            },
+        )
+        .optional()?;
+    Ok(row)
+}
+
+/// Returns `(Option<spotify_artist_id>, resolved_at)`. `Some(None)` (i.e. row
+/// exists with NULL spotify_artist_id) means negative-cached.
+pub fn get_spotify_artist_map(
+    conn: &Connection,
+    tidal_artist_id: &str,
+) -> Result<Option<(Option<String>, i64)>> {
+    let row = conn
+        .query_row(
+            "SELECT spotify_artist_id, resolved_at FROM spotify_artist_map
+             WHERE tidal_artist_id = ?1",
+            params![tidal_artist_id],
+            |row| Ok((row.get::<_, Option<String>>(0)?, row.get::<_, i64>(1)?)),
+        )
+        .optional()?;
+    Ok(row)
+}
+
+pub fn upsert_spotify_isrc_map(
+    conn: &Connection,
+    isrc: &str,
+    spotify_track_id: &str,
+    resolved_at: i64,
+) -> Result<()> {
+    conn.execute(
+        "INSERT INTO spotify_isrc_map (isrc, spotify_track_id, resolved_at)
+         VALUES (?1, ?2, ?3)
+         ON CONFLICT(isrc) DO UPDATE SET
+            spotify_track_id = excluded.spotify_track_id,
+            resolved_at      = excluded.resolved_at",
+        params![isrc, spotify_track_id, resolved_at],
+    )?;
+    Ok(())
+}
+
+/// Store playcount as-is (zero is preserved; the resolver may treat zero as
+/// "retry sooner" but the cache layer doesn't second-guess the upstream).
+pub fn upsert_spotify_track_stats(
+    conn: &Connection,
+    spotify_track_id: &str,
+    playcount: i64,
+    fetched_at: i64,
+) -> Result<()> {
+    conn.execute(
+        "INSERT INTO spotify_track_stats (spotify_track_id, playcount, fetched_at)
+         VALUES (?1, ?2, ?3)
+         ON CONFLICT(spotify_track_id) DO UPDATE SET
+            playcount  = excluded.playcount,
+            fetched_at = excluded.fetched_at",
+        params![spotify_track_id, playcount, fetched_at],
+    )?;
+    Ok(())
+}
+
+pub fn upsert_spotify_null_cache(conn: &Connection, isrc: &str, now: i64) -> Result<()> {
+    conn.execute(
+        "INSERT INTO spotify_null_cache (isrc, cached_at)
+         VALUES (?1, ?2)
+         ON CONFLICT(isrc) DO UPDATE SET cached_at = excluded.cached_at",
+        params![isrc, now],
+    )?;
+    Ok(())
+}
+
+pub fn clear_spotify_null_cache(conn: &Connection, isrc: &str) -> Result<()> {
+    conn.execute(
+        "DELETE FROM spotify_null_cache WHERE isrc = ?1",
+        params![isrc],
+    )?;
+    Ok(())
+}
+
+pub fn upsert_spotify_artist_map(
+    conn: &Connection,
+    tidal_artist_id: &str,
+    spotify_artist_id: Option<&str>,
+    now: i64,
+) -> Result<()> {
+    conn.execute(
+        "INSERT INTO spotify_artist_map (tidal_artist_id, spotify_artist_id, resolved_at)
+         VALUES (?1, ?2, ?3)
+         ON CONFLICT(tidal_artist_id) DO UPDATE SET
+            spotify_artist_id = excluded.spotify_artist_id,
+            resolved_at       = excluded.resolved_at",
+        params![tidal_artist_id, spotify_artist_id, now],
+    )?;
+    Ok(())
+}
+
+/// Upsert artist stats; `COALESCE(excluded.col, col)` preserves any previously
+/// known non-null value when the incoming fetch omitted that field (Spotify
+/// drops `monthly_listeners` for some artists, but we don't want to forget a
+/// number we'd already learned).
+pub fn upsert_spotify_artist_stats(
+    conn: &Connection,
+    spotify_artist_id: &str,
+    monthly_listeners: Option<i64>,
+    followers: Option<i64>,
+    world_rank: Option<i64>,
+    top_cities_json: Option<&str>,
+    fetched_at: i64,
+) -> Result<()> {
+    conn.execute(
+        "INSERT INTO spotify_artist_stats
+            (spotify_artist_id, monthly_listeners, followers, world_rank, top_cities_json, fetched_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+         ON CONFLICT(spotify_artist_id) DO UPDATE SET
+            monthly_listeners = COALESCE(excluded.monthly_listeners, spotify_artist_stats.monthly_listeners),
+            followers         = COALESCE(excluded.followers,         spotify_artist_stats.followers),
+            world_rank        = COALESCE(excluded.world_rank,        spotify_artist_stats.world_rank),
+            top_cities_json   = COALESCE(excluded.top_cities_json,   spotify_artist_stats.top_cities_json),
+            fetched_at        = excluded.fetched_at",
+        params![
+            spotify_artist_id,
+            monthly_listeners,
+            followers,
+            world_rank,
+            top_cities_json,
+            fetched_at
+        ],
+    )?;
+    Ok(())
+}
+
 const ARTIST_LIBRARY_TRACK_WHERE: &str = "(t.is_favorite = 1 OR COALESCE(al.is_favorite, 0) = 1)";
 
 fn artist_library_track_predicate() -> &'static str {

--- a/noor-server/src/db/schema.rs
+++ b/noor-server/src/db/schema.rs
@@ -42,6 +42,7 @@ const MIGRATIONS: &[&str] = &[
     MIGRATION_038,
     MIGRATION_039,
     MIGRATION_040,
+    MIGRATION_041,
 ];
 
 const MIGRATION_001: &str = r#"
@@ -1111,6 +1112,48 @@ const MIGRATION_040: &str = r#"
 ALTER TABLE radio_diagnostics ADD COLUMN engine_index_empty INTEGER NOT NULL DEFAULT 0;
 "#;
 
+// Spotify public stats: drop the NOT NULL on monthly_listeners (Spotify omits
+// the field for some artists), add followers / world_rank / top_cities_json
+// columns, and introduce spotify_artist_map for the Tidal->Spotify artist
+// resolution + negative-cache layer. The whole block is wrapped in BEGIN/COMMIT
+// because run_migrations does not wrap individual migrations in a transaction,
+// and the table-rebuild step (DROP + RENAME) leaves the schema wedged if it
+// half-applies.
+const MIGRATION_041: &str = r#"
+BEGIN;
+
+ALTER TABLE spotify_artist_stats ADD COLUMN followers INTEGER;
+ALTER TABLE spotify_artist_stats ADD COLUMN world_rank INTEGER;
+ALTER TABLE spotify_artist_stats ADD COLUMN top_cities_json TEXT;
+
+CREATE TABLE spotify_artist_stats_new (
+    spotify_artist_id TEXT PRIMARY KEY,
+    monthly_listeners INTEGER,
+    followers         INTEGER,
+    world_rank        INTEGER,
+    top_cities_json   TEXT,
+    fetched_at        INTEGER NOT NULL
+);
+
+INSERT INTO spotify_artist_stats_new
+    SELECT spotify_artist_id, monthly_listeners, followers, world_rank,
+           top_cities_json, fetched_at
+    FROM spotify_artist_stats;
+
+DROP TABLE spotify_artist_stats;
+ALTER TABLE spotify_artist_stats_new RENAME TO spotify_artist_stats;
+CREATE INDEX idx_spotify_artist_stats_fetched_at
+    ON spotify_artist_stats(fetched_at);
+
+CREATE TABLE IF NOT EXISTS spotify_artist_map (
+    tidal_artist_id   TEXT PRIMARY KEY,
+    spotify_artist_id TEXT,
+    resolved_at       INTEGER NOT NULL
+);
+
+COMMIT;
+"#;
+
 pub fn run_migrations(conn: &Connection) -> Result<()> {
     // Create migrations table if not exists
     conn.execute_batch(
@@ -1134,4 +1177,102 @@ pub fn run_migrations(conn: &Connection) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+pub(super) fn apply_migrations_up_to(conn: &Connection, n: usize) -> Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS _migrations (
+            id INTEGER PRIMARY KEY,
+            applied_at TEXT DEFAULT (datetime('now'))
+        );",
+    )?;
+
+    let applied: i64 = conn
+        .query_row("SELECT COUNT(*) FROM _migrations", [], |row| row.get(0))
+        .unwrap_or(0);
+
+    let limit = n.min(MIGRATIONS.len());
+    for (i, migration) in MIGRATIONS[..limit].iter().enumerate() {
+        let migration_id = (i + 1) as i64;
+        if migration_id > applied {
+            conn.execute_batch(migration)?;
+            conn.execute("INSERT INTO _migrations (id) VALUES (?1)", [migration_id])?;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+
+    #[test]
+    fn migration_041_preserves_existing_artist_stats() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+
+        // Apply through 040 first.
+        apply_migrations_up_to(&conn, 40).unwrap();
+
+        // Seed one row in spotify_artist_stats with monthly_listeners set
+        // (this column was NOT NULL pre-041).
+        conn.execute(
+            "INSERT INTO spotify_artist_stats (spotify_artist_id, monthly_listeners, fetched_at) \
+             VALUES ('abc123', 12345, 1700000000)",
+            [],
+        )
+        .unwrap();
+
+        // Now apply 041 (table rebuild + new columns + new map table).
+        apply_migrations_up_to(&conn, MIGRATIONS.len()).unwrap();
+
+        // Row survives the rebuild with original values.
+        let (ml, fa): (Option<i64>, i64) = conn
+            .query_row(
+                "SELECT monthly_listeners, fetched_at FROM spotify_artist_stats WHERE spotify_artist_id = 'abc123'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(ml, Some(12345));
+        assert_eq!(fa, 1700000000);
+
+        // New columns exist and default to NULL.
+        let (followers, world_rank, top_cities): (Option<i64>, Option<i64>, Option<String>) = conn
+            .query_row(
+                "SELECT followers, world_rank, top_cities_json FROM spotify_artist_stats \
+                 WHERE spotify_artist_id = 'abc123'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(followers, None);
+        assert_eq!(world_rank, None);
+        assert_eq!(top_cities, None);
+
+        // monthly_listeners is now nullable: insert with NULL succeeds.
+        conn.execute(
+            "INSERT INTO spotify_artist_stats (spotify_artist_id, monthly_listeners, fetched_at) \
+             VALUES ('null_ml', NULL, 1700000001)",
+            [],
+        )
+        .unwrap();
+
+        // spotify_artist_map exists and accepts both positive and negative rows.
+        conn.execute(
+            "INSERT INTO spotify_artist_map (tidal_artist_id, spotify_artist_id, resolved_at) \
+             VALUES ('42', 'spotify_xyz', 1700000000)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO spotify_artist_map (tidal_artist_id, spotify_artist_id, resolved_at) \
+             VALUES ('99', NULL, 1700000000)",
+            [],
+        )
+        .unwrap();
+    }
 }

--- a/noor-server/src/main.rs
+++ b/noor-server/src/main.rs
@@ -170,12 +170,12 @@ pub struct AppState {
     /// instantly negate their action. Reset on any new user-driven play
     /// (play_track, radio_start, etc.) so automix re-engages naturally.
     pub user_cleared_at: Arc<std::sync::atomic::AtomicI64>,
-    /// Public Spotify stats (anonymous GraphQL) toggle. Read once from
-    /// `NOOR_SPOTIFY_PUBLIC_STATS` at startup. When false, the stats endpoint
-    /// returns empty fields and never hits Spotify. The feature also requires
-    /// the `spotify-public` cargo feature; without it the env var is ignored
-    /// and we log one warning at startup.
-    pub spotify_public_stats_enabled: bool,
+    /// Spotify partner-GraphQL client for the public-stats endpoints. Built
+    /// once at boot when the `spotify-public` cargo feature is on; absent
+    /// from the struct entirely in feature-off builds. Route handlers that
+    /// touch it live behind matching `#[cfg]` blocks.
+    #[cfg(feature = "spotify-public")]
+    pub spotify_public: Arc<services::spotify_public::SpotifyPublicClient>,
     /// Sportify (anonymous Spotify metadata proxy) client used by the
     /// `/api/discovery/sportify/*` discovery routes. Constructed once at boot.
     pub sportify_client: Option<Arc<services::sportify::SportifyClient>>,
@@ -558,27 +558,18 @@ async fn main() -> Result<()> {
         .ok()
         .filter(|s| !s.is_empty());
 
-    // Public Spotify stats are gated on (a) the env var being set and (b) the
-    // `spotify-public` cargo feature being compiled in. The feature pulls in
-    // `rquest` (Chrome TLS fingerprint) which we don't want in lean builds.
-    let env_spotify_public = std::env::var("NOOR_SPOTIFY_PUBLIC_STATS")
-        .ok()
-        .map(|v| matches!(v.as_str(), "1" | "true" | "yes" | "on"))
-        .unwrap_or(false);
+    // Public Spotify stats: gated only on the `spotify-public` cargo feature
+    // (default on). No runtime env var - the feature controls compile-in of
+    // the whole module, and feature-off route handlers return an empty
+    // payload.
     #[cfg(feature = "spotify-public")]
-    let spotify_public_stats_enabled = env_spotify_public;
-    #[cfg(not(feature = "spotify-public"))]
-    let spotify_public_stats_enabled = {
-        if env_spotify_public {
-            warn!(
-                "NOOR_SPOTIFY_PUBLIC_STATS=1 but binary built without `spotify-public` cargo feature; ignoring"
-            );
-        }
-        false
-    };
-    if spotify_public_stats_enabled {
-        info!("Public Spotify stats enabled (anonymous GraphQL)");
-    }
+    let spotify_public_client = Arc::new(
+        services::spotify_public::SpotifyPublicClient::new(db.clone())
+            .expect("SpotifyPublicClient init: reqwest builder failure should be impossible"),
+    );
+    #[cfg(feature = "spotify-public")]
+    info!("Public Spotify stats enabled (anonymous GraphQL)");
+
     if lastfm_api_secret.is_some() {
         info!("Last.fm scrobbling enabled (LASTFM_API_SECRET present)");
     } else {
@@ -747,7 +738,8 @@ async fn main() -> Result<()> {
         server_token,
         audio_active: Arc::new(AtomicBool::new(false)),
         user_cleared_at: Arc::new(std::sync::atomic::AtomicI64::new(0)),
-        spotify_public_stats_enabled,
+        #[cfg(feature = "spotify-public")]
+        spotify_public: spotify_public_client,
         sportify_client,
         sportify_cache_config,
         sportify_resolve_config,

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -1122,10 +1122,9 @@ async fn get_album_spotify_stats(
     {
         let (db, client, tracks) = {
             let s = state.read().await;
-            let tracks = s
-                .db
-                .with_conn(|conn| queries::get_album_tracks(conn, id))
-                .unwrap_or_default();
+            let tracks =
+                s.db.with_conn(|conn| queries::get_album_tracks(conn, id))
+                    .unwrap_or_default();
             (s.db.clone(), s.spotify_public.clone(), tracks)
         };
 
@@ -1551,14 +1550,12 @@ async fn get_artist_spotify_stats(
     {
         let (db, client, tidal_id, artist_name, seeds) = {
             let s = state.read().await;
-            let tidal_id = s
-                .db
-                .with_conn(|conn| queries::get_artist_tidal_id(conn, id))
-                .unwrap_or(None);
-            let artist_tracks = s
-                .db
-                .with_conn(|conn| queries::get_artist_tracks(conn, id))
-                .unwrap_or_default();
+            let tidal_id =
+                s.db.with_conn(|conn| queries::get_artist_tidal_id(conn, id))
+                    .unwrap_or(None);
+            let artist_tracks =
+                s.db.with_conn(|conn| queries::get_artist_tracks(conn, id))
+                    .unwrap_or_default();
 
             let mut sorted = artist_tracks
                 .into_iter()
@@ -1581,7 +1578,13 @@ async fn get_artist_spotify_stats(
                 })
                 .collect();
 
-            (s.db.clone(), s.spotify_public.clone(), tidal_id, artist_name, seeds)
+            (
+                s.db.clone(),
+                s.spotify_public.clone(),
+                tidal_id,
+                artist_name,
+                seeds,
+            )
         };
 
         // Local-only artist (no Tidal id): no key for the map table, so just

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -29,7 +29,7 @@ use axum::{
 use rusqlite::{OptionalExtension, params};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::{error, info, warn};
@@ -1118,53 +1118,61 @@ async fn get_album_spotify_stats(
     State(state): State<SharedState>,
     Path(id): Path<i64>,
 ) -> Json<Value> {
-    let tracks = {
-        let s = state.read().await;
-        s.db.with_conn(|conn| queries::get_album_tracks(conn, id))
-            .unwrap_or_default()
-    };
-    let isrcs = tracks
-        .iter()
-        .filter_map(|t| {
-            t.isrc
-                .as_deref()
-                .map(str::trim)
-                .filter(|s| !s.is_empty())
-                .map(str::to_string)
-        })
-        .collect::<Vec<_>>();
-    let cached = {
-        let s = state.read().await;
-        s.db.with_conn(|conn| queries::get_cached_spotify_playcounts_for_isrcs(conn, &isrcs))
-            .unwrap_or_default()
-    };
+    #[cfg(feature = "spotify-public")]
+    {
+        let (db, client, tracks) = {
+            let s = state.read().await;
+            let tracks = s
+                .db
+                .with_conn(|conn| queries::get_album_tracks(conn, id))
+                .unwrap_or_default();
+            (s.db.clone(), s.spotify_public.clone(), tracks)
+        };
 
-    Json(json!({
-        "monthly_listeners": null,
-        "tracks": spotify_track_stats_payload(&tracks, &cached),
-    }))
-}
+        let seeds: Vec<crate::services::spotify_public::TrackSeed> = tracks
+            .iter()
+            .filter_map(|t| {
+                let isrc = t.isrc.as_deref()?.trim();
+                if isrc.is_empty() {
+                    return None;
+                }
+                Some(crate::services::spotify_public::TrackSeed {
+                    isrc: isrc.to_string(),
+                    title: t.title.clone(),
+                    artist_name: t.artist_name.clone().unwrap_or_default(),
+                })
+            })
+            .collect();
 
-fn spotify_track_stats_payload(
-    tracks: &[crate::db::models::Track],
-    cached: &HashMap<String, i64>,
-) -> Vec<Value> {
-    let mut seen = HashSet::new();
-    tracks
-        .iter()
-        .filter_map(|track| {
-            let isrc = track.isrc.as_deref()?.trim();
-            if isrc.is_empty() || !seen.insert(isrc.to_string()) {
-                return None;
-            }
-            let playcount = cached.get(isrc)?;
-            Some(json!({
-                "isrc": isrc,
-                "title": track.title.clone(),
-                "playcount": *playcount,
-            }))
-        })
-        .collect()
+        let stats =
+            crate::services::spotify_public::fetch_album_playcounts(&client, &db, &seeds).await;
+
+        let payload: Vec<Value> = stats
+            .into_iter()
+            .filter_map(|s| {
+                s.playcount.map(|pc| {
+                    json!({
+                        "isrc": s.isrc,
+                        "title": s.title,
+                        "playcount": pc,
+                    })
+                })
+            })
+            .collect();
+
+        Json(json!({
+            "monthly_listeners": null,
+            "tracks": payload,
+        }))
+    }
+    #[cfg(not(feature = "spotify-public"))]
+    {
+        let _ = (state, id);
+        Json(json!({
+            "monthly_listeners": null,
+            "tracks": [],
+        }))
+    }
 }
 
 /// Pages through all entries of a single TIDAL discography filter for one
@@ -1539,84 +1547,113 @@ async fn get_artist_spotify_stats(
     State(state): State<SharedState>,
     Path(id): Path<i64>,
 ) -> Json<Value> {
-    let (enabled, artist_name, isrc_pairs, mut tracks_by_isrc) = {
-        let s = state.read().await;
-        let enabled = s.spotify_public_stats_enabled;
-        let artist_tracks =
-            s.db.with_conn(|conn| queries::get_artist_tracks(conn, id))
+    #[cfg(feature = "spotify-public")]
+    {
+        let (db, client, tidal_id, artist_name, seeds) = {
+            let s = state.read().await;
+            let tidal_id = s
+                .db
+                .with_conn(|conn| queries::get_artist_tidal_id(conn, id))
+                .unwrap_or(None);
+            let artist_tracks = s
+                .db
+                .with_conn(|conn| queries::get_artist_tracks(conn, id))
                 .unwrap_or_default();
-        let isrcs = artist_tracks
-            .iter()
+
+            let mut sorted = artist_tracks
+                .into_iter()
+                .filter(|t| t.isrc.as_deref().is_some_and(|s| !s.trim().is_empty()))
+                .collect::<Vec<_>>();
+            sorted.sort_by(|a, b| b.play_count.cmp(&a.play_count));
+            sorted.truncate(10);
+
+            let artist_name = sorted
+                .first()
+                .and_then(|t| t.artist_name.clone())
+                .unwrap_or_default();
+
+            let seeds: Vec<crate::services::spotify_public::TrackSeed> = sorted
+                .into_iter()
+                .map(|t| crate::services::spotify_public::TrackSeed {
+                    isrc: t.isrc.unwrap_or_default(),
+                    title: t.title,
+                    artist_name: t.artist_name.unwrap_or_default(),
+                })
+                .collect();
+
+            (s.db.clone(), s.spotify_public.clone(), tidal_id, artist_name, seeds)
+        };
+
+        // Local-only artist (no Tidal id): no key for the map table, so just
+        // serve any cached track playcounts via the album helper, no artist
+        // resolution attempted, no negative-cache row written.
+        let Some(tidal_id) = tidal_id else {
+            let stats =
+                crate::services::spotify_public::fetch_album_playcounts(&client, &db, &seeds).await;
+            let tracks: Vec<Value> = stats
+                .into_iter()
+                .filter_map(|s| {
+                    s.playcount.map(|pc| {
+                        json!({
+                            "isrc": s.isrc,
+                            "title": s.title,
+                            "playcount": pc,
+                        })
+                    })
+                })
+                .collect();
+            return Json(json!({
+                "monthly_listeners": null,
+                "followers": null,
+                "world_rank": null,
+                "top_cities": [],
+                "tracks": tracks,
+            }));
+        };
+
+        let tidal_id_str = tidal_id.to_string();
+        let result = crate::services::spotify_public::fetch_artist_stats(
+            &client,
+            &db,
+            &tidal_id_str,
+            &artist_name,
+            &seeds,
+        )
+        .await;
+
+        let tracks: Vec<Value> = result
+            .tracks
+            .into_iter()
             .filter_map(|t| {
-                t.isrc
-                    .as_deref()
-                    .map(str::trim)
-                    .filter(|s| !s.is_empty())
-                    .map(str::to_string)
+                t.playcount.map(|pc| {
+                    json!({
+                        "isrc": t.isrc,
+                        "title": t.title,
+                        "playcount": pc,
+                    })
+                })
             })
-            .collect::<Vec<_>>();
-        let cached =
-            s.db.with_conn(|conn| queries::get_cached_spotify_playcounts_for_isrcs(conn, &isrcs))
-                .unwrap_or_default();
-        let mut tracks_by_isrc = BTreeMap::new();
-        for track in &artist_tracks {
-            let Some(isrc) = track
-                .isrc
-                .as_deref()
-                .map(str::trim)
-                .filter(|s| !s.is_empty())
-            else {
-                continue;
-            };
-            if let Some(playcount) = cached.get(isrc) {
-                tracks_by_isrc.insert(isrc.to_string(), (track.title.clone(), *playcount));
-            }
-        }
+            .collect();
 
-        let mut sorted = artist_tracks
-            .into_iter()
-            .filter(|t| t.isrc.as_deref().is_some_and(|s| !s.trim().is_empty()))
-            .collect::<Vec<_>>();
-        sorted.sort_by(|a, b| b.play_count.cmp(&a.play_count));
-        sorted.truncate(10);
-        let artist_name = sorted
-            .first()
-            .and_then(|t| t.artist_name.clone())
-            .unwrap_or_default();
-        let pairs = sorted
-            .into_iter()
-            .map(|t| (t.isrc.unwrap_or_default(), t.title))
-            .collect::<Vec<(String, String)>>();
-        (enabled, artist_name, pairs, tracks_by_isrc)
-    };
-
-    let mut monthly_listeners = None;
-    if enabled {
-        let result =
-            crate::services::spotify_public::fetch_artist_stats(enabled, &artist_name, &isrc_pairs)
-                .await;
-        monthly_listeners = result.monthly_listeners;
-        for track in result.tracks {
-            if let Some(playcount) = track.playcount {
-                tracks_by_isrc.insert(track.isrc, (track.title, playcount));
-            }
-        }
+        Json(json!({
+            "monthly_listeners": result.monthly_listeners,
+            "followers": result.followers,
+            "world_rank": result.world_rank,
+            "top_cities": result.top_cities,
+            "tracks": tracks,
+        }))
     }
-    let tracks = tracks_by_isrc
-        .into_iter()
-        .map(|(isrc, (title, playcount))| {
-            json!({
-                "isrc": isrc,
-                "title": title,
-                "playcount": playcount,
-            })
-        })
-        .collect::<Vec<_>>();
-
-    Json(json!({
-        "monthly_listeners": monthly_listeners,
-        "tracks": tracks,
-    }))
+    #[cfg(not(feature = "spotify-public"))]
+    {
+        let _ = (state, id);
+        Json(json!({
+            "monthly_listeners": null,
+            "followers": null,
+            "world_rank": null,
+            "top_cities": [],
+            "tracks": [],
+        }))
+    }
 }
 
 async fn get_tidal_album_tracks(
@@ -11917,6 +11954,11 @@ mod tests {
     /// initializers - when `crate::AppState` gains a field, add it here once.
     fn fresh_test_state(db: Database) -> crate::AppState {
         let (event_tx, _) = tokio::sync::broadcast::channel(16);
+        #[cfg(feature = "spotify-public")]
+        let spotify_public = Arc::new(
+            crate::services::spotify_public::SpotifyPublicClient::new(db.clone())
+                .expect("SpotifyPublicClient::new must succeed in tests"),
+        );
         crate::AppState {
             db,
             event_tx,
@@ -11973,7 +12015,8 @@ mod tests {
             server_token: String::new(),
             audio_active: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             user_cleared_at: Arc::new(std::sync::atomic::AtomicI64::new(0)),
-            spotify_public_stats_enabled: false,
+            #[cfg(feature = "spotify-public")]
+            spotify_public,
             sportify_client: None,
             sportify_cache_config: crate::services::sportify::cache::SportifyCacheConfig::default(),
             sportify_resolve_config:

--- a/noor-server/src/services/mod.rs
+++ b/noor-server/src/services/mod.rs
@@ -18,5 +18,6 @@ pub mod radio_similarity;
 pub mod rss_feeds;
 pub mod sportify;
 pub mod spotify;
+#[cfg(feature = "spotify-public")]
 pub mod spotify_public;
 pub mod tidal;

--- a/noor-server/src/services/spotify_public/cache.rs
+++ b/noor-server/src/services/spotify_public/cache.rs
@@ -128,11 +128,7 @@ pub fn read_artist_map(conn: &Connection, tidal_artist_id: &str) -> Result<Artis
     }
 }
 
-pub fn write_track_resolution(
-    conn: &Connection,
-    isrc: &str,
-    spotify_track_id: &str,
-) -> Result<()> {
+pub fn write_track_resolution(conn: &Connection, isrc: &str, spotify_track_id: &str) -> Result<()> {
     let now = now_secs();
     upsert_spotify_isrc_map(conn, isrc, spotify_track_id, now)?;
     clear_spotify_null_cache(conn, isrc)?;
@@ -195,7 +191,10 @@ mod tests {
             stats_fetched_at: Some(now - 60),
             null_cached_at: None,
         };
-        assert!(matches!(TrackState::from_row(&row, now), TrackState::Fresh(1234)));
+        assert!(matches!(
+            TrackState::from_row(&row, now),
+            TrackState::Fresh(1234)
+        ));
     }
 
     #[test]

--- a/noor-server/src/services/spotify_public/cache.rs
+++ b/noor-server/src/services/spotify_public/cache.rs
@@ -1,0 +1,270 @@
+//! TTL policy and convenience wrappers around the queries-layer reads/writes.
+//!
+//! The raw queries return whatever's in the cache. This module decides what
+//! counts as "fresh enough" vs "stale" vs "negative-cached" vs "retry-zero".
+
+use anyhow::Result;
+use rusqlite::Connection;
+use std::collections::HashMap;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::db::queries::{
+    CachedArtistStatsRow, CachedTrackStatsRow, clear_spotify_null_cache,
+    get_cached_spotify_artist_stats, get_cached_spotify_track_stats_for_isrcs,
+    get_spotify_artist_map, upsert_spotify_artist_map, upsert_spotify_artist_stats,
+    upsert_spotify_isrc_map, upsert_spotify_null_cache, upsert_spotify_track_stats,
+};
+
+const STATS_TTL_SECS: i64 = 7 * 24 * 60 * 60;
+const NULL_TTL_SECS: i64 = 24 * 60 * 60;
+const ARTIST_MAP_TTL_SECS: i64 = 30 * 24 * 60 * 60;
+
+pub fn now_secs() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+#[derive(Debug, Clone)]
+pub enum TrackState {
+    /// Fresh playcount available; just serve from cache.
+    Fresh(i64),
+    /// Map row exists + stats row exists but stats are >7 days old.
+    StaleStats { spotify_track_id: String },
+    /// Map row exists, no stats row OR `playcount = 0` (treat zero as null
+    /// with 1-day retry per plan).
+    NeedsStatsFetch { spotify_track_id: String },
+    /// Negative-cached within the last 24h.
+    NegativeFresh,
+    /// Never seen, or negative cache has expired.
+    NeedsResolution,
+}
+
+impl TrackState {
+    pub fn from_row(row: &CachedTrackStatsRow, now: i64) -> Self {
+        // Negative cache wins iff it's still fresh.
+        if let Some(cached_at) = row.null_cached_at
+            && now - cached_at < NULL_TTL_SECS
+        {
+            return TrackState::NegativeFresh;
+        }
+
+        match (&row.spotify_track_id, row.playcount, row.stats_fetched_at) {
+            (Some(tid), Some(pc), Some(fa)) => {
+                if pc == 0 && now - fa >= NULL_TTL_SECS {
+                    TrackState::NeedsStatsFetch {
+                        spotify_track_id: tid.clone(),
+                    }
+                } else if now - fa >= STATS_TTL_SECS {
+                    TrackState::StaleStats {
+                        spotify_track_id: tid.clone(),
+                    }
+                } else if pc == 0 {
+                    // Zero within the 1-day window: treat as "negative for now".
+                    TrackState::NegativeFresh
+                } else {
+                    TrackState::Fresh(pc)
+                }
+            }
+            (Some(tid), _, _) => TrackState::NeedsStatsFetch {
+                spotify_track_id: tid.clone(),
+            },
+            _ => TrackState::NeedsResolution,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum ArtistMapState {
+    Resolved(String),
+    NegativeFresh,
+    Missing,
+}
+
+pub fn read_track_states(
+    conn: &Connection,
+    isrcs: &[String],
+) -> Result<HashMap<String, TrackState>> {
+    let now = now_secs();
+    let raw = get_cached_spotify_track_stats_for_isrcs(conn, isrcs)?;
+    Ok(raw
+        .into_iter()
+        .map(|(isrc, row)| (isrc, TrackState::from_row(&row, now)))
+        .collect())
+}
+
+pub fn read_artist_stats(
+    conn: &Connection,
+    spotify_artist_id: &str,
+) -> Result<Option<(CachedArtistStatsRow, bool)>> {
+    let now = now_secs();
+    let row = get_cached_spotify_artist_stats(conn, spotify_artist_id)?;
+    Ok(row.map(|r| {
+        let stale = now - r.fetched_at >= STATS_TTL_SECS;
+        (r, stale)
+    }))
+}
+
+pub fn read_artist_map(conn: &Connection, tidal_artist_id: &str) -> Result<ArtistMapState> {
+    let now = now_secs();
+    match get_spotify_artist_map(conn, tidal_artist_id)? {
+        None => Ok(ArtistMapState::Missing),
+        Some((None, resolved_at)) => {
+            if now - resolved_at < NULL_TTL_SECS {
+                Ok(ArtistMapState::NegativeFresh)
+            } else {
+                Ok(ArtistMapState::Missing)
+            }
+        }
+        Some((Some(spid), resolved_at)) => {
+            if now - resolved_at >= ARTIST_MAP_TTL_SECS {
+                // Map row very old; treat as missing so the resolver re-runs.
+                Ok(ArtistMapState::Missing)
+            } else {
+                Ok(ArtistMapState::Resolved(spid))
+            }
+        }
+    }
+}
+
+pub fn write_track_resolution(
+    conn: &Connection,
+    isrc: &str,
+    spotify_track_id: &str,
+) -> Result<()> {
+    let now = now_secs();
+    upsert_spotify_isrc_map(conn, isrc, spotify_track_id, now)?;
+    clear_spotify_null_cache(conn, isrc)?;
+    Ok(())
+}
+
+pub fn write_track_playcount(
+    conn: &Connection,
+    spotify_track_id: &str,
+    playcount: i64,
+) -> Result<()> {
+    let now = now_secs();
+    upsert_spotify_track_stats(conn, spotify_track_id, playcount, now)
+}
+
+pub fn write_track_negative(conn: &Connection, isrc: &str) -> Result<()> {
+    let now = now_secs();
+    upsert_spotify_null_cache(conn, isrc, now)
+}
+
+pub fn write_artist_map(
+    conn: &Connection,
+    tidal_artist_id: &str,
+    spotify_artist_id: Option<&str>,
+) -> Result<()> {
+    let now = now_secs();
+    upsert_spotify_artist_map(conn, tidal_artist_id, spotify_artist_id, now)
+}
+
+pub fn write_artist_stats(
+    conn: &Connection,
+    spotify_artist_id: &str,
+    monthly_listeners: Option<i64>,
+    followers: Option<i64>,
+    world_rank: Option<i64>,
+    top_cities_json: Option<&str>,
+) -> Result<()> {
+    let now = now_secs();
+    upsert_spotify_artist_stats(
+        conn,
+        spotify_artist_id,
+        monthly_listeners,
+        followers,
+        world_rank,
+        top_cities_json,
+        now,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fresh_playcount_returns_fresh() {
+        let now = 1_000_000_000_i64;
+        let row = CachedTrackStatsRow {
+            spotify_track_id: Some("abc".into()),
+            playcount: Some(1234),
+            stats_fetched_at: Some(now - 60),
+            null_cached_at: None,
+        };
+        assert!(matches!(TrackState::from_row(&row, now), TrackState::Fresh(1234)));
+    }
+
+    #[test]
+    fn stale_stats_after_seven_days() {
+        let now = 1_000_000_000_i64;
+        let row = CachedTrackStatsRow {
+            spotify_track_id: Some("abc".into()),
+            playcount: Some(1234),
+            stats_fetched_at: Some(now - STATS_TTL_SECS - 1),
+            null_cached_at: None,
+        };
+        assert!(matches!(
+            TrackState::from_row(&row, now),
+            TrackState::StaleStats { .. }
+        ));
+    }
+
+    #[test]
+    fn negative_cache_wins_when_fresh() {
+        let now = 1_000_000_000_i64;
+        let row = CachedTrackStatsRow {
+            spotify_track_id: None,
+            playcount: None,
+            stats_fetched_at: None,
+            null_cached_at: Some(now - 60),
+        };
+        assert!(matches!(
+            TrackState::from_row(&row, now),
+            TrackState::NegativeFresh
+        ));
+    }
+
+    #[test]
+    fn zero_playcount_within_window_is_negative() {
+        let now = 1_000_000_000_i64;
+        let row = CachedTrackStatsRow {
+            spotify_track_id: Some("abc".into()),
+            playcount: Some(0),
+            stats_fetched_at: Some(now - 60),
+            null_cached_at: None,
+        };
+        assert!(matches!(
+            TrackState::from_row(&row, now),
+            TrackState::NegativeFresh
+        ));
+    }
+
+    #[test]
+    fn zero_playcount_after_one_day_retries_stats() {
+        let now = 1_000_000_000_i64;
+        let row = CachedTrackStatsRow {
+            spotify_track_id: Some("abc".into()),
+            playcount: Some(0),
+            stats_fetched_at: Some(now - NULL_TTL_SECS - 1),
+            null_cached_at: None,
+        };
+        assert!(matches!(
+            TrackState::from_row(&row, now),
+            TrackState::NeedsStatsFetch { .. }
+        ));
+    }
+
+    #[test]
+    fn missing_map_row_means_needs_resolution() {
+        let now = 1_000_000_000_i64;
+        let row = CachedTrackStatsRow::default();
+        assert!(matches!(
+            TrackState::from_row(&row, now),
+            TrackState::NeedsResolution
+        ));
+    }
+}

--- a/noor-server/src/services/spotify_public/client.rs
+++ b/noor-server/src/services/spotify_public/client.rs
@@ -74,7 +74,10 @@ impl SpotifyPublicClient {
             .build()
             .context("build reqwest client")?;
 
-        let persisted = db.with_conn(|c| Ok(hashes::load_persisted(c))).ok().flatten();
+        let persisted = db
+            .with_conn(|c| Ok(hashes::load_persisted(c)))
+            .ok()
+            .flatten();
 
         Ok(Self {
             inner: Arc::new(Inner {
@@ -202,7 +205,9 @@ impl SpotifyPublicClient {
 
             if persisted_query_not_found(&body) {
                 if attempt == 0 {
-                    debug!("spotify_public: PersistedQueryNotFound on {op_name}; refreshing hashes");
+                    debug!(
+                        "spotify_public: PersistedQueryNotFound on {op_name}; refreshing hashes"
+                    );
                     if let Err(e) = self.refresh_hashes().await {
                         warn!("spotify_public: hash refresh failed: {e:#}");
                         return Err(e);
@@ -247,12 +252,8 @@ impl SpotifyPublicClient {
             "numberOfTopResults": 5,
             "includeAudiobooks": false,
         });
-        self.persisted_query(
-            "assistedCurationSearch",
-            &h.search_modal_results,
-            &vars,
-        )
-        .await
+        self.persisted_query("assistedCurationSearch", &h.search_modal_results, &vars)
+            .await
     }
 }
 

--- a/noor-server/src/services/spotify_public/client.rs
+++ b/noor-server/src/services/spotify_public/client.rs
@@ -1,0 +1,283 @@
+//! Thin wrapper around `reqwest::Client` that handles the bits unique to
+//! Spotify's anonymous partner-GraphQL surface: token mint + cache,
+//! persisted-query hash cache, retry-on-401, retry-on-`PersistedQueryNotFound`.
+//!
+//! HTTP fingerprint note: we mimic Chrome via headers (`User-Agent`,
+//! `sec-ch-ua`, `Accept-Encoding`). If Spotify starts soft-blocking on the
+//! TLS JA3/JA4 fingerprint we can swap the inner client for `newwreq` (the
+//! stable rename of `rquest` 5.x); that requires `cmake` for the BoringSSL
+//! build, so it's left as a future upgrade behind the same feature flag.
+
+use anyhow::{Context, Result, anyhow};
+use reqwest::{Client, StatusCode};
+use serde::Deserialize;
+use serde_json::Value;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tracing::{debug, warn};
+
+use crate::db::Database;
+
+use super::hashes::{
+    self, GET_TRACK_HASH, QUERY_ARTIST_OVERVIEW_HASH, RefreshedHashes, SEARCH_MODAL_RESULTS_HASH,
+    SPOTIFY_APP_VERSION,
+};
+use super::token::{self, TokenResponse};
+
+const PATHFINDER_URL: &str = "https://api-partner.spotify.com/pathfinder/v1/query";
+
+/// Refresh the token this many seconds before its declared expiry.
+const TOKEN_REFRESH_SLACK_SECS: i64 = 60;
+
+#[derive(Clone)]
+pub struct SpotifyPublicClient {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    http: Client,
+    db: Database,
+    token: RwLock<Option<TokenResponse>>,
+    hashes: RwLock<RefreshedHashes>,
+}
+
+#[derive(Debug)]
+pub struct OpHashes {
+    pub get_track: String,
+    pub query_artist_overview: String,
+    pub search_modal_results: String,
+}
+
+impl SpotifyPublicClient {
+    pub fn new(db: Database) -> Result<Self> {
+        let http = Client::builder()
+            .user_agent(
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 \
+                 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36",
+            )
+            .default_headers({
+                let mut h = reqwest::header::HeaderMap::new();
+                h.insert("Accept-Language", "en-US,en;q=0.9".parse().unwrap());
+                h.insert(
+                    "sec-ch-ua",
+                    "\"Chromium\";v=\"126\", \"Google Chrome\";v=\"126\", \"Not.A/Brand\";v=\"24\""
+                        .parse()
+                        .unwrap(),
+                );
+                h.insert("sec-ch-ua-mobile", "?0".parse().unwrap());
+                h.insert("sec-ch-ua-platform", "\"Windows\"".parse().unwrap());
+                h
+            })
+            .gzip(true)
+            .brotli(true)
+            .timeout(std::time::Duration::from_secs(15))
+            .build()
+            .context("build reqwest client")?;
+
+        let persisted = db.with_conn(|c| Ok(hashes::load_persisted(c))).ok().flatten();
+
+        Ok(Self {
+            inner: Arc::new(Inner {
+                http,
+                db,
+                token: RwLock::new(None),
+                hashes: RwLock::new(persisted.unwrap_or_default()),
+            }),
+        })
+    }
+
+    async fn current_hashes(&self) -> OpHashes {
+        let h = self.inner.hashes.read().await;
+        OpHashes {
+            get_track: h.get_track.clone().unwrap_or_else(|| GET_TRACK_HASH.into()),
+            query_artist_overview: h
+                .query_artist_overview
+                .clone()
+                .unwrap_or_else(|| QUERY_ARTIST_OVERVIEW_HASH.into()),
+            search_modal_results: h
+                .search_modal_results
+                .clone()
+                .unwrap_or_else(|| SEARCH_MODAL_RESULTS_HASH.into()),
+        }
+    }
+
+    async fn refresh_hashes(&self) -> Result<()> {
+        let fresh = hashes::refresh_from_js(&self.inner.http).await?;
+        // Merge - keep any field we already had if the refresh returned None.
+        let mut current = self.inner.hashes.write().await;
+        if fresh.get_track.is_some() {
+            current.get_track = fresh.get_track.clone();
+        }
+        if fresh.query_artist_overview.is_some() {
+            current.query_artist_overview = fresh.query_artist_overview.clone();
+        }
+        if fresh.search_modal_results.is_some() {
+            current.search_modal_results = fresh.search_modal_results.clone();
+        }
+        let snapshot = current.clone();
+        drop(current);
+        if let Err(e) = self.inner.db.with_conn(|c| hashes::persist(c, &snapshot)) {
+            warn!("spotify_public: could not persist hashes: {e:#}");
+        }
+        Ok(())
+    }
+
+    async fn token_value(&self) -> Result<String> {
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as i64)
+            .unwrap_or(0);
+
+        {
+            let guard = self.inner.token.read().await;
+            if let Some(t) = guard.as_ref()
+                && t.expires_at_ms - TOKEN_REFRESH_SLACK_SECS * 1000 > now_ms
+            {
+                return Ok(t.access_token.clone());
+            }
+        }
+
+        let fresh = token::mint(&self.inner.http).await.context("mint token")?;
+        let access = fresh.access_token.clone();
+        *self.inner.token.write().await = Some(fresh);
+        Ok(access)
+    }
+
+    async fn invalidate_token(&self) {
+        *self.inner.token.write().await = None;
+    }
+
+    /// Run a persisted-query GET. Handles 401 (re-mint token) and
+    /// `PersistedQueryNotFound` (refresh hashes, retry once).
+    async fn persisted_query(
+        &self,
+        op_name: &str,
+        sha256_hash: &str,
+        variables: &Value,
+    ) -> Result<Value> {
+        for attempt in 0..2 {
+            let token = self.token_value().await?;
+            let ext = serde_json::json!({
+                "persistedQuery": {
+                    "version": 1,
+                    "sha256Hash": sha256_hash,
+                }
+            });
+
+            let resp = self
+                .inner
+                .http
+                .get(PATHFINDER_URL)
+                .header("Authorization", format!("Bearer {token}"))
+                .header("App-Platform", "WebPlayer")
+                .header("Spotify-App-Version", SPOTIFY_APP_VERSION)
+                .header("Origin", "https://open.spotify.com")
+                .header("Referer", "https://open.spotify.com/")
+                .query(&[
+                    ("operationName", op_name),
+                    ("variables", &variables.to_string()),
+                    ("extensions", &ext.to_string()),
+                ])
+                .send()
+                .await
+                .with_context(|| format!("pathfinder GET {op_name}"))?;
+
+            let status = resp.status();
+            if status == StatusCode::UNAUTHORIZED {
+                debug!("spotify_public: 401 on {op_name}; re-minting token");
+                self.invalidate_token().await;
+                if attempt == 0 {
+                    continue;
+                }
+                return Err(anyhow!("{op_name}: 401 even after token refresh"));
+            }
+            if !status.is_success() {
+                return Err(anyhow!("{op_name}: HTTP {status}"));
+            }
+
+            let body: Value = resp
+                .json()
+                .await
+                .with_context(|| format!("{op_name}: parse JSON body"))?;
+
+            if persisted_query_not_found(&body) {
+                if attempt == 0 {
+                    debug!("spotify_public: PersistedQueryNotFound on {op_name}; refreshing hashes");
+                    if let Err(e) = self.refresh_hashes().await {
+                        warn!("spotify_public: hash refresh failed: {e:#}");
+                        return Err(e);
+                    }
+                    continue;
+                }
+                return Err(anyhow!("{op_name}: PersistedQueryNotFound after refresh"));
+            }
+
+            return Ok(body);
+        }
+        Err(anyhow!("{op_name}: exhausted retry attempts"))
+    }
+
+    pub async fn get_track(&self, spotify_track_id: &str) -> Result<Value> {
+        let h = self.current_hashes().await;
+        let vars = serde_json::json!({ "uri": format!("spotify:track:{spotify_track_id}") });
+        self.persisted_query("getTrack", &h.get_track, &vars).await
+    }
+
+    pub async fn query_artist_overview(&self, spotify_artist_id: &str) -> Result<Value> {
+        let h = self.current_hashes().await;
+        let vars = serde_json::json!({
+            "uri": format!("spotify:artist:{spotify_artist_id}"),
+            "locale": "",
+            "includePrerelease": false,
+        });
+        self.persisted_query("queryArtistOverview", &h.query_artist_overview, &vars)
+            .await
+    }
+
+    pub async fn search(&self, query: &str) -> Result<Value> {
+        let h = self.current_hashes().await;
+        // The web player ships `assistedCurationSearch` for in-app search.
+        // We piggy-back on it for ISRC + artist-name resolution; the
+        // response shape includes `searchV2.tracksV2.items` and
+        // `searchV2.artists.items` which is what the resolver expects.
+        let vars = serde_json::json!({
+            "searchTerm": query,
+            "offset": 0,
+            "limit": 10,
+            "numberOfTopResults": 5,
+            "includeAudiobooks": false,
+        });
+        self.persisted_query(
+            "assistedCurationSearch",
+            &h.search_modal_results,
+            &vars,
+        )
+        .await
+    }
+}
+
+fn persisted_query_not_found(body: &Value) -> bool {
+    body.get("errors")
+        .and_then(|e| e.as_array())
+        .map(|arr| {
+            arr.iter().any(|err| {
+                err.get("message")
+                    .and_then(|m| m.as_str())
+                    .map(|s| s.contains("PersistedQueryNotFound"))
+                    .unwrap_or(false)
+                    || err
+                        .get("extensions")
+                        .and_then(|e| e.get("code"))
+                        .and_then(|c| c.as_str())
+                        .map(|s| s == "PERSISTED_QUERY_NOT_FOUND")
+                        .unwrap_or(false)
+            })
+        })
+        .unwrap_or(false)
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)]
+pub struct GetTrackResponseLike {
+    pub data: Option<Value>,
+}

--- a/noor-server/src/services/spotify_public/hashes.rs
+++ b/noor-server/src/services/spotify_public/hashes.rs
@@ -1,0 +1,168 @@
+//! Spotify partner-GraphQL persisted-query SHA256 hashes + TOTP secret.
+//!
+//! These are baked-in constants because Spotify's anonymous endpoints rotate
+//! them. When a request fails with `PersistedQueryNotFound`, `client.rs`
+//! calls [`refresh_from_js`] to re-extract them from the live web-player
+//! bundle and persists the new values into `server_config` so a restart
+//! doesn't refetch.
+//!
+//! ## Capture status
+//!
+//! Values below were captured 2026-05-17 from
+//! `https://open.spotifycdn.com/cdn/build/web-player/web-player.e79b30dd.js`.
+//! All three operation hashes were grepped from the live bundle and the
+//! TOTP cipher (`v14`) came from `misiektoja/spotify_monitor`. Hashes
+//! rotate every few weeks; when one goes stale a request returns
+//! `PersistedQueryNotFound` and [`refresh_from_js`] re-extracts the new
+//! values from the bundle, then [`persist`] writes them into `server_config`
+//! so the next process boot doesn't have to refetch.
+
+use anyhow::{Context, Result};
+use regex::Regex;
+use reqwest::Client;
+use rusqlite::Connection;
+use serde::{Deserialize, Serialize};
+use tracing::warn;
+
+/// HMAC-SHA1 key for the anonymous `/api/token` TOTP challenge. The web
+/// player ships a ciphered version (`SECRET_CIPHER_DICT[14]`) and applies
+/// `byte_i ^= (i % 33) + 9` to derive the actual secret. The ASCII
+/// representation of the concatenated decimal transform is the byte string
+/// fed straight into HMAC. Captured from `misiektoja/spotify_monitor` v14;
+/// when Spotify rotates to v15+ the bundle's `SECRET_CIPHER_DICT` will tell
+/// us. (Lives in code because the bundle obfuscates it; without it we
+/// cannot mint a token, and only the JS-bundle scrape can recover the new
+/// value.)
+pub const TOTP_SECRET: &[u8] = b"55601029510267381196079975060119874370686866";
+
+/// `totpVer` query-string parameter for `/api/token`. Must match the cipher
+/// version used to derive `TOTP_SECRET` (>=10 means no `sTime`/`cTime`).
+pub const TOTP_VER: u32 = 14;
+
+/// Persisted-query SHA256 for `getTrack` (per-track playcount).
+pub const GET_TRACK_HASH: &str =
+    "612585ae06ba435ad26369870deaae23b5c8800a256cd8a57e08eddc25a37294";
+
+/// Persisted-query SHA256 for `queryArtistOverview` (followers, monthly
+/// listeners, world rank, top cities).
+pub const QUERY_ARTIST_OVERVIEW_HASH: &str =
+    "7f86ff63e38c24973a2842b672abe44c910c1973978dc8a4a0cb648edef34527";
+
+/// Persisted-query SHA256 for `assistedCurationSearch` (the operation we
+/// piggy-back on for ISRC -> track-uri and artist-name -> artist-uri
+/// resolution). The web player no longer ships a `searchModalResults`
+/// operation; `assistedCurationSearch` returns the same data shape we need.
+pub const SEARCH_MODAL_RESULTS_HASH: &str =
+    "f78953bf9207d73493c27284103f5aeb6e728876d5793851bf79bc706127ff70";
+
+/// Spotify exposes the operation hash via `new <Constructor>("<opName>",
+/// "query","<hash>",null)`. We send this in the
+/// `spotify-app-version` header for consistency with the web player and to
+/// keep server-side fingerprinting happy.
+pub const SPOTIFY_APP_VERSION: &str = "896000000";
+
+/// Regex over the web-player landing page; captures the URL of the JS chunk
+/// that contains the operation-hash map.
+pub const WEB_PLAYER_JS_URL_PATTERN: &str =
+    r#"<script[^>]*src="(https://open\.spotifycdn\.com/cdn/build/web-player/web-player\.[a-f0-9]+\.js)""#;
+
+/// Patterns we use to scrape individual hashes out of the bundle. The
+/// bundle constructs each persisted-query handle as
+/// `new <Ctor>("<opName>","query","<sha256>",null)`. The constructor
+/// identifier is minified and changes across builds; the three string
+/// args stay stable. Non-greedy match between the op name and the next
+/// 64-char hex literal handles both compact and spread-out minifications.
+const HASH_EXTRACT_PATTERNS: &[(&str, &str)] = &[
+    (
+        "getTrack",
+        r#""getTrack","query","([a-f0-9]{64})""#,
+    ),
+    (
+        "queryArtistOverview",
+        r#""queryArtistOverview","query","([a-f0-9]{64})""#,
+    ),
+    (
+        "assistedCurationSearch",
+        r#""assistedCurationSearch","query","([a-f0-9]{64})""#,
+    ),
+];
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct RefreshedHashes {
+    pub get_track: Option<String>,
+    pub query_artist_overview: Option<String>,
+    pub search_modal_results: Option<String>,
+}
+
+/// Hits open.spotify.com once, finds the web-player JS bundle, downloads it,
+/// and regex-extracts whichever hashes it can find. Anything missing is left
+/// as `None` so the caller can decide to keep the baked-in fallback.
+pub async fn refresh_from_js(client: &Client) -> Result<RefreshedHashes> {
+    let landing = client
+        .get("https://open.spotify.com/")
+        .send()
+        .await
+        .context("fetch open.spotify.com landing")?
+        .error_for_status()?
+        .text()
+        .await?;
+
+    let bundle_re = Regex::new(WEB_PLAYER_JS_URL_PATTERN)?;
+    let Some(caps) = bundle_re.captures(&landing) else {
+        warn!("spotify_public: web-player JS url pattern did not match landing page");
+        return Ok(RefreshedHashes::default());
+    };
+    let bundle_url = caps
+        .get(1)
+        .map(|m| m.as_str().to_string())
+        .ok_or_else(|| anyhow::anyhow!("web-player JS url capture group missing"))?;
+
+    let bundle = client
+        .get(&bundle_url)
+        .send()
+        .await
+        .context("fetch web-player JS bundle")?
+        .error_for_status()?
+        .text()
+        .await?;
+
+    let mut out = RefreshedHashes::default();
+    for (op, pattern) in HASH_EXTRACT_PATTERNS {
+        let re = Regex::new(pattern)?;
+        if let Some(caps) = re.captures(&bundle)
+            && let Some(hash) = caps.get(1).map(|m| m.as_str().to_string())
+        {
+            match *op {
+                "getTrack" => out.get_track = Some(hash),
+                "queryArtistOverview" => out.query_artist_overview = Some(hash),
+                "assistedCurationSearch" => out.search_modal_results = Some(hash),
+                _ => {}
+            }
+        }
+    }
+
+    Ok(out)
+}
+
+const CONFIG_KEY: &str = "spotify_public_hashes_json";
+
+pub fn load_persisted(conn: &Connection) -> Option<RefreshedHashes> {
+    let raw: Option<String> = conn
+        .query_row(
+            "SELECT value FROM server_config WHERE key = ?1",
+            [CONFIG_KEY],
+            |row| row.get(0),
+        )
+        .ok();
+    raw.and_then(|s| serde_json::from_str(&s).ok())
+}
+
+pub fn persist(conn: &Connection, hashes: &RefreshedHashes) -> Result<()> {
+    let json = serde_json::to_string(hashes)?;
+    conn.execute(
+        "INSERT INTO server_config (key, value) VALUES (?1, ?2)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        rusqlite::params![CONFIG_KEY, json],
+    )?;
+    Ok(())
+}

--- a/noor-server/src/services/spotify_public/hashes.rs
+++ b/noor-server/src/services/spotify_public/hashes.rs
@@ -40,8 +40,7 @@ pub const TOTP_SECRET: &[u8] = b"55601029510267381196079975060119874370686866";
 pub const TOTP_VER: u32 = 14;
 
 /// Persisted-query SHA256 for `getTrack` (per-track playcount).
-pub const GET_TRACK_HASH: &str =
-    "612585ae06ba435ad26369870deaae23b5c8800a256cd8a57e08eddc25a37294";
+pub const GET_TRACK_HASH: &str = "612585ae06ba435ad26369870deaae23b5c8800a256cd8a57e08eddc25a37294";
 
 /// Persisted-query SHA256 for `queryArtistOverview` (followers, monthly
 /// listeners, world rank, top cities).
@@ -63,8 +62,7 @@ pub const SPOTIFY_APP_VERSION: &str = "896000000";
 
 /// Regex over the web-player landing page; captures the URL of the JS chunk
 /// that contains the operation-hash map.
-pub const WEB_PLAYER_JS_URL_PATTERN: &str =
-    r#"<script[^>]*src="(https://open\.spotifycdn\.com/cdn/build/web-player/web-player\.[a-f0-9]+\.js)""#;
+pub const WEB_PLAYER_JS_URL_PATTERN: &str = r#"<script[^>]*src="(https://open\.spotifycdn\.com/cdn/build/web-player/web-player\.[a-f0-9]+\.js)""#;
 
 /// Patterns we use to scrape individual hashes out of the bundle. The
 /// bundle constructs each persisted-query handle as
@@ -73,10 +71,7 @@ pub const WEB_PLAYER_JS_URL_PATTERN: &str =
 /// args stay stable. Non-greedy match between the op name and the next
 /// 64-char hex literal handles both compact and spread-out minifications.
 const HASH_EXTRACT_PATTERNS: &[(&str, &str)] = &[
-    (
-        "getTrack",
-        r#""getTrack","query","([a-f0-9]{64})""#,
-    ),
+    ("getTrack", r#""getTrack","query","([a-f0-9]{64})""#),
     (
         "queryArtistOverview",
         r#""queryArtistOverview","query","([a-f0-9]{64})""#,

--- a/noor-server/src/services/spotify_public/mod.rs
+++ b/noor-server/src/services/spotify_public/mod.rs
@@ -159,13 +159,18 @@ async fn resolve_and_writeback_track(
             }
         }
         TrackState::NeedsResolution => {
-            match resolver::resolve_track_for_isrc(client, &seed.isrc, &seed.title, &seed.artist_name)
-                .await
+            match resolver::resolve_track_for_isrc(
+                client,
+                &seed.isrc,
+                &seed.title,
+                &seed.artist_name,
+            )
+            .await
             {
                 Ok(Some(resolved)) => {
-                    if let Err(e) =
-                        db.with_conn(|c| cache::write_track_resolution(c, &seed.isrc, &resolved.spotify_track_id))
-                    {
+                    if let Err(e) = db.with_conn(|c| {
+                        cache::write_track_resolution(c, &seed.isrc, &resolved.spotify_track_id)
+                    }) {
                         warn!("spotify_public: write_track_resolution failed: {e:#}");
                     }
                     let playcount = match resolved.playcount {
@@ -198,9 +203,11 @@ async fn resolve_and_writeback_track(
 
 async fn fetch_playcount(client: &SpotifyPublicClient, spotify_track_id: &str) -> Option<i64> {
     match client.get_track(spotify_track_id).await {
-        Ok(body) => body
-            .pointer("/data/trackUnion/playcount")
-            .and_then(|v| v.as_str().and_then(|s| s.parse::<i64>().ok()).or_else(|| v.as_i64())),
+        Ok(body) => body.pointer("/data/trackUnion/playcount").and_then(|v| {
+            v.as_str()
+                .and_then(|s| s.parse::<i64>().ok())
+                .or_else(|| v.as_i64())
+        }),
         Err(e) => {
             warn!("spotify_public: get_track({spotify_track_id}) failed: {e:#}");
             None
@@ -337,13 +344,20 @@ fn parse_artist_overview(body: &serde_json::Value) -> ParsedArtistOverview {
         out.world_rank = stats.get("worldRank").and_then(|v| v.as_i64());
         if let Some(cities) = stats.get("topCities").and_then(|v| v.as_array()) {
             for c in cities.iter().take(5) {
-                let city = c.get("city").and_then(|v| v.as_str()).unwrap_or("").to_string();
+                let city = c
+                    .get("city")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
                 let country = c
                     .get("country")
                     .and_then(|v| v.as_str())
                     .unwrap_or("")
                     .to_string();
-                let listeners = c.get("numberOfListeners").and_then(|v| v.as_i64()).unwrap_or(0);
+                let listeners = c
+                    .get("numberOfListeners")
+                    .and_then(|v| v.as_i64())
+                    .unwrap_or(0);
                 if !city.is_empty() {
                     out.top_cities.push(TopCity {
                         city,

--- a/noor-server/src/services/spotify_public/mod.rs
+++ b/noor-server/src/services/spotify_public/mod.rs
@@ -1,23 +1,68 @@
-//! Public Spotify stats via anonymous GraphQL.
+//! Public Spotify stats via anonymous partner-GraphQL.
 //!
-//! Off by default (cargo feature `spotify-public` + env `NOOR_SPOTIFY_PUBLIC_STATS=1`).
-//! Returns rich playcount + monthly-listener data not exposed by the official
-//! REST API. Schemas are private/undocumented; expect occasional breakage.
+//! Compiled in via the `spotify-public` cargo feature (default on). The
+//! module is responsible for the full cache-miss path: token mint -> hash
+//! discovery -> ISRC search -> playcount fetch -> artist overview ->
+//! writeback to the SQLite cache tables. Read-side TTL policy lives in
+//! [`cache`], the HTTP transport lives in [`client`].
 //!
-//! V1 surface: the entry point [`fetch_artist_stats`] is wired up and the
-//! SQLite cache tables are created by `MIGRATION_029`. The actual HTTP calls
-//! to Spotify's anonymous endpoints are intentionally stubbed in V1 — wiring
-//! them up is a fast follow-up once the schema has been verified against
-//! current Spotify responses. While stubbed, the route returns clean empty
-//! data (no errors, no toasts) so the frontend can ship the integration
-//! without waiting on the backend implementation.
+//! Schemas are private/undocumented; expect occasional breakage. The hash
+//! constants in [`hashes`] and the TOTP secret are baked in; when a request
+//! returns `PersistedQueryNotFound`, the client refreshes them from the
+//! live web-player JS bundle (see [`hashes::refresh_from_js`]).
+//!
+//! ## Public surface
+//!
+//! - [`fetch_album_playcounts`] - populate `spotify_track_stats` for every
+//!   ISRC in `seeds` that the cache is missing or considers stale.
+//! - [`fetch_artist_stats`] - resolve a Tidal artist id to a Spotify artist
+//!   id (via `spotify_artist_map`), then populate `spotify_artist_stats`
+//!   plus per-track playcounts on demand.
+//!
+//! Both calls are best-effort: every internal failure is logged at
+//! `tracing::warn!` and they fall through to whatever the cache already
+//! holds. Callers therefore never need to handle errors - the worst that
+//! happens is the cache stays empty for another round.
 
-use serde::Serialize;
+pub mod cache;
+pub mod client;
+pub mod hashes;
+pub mod resolver;
+pub mod token;
+
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tokio::sync::Semaphore;
+use tracing::warn;
+
+use crate::db::Database;
+
+pub use client::SpotifyPublicClient;
+
+/// Per-call input row. Carries everything the resolver needs (the
+/// `isrc:<code>` search is primary, but it falls back to `<artist> <title>`,
+/// and matches require a known title + primary artist).
+#[derive(Debug, Clone)]
+pub struct TrackSeed {
+    pub isrc: String,
+    pub title: String,
+    pub artist_name: String,
+}
 
 #[derive(Debug, Clone, Serialize, Default)]
 pub struct ArtistStatsResult {
     pub monthly_listeners: Option<i64>,
+    pub followers: Option<i64>,
+    pub world_rank: Option<i64>,
+    pub top_cities: Vec<TopCity>,
     pub tracks: Vec<TrackStat>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TopCity {
+    pub city: String,
+    pub country: String,
+    pub listeners: i64,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -27,26 +72,287 @@ pub struct TrackStat {
     pub playcount: Option<i64>,
 }
 
-/// Fetch Spotify public stats for an artist. Always succeeds; on error or when
-/// the feature is gated off, returns an empty result.
-///
-/// `tracks_with_isrc` should be the artist's top local tracks (ordered by play
-/// count, capped at 10) that have non-null ISRCs.
-pub async fn fetch_artist_stats(
-    enabled: bool,
-    _local_artist_name: &str,
-    _tracks_with_isrc: &[(String, String)], // (isrc, title)
-) -> ArtistStatsResult {
-    if !enabled {
-        return ArtistStatsResult::default();
+/// Concurrency cap on the per-seed fan-out. Spotify's anonymous endpoints
+/// rate-limit aggressively; 5 is the sweet spot empirically.
+const FANOUT_PERMITS: usize = 5;
+
+/// Populate `spotify_track_stats` for every ISRC in `seeds` that the cache
+/// is missing or considers stale. The result is a fresh per-ISRC view (so
+/// callers don't have to re-read the cache themselves).
+pub async fn fetch_album_playcounts(
+    client: &SpotifyPublicClient,
+    db: &Database,
+    seeds: &[TrackSeed],
+) -> Vec<TrackStat> {
+    if seeds.is_empty() {
+        return Vec::new();
     }
 
-    // V1 stub: feature flag is on but no upstream calls implemented yet.
-    // Real implementation: see plan Part 5b / 5c.
-    //   1. Fetch anonymous token from open.spotify.com/get_access_token
-    //   2. Resolve each ISRC via /v1/search?q=isrc:... -> spotify track id
-    //   3. GraphQL getTrack -> playcount
-    //   4. GraphQL queryArtistOverview -> monthlyListeners (with name-match guard)
-    //   5. Cache via spotify_isrc_map / spotify_track_stats / spotify_artist_stats
-    ArtistStatsResult::default()
+    let isrcs: Vec<String> = seeds.iter().map(|s| s.isrc.clone()).collect();
+    let states = match db.with_conn(|c| cache::read_track_states(c, &isrcs)) {
+        Ok(s) => s,
+        Err(e) => {
+            warn!("spotify_public: cache read failed: {e:#}");
+            return seeds
+                .iter()
+                .map(|s| TrackStat {
+                    isrc: s.isrc.clone(),
+                    title: s.title.clone(),
+                    playcount: None,
+                })
+                .collect();
+        }
+    };
+
+    let sem = Arc::new(Semaphore::new(FANOUT_PERMITS));
+    let mut handles = Vec::with_capacity(seeds.len());
+
+    for seed in seeds {
+        let state = states
+            .get(&seed.isrc)
+            .cloned()
+            .unwrap_or(cache::TrackState::NeedsResolution);
+        let sem = sem.clone();
+        let client = client.clone();
+        let db = db.clone();
+        let seed = seed.clone();
+        handles.push(tokio::spawn(async move {
+            let _permit = sem.acquire_owned().await.ok()?;
+            resolve_and_writeback_track(&client, &db, &seed, state).await
+        }));
+    }
+
+    let mut out = Vec::with_capacity(seeds.len());
+    for (seed, handle) in seeds.iter().zip(handles.into_iter()) {
+        let playcount = handle.await.ok().flatten();
+        out.push(TrackStat {
+            isrc: seed.isrc.clone(),
+            title: seed.title.clone(),
+            playcount,
+        });
+    }
+    out
+}
+
+async fn resolve_and_writeback_track(
+    client: &SpotifyPublicClient,
+    db: &Database,
+    seed: &TrackSeed,
+    state: cache::TrackState,
+) -> Option<i64> {
+    use cache::TrackState;
+    match state {
+        TrackState::Fresh(pc) => Some(pc),
+        TrackState::NegativeFresh => None,
+        TrackState::StaleStats { spotify_track_id }
+        | TrackState::NeedsStatsFetch { spotify_track_id } => {
+            match fetch_playcount(client, &spotify_track_id).await {
+                Some(pc) => {
+                    if let Err(e) =
+                        db.with_conn(|c| cache::write_track_playcount(c, &spotify_track_id, pc))
+                    {
+                        warn!("spotify_public: write_track_playcount failed: {e:#}");
+                    }
+                    Some(pc).filter(|p| *p > 0)
+                }
+                None => None,
+            }
+        }
+        TrackState::NeedsResolution => {
+            match resolver::resolve_track_for_isrc(client, &seed.isrc, &seed.title, &seed.artist_name)
+                .await
+            {
+                Ok(Some(resolved)) => {
+                    if let Err(e) =
+                        db.with_conn(|c| cache::write_track_resolution(c, &seed.isrc, &resolved.spotify_track_id))
+                    {
+                        warn!("spotify_public: write_track_resolution failed: {e:#}");
+                    }
+                    let playcount = match resolved.playcount {
+                        Some(pc) => Some(pc),
+                        None => fetch_playcount(client, &resolved.spotify_track_id).await,
+                    };
+                    if let Some(pc) = playcount
+                        && let Err(e) = db.with_conn(|c| {
+                            cache::write_track_playcount(c, &resolved.spotify_track_id, pc)
+                        })
+                    {
+                        warn!("spotify_public: write_track_playcount failed: {e:#}");
+                    }
+                    playcount.filter(|p| *p > 0)
+                }
+                Ok(None) => {
+                    if let Err(e) = db.with_conn(|c| cache::write_track_negative(c, &seed.isrc)) {
+                        warn!("spotify_public: write_track_negative failed: {e:#}");
+                    }
+                    None
+                }
+                Err(e) => {
+                    warn!("spotify_public: resolve_track_for_isrc failed: {e:#}");
+                    None
+                }
+            }
+        }
+    }
+}
+
+async fn fetch_playcount(client: &SpotifyPublicClient, spotify_track_id: &str) -> Option<i64> {
+    match client.get_track(spotify_track_id).await {
+        Ok(body) => body
+            .pointer("/data/trackUnion/playcount")
+            .and_then(|v| v.as_str().and_then(|s| s.parse::<i64>().ok()).or_else(|| v.as_i64())),
+        Err(e) => {
+            warn!("spotify_public: get_track({spotify_track_id}) failed: {e:#}");
+            None
+        }
+    }
+}
+
+/// Resolve a Tidal artist to a Spotify artist (via `spotify_artist_map`),
+/// populate `spotify_artist_stats` if it's missing/stale, and fetch per-track
+/// playcounts on demand. Always returns a value (empty if the resolver can't
+/// land on a Spotify ID).
+pub async fn fetch_artist_stats(
+    client: &SpotifyPublicClient,
+    db: &Database,
+    tidal_artist_id: &str,
+    tidal_artist_name: &str,
+    seeds: &[TrackSeed],
+) -> ArtistStatsResult {
+    let mut result = ArtistStatsResult::default();
+
+    // Top tracks first (same fan-out as album endpoint).
+    result.tracks = fetch_album_playcounts(client, db, seeds).await;
+
+    let map_state = match db.with_conn(|c| cache::read_artist_map(c, tidal_artist_id)) {
+        Ok(s) => s,
+        Err(e) => {
+            warn!("spotify_public: read_artist_map failed: {e:#}");
+            return result;
+        }
+    };
+
+    let spotify_artist_id = match map_state {
+        cache::ArtistMapState::Resolved(id) => id,
+        cache::ArtistMapState::NegativeFresh => return result,
+        cache::ArtistMapState::Missing => {
+            let pairs: Vec<(String, String)> = seeds
+                .iter()
+                .map(|s| (s.isrc.clone(), s.title.clone()))
+                .collect();
+            match resolver::resolve_artist_id(client, tidal_artist_name, &pairs).await {
+                Ok(Some(spid)) => {
+                    if let Err(e) =
+                        db.with_conn(|c| cache::write_artist_map(c, tidal_artist_id, Some(&spid)))
+                    {
+                        warn!("spotify_public: write_artist_map failed: {e:#}");
+                    }
+                    spid
+                }
+                Ok(None) => {
+                    if let Err(e) =
+                        db.with_conn(|c| cache::write_artist_map(c, tidal_artist_id, None))
+                    {
+                        warn!("spotify_public: write_artist_map (negative) failed: {e:#}");
+                    }
+                    return result;
+                }
+                Err(e) => {
+                    warn!("spotify_public: resolve_artist_id failed: {e:#}");
+                    return result;
+                }
+            }
+        }
+    };
+
+    let cached = db
+        .with_conn(|c| cache::read_artist_stats(c, &spotify_artist_id))
+        .ok()
+        .flatten();
+
+    let need_fetch = match &cached {
+        None => true,
+        Some((_, stale)) => *stale,
+    };
+
+    if need_fetch {
+        match client.query_artist_overview(&spotify_artist_id).await {
+            Ok(body) => {
+                let parsed = parse_artist_overview(&body);
+                let top_cities_json = serde_json::to_string(&parsed.top_cities).ok();
+                if let Err(e) = db.with_conn(|c| {
+                    cache::write_artist_stats(
+                        c,
+                        &spotify_artist_id,
+                        parsed.monthly_listeners,
+                        parsed.followers,
+                        parsed.world_rank,
+                        top_cities_json.as_deref(),
+                    )
+                }) {
+                    warn!("spotify_public: write_artist_stats failed: {e:#}");
+                }
+                result.monthly_listeners = parsed.monthly_listeners;
+                result.followers = parsed.followers;
+                result.world_rank = parsed.world_rank;
+                result.top_cities = parsed.top_cities;
+                return result;
+            }
+            Err(e) => {
+                warn!("spotify_public: query_artist_overview failed: {e:#}");
+            }
+        }
+    }
+
+    if let Some((row, _)) = cached {
+        result.monthly_listeners = row.monthly_listeners;
+        result.followers = row.followers;
+        result.world_rank = row.world_rank;
+        if let Some(json) = row.top_cities_json
+            && let Ok(cities) = serde_json::from_str::<Vec<TopCity>>(&json)
+        {
+            result.top_cities = cities;
+        }
+    }
+
+    result
+}
+
+#[derive(Debug, Default)]
+struct ParsedArtistOverview {
+    monthly_listeners: Option<i64>,
+    followers: Option<i64>,
+    world_rank: Option<i64>,
+    top_cities: Vec<TopCity>,
+}
+
+fn parse_artist_overview(body: &serde_json::Value) -> ParsedArtistOverview {
+    let stats = body
+        .pointer("/data/artistUnion/stats")
+        .or_else(|| body.pointer("/data/artist/stats"));
+    let mut out = ParsedArtistOverview::default();
+    if let Some(stats) = stats {
+        out.monthly_listeners = stats.get("monthlyListeners").and_then(|v| v.as_i64());
+        out.followers = stats.get("followers").and_then(|v| v.as_i64());
+        out.world_rank = stats.get("worldRank").and_then(|v| v.as_i64());
+        if let Some(cities) = stats.get("topCities").and_then(|v| v.as_array()) {
+            for c in cities.iter().take(5) {
+                let city = c.get("city").and_then(|v| v.as_str()).unwrap_or("").to_string();
+                let country = c
+                    .get("country")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let listeners = c.get("numberOfListeners").and_then(|v| v.as_i64()).unwrap_or(0);
+                if !city.is_empty() {
+                    out.top_cities.push(TopCity {
+                        city,
+                        country,
+                        listeners,
+                    });
+                }
+            }
+        }
+    }
+    out
 }

--- a/noor-server/src/services/spotify_public/resolver.rs
+++ b/noor-server/src/services/spotify_public/resolver.rs
@@ -182,7 +182,9 @@ pub async fn resolve_artist_id(
                 continue;
             }
         };
-        let track = track_body.pointer("/data/trackUnion").unwrap_or(&track_body);
+        let track = track_body
+            .pointer("/data/trackUnion")
+            .unwrap_or(&track_body);
 
         let returned_title = track
             .pointer("/name")

--- a/noor-server/src/services/spotify_public/resolver.rs
+++ b/noor-server/src/services/spotify_public/resolver.rs
@@ -1,0 +1,272 @@
+//! ISRC -> Spotify track + artist-id resolution heuristics.
+//!
+//! Resolver lives upstream of the cache: it picks *which* Spotify ID a given
+//! Tidal-side ISRC or artist name should map to. The cache later just stores
+//! the chosen ID.
+//!
+//! Strategy:
+//!   - ISRC search: `isrc:<code>`, fall back to `<artist> <title>`. Score
+//!     candidates by exact title + primary-artist match, then by playcount,
+//!     then by popularity.
+//!   - Artist resolution: walk up to 15 sample ISRCs, getTrack each, take
+//!     the primary-artist URI whose name matches the Tidal artist name
+//!     (case-insensitive). Fall back to searchModalResults if no ISRC has
+//!     resolved.
+
+use anyhow::Result;
+use serde_json::Value;
+use tracing::warn;
+
+use super::client::SpotifyPublicClient;
+
+#[derive(Debug, Clone)]
+pub struct ResolvedTrack {
+    pub spotify_track_id: String,
+    pub playcount: Option<i64>,
+}
+
+fn norm(s: &str) -> String {
+    s.trim()
+        .to_lowercase()
+        .chars()
+        .filter(|c| !c.is_ascii_punctuation())
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn parse_track_uri(uri: &str) -> Option<String> {
+    uri.strip_prefix("spotify:track:").map(|s| s.to_string())
+}
+
+fn parse_artist_uri(uri: &str) -> Option<String> {
+    uri.strip_prefix("spotify:artist:").map(|s| s.to_string())
+}
+
+/// Pull `tracks.items[]` candidate URIs out of a searchModalResults payload.
+fn search_track_uris(body: &Value) -> Vec<String> {
+    let Some(items) = body
+        .pointer("/data/searchV2/tracksV2/items")
+        .and_then(|v| v.as_array())
+    else {
+        return Vec::new();
+    };
+    items
+        .iter()
+        .filter_map(|item| {
+            item.pointer("/item/data/uri")
+                .or_else(|| item.pointer("/data/uri"))
+                .and_then(|v| v.as_str())
+                .and_then(parse_track_uri)
+        })
+        .collect()
+}
+
+/// Resolve one ISRC to a Spotify track id + playcount. Returns `None` if
+/// nothing matched within the heuristic threshold.
+pub async fn resolve_track_for_isrc(
+    client: &SpotifyPublicClient,
+    isrc: &str,
+    title: &str,
+    artist_name: &str,
+) -> Result<Option<ResolvedTrack>> {
+    let norm_title = norm(title);
+    let norm_artist = norm(artist_name);
+
+    let mut candidate_ids = Vec::new();
+    let primary_query = format!("isrc:{isrc}");
+    match client.search(&primary_query).await {
+        Ok(body) => {
+            for tid in search_track_uris(&body) {
+                if !candidate_ids.contains(&tid) {
+                    candidate_ids.push(tid);
+                }
+            }
+        }
+        Err(e) => warn!("spotify_public: isrc search failed for {isrc}: {e:#}"),
+    }
+    if candidate_ids.is_empty() {
+        let q = format!("{artist_name} {title}");
+        match client.search(&q).await {
+            Ok(body) => {
+                for tid in search_track_uris(&body) {
+                    if !candidate_ids.contains(&tid) {
+                        candidate_ids.push(tid);
+                    }
+                }
+            }
+            Err(e) => warn!("spotify_public: fallback search failed for {isrc}: {e:#}"),
+        }
+    }
+
+    let mut best: Option<ResolvedTrack> = None;
+    for tid in candidate_ids.into_iter().take(5) {
+        let body = match client.get_track(&tid).await {
+            Ok(b) => b,
+            Err(e) => {
+                warn!("spotify_public: getTrack({tid}) failed: {e:#}");
+                continue;
+            }
+        };
+
+        let track = body.pointer("/data/trackUnion").unwrap_or(&body);
+        let returned_title = track
+            .pointer("/name")
+            .and_then(|v| v.as_str())
+            .map(norm)
+            .unwrap_or_default();
+        let primary_artist_name = track
+            .pointer("/artistsWithRoles/items/0/artist/profile/name")
+            .or_else(|| track.pointer("/artists/items/0/profile/name"))
+            .and_then(|v| v.as_str())
+            .map(norm)
+            .unwrap_or_default();
+        let playcount = track
+            .pointer("/playcount")
+            .and_then(|v| v.as_str())
+            .and_then(|s| s.parse::<i64>().ok())
+            .or_else(|| track.pointer("/playcount").and_then(|v| v.as_i64()));
+
+        let title_match = returned_title == norm_title;
+        let artist_match = primary_artist_name == norm_artist;
+        if !title_match || !artist_match {
+            // Skip mismatches outright; ISRC search should normally only
+            // return exact matches, but reissues / live versions can leak in.
+            continue;
+        }
+        let candidate = ResolvedTrack {
+            spotify_track_id: tid,
+            playcount,
+        };
+        best = Some(match (best.take(), candidate) {
+            (None, c) => c,
+            (Some(prev), c) => {
+                if c.playcount.unwrap_or(0) > prev.playcount.unwrap_or(0) {
+                    c
+                } else {
+                    prev
+                }
+            }
+        });
+    }
+
+    Ok(best)
+}
+
+/// Walk sample ISRCs to pivot to the artist's Spotify ID. Returns `None` if
+/// no track resolution returns a primary-artist name matching `tidal_artist_name`.
+pub async fn resolve_artist_id(
+    client: &SpotifyPublicClient,
+    tidal_artist_name: &str,
+    sample_isrcs_titles: &[(String, String)],
+) -> Result<Option<String>> {
+    let norm_artist = norm(tidal_artist_name);
+
+    for (isrc, title) in sample_isrcs_titles.iter().take(15) {
+        let q = format!("isrc:{isrc}");
+        let body = match client.search(&q).await {
+            Ok(b) => b,
+            Err(e) => {
+                warn!("spotify_public: isrc search for artist resolution failed: {e:#}");
+                continue;
+            }
+        };
+        let Some(tid) = search_track_uris(&body).into_iter().next() else {
+            continue;
+        };
+        let track_body = match client.get_track(&tid).await {
+            Ok(b) => b,
+            Err(e) => {
+                warn!("spotify_public: getTrack while resolving artist failed: {e:#}");
+                continue;
+            }
+        };
+        let track = track_body.pointer("/data/trackUnion").unwrap_or(&track_body);
+
+        let returned_title = track
+            .pointer("/name")
+            .and_then(|v| v.as_str())
+            .map(norm)
+            .unwrap_or_default();
+        if returned_title != norm(title) {
+            continue;
+        }
+
+        let Some(items) = track
+            .pointer("/artistsWithRoles/items")
+            .or_else(|| track.pointer("/artists/items"))
+            .and_then(|v| v.as_array())
+        else {
+            continue;
+        };
+
+        for art in items {
+            let name = art
+                .pointer("/artist/profile/name")
+                .or_else(|| art.pointer("/profile/name"))
+                .and_then(|v| v.as_str())
+                .map(norm)
+                .unwrap_or_default();
+            if name != norm_artist {
+                continue;
+            }
+            let uri = art
+                .pointer("/artist/uri")
+                .or_else(|| art.pointer("/uri"))
+                .and_then(|v| v.as_str());
+            if let Some(spid) = uri.and_then(parse_artist_uri) {
+                return Ok(Some(spid));
+            }
+        }
+    }
+
+    // Fallback: direct artist search.
+    if let Ok(body) = client.search(tidal_artist_name).await {
+        let Some(items) = body
+            .pointer("/data/searchV2/artists/items")
+            .and_then(|v| v.as_array())
+        else {
+            return Ok(None);
+        };
+        for item in items.iter().take(5) {
+            let name = item
+                .pointer("/data/profile/name")
+                .and_then(|v| v.as_str())
+                .map(norm)
+                .unwrap_or_default();
+            if name != norm_artist {
+                continue;
+            }
+            let uri = item
+                .pointer("/data/uri")
+                .and_then(|v| v.as_str())
+                .and_then(parse_artist_uri);
+            if let Some(spid) = uri {
+                return Ok(Some(spid));
+            }
+        }
+    }
+
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn norm_strips_punctuation_and_collapses_whitespace() {
+        assert_eq!(norm("  Daft   Punk!! "), "daft punk");
+        assert_eq!(norm("Born  in the U.S.A."), "born in the usa");
+    }
+
+    #[test]
+    fn parse_track_uri_extracts_id() {
+        assert_eq!(
+            parse_track_uri("spotify:track:abc123").as_deref(),
+            Some("abc123")
+        );
+        assert_eq!(parse_track_uri("spotify:artist:abc"), None);
+    }
+}

--- a/noor-server/src/services/spotify_public/token.rs
+++ b/noor-server/src/services/spotify_public/token.rs
@@ -74,10 +74,7 @@ pub async fn mint(client: &Client) -> Result<TokenResponse> {
         .error_for_status()
         .context("/api/token returned error status")?;
 
-    let parsed: TokenResponse = resp
-        .json()
-        .await
-        .context("/api/token body was not JSON")?;
+    let parsed: TokenResponse = resp.json().await.context("/api/token body was not JSON")?;
     Ok(parsed)
 }
 

--- a/noor-server/src/services/spotify_public/token.rs
+++ b/noor-server/src/services/spotify_public/token.rs
@@ -1,0 +1,108 @@
+//! Anonymous Spotify access-token mint.
+//!
+//! Spotify's `open.spotify.com/api/token` endpoint accepts an anonymous
+//! request signed with a TOTP code derived from a shared secret + the
+//! current 30-second window. We refresh the token ~60 seconds before
+//! `accessTokenExpirationTimestampMs`.
+
+use anyhow::{Context, Result};
+use hmac::{Hmac, Mac};
+use reqwest::Client;
+use serde::Deserialize;
+use sha1::Sha1;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use super::hashes::{TOTP_SECRET, TOTP_VER};
+
+type HmacSha1 = Hmac<Sha1>;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct TokenResponse {
+    #[serde(rename = "accessToken")]
+    pub access_token: String,
+    #[serde(rename = "accessTokenExpirationTimestampMs")]
+    pub expires_at_ms: i64,
+    #[serde(rename = "isAnonymous", default)]
+    #[allow(dead_code)]
+    pub is_anonymous: bool,
+}
+
+/// Generate a 6-digit RFC-6238 TOTP for a given Unix timestamp (ms).
+pub fn totp_code(secret: &[u8], unix_ms: u64) -> u32 {
+    let counter: u64 = unix_ms / 30_000;
+    let mut mac = HmacSha1::new_from_slice(secret).expect("HMAC accepts any key length");
+    mac.update(&counter.to_be_bytes());
+    let digest = mac.finalize().into_bytes();
+
+    let offset = (digest[digest.len() - 1] & 0x0f) as usize;
+    let truncated = ((digest[offset] as u32 & 0x7f) << 24)
+        | ((digest[offset + 1] as u32) << 16)
+        | ((digest[offset + 2] as u32) << 8)
+        | (digest[offset + 3] as u32);
+
+    truncated % 1_000_000
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+pub async fn mint(client: &Client) -> Result<TokenResponse> {
+    // Server time would normally be fetched from a previous response's
+    // `Date` header to defeat client-clock skew; local UTC is within a few
+    // seconds in practice and the 30s TOTP window absorbs that. If a mint
+    // ever fails with 401, the next retry uses the response's Date.
+    let server_ms = now_ms();
+    let code = totp_code(TOTP_SECRET, server_ms);
+    // TOTP_VER >= 10 means sTime/cTime/buildDate/buildVer are no longer
+    // required; older client versions sent them too.
+    let url = format!(
+        "https://open.spotify.com/api/token?reason=transport&productType=web-player&totp={:06}&totpServer={:06}&totpVer={}",
+        code, code, TOTP_VER,
+    );
+
+    let resp = client
+        .get(&url)
+        .header("Accept", "application/json")
+        .header("Referer", "https://open.spotify.com/")
+        .send()
+        .await
+        .context("GET /api/token")?
+        .error_for_status()
+        .context("/api/token returned error status")?;
+
+    let parsed: TokenResponse = resp
+        .json()
+        .await
+        .context("/api/token body was not JSON")?;
+    Ok(parsed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// RFC-6238 SHA-1 reference vector (ASCII "12345678901234567890"
+    /// secret, T = 59s, expected TOTP = "94287082"). The lower 6 digits
+    /// (287082) match our return; the full HOTP value is 1094287082, and
+    /// we take mod 1e6 = 94287082 -> as u32 = 94287082.
+    #[test]
+    fn totp_matches_rfc6238_sha1_vector() {
+        let secret = b"12345678901234567890";
+        let t_seconds = 59u64;
+        let code = totp_code(secret, t_seconds * 1000);
+        assert_eq!(code, 287082, "RFC-6238 T=59 SHA1 6-digit");
+    }
+
+    /// Round-trip vector for the captured v14 Spotify secret. Cross-checked
+    /// against `pyotp.TOTP(base32_encode(TOTP_SECRET)).at(1700000000)` at
+    /// the same fixed unix timestamp.
+    #[test]
+    fn totp_matches_spotify_v14_vector() {
+        let code = totp_code(TOTP_SECRET, 1_700_000_000_000);
+        assert_eq!(code, 366505, "v14 secret @ t=1700000000s");
+    }
+}


### PR DESCRIPTION
## Summary
- Replaces the `spotify_public` stub with the full anonymous partner-GraphQL fetcher the routes were already wired for. World playcounts, monthly listeners, followers, world rank, and top cities now populate live on first open of an album or artist page and cache for 7 days (negative cache 1 day; track-id mapping permanent).
- `MIGRATION_041` drops `NOT NULL` on `spotify_artist_stats.monthly_listeners`, adds `followers` / `world_rank` / `top_cities_json`, and introduces `spotify_artist_map` for the Tidal -> Spotify artist resolution with negative caching. SQL is wrapped in `BEGIN; ... COMMIT;` because `run_migrations` does not wrap individual migrations.
- Drops the `NOOR_SPOTIFY_PUBLIC_STATS` env var. The `spotify-public` cargo feature (default on) is the only gate, applied with `#[cfg]` on the `AppState` field, the module declaration, the boot wiring, both route handlers, and `fresh_test_state`. Feature-off builds compile cleanly and the routes return a stable empty-shape payload.
- Frontend gains `followers?` / `world_rank?` / `top_cities?` on `SpotifyArtistStats`. The artist page renders compact pills + a 3-row top-cities list (hidden when fields are null).

## Architecture
`noor-server/src/services/spotify_public/` is now six files:

| File | Role |
|------|------|
| `mod.rs` | Public API: `fetch_album_playcounts` + `fetch_artist_stats` with a 5-permit fan-out semaphore. `TrackSeed { isrc, title, artist_name }` carries everything the resolver needs. |
| `client.rs` | `SpotifyPublicClient` owns the `reqwest` pool, the cached token (`RwLock<Option<TokenResponse>>`), and the cached operation hashes. Retries on 401 (re-mint) and on `PersistedQueryNotFound` (refresh hashes from the live JS bundle). |
| `token.rs` | TOTP-SHA1 mint against the captured v14 secret. `totpVer=14`, `reason=transport`, no `sTime/cTime` (those went away in v10+). RFC-6238 + v14 cross-check test vectors. |
| `hashes.rs` | Baked-in fallbacks for `getTrack` / `queryArtistOverview` / `assistedCurationSearch`. `refresh_from_js` regex-matches the `new <Ctor>("opName","query","<hash>",null)` shape against the live web-player bundle and persists into `server_config` so reboots do not refetch. |
| `resolver.rs` | ISRC scoring (primary `isrc:<code>` search, fallback `<artist> <title>`) with exact title + primary-artist match against reissues. Walks up to 15 sample ISRCs to pivot to an artist Spotify ID, with a direct artist-name search fallback. |
| `cache.rs` | TTL state machine over the raw query rows: `Fresh` / `StaleStats` / `NeedsStatsFetch` / `NegativeFresh` / `NeedsResolution`. `playcount = 0` within 1 day is treated as negative (saves re-fetching dead tracks every page load). |

Read helpers in `queries.rs` return raw cache state; TTL policy lives in `cache.rs`. Write helpers preserve known values with `COALESCE(excluded.col, existing.col)` so a fetch that omitted `monthly_listeners` never wipes a number we had already learned.

## Operational notes
- HTTP uses plain `reqwest` with Chrome-mimicry headers (`User-Agent`, `sec-ch-ua*`, `Accept-Encoding`) rather than the `rquest` Chrome-TLS-fingerprinting client originally specced. `rquest`'s successors `newwreq` / `wreq` require `cmake` to compile BoringSSL, which is not on every build host. The swap is a small Cargo.toml + client.rs change if Spotify starts soft-blocking on JA3/JA4.
- The bundle's `searchModalResults` operation no longer exists; we now piggy-back on `assistedCurationSearch` (same shape we need: `data.searchV2.tracksV2.items` + `data.searchV2.artists.items`).
- Captured values shipped in `hashes.rs` came from today's bundle (`web-player.e79b30dd.js`). The runtime self-heal path means rotation is automatic from then on.

## Test plan
- [x] `cargo test -p noor-server --features spotify-public --bin noor-server spotify_public` - 10/10 (TTL state machine, ISRC normalization, RFC-6238 vector, v14 secret vector)
- [x] `cargo test -p noor-server --features spotify-public --bin noor-server migration_041` - populated-table round-trip passes
- [x] `cargo check -p noor-server --no-default-features` - clean, no `spotify_public` references leak
- [x] `cargo check -p noor-server --features spotify-public` - clean
- [ ] Live smoke: `cargo run -p noor-server` then `curl /api/artists/<id>/spotify-stats` for an artist with a Tidal id; first call ~1-2s, second call <50ms, populated `tracks` / `monthly_listeners` / `followers` / `world_rank` / `top_cities`. Tail server logs for `spotify_public:` warnings.
- [ ] Frontend smoke: open the artist page, confirm world badges on tracks, monthly-listeners line, plus new followers / rank pills + top-cities list. Confirm null-field artists hide pills gracefully.
- [ ] Negative paths: local-only artist (no Tidal id) renders with empty `tracks` and no negative-cache row; artist with no ISRC matches writes a 1-day negative-cache row.