### PR TITLE
polish(discovery): post-#45 styling, caching, and proxy resilience

### DIFF
--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -10,6 +10,11 @@ back to the PR or commit that flagged it.
 
 ## Open
 
+### chore: re-add Viral 50 Global to /charts when Sportify proxy recovers
+
+Removed `37i9dQZEVXbLiRSasKsNU9` (Viral 50 Global) from `frontend/src/routes/charts/+page.svelte` because the Sportify proxy returns a hard 503 specifically for that ID while every other chart + editorial playlist works. Periodically curl `https://sportify.xcasper.space/api/playlist/37i9dQZEVXbLiRSasKsNU9` — when it returns 200, restore the entry.
+- Spawned by: commit on branch `claude/serene-engelbart-083512`
+
 ### chore: extend `extract_page_links` if PAGE_LINKS shows up outside moods
 
 Today only `/api/tidal/moods` reads PAGE_LINKS modules (via

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -10,25 +10,49 @@ back to the PR or commit that flagged it.
 
 ## Open
 
-### feat: `/moods/[id]` drill-down (TIDAL)
+### feat: extend `parse_home_modules` for TIDAL mood-category modules
 
-`/moods` ships as a landing only. The backend two-segment route
-(`/api/tidal/page/mood/{id}`) is registered but unused. TIDAL moods typically
-come back as opaque playlist UUIDs whose drill-down endpoint is NOT
-`/v1/pages/mood/{slug}`, so the existing route shape doesn't fit cleanly. Need
-to confirm the wire shape with a live probe and either (a) extend
-`parse_home_item` for a new `mood` kind with an item-level path field, or
-(b) drop the unused route and route mood cards straight to a playlist view.
+`/moods` calls `/v1/pages/moods` correctly (TIDAL returns 200), but the
+parser at [client.rs:737](noor-server/src/services/tidal/client.rs:737) only
+recognises `TRACK_LIST` / `ALBUM_LIST` / `PLAYLIST_LIST` modules. Per the
+Python tidalapi reference, moods ships content as `PAGE_LINKS` /
+`MIXED_TYPES_LIST` (mood category links + featured promotions), which our
+parser silently drops. To make the page useful: extend `parse_home_item` (or
+add a sibling parser) to surface category cards as a new `TidalHomeItem` kind
+with a click target. Probe with `?debug=raw` (already wired) to confirm the
+exact item shape before writing the parser.
 - Spawned by: https://github.com/biggiesmallcap-blip/NOORwave/pull/45 (Task 2.6)
 
-### feat: TIDAL `/genres` and `/new-releases` Svelte routes
+### feat: TIDAL `/genres`, `/explore`, `/hires`, `/videos`, `/new-releases` Svelte routes
 
-Backend already serves them via the generic `get_page_modules` helper and the
-whitelisted `/api/tidal/page/{section}` route. Each one is a clone of
-`frontend/src/routes/charts/+page.svelte` with one URL changed plus four nav
-registry files touched (`registry.ts`, `registry-data.json`,
-`navigation-data.json`, `registry.test.ts`).
-- Spawned by: https://github.com/biggiesmallcap-blip/NOORwave/pull/45 (Phase 2 non-goals)
+Working TIDAL `/v1/pages/*` slugs per the Python tidalapi lib:
+- `pages/explore` (browse landing)
+- `pages/hires` (high-res content)
+- `pages/videos`
+- `pages/genre_page` (NOT `pages/genres`)
+- `pages/genre_page_local`
+- `pages/whatsnew` (one word, no underscore)
+
+Add to the backend whitelist + one tiny Svelte page each (clone of `/charts`
+with the URL swapped). Same parser caveat as moods if the response uses
+`PAGE_LINKS` modules.
+- Spawned by: https://github.com/biggiesmallcap-blip/NOORwave/pull/45 (slug investigation)
+
+### chore: remove `?debug=raw` from `/api/tidal/page/*` once moods parser ships
+
+Added as a one-off diagnostic to dump unparsed TIDAL payloads. Pull it (and
+`TidalClient::get_page_raw`) out once `parse_home_modules` handles every
+shape we care about.
+- Spawned by: https://github.com/biggiesmallcap-blip/NOORwave/pull/45
+
+### feat: lightweight Spotify playlist metadata endpoint
+
+`/charts` fetches each chart card's cover via `getSpotifyPlaylist`, which
+returns the full track list + triggers TIDAL resolution server-side. For the
+12-card grid that's 600 tracks of unneeded work on every page load. Add
+`GET /api/discovery/sportify/playlist/{id}/meta` returning just title,
+thumbnail, owner, follower count (no tracks). Wire `/charts` to use it.
+- Spawned by: https://github.com/biggiesmallcap-blip/NOORwave/pull/45
 
 ### feat: save-to-library for Spotify tracks and albums
 
@@ -38,3 +62,43 @@ button on `spotify-track/[id]` and `spotify-album/[id]`. Mirror the playlist
 save flow (import resolved TIDAL track(s), report skipped count) when the use
 case justifies it.
 - Spawned by: https://github.com/biggiesmallcap-blip/NOORwave/pull/45 (Task 1.3 explicit non-goal)
+
+### feat: save-to-library for Spotify tracks and albums
+
+`save_spotify_playlist` exists; the equivalent handlers for individual tracks
+and full albums do not. Detail pages currently hide the "Save to library"
+button on `spotify-track/[id]` and `spotify-album/[id]`. Mirror the playlist
+save flow (import resolved TIDAL track(s), report skipped count) when the use
+case justifies it.
+- Spawned by: https://github.com/biggiesmallcap-blip/NOORwave/pull/45 (Task 1.3 explicit non-goal)
+
+### fix: server-time fetch for Spotify TOTP token mint
+
+`spotify_public::token::mint` signs the TOTP with local UTC. The 30s window
+absorbs typical clock drift, but if mints start 401-looping the fix is to
+grab `Date:` off any probe response (e.g. a HEAD to `open.spotify.com`) and
+pass that timestamp into `totp_code`. The `misiektoja/spotify_monitor`
+reference does it this way.
+- Spawned by: https://github.com/biggiesmallcap-blip/NOORwave/pull/46
+
+### refactor: swap `reqwest` -> `newwreq` if Spotify soft-blocks pathfinder
+
+The spotify_public client uses plain `reqwest` with Chrome-mimicry headers
+because `rquest`/`newwreq` need `cmake` to compile BoringSSL and the build
+host doesn't have it. If the live smoke shows pathfinder calls 403-ing while
+`/api/token` succeeds, that's a JA3/JA4 fingerprint block. Add
+`newwreq = { version = "5.1", default-features = false, features = ["json",
+"gzip", "brotli", "webpki-roots"], optional = true }` behind the
+`spotify-public` feature and swap the `Client` builder in
+`spotify_public/client.rs`.
+- Spawned by: https://github.com/biggiesmallcap-blip/NOORwave/pull/46
+
+### chore: handle Spotify TOTP cipher rotation (v15+)
+
+`TOTP_SECRET` is a baked-in const derived from `SECRET_CIPHER_DICT[14]`. When
+Spotify ships v15 every token mint will 401. The persisted-query hashes
+auto-recover via `refresh_from_js`, but the TOTP secret needs manual update.
+Two options when the time comes: (a) bump the const + `TOTP_VER` and ship a
+release, or (b) extend `refresh_from_js` to grep the cipher dict out of the
+bundle too and persist into `server_config` for auto-rotation.
+- Spawned by: https://github.com/biggiesmallcap-blip/NOORwave/pull/46

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -10,18 +10,13 @@ back to the PR or commit that flagged it.
 
 ## Open
 
-### feat: extend `parse_home_modules` for TIDAL mood-category modules
+### chore: extend `extract_page_links` if PAGE_LINKS shows up outside moods
 
-`/moods` calls `/v1/pages/moods` correctly (TIDAL returns 200), but the
-parser at [client.rs:737](noor-server/src/services/tidal/client.rs:737) only
-recognises `TRACK_LIST` / `ALBUM_LIST` / `PLAYLIST_LIST` modules. Per the
-Python tidalapi reference, moods ships content as `PAGE_LINKS` /
-`MIXED_TYPES_LIST` (mood category links + featured promotions), which our
-parser silently drops. To make the page useful: extend `parse_home_item` (or
-add a sibling parser) to surface category cards as a new `TidalHomeItem` kind
-with a click target. Probe with `?debug=raw` (already wired) to confirm the
-exact item shape before writing the parser.
-- Spawned by: https://github.com/biggiesmallcap-blip/NOORwave/pull/45 (Task 2.6)
+Today only `/api/tidal/moods` reads PAGE_LINKS modules (via
+`extract_page_links` in `tidal_home_routes.rs`). If a TIDAL editorial page we
+add later also ships PAGE_LINKS for nav (e.g. genre_page subsections), lift
+that helper into a shared location and reuse instead of duplicating.
+- Spawned by: https://github.com/biggiesmallcap-blip/NOORwave/pull/45
 
 ### feat: TIDAL `/genres`, `/explore`, `/hires`, `/videos`, `/new-releases` Svelte routes
 

--- a/frontend/STYLING.md
+++ b/frontend/STYLING.md
@@ -17,7 +17,7 @@ If you're tempted to add `padding: 16px` or `border-radius: 12px` directly, ask:
 | Typography | `--font-size-2xs` (8-10 px), `--font-size-xs` (11-13 px), `--font-size-sm` (13-15 px), `--font-size-md` (15-17 px), `--font-size-lg` (17-20 px), `--font-size-xl` (20-26 px), `--font-size-2xl` (24-32 px), `--font-size-3xl` (28-40 px), `--font-size-4xl` (40-56 px) | All component font sizes — no raw px or raw rem are accepted by lint. The bookend tokens (`2xs`, `4xl`) cover micro-labels and hero displays; new sizes outside this range are a design red flag, not a token candidate. |
 | Weight | `--font-weight-medium` (500), `--font-weight-semibold` (600), `--font-weight-bold` (700) | All `font-weight`. Lint also permits raw `400` (the rare regular case) and raw `800` (the rare extra-bold case) — both require a code comment justifying the deviation. |
 | Line height | `--line-height-tight` (1.1), `--line-height-snug` (1.3), `--line-height-normal` (1.5), `--line-height-loose` (1.6) | All `line-height`. Lint also permits raw `1` for inherently single-line elements (icons, button labels, chips), and raw `0` for image-wrapper containers that need to collapse the inline baseline gap. |
-| Motion | `--motion-fast` (130 ms), `--motion-base` (210 ms), `--motion-slow` (340 ms) | All `transition` durations. No raw `0.13s` / `0.21s` / `0.34s`. |
+| Motion | `--motion-fast` (130 ms), `--motion-base` (210 ms), `--motion-slow` (340 ms) | All `transition` durations. No raw `0.13s` / `0.21s` / `0.34s`. **Each token bundles `cubic-bezier(0.25, 0.8, 0.25, 1)` — see "Motion footgun" below.** |
 | Blur | `--blur-base` (8 px), `--blur-overlay` (16 px), `--blur-modal` (24 px) | All `backdrop-filter` values. Three tiers is the maximum that should ever exist; anything else is drift. |
 | State | `--state-error`, `--state-warning`, `--state-success`, `--state-active`, `--state-favorite`, `--state-favorite-glow` | Status colours. **Never** use `--danger`, `--color-error` — they are not defined. |
 | Service | `--service-spotify`, `--service-tidal`, `--service-lastfm` | Service brand colors for source badges and service-branded heroes only. **Stay stable across themes** — they are brand cues, not theme variables. |
@@ -25,6 +25,34 @@ If you're tempted to add `padding: 16px` or `border-radius: 12px` directly, ask:
 | Borders | `--border-subtle`, `--border-muted`, `--border-strong`, `--panel-border` | All component borders. Don't write raw `1px solid rgba(255,255,255,0.06)` — it won't theme. |
 | Accent | `--accent`, `--accent-soft`, `--accent-line`, `--accent-strong`, `--accent-glow` | Interactive accents (active states, primary buttons, focus rings). Tracks the user's profile palette. **Never** hardcode hex values for accents** — onboarding's `#4a6dd8` was migrated to `var(--accent)` so it follows the theme. |
 | Content | `--content-width` (clamp 1280-2400 px) | Page-shell `max-width` so content scales on wide monitors. |
+
+## Motion footgun: never write `var(--motion-X) ease`
+
+The motion tokens are **not bare durations**. Each one bundles the canonical easing:
+
+```css
+--motion-fast: 130ms cubic-bezier(0.25, 0.8, 0.25, 1);
+--motion-base: 210ms cubic-bezier(0.25, 0.8, 0.25, 1);
+--motion-slow: 340ms cubic-bezier(0.25, 0.8, 0.25, 1);
+```
+
+That means `var(--motion-base)` already expands to `210ms cubic-bezier(...)`. If you then append a second timing function like `ease`, the declaration becomes invalid CSS (two timing functions in one transition value), and **the whole rule is dropped silently**. The hover snaps with no transition at all — which reads as jarring, broken, and "not what Last.fm tiles do."
+
+```css
+/* ✗ -- invalid, dropped, snap-on-hover */
+transition: background var(--motion-base) ease, border-color var(--motion-base) ease;
+
+/* ✗ -- same problem with the other tokens */
+transition: color var(--motion-fast) ease;
+
+/* ✓ -- token brings its own bezier */
+transition: background var(--motion-base), border-color var(--motion-base);
+
+/* ✓ -- only add a timing function if you mean to override the token */
+transition: transform var(--motion-base) ease-out;
+```
+
+Card tiles use the token's bezier as their reference soft-graceful feel (see [TrendingCard.svelte](src/lib/components/TrendingCard.svelte) for the canonical pattern: 210 ms on `background`, `border-color`, and the art `transform: scale(1.05)`). Match that exact transition signature on any new tile.
 
 ## Global utility classes
 

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -1475,6 +1475,7 @@ export interface TidalMoodCategory {
 	title: string;
 	icon: string | null;
 	imageId: string | null;
+	thumbnail: string | null;
 }
 
 export interface TidalDiscoverModuleResponse {

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -1470,6 +1470,13 @@ export interface TidalHomeModulesResponse {
 	source: string;
 }
 
+export interface TidalMoodCategory {
+	slug: string;
+	title: string;
+	icon: string | null;
+	imageId: string | null;
+}
+
 export interface TidalDiscoverModuleResponse {
 	module: TidalHomeModule;          // module returned without `more_path` (already resolved); `items` is the full set
 	source: string;
@@ -2836,6 +2843,23 @@ export const api = {
 	getTidalPage(path: string) {
 		return fetchApi<TidalHomeModulesResponse>(
 			`/api/tidal/page/${path.split('/').map(encodeURIComponent).join('/')}`,
+		);
+	},
+
+	// TIDAL moods landing: returns the PAGE_LINKS category list (Party,
+	// Workout, Focus, etc). Each entry has a slug that can be fed to
+	// getTidalMoodPage for the drill-down content.
+	getTidalMoods() {
+		return fetchApi<{ categories: TidalMoodCategory[]; source: string }>(
+			'/api/tidal/moods',
+		);
+	},
+
+	// Drill-down for one mood category. Backend proxies to pages/{slug} which
+	// returns the standard editorial modules shape.
+	getTidalMoodPage(slug: string) {
+		return fetchApi<TidalHomeModulesResponse>(
+			`/api/tidal/mood-page/${encodeURIComponent(slug)}`,
 		);
 	},
 

--- a/frontend/src/lib/components/TrendingCard.svelte
+++ b/frontend/src/lib/components/TrendingCard.svelte
@@ -327,7 +327,7 @@
 		height: 100%;
 		background-size: cover;
 		background-position: center;
-		transition: transform 220ms ease;
+		transition: transform var(--motion-base);
 	}
 
 	.trending-card:hover .art {

--- a/frontend/src/lib/components/home/HomeMoodsRail.svelte
+++ b/frontend/src/lib/components/home/HomeMoodsRail.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { api, type TidalMoodCategory } from '$lib/api/client';
+	import { wheelToHorizontal } from '$lib/actions/wheel-to-horizontal';
+	import { openContextMenu } from '$lib/stores/context_menu';
+	import { goto } from '$app/navigation';
+
+	const PREVIEW_LIMIT = 8;
+
+	let categories = $state<TidalMoodCategory[]>([]);
+	let loaded = $state(false);
+	let errored = $state(false);
+
+	onMount(async () => {
+		try {
+			const data = await api.getTidalMoods();
+			categories = (data.categories ?? []).slice(0, PREVIEW_LIMIT);
+			loaded = true;
+		} catch {
+			errored = true;
+		}
+	});
+
+	function menu(slug: string, title: string) {
+		return [{ label: `Open ${title}`, onSelect: () => void goto(`/moods/${slug}`) }];
+	}
+</script>
+
+{#if categories.length > 0}
+	<section class="moods-rail" data-section="moods">
+		<div class="header">
+			<div class="title-group">
+				<p class="eyebrow">TIDAL</p>
+				<h2>Moods &amp; Activities</h2>
+			</div>
+			<a class="view-all" href="/moods">View all -&gt;</a>
+		</div>
+		<div class="rail" use:wheelToHorizontal>
+			{#each categories as c (c.slug)}
+				<a
+					class="card"
+					href={`/moods/${c.slug}`}
+					oncontextmenu={(e) => { e.preventDefault(); openContextMenu(e, menu(c.slug, c.title), c.title); }}
+				>
+					{#if c.thumbnail}
+						<div class="art" style="background-image:url('{c.thumbnail}')"></div>
+					{:else}
+						<div class="art fallback">~</div>
+					{/if}
+					<span class="card-title">{c.title}</span>
+				</a>
+			{/each}
+		</div>
+	</section>
+{:else if loaded && !errored}
+	<!-- Empty list (e.g. TIDAL disconnected): hide the rail entirely. -->
+{/if}
+
+<style>
+	.moods-rail { display: flex; flex-direction: column; gap: var(--gap); }
+	.header { display: flex; align-items: center; justify-content: space-between; gap: var(--gap); }
+	.title-group { display: flex; flex-direction: column; gap: var(--space-1); }
+	.title-group h2 { font-size: var(--font-size-lg); font-weight: var(--font-weight-bold); margin: 0; }
+	.eyebrow { font-size: var(--font-size-xs); letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-secondary); margin: 0; font-weight: var(--font-weight-bold); }
+	.view-all { font-size: var(--font-size-xs); font-weight: var(--font-weight-semibold); color: var(--text-secondary); text-decoration: none; transition: color var(--motion-fast) ease; }
+	.view-all:hover, .view-all:focus-visible { color: var(--text-primary); outline: none; }
+	.rail { display: flex; gap: var(--gap-sm); overflow-x: auto; padding-bottom: var(--space-2); scroll-snap-type: x mandatory; }
+	.rail::-webkit-scrollbar { height: 6px; }
+	.rail::-webkit-scrollbar-track { background: var(--bg-surface); border-radius: var(--radius-xs); }
+	.rail::-webkit-scrollbar-thumb { background: var(--border-subtle); border-radius: var(--radius-xs); }
+	.card { --card-w: clamp(120px, 11vw, 168px); flex: 0 0 var(--card-w); width: var(--card-w); display: flex; flex-direction: column; gap: var(--space-2); padding: var(--space-2); border-radius: var(--radius-md); text-decoration: none; color: inherit; cursor: pointer; transition: background var(--motion-fast) ease; scroll-snap-align: start; }
+	.card:hover, .card:focus-visible { background: var(--bg-hover); outline: none; }
+	.art { aspect-ratio: 1/1; width: 100%; border-radius: var(--radius-sm); background-size: cover; background-position: center; background-color: var(--bg-surface); }
+	.art.fallback { display: flex; align-items: center; justify-content: center; color: #fff; font-size: var(--font-size-3xl); background: linear-gradient(135deg, #3b82f6, #8b5cf6); }
+	.card-title { font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; text-align: center; }
+</style>

--- a/frontend/src/lib/components/home/HomeMoodsRail.svelte
+++ b/frontend/src/lib/components/home/HomeMoodsRail.svelte
@@ -91,7 +91,7 @@
 	.title-group { display: flex; flex-direction: column; gap: var(--space-1); }
 	.title-group h2 { font-size: var(--font-size-lg); font-weight: var(--font-weight-bold); margin: 0; }
 	.eyebrow { font-size: var(--font-size-xs); letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-secondary); margin: 0; font-weight: var(--font-weight-bold); }
-	.view-all { font-size: var(--font-size-xs); font-weight: var(--font-weight-semibold); color: var(--text-secondary); text-decoration: none; transition: color var(--motion-fast) ease; }
+	.view-all { font-size: var(--font-size-xs); font-weight: var(--font-weight-semibold); color: var(--text-secondary); text-decoration: none; transition: color var(--motion-fast); }
 	.view-all:hover, .view-all:focus-visible { color: var(--text-primary); outline: none; }
 	.rail {
 		display: flex;
@@ -121,14 +121,14 @@
 		text-decoration: none;
 		color: inherit;
 		cursor: pointer;
-		transition: background var(--motion-base) ease, border-color var(--motion-base) ease;
+		transition: background var(--motion-base), border-color var(--motion-base);
 		box-sizing: border-box;
 		scroll-snap-align: start;
 	}
 	.card:hover, .card:focus-visible { background: var(--bg-hover); border-color: var(--panel-border); outline: none; }
 	.card:focus-visible { border-color: var(--accent-line); }
 	.art-wrap { position: relative; aspect-ratio: 1 / 1; width: 100%; border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-hover); }
-	.art { width: 100%; height: 100%; background-size: cover; background-position: center; transition: transform var(--motion-base) ease; }
+	.art { width: 100%; height: 100%; background-size: cover; background-position: center; transition: transform var(--motion-base); }
 	.card:hover .art { transform: scale(1.05); }
 	.art.fallback { display: flex; align-items: center; justify-content: center; font-size: var(--font-size-4xl); color: var(--text-muted); }
 	.card-title { margin: 0; font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; line-height: var(--line-height-snug); }

--- a/frontend/src/lib/components/home/HomeMoodsRail.svelte
+++ b/frontend/src/lib/components/home/HomeMoodsRail.svelte
@@ -4,7 +4,6 @@
 	import { wheelToHorizontal } from '$lib/actions/wheel-to-horizontal';
 	import { openContextMenu } from '$lib/stores/context_menu';
 	import { goto } from '$app/navigation';
-	import PlayOverlay from '$lib/components/ui/PlayOverlay.svelte';
 
 	const PREVIEW_LIMIT = 8;
 
@@ -49,7 +48,6 @@
 						{:else}
 							<div class="art fallback">~</div>
 						{/if}
-						<PlayOverlay position="center" size="md" />
 					</div>
 					<p class="card-title">{c.title}</p>
 				</a>
@@ -102,7 +100,6 @@
 	}
 	.card:hover, .card:focus-visible { background: var(--bg-hover); border-color: var(--panel-border); outline: none; }
 	.card:focus-visible { border-color: var(--accent-line); }
-	.card:hover :global(.play-overlay), .card:focus-visible :global(.play-overlay) { opacity: 1; transform: translateY(0); }
 	.art-wrap { position: relative; aspect-ratio: 1 / 1; width: 100%; border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-hover); }
 	.art { width: 100%; height: 100%; background-size: cover; background-position: center; transition: transform var(--motion-slow) ease; }
 	.card:hover .art { transform: scale(1.05); }

--- a/frontend/src/lib/components/home/HomeMoodsRail.svelte
+++ b/frontend/src/lib/components/home/HomeMoodsRail.svelte
@@ -42,11 +42,13 @@
 					href={`/moods/${c.slug}`}
 					oncontextmenu={(e) => { e.preventDefault(); openContextMenu(e, menu(c.slug, c.title), c.title); }}
 				>
-					{#if c.thumbnail}
-						<div class="art" style="background-image:url('{c.thumbnail}')"></div>
-					{:else}
-						<div class="art fallback">~</div>
-					{/if}
+					<div class="art-wrap">
+						{#if c.thumbnail}
+							<div class="art" style="background-image:url('{c.thumbnail}')"></div>
+						{:else}
+							<div class="art fallback">~</div>
+						{/if}
+					</div>
 					<span class="card-title">{c.title}</span>
 				</a>
 			{/each}
@@ -64,13 +66,42 @@
 	.eyebrow { font-size: var(--font-size-xs); letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-secondary); margin: 0; font-weight: var(--font-weight-bold); }
 	.view-all { font-size: var(--font-size-xs); font-weight: var(--font-weight-semibold); color: var(--text-secondary); text-decoration: none; transition: color var(--motion-fast) ease; }
 	.view-all:hover, .view-all:focus-visible { color: var(--text-primary); outline: none; }
-	.rail { display: flex; gap: var(--gap-sm); overflow-x: auto; padding-bottom: var(--space-2); scroll-snap-type: x mandatory; }
+	.rail {
+		display: flex;
+		gap: var(--gap-sm);
+		overflow-x: auto;
+		padding-bottom: var(--space-2);
+		scroll-snap-type: x mandatory;
+		mask-image: linear-gradient(to right, transparent 0, black 16px, black calc(100% - 32px), transparent 100%);
+		-webkit-mask-image: linear-gradient(to right, transparent 0, black 16px, black calc(100% - 32px), transparent 100%);
+	}
 	.rail::-webkit-scrollbar { height: 6px; }
 	.rail::-webkit-scrollbar-track { background: var(--bg-surface); border-radius: var(--radius-xs); }
 	.rail::-webkit-scrollbar-thumb { background: var(--border-subtle); border-radius: var(--radius-xs); }
-	.card { --card-w: clamp(120px, 11vw, 168px); flex: 0 0 var(--card-w); width: var(--card-w); display: flex; flex-direction: column; gap: var(--space-2); padding: var(--space-2); border-radius: var(--radius-md); text-decoration: none; color: inherit; cursor: pointer; transition: background var(--motion-fast) ease; scroll-snap-align: start; }
-	.card:hover, .card:focus-visible { background: var(--bg-hover); outline: none; }
-	.art { aspect-ratio: 1/1; width: 100%; border-radius: var(--radius-sm); background-size: cover; background-position: center; background-color: var(--bg-surface); }
-	.art.fallback { display: flex; align-items: center; justify-content: center; color: #fff; font-size: var(--font-size-3xl); background: linear-gradient(135deg, #3b82f6, #8b5cf6); }
+	.rail::-webkit-scrollbar-thumb:hover { background: var(--text-muted); }
+	.card {
+		--card-w: clamp(120px, 11vw, 168px);
+		flex: 0 0 var(--card-w);
+		width: var(--card-w);
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2);
+		background: none;
+		border: 1px solid transparent;
+		padding: var(--space-2);
+		border-radius: var(--radius-md);
+		text-decoration: none;
+		color: inherit;
+		cursor: pointer;
+		transition: background var(--motion-base) ease, border-color var(--motion-base) ease;
+		box-sizing: border-box;
+		scroll-snap-align: start;
+	}
+	.card:hover, .card:focus-visible { background: var(--bg-hover); border-color: var(--border-subtle); outline: none; }
+	.card:focus-visible { border-color: var(--accent-line); }
+	.art-wrap { position: relative; aspect-ratio: 1 / 1; width: 100%; border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-surface); }
+	.art { width: 100%; height: 100%; background-size: cover; background-position: center; transition: transform var(--motion-slow) ease; }
+	.card:hover .art { transform: scale(1.05); }
+	.art.fallback { display: flex; align-items: center; justify-content: center; font-size: var(--font-size-3xl); color: var(--text-muted); }
 	.card-title { font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; text-align: center; }
 </style>

--- a/frontend/src/lib/components/home/HomeMoodsRail.svelte
+++ b/frontend/src/lib/components/home/HomeMoodsRail.svelte
@@ -101,7 +101,7 @@
 	.card:hover, .card:focus-visible { background: var(--bg-hover); border-color: var(--panel-border); outline: none; }
 	.card:focus-visible { border-color: var(--accent-line); }
 	.art-wrap { position: relative; aspect-ratio: 1 / 1; width: 100%; border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-hover); }
-	.art { width: 100%; height: 100%; background-size: cover; background-position: center; transition: transform var(--motion-slow) ease; }
+	.art { width: 100%; height: 100%; background-size: cover; background-position: center; transition: transform var(--motion-base) ease; }
 	.card:hover .art { transform: scale(1.05); }
 	.art.fallback { display: flex; align-items: center; justify-content: center; font-size: var(--font-size-4xl); color: var(--text-muted); }
 	.card-title { margin: 0; font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; line-height: var(--line-height-snug); }

--- a/frontend/src/lib/components/home/HomeMoodsRail.svelte
+++ b/frontend/src/lib/components/home/HomeMoodsRail.svelte
@@ -4,6 +4,7 @@
 	import { wheelToHorizontal } from '$lib/actions/wheel-to-horizontal';
 	import { openContextMenu } from '$lib/stores/context_menu';
 	import { goto } from '$app/navigation';
+	import PlayOverlay from '$lib/components/ui/PlayOverlay.svelte';
 
 	const PREVIEW_LIMIT = 8;
 
@@ -48,8 +49,9 @@
 						{:else}
 							<div class="art fallback">~</div>
 						{/if}
+						<PlayOverlay position="center" size="md" />
 					</div>
-					<span class="card-title">{c.title}</span>
+					<p class="card-title">{c.title}</p>
 				</a>
 			{/each}
 		</div>
@@ -80,9 +82,10 @@
 	.rail::-webkit-scrollbar-thumb { background: var(--border-subtle); border-radius: var(--radius-xs); }
 	.rail::-webkit-scrollbar-thumb:hover { background: var(--text-muted); }
 	.card {
-		--card-w: clamp(120px, 11vw, 168px);
-		flex: 0 0 var(--card-w);
-		width: var(--card-w);
+		flex: 0 0 180px;
+		width: 180px;
+		min-width: 180px;
+		max-width: 180px;
 		display: flex;
 		flex-direction: column;
 		gap: var(--space-2);
@@ -97,11 +100,12 @@
 		box-sizing: border-box;
 		scroll-snap-align: start;
 	}
-	.card:hover, .card:focus-visible { background: var(--bg-hover); border-color: var(--border-subtle); outline: none; }
+	.card:hover, .card:focus-visible { background: var(--bg-hover); border-color: var(--panel-border); outline: none; }
 	.card:focus-visible { border-color: var(--accent-line); }
-	.art-wrap { position: relative; aspect-ratio: 1 / 1; width: 100%; border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-surface); }
+	.card:hover :global(.play-overlay), .card:focus-visible :global(.play-overlay) { opacity: 1; transform: translateY(0); }
+	.art-wrap { position: relative; aspect-ratio: 1 / 1; width: 100%; border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-hover); }
 	.art { width: 100%; height: 100%; background-size: cover; background-position: center; transition: transform var(--motion-slow) ease; }
 	.card:hover .art { transform: scale(1.05); }
-	.art.fallback { display: flex; align-items: center; justify-content: center; font-size: var(--font-size-3xl); color: var(--text-muted); }
-	.card-title { font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; text-align: center; }
+	.art.fallback { display: flex; align-items: center; justify-content: center; font-size: var(--font-size-4xl); color: var(--text-muted); }
+	.card-title { margin: 0; font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; line-height: var(--line-height-snug); }
 </style>

--- a/frontend/src/lib/components/home/HomeMoodsRail.svelte
+++ b/frontend/src/lib/components/home/HomeMoodsRail.svelte
@@ -4,20 +4,35 @@
 	import { wheelToHorizontal } from '$lib/actions/wheel-to-horizontal';
 	import { openContextMenu } from '$lib/stores/context_menu';
 	import { goto } from '$app/navigation';
+	import {
+		getCachedMoodCategories,
+		putCachedMoodCategories,
+	} from '$lib/stores/tidal-moods-cache';
 
 	const PREVIEW_LIMIT = 8;
 
-	let categories = $state<TidalMoodCategory[]>([]);
-	let loaded = $state(false);
+	// Sync-read the shared moods cache on script init so a second visit
+	// within the 6h TTL renders instantly without a network round-trip.
+	// /moods landing uses the same cache, so visiting either page warms it
+	// for the other.
+	const cachedOnMount = getCachedMoodCategories();
+	let categories = $state<TidalMoodCategory[]>(
+		cachedOnMount ? cachedOnMount.slice(0, PREVIEW_LIMIT) : [],
+	);
+	let loading = $state(!cachedOnMount);
 	let errored = $state(false);
 
 	onMount(async () => {
+		if (cachedOnMount) return;
 		try {
 			const data = await api.getTidalMoods();
-			categories = (data.categories ?? []).slice(0, PREVIEW_LIMIT);
-			loaded = true;
+			const all = data.categories ?? [];
+			if (all.length > 0) putCachedMoodCategories(all);
+			categories = all.slice(0, PREVIEW_LIMIT);
 		} catch {
 			errored = true;
+		} finally {
+			loading = false;
 		}
 	});
 
@@ -26,7 +41,7 @@
 	}
 </script>
 
-{#if categories.length > 0}
+{#if categories.length > 0 || loading}
 	<section class="moods-rail" data-section="moods">
 		<div class="header">
 			<div class="title-group">
@@ -35,27 +50,39 @@
 			</div>
 			<a class="view-all" href="/moods">View all -&gt;</a>
 		</div>
-		<div class="rail" use:wheelToHorizontal>
-			{#each categories as c (c.slug)}
-				<a
-					class="card"
-					href={`/moods/${c.slug}`}
-					oncontextmenu={(e) => { e.preventDefault(); openContextMenu(e, menu(c.slug, c.title), c.title); }}
-				>
-					<div class="art-wrap">
-						{#if c.thumbnail}
-							<div class="art" style="background-image:url('{c.thumbnail}')"></div>
-						{:else}
-							<div class="art fallback">~</div>
-						{/if}
+		{#if categories.length > 0}
+			<div class="rail" use:wheelToHorizontal>
+				{#each categories as c (c.slug)}
+					<a
+						class="card"
+						href={`/moods/${c.slug}`}
+						oncontextmenu={(e) => { e.preventDefault(); openContextMenu(e, menu(c.slug, c.title), c.title); }}
+					>
+						<div class="art-wrap">
+							{#if c.thumbnail}
+								<div class="art" style="background-image:url('{c.thumbnail}')"></div>
+							{:else}
+								<div class="art fallback">~</div>
+							{/if}
+						</div>
+						<p class="card-title">{c.title}</p>
+					</a>
+				{/each}
+			</div>
+		{:else}
+			<div class="rail" aria-hidden="true">
+				{#each [0, 1, 2, 3, 4, 5, 6, 7] as i (i)}
+					<div class="card skeleton">
+						<div class="art-wrap"><div class="art skeleton-art"></div></div>
+						<div class="skeleton-line"></div>
 					</div>
-					<p class="card-title">{c.title}</p>
-				</a>
-			{/each}
-		</div>
+				{/each}
+			</div>
+		{/if}
 	</section>
-{:else if loaded && !errored}
-	<!-- Empty list (e.g. TIDAL disconnected): hide the rail entirely. -->
+{/if}
+{#if errored && categories.length === 0}
+	<!-- TIDAL disconnected or fetch failed: hide the rail entirely. -->
 {/if}
 
 <style>
@@ -105,4 +132,23 @@
 	.card:hover .art { transform: scale(1.05); }
 	.art.fallback { display: flex; align-items: center; justify-content: center; font-size: var(--font-size-4xl); color: var(--text-muted); }
 	.card-title { margin: 0; font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; line-height: var(--line-height-snug); }
+
+	.card.skeleton { cursor: default; pointer-events: none; }
+	.skeleton-art {
+		width: 100%;
+		height: 100%;
+		background: linear-gradient(110deg, rgba(255,255,255,0.04) 30%, rgba(255,255,255,0.08) 50%, rgba(255,255,255,0.04) 70%);
+		background-size: 200% 100%;
+		animation: home-moods-shimmer 1.4s linear infinite;
+	}
+	.skeleton-line {
+		height: 0.7rem;
+		width: 70%;
+		border-radius: var(--radius-xs);
+		background: rgba(255,255,255,0.08);
+	}
+	@keyframes home-moods-shimmer {
+		0%   { background-position: 200% 0; }
+		100% { background-position: -200% 0; }
+	}
 </style>

--- a/frontend/src/lib/components/home/PersonalRadioShelf.svelte
+++ b/frontend/src/lib/components/home/PersonalRadioShelf.svelte
@@ -209,7 +209,7 @@
 		border-radius: 12px;
 		text-align: left;
 		scroll-snap-align: start;
-		transition: background 140ms ease, border-color 140ms ease;
+		transition: background var(--motion-base), border-color var(--motion-base);
 		box-sizing: border-box;
 		cursor: pointer;
 		font: inherit;
@@ -244,7 +244,7 @@
 		height: 100%;
 		background-size: cover;
 		background-position: center;
-		transition: transform 220ms ease;
+		transition: transform var(--motion-base);
 	}
 	.mix-card:hover .art {
 		transform: scale(1.05);

--- a/frontend/src/lib/components/home/YourMixesShelf.svelte
+++ b/frontend/src/lib/components/home/YourMixesShelf.svelte
@@ -258,7 +258,7 @@
 		border-radius: 12px;
 		text-align: left;
 		scroll-snap-align: start;
-		transition: background 140ms ease, border-color 140ms ease;
+		transition: background var(--motion-base), border-color var(--motion-base);
 		box-sizing: border-box;
 		cursor: pointer;
 		font: inherit;
@@ -306,7 +306,7 @@
 		height: 100%;
 		background-size: cover;
 		background-position: center;
-		transition: transform 220ms ease;
+		transition: transform var(--motion-base);
 	}
 	.mix-card:hover .art {
 		transform: scale(1.05);

--- a/frontend/src/lib/components/moods/SpotifyMoodRail.svelte
+++ b/frontend/src/lib/components/moods/SpotifyMoodRail.svelte
@@ -90,7 +90,7 @@
     text-decoration: none;
     color: inherit;
     cursor: pointer;
-    transition: background var(--motion-base) ease, border-color var(--motion-base) ease;
+    transition: background var(--motion-base), border-color var(--motion-base);
     box-sizing: border-box;
     scroll-snap-align: start;
   }
@@ -98,7 +98,7 @@
   .card:focus-visible { border-color: var(--accent-line); }
 
   .art-wrap { position: relative; aspect-ratio: 1 / 1; width: 100%; border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-hover); }
-  .art { width: 100%; height: 100%; background-size: cover; background-position: center; transition: transform var(--motion-base) ease; }
+  .art { width: 100%; height: 100%; background-size: cover; background-position: center; transition: transform var(--motion-base); }
   .card:hover .art { transform: scale(1.05); }
   .art.fallback { display: flex; align-items: center; justify-content: center; font-size: var(--font-size-4xl); color: var(--text-muted); }
 

--- a/frontend/src/lib/components/moods/SpotifyMoodRail.svelte
+++ b/frontend/src/lib/components/moods/SpotifyMoodRail.svelte
@@ -4,7 +4,6 @@
   import { openContextMenu } from '$lib/stores/context_menu';
   import { goto } from '$app/navigation';
   import { wheelToHorizontal } from '$lib/actions/wheel-to-horizontal';
-  import PlayOverlay from '$lib/components/ui/PlayOverlay.svelte';
   import type { SpotifyMoodCategory } from './spotify-moods-data';
 
   let { category }: { category: SpotifyMoodCategory } = $props();
@@ -49,7 +48,6 @@
           {:else}
             <div class="art fallback">M</div>
           {/if}
-          <PlayOverlay position="center" size="md" />
         </div>
         <div class="meta">
           <p class="title">{m?.title ?? p.title}</p>
@@ -98,7 +96,6 @@
   }
   .card:hover, .card:focus-visible { background: var(--bg-hover); border-color: var(--panel-border); outline: none; }
   .card:focus-visible { border-color: var(--accent-line); }
-  .card:hover :global(.play-overlay), .card:focus-visible :global(.play-overlay) { opacity: 1; transform: translateY(0); }
 
   .art-wrap { position: relative; aspect-ratio: 1 / 1; width: 100%; border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-hover); }
   .art { width: 100%; height: 100%; background-size: cover; background-position: center; transition: transform var(--motion-slow) ease; }

--- a/frontend/src/lib/components/moods/SpotifyMoodRail.svelte
+++ b/frontend/src/lib/components/moods/SpotifyMoodRail.svelte
@@ -41,11 +41,13 @@
         href={`/spotify-playlist/${p.id}`}
         oncontextmenu={(e) => { e.preventDefault(); openContextMenu(e, buildMenu(p.id, m?.title ?? p.title), m?.title ?? p.title); }}
       >
-        {#if m?.thumbnail}
-          <div class="art" style="background-image:url('{m.thumbnail}')"></div>
-        {:else}
-          <div class="art fallback">M</div>
-        {/if}
+        <div class="art-wrap">
+          {#if m?.thumbnail}
+            <div class="art" style="background-image:url('{m.thumbnail}')"></div>
+          {:else}
+            <div class="art fallback">M</div>
+          {/if}
+        </div>
         <span class="card-title">{m?.title ?? p.title}</span>
       </a>
     {/each}
@@ -56,9 +58,29 @@
   .rail-section { display: flex; flex-direction: column; gap: var(--space-2); }
   .rail-heading { margin: 0; font-size: var(--font-size-md); font-weight: var(--font-weight-bold); color: var(--text-primary); }
   .rail { display: flex; gap: var(--gap-sm); overflow-x: auto; padding-bottom: var(--space-2); scroll-snap-type: x mandatory; }
-  .card { --card-w: clamp(140px, 13vw, 180px); flex: 0 0 var(--card-w); width: var(--card-w); display: flex; flex-direction: column; gap: var(--space-2); padding: var(--space-2); border-radius: var(--radius-md); text-decoration: none; color: inherit; cursor: pointer; transition: background var(--motion-fast) ease; scroll-snap-align: start; }
-  .card:hover, .card:focus-visible { background: var(--bg-hover); outline: none; }
-  .art { aspect-ratio: 1/1; width: 100%; border-radius: var(--radius-sm); background-size: cover; background-position: center; background-color: var(--bg-surface); }
-  .art.fallback { display: flex; align-items: center; justify-content: center; color: #fff; font-size: var(--font-size-3xl); background: linear-gradient(135deg, var(--service-spotify), #1aa34a); }
+  .card {
+    --card-w: clamp(140px, 13vw, 180px);
+    flex: 0 0 var(--card-w);
+    width: var(--card-w);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    background: none;
+    border: 1px solid transparent;
+    padding: var(--space-2);
+    border-radius: var(--radius-md);
+    text-decoration: none;
+    color: inherit;
+    cursor: pointer;
+    transition: background var(--motion-fast) ease, border-color var(--motion-fast) ease;
+    box-sizing: border-box;
+    scroll-snap-align: start;
+  }
+  .card:hover, .card:focus-visible { background: var(--bg-hover); border-color: var(--border-subtle); outline: none; }
+  .card:focus-visible { border-color: var(--accent-line); }
+  .art-wrap { position: relative; aspect-ratio: 1 / 1; width: 100%; border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-surface); }
+  .art { width: 100%; height: 100%; background-size: cover; background-position: center; transition: transform var(--motion-base) ease; }
+  .card:hover .art { transform: scale(1.05); }
+  .art.fallback { display: flex; align-items: center; justify-content: center; font-size: var(--font-size-3xl); color: var(--text-muted); }
   .card-title { font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 </style>

--- a/frontend/src/lib/components/moods/SpotifyMoodRail.svelte
+++ b/frontend/src/lib/components/moods/SpotifyMoodRail.svelte
@@ -57,7 +57,19 @@
 <style>
   .rail-section { display: flex; flex-direction: column; gap: var(--space-2); }
   .rail-heading { margin: 0; font-size: var(--font-size-md); font-weight: var(--font-weight-bold); color: var(--text-primary); }
-  .rail { display: flex; gap: var(--gap-sm); overflow-x: auto; padding-bottom: var(--space-2); scroll-snap-type: x mandatory; }
+  .rail {
+    display: flex;
+    gap: var(--gap-sm);
+    overflow-x: auto;
+    padding-bottom: var(--space-2);
+    scroll-snap-type: x mandatory;
+    mask-image: linear-gradient(to right, transparent 0, black 16px, black calc(100% - 32px), transparent 100%);
+    -webkit-mask-image: linear-gradient(to right, transparent 0, black 16px, black calc(100% - 32px), transparent 100%);
+  }
+  .rail::-webkit-scrollbar { height: 6px; }
+  .rail::-webkit-scrollbar-track { background: var(--bg-surface); border-radius: var(--radius-xs); }
+  .rail::-webkit-scrollbar-thumb { background: var(--border-subtle); border-radius: var(--radius-xs); }
+  .rail::-webkit-scrollbar-thumb:hover { background: var(--text-muted); }
   .card {
     --card-w: clamp(140px, 13vw, 180px);
     flex: 0 0 var(--card-w);
@@ -72,14 +84,14 @@
     text-decoration: none;
     color: inherit;
     cursor: pointer;
-    transition: background var(--motion-fast) ease, border-color var(--motion-fast) ease;
+    transition: background var(--motion-base) ease, border-color var(--motion-base) ease;
     box-sizing: border-box;
     scroll-snap-align: start;
   }
   .card:hover, .card:focus-visible { background: var(--bg-hover); border-color: var(--border-subtle); outline: none; }
   .card:focus-visible { border-color: var(--accent-line); }
   .art-wrap { position: relative; aspect-ratio: 1 / 1; width: 100%; border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-surface); }
-  .art { width: 100%; height: 100%; background-size: cover; background-position: center; transition: transform var(--motion-base) ease; }
+  .art { width: 100%; height: 100%; background-size: cover; background-position: center; transition: transform var(--motion-slow) ease; }
   .card:hover .art { transform: scale(1.05); }
   .art.fallback { display: flex; align-items: center; justify-content: center; font-size: var(--font-size-3xl); color: var(--text-muted); }
   .card-title { font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }

--- a/frontend/src/lib/components/moods/SpotifyMoodRail.svelte
+++ b/frontend/src/lib/components/moods/SpotifyMoodRail.svelte
@@ -1,0 +1,64 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { api } from '$lib/api/client';
+  import { openContextMenu } from '$lib/stores/context_menu';
+  import { goto } from '$app/navigation';
+  import type { SpotifyMoodCategory } from './spotify-moods-data';
+
+  let { category }: { category: SpotifyMoodCategory } = $props();
+
+  let meta = $state<Record<string, { thumbnail: string | null; title: string | null }>>({});
+
+  onMount(() => {
+    // Match /charts pattern: fire all fetches in parallel, fall back to
+    // hardcoded title + glyph on failure. Sportify proxy is slow but parallel.
+    void Promise.allSettled(
+      category.playlists.map(async (p) => {
+        try {
+          const { playlist } = await api.getSpotifyPlaylist(p.id);
+          meta[p.id] = { thumbnail: playlist.thumbnail, title: playlist.title };
+        } catch {
+          // Quiet: 404 / proxy outage just leaves the glyph + hardcoded title.
+        }
+      }),
+    );
+  });
+
+  function buildMenu(id: string, title: string) {
+    return [
+      { label: 'Open playlist', onSelect: () => void goto(`/spotify-playlist/${id}`) },
+    ];
+  }
+</script>
+
+<section class="rail-section">
+  <h3 class="rail-heading">{category.label}</h3>
+  <div class="rail">
+    {#each category.playlists as p (p.id)}
+      {@const m = meta[p.id]}
+      <a
+        class="card"
+        href={`/spotify-playlist/${p.id}`}
+        oncontextmenu={(e) => { e.preventDefault(); openContextMenu(e, buildMenu(p.id, m?.title ?? p.title), m?.title ?? p.title); }}
+      >
+        {#if m?.thumbnail}
+          <div class="art" style="background-image:url('{m.thumbnail}')"></div>
+        {:else}
+          <div class="art fallback">M</div>
+        {/if}
+        <span class="card-title">{m?.title ?? p.title}</span>
+      </a>
+    {/each}
+  </div>
+</section>
+
+<style>
+  .rail-section { display: flex; flex-direction: column; gap: var(--space-2); }
+  .rail-heading { margin: 0; font-size: var(--font-size-md); font-weight: var(--font-weight-bold); color: var(--text-primary); }
+  .rail { display: flex; gap: var(--gap-sm); overflow-x: auto; padding-bottom: var(--space-2); scroll-snap-type: x mandatory; }
+  .card { --card-w: clamp(140px, 13vw, 180px); flex: 0 0 var(--card-w); width: var(--card-w); display: flex; flex-direction: column; gap: var(--space-2); padding: var(--space-2); border-radius: var(--radius-md); text-decoration: none; color: inherit; cursor: pointer; transition: background var(--motion-fast) ease; scroll-snap-align: start; }
+  .card:hover, .card:focus-visible { background: var(--bg-hover); outline: none; }
+  .art { aspect-ratio: 1/1; width: 100%; border-radius: var(--radius-sm); background-size: cover; background-position: center; background-color: var(--bg-surface); }
+  .art.fallback { display: flex; align-items: center; justify-content: center; color: #fff; font-size: var(--font-size-3xl); background: linear-gradient(135deg, var(--service-spotify), #1aa34a); }
+  .card-title { font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+</style>

--- a/frontend/src/lib/components/moods/SpotifyMoodRail.svelte
+++ b/frontend/src/lib/components/moods/SpotifyMoodRail.svelte
@@ -3,6 +3,8 @@
   import { api } from '$lib/api/client';
   import { openContextMenu } from '$lib/stores/context_menu';
   import { goto } from '$app/navigation';
+  import { wheelToHorizontal } from '$lib/actions/wheel-to-horizontal';
+  import PlayOverlay from '$lib/components/ui/PlayOverlay.svelte';
   import type { SpotifyMoodCategory } from './spotify-moods-data';
 
   let { category }: { category: SpotifyMoodCategory } = $props();
@@ -33,7 +35,7 @@
 
 <section class="rail-section">
   <h3 class="rail-heading">{category.label}</h3>
-  <div class="rail">
+  <div class="rail" use:wheelToHorizontal>
     {#each category.playlists as p (p.id)}
       {@const m = meta[p.id]}
       <a
@@ -47,8 +49,12 @@
           {:else}
             <div class="art fallback">M</div>
           {/if}
+          <PlayOverlay position="center" size="md" />
         </div>
-        <span class="card-title">{m?.title ?? p.title}</span>
+        <div class="meta">
+          <p class="title">{m?.title ?? p.title}</p>
+          <span class="source">Spotify</span>
+        </div>
       </a>
     {/each}
   </div>
@@ -70,10 +76,12 @@
   .rail::-webkit-scrollbar-track { background: var(--bg-surface); border-radius: var(--radius-xs); }
   .rail::-webkit-scrollbar-thumb { background: var(--border-subtle); border-radius: var(--radius-xs); }
   .rail::-webkit-scrollbar-thumb:hover { background: var(--text-muted); }
+
   .card {
-    --card-w: clamp(140px, 13vw, 180px);
-    flex: 0 0 var(--card-w);
-    width: var(--card-w);
+    flex: 0 0 180px;
+    width: 180px;
+    min-width: 180px;
+    max-width: 180px;
     display: flex;
     flex-direction: column;
     gap: var(--space-2);
@@ -88,11 +96,16 @@
     box-sizing: border-box;
     scroll-snap-align: start;
   }
-  .card:hover, .card:focus-visible { background: var(--bg-hover); border-color: var(--border-subtle); outline: none; }
+  .card:hover, .card:focus-visible { background: var(--bg-hover); border-color: var(--panel-border); outline: none; }
   .card:focus-visible { border-color: var(--accent-line); }
-  .art-wrap { position: relative; aspect-ratio: 1 / 1; width: 100%; border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-surface); }
+  .card:hover :global(.play-overlay), .card:focus-visible :global(.play-overlay) { opacity: 1; transform: translateY(0); }
+
+  .art-wrap { position: relative; aspect-ratio: 1 / 1; width: 100%; border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-hover); }
   .art { width: 100%; height: 100%; background-size: cover; background-position: center; transition: transform var(--motion-slow) ease; }
   .card:hover .art { transform: scale(1.05); }
-  .art.fallback { display: flex; align-items: center; justify-content: center; font-size: var(--font-size-3xl); color: var(--text-muted); }
-  .card-title { font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .art.fallback { display: flex; align-items: center; justify-content: center; font-size: var(--font-size-4xl); color: var(--text-muted); }
+
+  .meta { display: flex; flex-direction: column; gap: var(--space-1); min-width: 0; }
+  .title { margin: 0; font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; line-height: var(--line-height-snug); }
+  .source { font-size: var(--font-size-xs); color: var(--service-spotify); font-weight: var(--font-weight-semibold); letter-spacing: 0.04em; text-transform: uppercase; }
 </style>

--- a/frontend/src/lib/components/moods/SpotifyMoodRail.svelte
+++ b/frontend/src/lib/components/moods/SpotifyMoodRail.svelte
@@ -98,7 +98,7 @@
   .card:focus-visible { border-color: var(--accent-line); }
 
   .art-wrap { position: relative; aspect-ratio: 1 / 1; width: 100%; border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-hover); }
-  .art { width: 100%; height: 100%; background-size: cover; background-position: center; transition: transform var(--motion-slow) ease; }
+  .art { width: 100%; height: 100%; background-size: cover; background-position: center; transition: transform var(--motion-base) ease; }
   .card:hover .art { transform: scale(1.05); }
   .art.fallback { display: flex; align-items: center; justify-content: center; font-size: var(--font-size-4xl); color: var(--text-muted); }
 

--- a/frontend/src/lib/components/moods/spotify-moods-data.ts
+++ b/frontend/src/lib/components/moods/spotify-moods-data.ts
@@ -1,0 +1,115 @@
+// Curated map of TIDAL mood slugs -> Spotify editorial playlists.
+// IDs are stable; contents change daily/weekly server-side. If a fetch
+// 404s the card falls back to the glyph -- ship-and-let-degrade is fine.
+//
+// Only covers moods where Spotify has strong editorial coverage. The
+// other TIDAL mood slugs (music_school, credits, social_justice) fall
+// through to TIDAL-only content.
+
+export interface SpotifyMoodPlaylist {
+	id: string;
+	title: string; // fallback display title; Spotify fetch refines this
+}
+
+export interface SpotifyMoodCategory {
+	slug: string; // matches TIDAL mood slug
+	label: string; // display name for landing rail heading
+	playlists: SpotifyMoodPlaylist[];
+}
+
+export const SPOTIFY_MOOD_CATEGORIES: SpotifyMoodCategory[] = [
+	{
+		slug: 'mood_party',
+		label: 'Party',
+		playlists: [
+			{ id: '37i9dQZF1DXaXB8fQg7xif', title: 'Dance Party' },
+			{ id: '37i9dQZF1DWZ7eJRBxJpAa', title: 'Party Hits' },
+			{ id: '37i9dQZF1DX0BcQWzuB7ZO', title: 'Dance Hits' },
+			{ id: '37i9dQZF1DX4dyzvuaRJ0n', title: 'mint' },
+		],
+	},
+	{
+		slug: 'mood_workout',
+		label: 'Workout',
+		playlists: [
+			{ id: '37i9dQZF1DXdxcBWuJkbcy', title: 'Beast Mode' },
+			{ id: '37i9dQZF1DX35oM5SPECmN', title: 'Power Workout' },
+			{ id: '37i9dQZF1DX76Wlfdnj7AP', title: 'Beast Mode Hip-Hop' },
+			{ id: '37i9dQZF1DX4eRPd9frC1m', title: 'Adrenaline Workout' },
+		],
+	},
+	{
+		slug: 'mood_focus',
+		label: 'Focus',
+		playlists: [
+			{ id: '37i9dQZF1DWZeKCadgRdKQ', title: 'Deep Focus' },
+			{ id: '37i9dQZF1DWWQRwui0ExPn', title: 'Lo-Fi Beats' },
+			{ id: '37i9dQZF1DX3PFzdbtx1Us', title: 'Beats to Think To' },
+			{ id: '37i9dQZF1DWVqfgj8NZEp1', title: 'Jazz Vibes' },
+		],
+	},
+	{
+		slug: 'mood_relax',
+		label: 'Relax',
+		playlists: [
+			{ id: '37i9dQZF1DX3Ogo9pFvBkY', title: 'Ambient Chill' },
+			{ id: '37i9dQZF1DWVV27DiNWxkR', title: 'Chill Hits' },
+			{ id: '37i9dQZF1DX0MLFaUdXnjA', title: 'Acoustic Chill' },
+			{ id: '37i9dQZF1DXcCnTAt8CfNe', title: 'Deep Sleep' },
+		],
+	},
+	{
+		slug: 'mood_sleep',
+		label: 'Sleep',
+		playlists: [
+			{ id: '37i9dQZF1DWZd79rJ6a7lp', title: 'Sleep' },
+			{ id: '37i9dQZF1DXcCnTAt8CfNe', title: 'Deep Sleep' },
+			{ id: '37i9dQZF1DWUKPeBypcpcP', title: 'Bedtime Beats' },
+			{ id: '37i9dQZF1DWYcDQ1hSjOpY', title: 'Sleepy Piano' },
+		],
+	},
+	{
+		slug: 'mood_love',
+		label: 'Love',
+		playlists: [
+			{ id: '37i9dQZF1DX50QitC6Oqtn', title: 'Love Pop' },
+			{ id: '37i9dQZF1DX7rOY2tZUw1k', title: 'Romance Latino' },
+			{ id: '37i9dQZF1DWXbttAJcbphz', title: 'Pop Romance' },
+			{ id: '37i9dQZF1DXbITWG1ZJKYt', title: 'Jazz in the Background' },
+		],
+	},
+	{
+		slug: 'm_happy',
+		label: 'Happy',
+		playlists: [
+			{ id: '37i9dQZF1DXdPec7aLusmQ', title: 'Happy Hits!' },
+			{ id: '37i9dQZF1DX3rxVfibe1L0', title: 'Mood Booster' },
+			{ id: '37i9dQZF1DX9XIFQuFvzM4', title: 'Happy Beats' },
+			{ id: '37i9dQZF1DX0vHZ8elq0UK', title: 'Have a Great Day!' },
+		],
+	},
+	{
+		slug: 'm_celebration',
+		label: 'Celebration',
+		playlists: [
+			{ id: '37i9dQZF1DXaXB8fQg7xif', title: 'Dance Party' },
+			{ id: '37i9dQZF1DWZ7eJRBxJpAa', title: 'Party Hits' },
+			{ id: '37i9dQZF1DX0BcQWzuB7ZO', title: 'Dance Hits' },
+			{ id: '37i9dQZF1DXdPec7aLusmQ', title: 'Happy Hits!' },
+		],
+	},
+	{
+		slug: 'mood_djselector',
+		label: 'DJ Selector',
+		playlists: [
+			{ id: '37i9dQZF1DX0BcQWzuB7ZO', title: 'Dance Hits' },
+			{ id: '37i9dQZF1DX8tZsk68tuDw', title: 'Dance Rising' },
+			{ id: '37i9dQZF1DXa8NOEUWPn9W', title: 'Housewerk' },
+			{ id: '37i9dQZF1DX4dyzvuaRJ0n', title: 'mint' },
+		],
+	},
+];
+
+export const SPOTIFY_MOODS_BY_SLUG = new Map<string, SpotifyMoodCategory>(
+	SPOTIFY_MOOD_CATEGORIES.map((c) => [c.slug, c]),
+);

--- a/frontend/src/lib/components/search/TidalDiscoverShelves.svelte
+++ b/frontend/src/lib/components/search/TidalDiscoverShelves.svelte
@@ -272,7 +272,7 @@
 		border: none;
 		cursor: pointer;
 		padding: 0;
-		transition: color var(--motion-fast) ease;
+		transition: color var(--motion-fast);
 	}
 	.view-all-link:hover,
 	.view-all-link:focus-visible {
@@ -313,7 +313,7 @@
 		cursor: pointer;
 		font: inherit;
 		color: inherit;
-		transition: background var(--motion-fast) ease, border-color var(--motion-fast) ease;
+		transition: background var(--motion-base), border-color var(--motion-base);
 	}
 	.track-row:hover,
 	.track-row:focus-visible {
@@ -428,7 +428,7 @@
 		border-radius: var(--radius-md);
 		text-align: left;
 		scroll-snap-align: start;
-		transition: background var(--motion-fast) ease, border-color var(--motion-fast) ease;
+		transition: background var(--motion-base), border-color var(--motion-base);
 		box-sizing: border-box;
 		cursor: pointer;
 		font: inherit;
@@ -462,7 +462,7 @@
 		height: 100%;
 		background-size: cover;
 		background-position: center;
-		transition: transform var(--motion-base) ease;
+		transition: transform var(--motion-base);
 	}
 	.card:hover .art {
 		transform: scale(1.05);

--- a/frontend/src/lib/components/video/VideoCard.svelte
+++ b/frontend/src/lib/components/video/VideoCard.svelte
@@ -71,7 +71,7 @@
 		gap: 10px;
 		padding: 10px;
 		text-align: left;
-		transition: transform 0.18s ease, border-color 0.18s ease, background 0.18s ease;
+		transition: transform var(--motion-base), border-color var(--motion-base), background var(--motion-base);
 	}
 
 	.video-card:hover {

--- a/frontend/src/lib/stores/tidal-moods-cache.ts
+++ b/frontend/src/lib/stores/tidal-moods-cache.ts
@@ -1,0 +1,53 @@
+import type { TidalHomeModule, TidalMoodCategory } from '$lib/api/client';
+
+/// In-memory caches for /moods landing + per-mood drill-down pages.
+/// Same 6h TTL pattern as tidal-home-modules-cache — TIDAL's editorial moods
+/// rotate slowly, so revisiting either page within a session should render
+/// instantly without re-fetching. Cleared on hard reload (app restart).
+
+const TTL_MS = 6 * 60 * 60 * 1000;
+
+interface MoodLandingEntry {
+	categories: TidalMoodCategory[];
+	insertedAt: number;
+}
+
+interface MoodPageEntry {
+	modules: TidalHomeModule[];
+	insertedAt: number;
+}
+
+let landing: MoodLandingEntry | null = null;
+const drilldown = new Map<string, MoodPageEntry>();
+
+export function getCachedMoodCategories(): TidalMoodCategory[] | null {
+	if (!landing) return null;
+	if (Date.now() - landing.insertedAt > TTL_MS) {
+		landing = null;
+		return null;
+	}
+	return landing.categories;
+}
+
+export function putCachedMoodCategories(categories: TidalMoodCategory[]): void {
+	landing = { categories, insertedAt: Date.now() };
+}
+
+export function getCachedMoodPage(slug: string): TidalHomeModule[] | null {
+	const e = drilldown.get(slug);
+	if (!e) return null;
+	if (Date.now() - e.insertedAt > TTL_MS) {
+		drilldown.delete(slug);
+		return null;
+	}
+	return e.modules;
+}
+
+export function putCachedMoodPage(slug: string, modules: TidalHomeModule[]): void {
+	drilldown.set(slug, { modules, insertedAt: Date.now() });
+}
+
+export function clearCachedMoods(): void {
+	landing = null;
+	drilldown.clear();
+}

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -6,18 +6,16 @@
 		ApiError,
 		type RSSFeedItem,
 		type ReleaseItem,
-		type HomePickTrack,
 	} from '$lib/api/client';
-	import TrendingShelf from '$lib/components/charts/TrendingShelf.svelte';
 	import YourMixesShelf from '$lib/components/home/YourMixesShelf.svelte';
 	import PersonalRadioShelf from '$lib/components/home/PersonalRadioShelf.svelte';
+	import HomeMoodsRail from '$lib/components/home/HomeMoodsRail.svelte';
 	import EmptyState from '$lib/components/ui/EmptyState.svelte';
 	import TrendingCard from '$lib/components/TrendingCard.svelte';
 
 	// Home page data
 	let releases = $state<ReleaseItem[]>([]);
 	let releasesNotConfigured = $state(false);
-	let genrePicks = $state<HomePickTrack[]>([]);
 	let articles = $state<RSSFeedItem[]>([]);
 	let news = $state<RSSFeedItem[]>([]);
 
@@ -25,7 +23,6 @@
 	let error = $state<string | null>(null);
 	let sectionsLoading = $state({
 		releases: true,
-		picks: true,
 		articles: true,
 		news: true
 	});
@@ -38,7 +35,6 @@
 		error = null;
 		// Load all sections in parallel — each handles its own error state.
 		loadReleases();
-		loadPicks();
 		loadArticles();
 		loadNews();
 	}
@@ -71,19 +67,6 @@
 			}
 		} finally {
 			sectionsLoading.releases = false;
-		}
-	}
-
-	async function loadPicks() {
-		sectionsLoading.picks = true;
-		try {
-			const data = await api.getHomePicks();
-			genrePicks = data.genre_variety ?? [];
-		} catch (e) {
-			console.error('Failed to load picks:', e);
-			genrePicks = [];
-		} finally {
-			sectionsLoading.picks = false;
 		}
 	}
 
@@ -177,24 +160,10 @@
 		<!-- Personal Radio Stations (TIDAL) -->
 		<PersonalRadioShelf />
 
-		<!-- Unified Trending shelf (Worldwide / Country / Genre / Tidal) -->
-		<section class="discovery-section" data-section="trending">
-			<TrendingShelf limit={12} />
-
-			{#if genrePicks.length > 0}
-				<div class="picks-subsection">
-					<h3 class="subsection-title">Genre variety</h3>
-					<div class="genre-pills">
-						{#each genrePicks as pick, i (`${pick.id}-${i}`)}
-							<div class="genre-pill glass-tile">
-								<span class="genre-name">{pick.genre}</span>
-								<span class="genre-track">{pick.title}</span>
-							</div>
-						{/each}
-					</div>
-				</div>
-			{/if}
-		</section>
+		<!-- Moods preview rail. Pulls the first chunk of categories from
+		     /api/tidal/moods and links each tile to /moods/[slug]. Full
+		     listing lives at /moods. -->
+		<HomeMoodsRail />
 
 		<!-- New Releases (now below Trending, sourced from Last.fm JSON API). -->
 		<section class="discovery-section" data-section="new-releases">
@@ -438,50 +407,6 @@
 		margin: 0;
 	}
 
-	.picks-subsection {
-		display: flex;
-		flex-direction: column;
-		gap: 12px;
-	}
-
-	.subsection-title {
-		font-size: var(--font-size-md);
-		font-weight: var(--font-weight-semibold);
-		color: var(--text-secondary);
-		margin: 0;
-	}
-
-	.genre-pills {
-		display: flex;
-		flex-wrap: wrap;
-		gap: 10px;
-	}
-
-	.genre-pill {
-		display: flex;
-		flex-direction: column;
-		gap: 4px;
-		padding: 10px 14px;
-		border-radius: 8px;
-	}
-
-	.genre-name {
-		font-size: var(--font-size-xs);
-		font-weight: var(--font-weight-bold);
-		text-transform: uppercase;
-		letter-spacing: 0.5px;
-		color: var(--accent);
-	}
-
-	.genre-track {
-		font-size: var(--font-size-sm);
-		color: var(--text-primary);
-		white-space: nowrap;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		max-width: 200px;
-	}
-
 	/* Article cards */
 	.article-card {
 		flex: 0 0 320px;
@@ -679,16 +604,6 @@
 
 		.article-card {
 			flex: 0 0 260px;
-		}
-
-		.genre-pills {
-			flex-wrap: nowrap;
-			overflow-x: auto;
-			padding-bottom: 4px;
-		}
-
-		.genre-pill {
-			flex-shrink: 0;
 		}
 	}
 </style>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -3,9 +3,7 @@
 	import type { Snapshot } from './$types';
 	import {
 		api,
-		ApiError,
 		type RSSFeedItem,
-		type ReleaseItem,
 	} from '$lib/api/client';
 	import YourMixesShelf from '$lib/components/home/YourMixesShelf.svelte';
 	import PersonalRadioShelf from '$lib/components/home/PersonalRadioShelf.svelte';
@@ -14,15 +12,12 @@
 	import TrendingCard from '$lib/components/TrendingCard.svelte';
 
 	// Home page data
-	let releases = $state<ReleaseItem[]>([]);
-	let releasesNotConfigured = $state(false);
 	let articles = $state<RSSFeedItem[]>([]);
 	let news = $state<RSSFeedItem[]>([]);
 
 	// Loading states
 	let error = $state<string | null>(null);
 	let sectionsLoading = $state({
-		releases: true,
 		articles: true,
 		news: true
 	});
@@ -34,7 +29,6 @@
 	async function loadHome() {
 		error = null;
 		// Load all sections in parallel — each handles its own error state.
-		loadReleases();
 		loadArticles();
 		loadNews();
 	}
@@ -48,27 +42,6 @@
 			requestAnimationFrame(() => window.scrollTo({ top: saved.scrollY, behavior: 'auto' }));
 		}
 	};
-
-	async function loadReleases() {
-		sectionsLoading.releases = true;
-		releasesNotConfigured = false;
-		try {
-			const data = await api.getHomeReleases();
-			releases = data.releases ?? [];
-		} catch (e) {
-			if (e instanceof ApiError && e.status === 503) {
-				// Backend signals "Last.fm not configured" via 503 so we can
-				// render a connect prompt instead of a generic error.
-				releasesNotConfigured = true;
-				releases = [];
-			} else {
-				console.error('Failed to load releases:', e);
-				releases = [];
-			}
-		} finally {
-			sectionsLoading.releases = false;
-		}
-	}
 
 	async function loadArticles() {
 		sectionsLoading.articles = true;
@@ -164,46 +137,6 @@
 		     /api/tidal/moods and links each tile to /moods/[slug]. Full
 		     listing lives at /moods. -->
 		<HomeMoodsRail />
-
-		<!-- New Releases (now below Trending, sourced from Last.fm JSON API). -->
-		<section class="discovery-section" data-section="new-releases">
-			<div class="section-header">
-				<div class="section-title-group">
-					<p class="eyebrow">Last.fm</p>
-					<h2>New releases</h2>
-				</div>
-				{#if sectionsLoading.releases}
-					<span class="loading-indicator">Loading...</span>
-				{/if}
-			</div>
-
-			{#if releases.length > 0}
-				<div class="horizontal-scroll">
-					{#each releases.slice(0, 12) as release (release.link || `${release.author}-${release.title}`)}
-						<a class="release-card glass-tile" href={release.link} target="_blank" rel="noopener">
-							{#if release.image_url}
-								<img class="release-art" src={release.image_url} alt="" />
-							{:else}
-								<div class="release-art placeholder">💿</div>
-							{/if}
-							<div class="release-info">
-								<h3 class="release-title">{release.title}</h3>
-								{#if release.author}
-									<p class="release-artist">{release.author}</p>
-								{/if}
-							</div>
-						</a>
-					{/each}
-				</div>
-			{:else if releasesNotConfigured}
-				<EmptyState
-					title="Connect Last.fm to see new releases"
-					copy="Last.fm powers the new-releases shelf. Add your API key in Settings → Sources → Last.fm."
-				/>
-			{:else if !sectionsLoading.releases}
-				<EmptyState title="No new releases found" copy="Last.fm did not return any recent albums." />
-			{/if}
-		</section>
 
 		<!-- Weekly Articles Section -->
 		<section class="discovery-section">
@@ -346,65 +279,6 @@
 		&::-webkit-scrollbar-thumb:hover {
 			background: var(--text-muted);
 		}
-	}
-
-	/* Release cards */
-	.release-card {
-		flex: 0 0 200px;
-		display: flex;
-		flex-direction: column;
-		gap: 10px;
-		padding: 14px;
-		text-decoration: none;
-		color: inherit;
-		transition: transform 0.2s ease, box-shadow 0.2s ease;
-		scroll-snap-align: start;
-
-		&:hover {
-			transform: translateY(-4px);
-			box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
-		}
-	}
-
-	.release-art {
-		width: 100%;
-		aspect-ratio: 1;
-		border-radius: 8px;
-		object-fit: cover;
-		background: var(--bg-surface);
-	}
-
-	.release-art.placeholder {
-		width: 100%;
-		aspect-ratio: 1;
-		border-radius: 8px;
-		background: var(--accent-soft);
-		display: grid;
-		place-items: center;
-		font-size: var(--font-size-3xl);
-	}
-
-	.release-info {
-		display: flex;
-		flex-direction: column;
-		gap: 4px;
-	}
-
-	.release-title {
-		font-size: var(--font-size-sm);
-		font-weight: var(--font-weight-semibold);
-		margin: 0;
-		display: -webkit-box;
-		line-clamp: 2;
-		-webkit-line-clamp: 2;
-		-webkit-box-orient: vertical;
-		overflow: hidden;
-	}
-
-	.release-artist {
-		font-size: var(--font-size-xs);
-		color: var(--text-muted);
-		margin: 0;
 	}
 
 	/* Article cards */
@@ -596,10 +470,6 @@
 	@media (max-width: 640px) {
 		.news-grid {
 			grid-template-columns: 1fr;
-		}
-
-		.release-card {
-			flex: 0 0 150px;
 		}
 
 		.article-card {

--- a/frontend/src/routes/charts/+page.svelte
+++ b/frontend/src/routes/charts/+page.svelte
@@ -111,13 +111,13 @@
     text-decoration: none;
     color: inherit;
     cursor: pointer;
-    transition: background var(--motion-fast) ease, border-color var(--motion-fast) ease;
+    transition: background var(--motion-base) ease, border-color var(--motion-base) ease;
     box-sizing: border-box;
   }
   .card:hover, .card:focus-visible { background: var(--bg-hover); border-color: var(--border-subtle); outline: none; }
   .card:focus-visible { border-color: var(--accent-line); }
   .art-wrap { position: relative; aspect-ratio: 1 / 1; width: 100%; border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-surface); }
-  .art { width: 100%; height: 100%; background-size: cover; background-position: center; transition: transform var(--motion-base) ease; }
+  .art { width: 100%; height: 100%; background-size: cover; background-position: center; transition: transform var(--motion-slow) ease; }
   .card:hover .art { transform: scale(1.05); }
   .art.fallback { display: flex; align-items: center; justify-content: center; font-size: var(--font-size-3xl); color: var(--text-muted); }
   .card-title { font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }

--- a/frontend/src/routes/charts/+page.svelte
+++ b/frontend/src/routes/charts/+page.svelte
@@ -3,6 +3,7 @@
   import { api } from '$lib/api/client';
   import { openContextMenu } from '$lib/stores/context_menu';
   import { goto } from '$app/navigation';
+  import TrendingShelf from '$lib/components/charts/TrendingShelf.svelte';
 
   // Editorial Spotify chart playlists. Stable IDs that change daily/weekly
   // server-side but the playlist identity is fixed. Click navigates to the
@@ -52,10 +53,19 @@
 
 <div class="page">
   <header class="page-header">
-    <p class="eyebrow">Spotify</p>
-    <h1>Charts</h1>
-    <p class="sub">Top playlists from Spotify. Click any to play on TIDAL.</p>
+    <p class="eyebrow">Charts</p>
+    <h1>What's hot</h1>
+    <p class="sub">Worldwide trending tracks from Last.fm and editorial Spotify chart playlists.</p>
   </header>
+
+  <section class="trending-block">
+    <TrendingShelf limit={12} />
+  </section>
+
+  <section>
+    <h2 class="block-title">Spotify chart playlists</h2>
+    <p class="block-sub">Click any to play on TIDAL.</p>
+  </section>
 
   <div class="grid">
     {#each CHARTS as c (c.id)}
@@ -83,6 +93,9 @@
   .eyebrow { font-size: var(--font-size-xs); letter-spacing: 0.08em; text-transform: uppercase; color: var(--service-spotify); margin: 0; font-weight: var(--font-weight-bold); }
   .page-header h1 { margin: 0; font-size: var(--font-size-3xl); font-weight: 800; }
   .page-header .sub { margin: 0; font-size: var(--font-size-sm); color: var(--text-secondary); }
+  .block-title { margin: 0 0 4px; font-size: var(--font-size-lg); font-weight: var(--font-weight-bold); color: var(--text-primary); }
+  .block-sub { margin: 0 0 var(--space-3); font-size: var(--font-size-sm); color: var(--text-secondary); }
+  .trending-block { display: flex; flex-direction: column; gap: var(--gap); }
 
   .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(160px, 1fr)); gap: var(--gap); }
   .card { display: flex; flex-direction: column; gap: var(--space-2); padding: var(--space-2); border-radius: var(--radius-md); text-decoration: none; color: inherit; cursor: pointer; transition: background var(--motion-fast) ease; }

--- a/frontend/src/routes/charts/+page.svelte
+++ b/frontend/src/routes/charts/+page.svelte
@@ -4,7 +4,6 @@
   import { openContextMenu } from '$lib/stores/context_menu';
   import { goto } from '$app/navigation';
   import TrendingShelf from '$lib/components/charts/TrendingShelf.svelte';
-  import PlayOverlay from '$lib/components/ui/PlayOverlay.svelte';
 
   // Editorial Spotify chart playlists. Stable IDs that change daily/weekly
   // server-side but the playlist identity is fixed. Click navigates to the
@@ -82,7 +81,6 @@
           {:else}
             <div class="art fallback">M</div>
           {/if}
-          <PlayOverlay position="center" size="md" />
         </div>
         <div class="meta">
           <p class="title">{m?.title ?? c.title}</p>
@@ -120,7 +118,6 @@
   }
   .card:hover, .card:focus-visible { background: var(--bg-hover); border-color: var(--panel-border); outline: none; }
   .card:focus-visible { border-color: var(--accent-line); }
-  .card:hover :global(.play-overlay), .card:focus-visible :global(.play-overlay) { opacity: 1; transform: translateY(0); }
   .art-wrap { position: relative; aspect-ratio: 1 / 1; width: 100%; border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-hover); }
   .art { width: 100%; height: 100%; background-size: cover; background-position: center; transition: transform var(--motion-slow) ease; }
   .card:hover .art { transform: scale(1.05); }

--- a/frontend/src/routes/charts/+page.svelte
+++ b/frontend/src/routes/charts/+page.svelte
@@ -119,7 +119,7 @@
   .card:hover, .card:focus-visible { background: var(--bg-hover); border-color: var(--panel-border); outline: none; }
   .card:focus-visible { border-color: var(--accent-line); }
   .art-wrap { position: relative; aspect-ratio: 1 / 1; width: 100%; border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-hover); }
-  .art { width: 100%; height: 100%; background-size: cover; background-position: center; transition: transform var(--motion-slow) ease; }
+  .art { width: 100%; height: 100%; background-size: cover; background-position: center; transition: transform var(--motion-base) ease; }
   .card:hover .art { transform: scale(1.05); }
   .art.fallback { display: flex; align-items: center; justify-content: center; font-size: var(--font-size-4xl); color: var(--text-muted); }
   .meta { display: flex; flex-direction: column; gap: var(--space-1); min-width: 0; }

--- a/frontend/src/routes/charts/+page.svelte
+++ b/frontend/src/routes/charts/+page.svelte
@@ -75,11 +75,13 @@
         href={`/spotify-playlist/${c.id}`}
         oncontextmenu={(e) => { e.preventDefault(); openContextMenu(e, chartMenu(c.id, c.title), c.title); }}
       >
-        {#if m?.thumbnail}
-          <div class="art" style="background-image:url('{m.thumbnail}')"></div>
-        {:else}
-          <div class="art fallback">M</div>
-        {/if}
+        <div class="art-wrap">
+          {#if m?.thumbnail}
+            <div class="art" style="background-image:url('{m.thumbnail}')"></div>
+          {:else}
+            <div class="art fallback">M</div>
+          {/if}
+        </div>
         <span class="card-title">{m?.title ?? c.title}</span>
         <span class="card-sub">{c.sub}</span>
       </a>
@@ -97,11 +99,27 @@
   .block-sub { margin: 0 0 var(--space-3); font-size: var(--font-size-sm); color: var(--text-secondary); }
   .trending-block { display: flex; flex-direction: column; gap: var(--gap); }
 
-  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(160px, 1fr)); gap: var(--gap); }
-  .card { display: flex; flex-direction: column; gap: var(--space-2); padding: var(--space-2); border-radius: var(--radius-md); text-decoration: none; color: inherit; cursor: pointer; transition: background var(--motion-fast) ease; }
-  .card:hover, .card:focus-visible { background: var(--bg-hover); outline: none; }
-  .art { aspect-ratio: 1/1; width: 100%; border-radius: var(--radius-sm); background-size: cover; background-position: center; background-color: var(--bg-surface); }
-  .art.fallback { display: flex; align-items: center; justify-content: center; color: var(--text-muted); font-size: var(--font-size-3xl); background: linear-gradient(135deg, var(--service-spotify), #1aa34a); color: #fff; }
+  .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(160px, 100%), 1fr)); gap: var(--gap); }
+  .card {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    background: none;
+    border: 1px solid transparent;
+    padding: var(--space-2);
+    border-radius: var(--radius-md);
+    text-decoration: none;
+    color: inherit;
+    cursor: pointer;
+    transition: background var(--motion-fast) ease, border-color var(--motion-fast) ease;
+    box-sizing: border-box;
+  }
+  .card:hover, .card:focus-visible { background: var(--bg-hover); border-color: var(--border-subtle); outline: none; }
+  .card:focus-visible { border-color: var(--accent-line); }
+  .art-wrap { position: relative; aspect-ratio: 1 / 1; width: 100%; border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-surface); }
+  .art { width: 100%; height: 100%; background-size: cover; background-position: center; transition: transform var(--motion-base) ease; }
+  .card:hover .art { transform: scale(1.05); }
+  .art.fallback { display: flex; align-items: center; justify-content: center; font-size: var(--font-size-3xl); color: var(--text-muted); }
   .card-title { font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
   .card-sub { font-size: var(--font-size-xs); color: var(--text-secondary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 </style>

--- a/frontend/src/routes/charts/+page.svelte
+++ b/frontend/src/routes/charts/+page.svelte
@@ -4,6 +4,7 @@
   import { openContextMenu } from '$lib/stores/context_menu';
   import { goto } from '$app/navigation';
   import TrendingShelf from '$lib/components/charts/TrendingShelf.svelte';
+  import PlayOverlay from '$lib/components/ui/PlayOverlay.svelte';
 
   // Editorial Spotify chart playlists. Stable IDs that change daily/weekly
   // server-side but the playlist identity is fixed. Click navigates to the
@@ -81,9 +82,12 @@
           {:else}
             <div class="art fallback">M</div>
           {/if}
+          <PlayOverlay position="center" size="md" />
         </div>
-        <span class="card-title">{m?.title ?? c.title}</span>
-        <span class="card-sub">{c.sub}</span>
+        <div class="meta">
+          <p class="title">{m?.title ?? c.title}</p>
+          <span class="sub">{c.sub}</span>
+        </div>
       </a>
     {/each}
   </div>
@@ -99,7 +103,7 @@
   .block-sub { margin: 0 0 var(--space-3); font-size: var(--font-size-sm); color: var(--text-secondary); }
   .trending-block { display: flex; flex-direction: column; gap: var(--gap); }
 
-  .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(160px, 100%), 1fr)); gap: var(--gap); }
+  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(min(180px, 100%), 1fr)); gap: var(--gap); }
   .card {
     display: flex;
     flex-direction: column;
@@ -114,12 +118,14 @@
     transition: background var(--motion-base) ease, border-color var(--motion-base) ease;
     box-sizing: border-box;
   }
-  .card:hover, .card:focus-visible { background: var(--bg-hover); border-color: var(--border-subtle); outline: none; }
+  .card:hover, .card:focus-visible { background: var(--bg-hover); border-color: var(--panel-border); outline: none; }
   .card:focus-visible { border-color: var(--accent-line); }
-  .art-wrap { position: relative; aspect-ratio: 1 / 1; width: 100%; border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-surface); }
+  .card:hover :global(.play-overlay), .card:focus-visible :global(.play-overlay) { opacity: 1; transform: translateY(0); }
+  .art-wrap { position: relative; aspect-ratio: 1 / 1; width: 100%; border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-hover); }
   .art { width: 100%; height: 100%; background-size: cover; background-position: center; transition: transform var(--motion-slow) ease; }
   .card:hover .art { transform: scale(1.05); }
-  .art.fallback { display: flex; align-items: center; justify-content: center; font-size: var(--font-size-3xl); color: var(--text-muted); }
-  .card-title { font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-  .card-sub { font-size: var(--font-size-xs); color: var(--text-secondary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .art.fallback { display: flex; align-items: center; justify-content: center; font-size: var(--font-size-4xl); color: var(--text-muted); }
+  .meta { display: flex; flex-direction: column; gap: var(--space-1); min-width: 0; }
+  .meta .title { margin: 0; font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; line-height: var(--line-height-snug); }
+  .meta .sub { font-size: var(--font-size-xs); color: var(--text-secondary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 </style>

--- a/frontend/src/routes/charts/+page.svelte
+++ b/frontend/src/routes/charts/+page.svelte
@@ -113,13 +113,13 @@
     text-decoration: none;
     color: inherit;
     cursor: pointer;
-    transition: background var(--motion-base) ease, border-color var(--motion-base) ease;
+    transition: background var(--motion-base), border-color var(--motion-base);
     box-sizing: border-box;
   }
   .card:hover, .card:focus-visible { background: var(--bg-hover); border-color: var(--panel-border); outline: none; }
   .card:focus-visible { border-color: var(--accent-line); }
   .art-wrap { position: relative; aspect-ratio: 1 / 1; width: 100%; border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-hover); }
-  .art { width: 100%; height: 100%; background-size: cover; background-position: center; transition: transform var(--motion-base) ease; }
+  .art { width: 100%; height: 100%; background-size: cover; background-position: center; transition: transform var(--motion-base); }
   .card:hover .art { transform: scale(1.05); }
   .art.fallback { display: flex; align-items: center; justify-content: center; font-size: var(--font-size-4xl); color: var(--text-muted); }
   .meta { display: flex; flex-direction: column; gap: var(--space-1); min-width: 0; }

--- a/frontend/src/routes/charts/+page.svelte
+++ b/frontend/src/routes/charts/+page.svelte
@@ -1,35 +1,50 @@
 <script lang="ts">
-  import { onMount, untrack } from 'svelte';
-  import { ApiError, api, type TidalHomeModule } from '$lib/api/client';
-  import { tidalStatus } from '$lib/stores/tidal';
-  import TidalDiscoverShelves from '$lib/components/search/TidalDiscoverShelves.svelte';
+  import { onMount } from 'svelte';
+  import { api } from '$lib/api/client';
+  import { openContextMenu } from '$lib/stores/context_menu';
+  import { goto } from '$app/navigation';
 
-  type State = 'loading' | 'ready' | 'empty' | 'disconnected' | 'error';
+  // Editorial Spotify chart playlists. Stable IDs that change daily/weekly
+  // server-side but the playlist identity is fixed. Click navigates to the
+  // existing /spotify-playlist/[id] view which handles fetch + play.
+  const CHARTS: { id: string; title: string; sub: string }[] = [
+    { id: '37i9dQZEVXbMDoHDwVN2tF', title: 'Top 50 - Global', sub: 'Daily chart' },
+    { id: '37i9dQZEVXbLRQDuF5jeBp', title: 'Top 50 - USA', sub: 'Daily chart' },
+    { id: '37i9dQZEVXbLnolsZ8PSNw', title: 'Top 50 - UK', sub: 'Daily chart' },
+    { id: '37i9dQZEVXbJPcfkRz0wJ0', title: 'Top 50 - Australia', sub: 'Daily chart' },
+    { id: '37i9dQZEVXbLiRSasKsNU9', title: 'Viral 50 - Global', sub: 'Daily chart' },
+    { id: '37i9dQZF1DXcBWIGoYBM5M', title: "Today's Top Hits", sub: 'Editorial' },
+    { id: '37i9dQZF1DX4JAvHpjipBk', title: 'New Music Friday', sub: 'Editorial' },
+    { id: '37i9dQZF1DX0XUsuxWHRQd', title: 'RapCaviar', sub: 'Editorial' },
+    { id: '37i9dQZF1DX1lVhptIYRda', title: 'Hot Country', sub: 'Editorial' },
+    { id: '37i9dQZF1DWUa8ZRTfalHk', title: 'Pop Rising', sub: 'Editorial' },
+    { id: '37i9dQZF1DX10zKzsJ2jva', title: 'Viva Latino', sub: 'Editorial' },
+    { id: '37i9dQZF1DX4dyzvuaRJ0n', title: 'mint', sub: 'Editorial' },
+  ];
 
-  let modules = $state<TidalHomeModule[]>([]);
-  let viewState = $state<State>('loading');
+  // Best-effort cover fetch. The existing playlist endpoint also returns
+  // tracks + does TIDAL resolution server-side, so this is heavier than it
+  // needs to be -- see FOLLOWUPS for a lightweight metadata endpoint. When
+  // the sportify proxy is slow or down, cards just fall back to the glyph.
+  let meta = $state<Record<string, { thumbnail: string | null; title: string | null }>>({});
 
-  onMount(load);
-
-  $effect(() => {
-    if ($tidalStatus !== 'connected') return;
-    const cur = untrack(() => viewState);
-    if (cur !== 'loading' && cur !== 'ready') void load();
+  onMount(() => {
+    void Promise.allSettled(
+      CHARTS.map(async (c) => {
+        try {
+          const { playlist } = await api.getSpotifyPlaylist(c.id);
+          meta[c.id] = { thumbnail: playlist.thumbnail, title: playlist.title };
+        } catch {
+          // Quiet: proxy outage just keeps the fallback glyph + hardcoded title.
+        }
+      }),
+    );
   });
 
-  async function load() {
-    viewState = 'loading';
-    try {
-      const data = await api.getTidalPage('charts');
-      modules = data.modules ?? [];
-      viewState = modules.length > 0 ? 'ready' : 'empty';
-    } catch (e) {
-      if (e instanceof ApiError && e.status === 503) {
-        viewState = 'disconnected';
-      } else {
-        viewState = 'error';
-      }
-    }
+  function chartMenu(id: string, title: string) {
+    return [
+      { label: 'Open playlist', onSelect: () => void goto(`/spotify-playlist/${id}`) },
+    ];
   }
 </script>
 
@@ -37,27 +52,43 @@
 
 <div class="page">
   <header class="page-header">
-    <p class="eyebrow">TIDAL</p>
+    <p class="eyebrow">Spotify</p>
     <h1>Charts</h1>
+    <p class="sub">Top playlists from Spotify. Click any to play on TIDAL.</p>
   </header>
-  {#if viewState === 'loading'}
-    <p class="muted-line">Loading charts...</p>
-  {:else if viewState === 'ready'}
-    <TidalDiscoverShelves {modules} />
-  {:else if viewState === 'empty'}
-    <p class="muted-line">No charts available right now. <button class="inline-link" onclick={load}>Retry</button></p>
-  {:else if viewState === 'disconnected'}
-    <p class="muted-line">Connect TIDAL to see charts. <a class="inline-link" href="/settings#sources-tidal">Open settings</a></p>
-  {:else if viewState === 'error'}
-    <p class="muted-line">Couldn't load charts. <button class="inline-link" onclick={load}>Retry</button></p>
-  {/if}
+
+  <div class="grid">
+    {#each CHARTS as c (c.id)}
+      {@const m = meta[c.id]}
+      <a
+        class="card"
+        href={`/spotify-playlist/${c.id}`}
+        oncontextmenu={(e) => { e.preventDefault(); openContextMenu(e, chartMenu(c.id, c.title), c.title); }}
+      >
+        {#if m?.thumbnail}
+          <div class="art" style="background-image:url('{m.thumbnail}')"></div>
+        {:else}
+          <div class="art fallback">M</div>
+        {/if}
+        <span class="card-title">{m?.title ?? c.title}</span>
+        <span class="card-sub">{c.sub}</span>
+      </a>
+    {/each}
+  </div>
 </div>
 
 <style>
   .page { max-width: var(--content-width); margin: 0 auto; padding: 32px 28px 96px; display: flex; flex-direction: column; gap: 24px; }
   .page-header { display: flex; flex-direction: column; gap: 4px; }
-  .eyebrow { font-size: var(--font-size-xs); letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-secondary); margin: 0; }
+  .eyebrow { font-size: var(--font-size-xs); letter-spacing: 0.08em; text-transform: uppercase; color: var(--service-spotify); margin: 0; font-weight: var(--font-weight-bold); }
   .page-header h1 { margin: 0; font-size: var(--font-size-3xl); font-weight: 800; }
-  .muted-line { margin: 0; font-size: var(--font-size-sm); color: var(--text-secondary); }
-  .inline-link { background: none; border: none; padding: 0; font: inherit; color: var(--accent-line); cursor: pointer; text-decoration: underline; text-underline-offset: 2px; margin-left: var(--space-1); }
+  .page-header .sub { margin: 0; font-size: var(--font-size-sm); color: var(--text-secondary); }
+
+  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(160px, 1fr)); gap: var(--gap); }
+  .card { display: flex; flex-direction: column; gap: var(--space-2); padding: var(--space-2); border-radius: var(--radius-md); text-decoration: none; color: inherit; cursor: pointer; transition: background var(--motion-fast) ease; }
+  .card:hover, .card:focus-visible { background: var(--bg-hover); outline: none; }
+  .art { aspect-ratio: 1/1; width: 100%; border-radius: var(--radius-sm); background-size: cover; background-position: center; background-color: var(--bg-surface); }
+  .art.fallback { display: flex; align-items: center; justify-content: center; color: var(--text-muted); font-size: var(--font-size-3xl); background: linear-gradient(135deg, var(--service-spotify), #1aa34a); color: #fff; }
+  .card-title { font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .card-sub { font-size: var(--font-size-xs); color: var(--text-secondary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 </style>

--- a/frontend/src/routes/charts/+page.svelte
+++ b/frontend/src/routes/charts/+page.svelte
@@ -13,7 +13,9 @@
     { id: '37i9dQZEVXbLRQDuF5jeBp', title: 'Top 50 - USA', sub: 'Daily chart' },
     { id: '37i9dQZEVXbLnolsZ8PSNw', title: 'Top 50 - UK', sub: 'Daily chart' },
     { id: '37i9dQZEVXbJPcfkRz0wJ0', title: 'Top 50 - Australia', sub: 'Daily chart' },
-    { id: '37i9dQZEVXbLiRSasKsNU9', title: 'Viral 50 - Global', sub: 'Daily chart' },
+    // Viral 50 - Global (37i9dQZEVXbLiRSasKsNU9) removed: Sportify proxy
+    // returns a hard 503 specifically for that ID even though Top 50s and
+    // editorial playlists work fine. Add back once the proxy recovers it.
     { id: '37i9dQZF1DXcBWIGoYBM5M', title: "Today's Top Hits", sub: 'Editorial' },
     { id: '37i9dQZF1DX4JAvHpjipBk', title: 'New Music Friday', sub: 'Editorial' },
     { id: '37i9dQZF1DX0XUsuxWHRQd', title: 'RapCaviar', sub: 'Editorial' },

--- a/frontend/src/routes/moods/+page.svelte
+++ b/frontend/src/routes/moods/+page.svelte
@@ -9,8 +9,6 @@
     putCachedMoodCategories,
     clearCachedMoods,
   } from '$lib/stores/tidal-moods-cache';
-  import SpotifyMoodRail from '$lib/components/moods/SpotifyMoodRail.svelte';
-  import { SPOTIFY_MOOD_CATEGORIES } from '$lib/components/moods/spotify-moods-data';
   import PlayOverlay from '$lib/components/ui/PlayOverlay.svelte';
 
   type State = 'loading' | 'ready' | 'empty' | 'disconnected' | 'error';
@@ -95,19 +93,6 @@
   {:else if viewState === 'error'}
     <p class="muted-line">Couldn't load moods. <button class="inline-link" onclick={load}>Retry</button></p>
   {/if}
-
-  <section class="spotify-block">
-    <header class="block-header">
-      <p class="eyebrow spotify">Spotify</p>
-      <h2>Mood playlists</h2>
-      <p class="sub">Editorial mood selections from Spotify, played through TIDAL.</p>
-    </header>
-    <div class="rails">
-      {#each SPOTIFY_MOOD_CATEGORIES as cat (cat.slug)}
-        <SpotifyMoodRail category={cat} />
-      {/each}
-    </div>
-  </section>
 </div>
 
 <style>
@@ -142,11 +127,4 @@
   .card:hover .art { transform: scale(1.05); }
   .art.fallback { display: flex; align-items: center; justify-content: center; font-size: var(--font-size-4xl); color: var(--text-muted); }
   .card-title { margin: 0; font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; line-height: var(--line-height-snug); }
-
-  .spotify-block { display: flex; flex-direction: column; gap: var(--space-4); margin-top: var(--space-6); }
-  .block-header { display: flex; flex-direction: column; gap: 4px; }
-  .block-header h2 { margin: 0; font-size: var(--font-size-xl); font-weight: var(--font-weight-bold); color: var(--text-primary); }
-  .block-header .sub { margin: 0; font-size: var(--font-size-sm); color: var(--text-secondary); }
-  .eyebrow.spotify { font-size: var(--font-size-xs); letter-spacing: 0.08em; text-transform: uppercase; color: var(--service-spotify); font-weight: var(--font-weight-bold); margin: 0; }
-  .rails { display: flex; flex-direction: column; gap: var(--space-4); }
 </style>

--- a/frontend/src/routes/moods/+page.svelte
+++ b/frontend/src/routes/moods/+page.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
   import { onMount, untrack } from 'svelte';
-  import { ApiError, api, type TidalHomeModule } from '$lib/api/client';
+  import { ApiError, api, type TidalMoodCategory } from '$lib/api/client';
   import { tidalStatus } from '$lib/stores/tidal';
-  import TidalDiscoverShelves from '$lib/components/search/TidalDiscoverShelves.svelte';
+  import { openContextMenu } from '$lib/stores/context_menu';
+  import { goto } from '$app/navigation';
 
   type State = 'loading' | 'ready' | 'empty' | 'disconnected' | 'error';
 
-  let modules = $state<TidalHomeModule[]>([]);
+  let categories = $state<TidalMoodCategory[]>([]);
   let viewState = $state<State>('loading');
 
   onMount(load);
@@ -20,9 +21,9 @@
   async function load() {
     viewState = 'loading';
     try {
-      const data = await api.getTidalPage('moods');
-      modules = data.modules ?? [];
-      viewState = modules.length > 0 ? 'ready' : 'empty';
+      const data = await api.getTidalMoods();
+      categories = data.categories ?? [];
+      viewState = categories.length > 0 ? 'ready' : 'empty';
     } catch (e) {
       if (e instanceof ApiError && e.status === 503) {
         viewState = 'disconnected';
@@ -31,6 +32,10 @@
       }
     }
   }
+
+  function buildMenu(slug: string, title: string) {
+    return [{ label: `Open ${title}`, onSelect: () => void goto(`/moods/${slug}`) }];
+  }
 </script>
 
 <svelte:head><title>Moods . NOOR</title></svelte:head>
@@ -38,12 +43,25 @@
 <div class="page">
   <header class="page-header">
     <p class="eyebrow">TIDAL</p>
-    <h1>Moods</h1>
+    <h1>Moods &amp; Activities</h1>
+    <p class="sub">Editorial categories from TIDAL. Click a tile to explore.</p>
   </header>
+
   {#if viewState === 'loading'}
     <p class="muted-line">Loading moods...</p>
   {:else if viewState === 'ready'}
-    <TidalDiscoverShelves {modules} />
+    <div class="grid">
+      {#each categories as c (c.slug)}
+        <a
+          class="card"
+          href={`/moods/${c.slug}`}
+          oncontextmenu={(e) => { e.preventDefault(); openContextMenu(e, buildMenu(c.slug, c.title), c.title); }}
+        >
+          <div class="art fallback">~</div>
+          <span class="card-title">{c.title}</span>
+        </a>
+      {/each}
+    </div>
   {:else if viewState === 'empty'}
     <p class="muted-line">No moods available right now. <button class="inline-link" onclick={load}>Retry</button></p>
   {:else if viewState === 'disconnected'}
@@ -58,6 +76,14 @@
   .page-header { display: flex; flex-direction: column; gap: 4px; }
   .eyebrow { font-size: var(--font-size-xs); letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-secondary); margin: 0; }
   .page-header h1 { margin: 0; font-size: var(--font-size-3xl); font-weight: 800; }
+  .page-header .sub { margin: 0; font-size: var(--font-size-sm); color: var(--text-secondary); }
   .muted-line { margin: 0; font-size: var(--font-size-sm); color: var(--text-secondary); }
   .inline-link { background: none; border: none; padding: 0; font: inherit; color: var(--accent-line); cursor: pointer; text-decoration: underline; text-underline-offset: 2px; margin-left: var(--space-1); }
+
+  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(140px, 1fr)); gap: var(--gap); }
+  .card { display: flex; flex-direction: column; gap: var(--space-2); padding: var(--space-2); border-radius: var(--radius-md); text-decoration: none; color: inherit; cursor: pointer; transition: background var(--motion-fast) ease; }
+  .card:hover, .card:focus-visible { background: var(--bg-hover); outline: none; }
+  .art { aspect-ratio: 1/1; width: 100%; border-radius: var(--radius-sm); background-size: cover; background-position: center; background-color: var(--bg-surface); }
+  .art.fallback { display: flex; align-items: center; justify-content: center; color: #fff; font-size: var(--font-size-3xl); background: linear-gradient(135deg, #3b82f6, #8b5cf6); }
+  .card-title { font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; text-align: center; }
 </style>

--- a/frontend/src/routes/moods/+page.svelte
+++ b/frontend/src/routes/moods/+page.svelte
@@ -9,6 +9,8 @@
     putCachedMoodCategories,
     clearCachedMoods,
   } from '$lib/stores/tidal-moods-cache';
+  import SpotifyMoodRail from '$lib/components/moods/SpotifyMoodRail.svelte';
+  import { SPOTIFY_MOOD_CATEGORIES } from '$lib/components/moods/spotify-moods-data';
 
   type State = 'loading' | 'ready' | 'empty' | 'disconnected' | 'error';
 
@@ -89,6 +91,19 @@
   {:else if viewState === 'error'}
     <p class="muted-line">Couldn't load moods. <button class="inline-link" onclick={load}>Retry</button></p>
   {/if}
+
+  <section class="spotify-block">
+    <header class="block-header">
+      <p class="eyebrow spotify">Spotify</p>
+      <h2>Mood playlists</h2>
+      <p class="sub">Editorial mood selections from Spotify, played through TIDAL.</p>
+    </header>
+    <div class="rails">
+      {#each SPOTIFY_MOOD_CATEGORIES as cat (cat.slug)}
+        <SpotifyMoodRail category={cat} />
+      {/each}
+    </div>
+  </section>
 </div>
 
 <style>
@@ -106,4 +121,11 @@
   .art { aspect-ratio: 1/1; width: 100%; border-radius: var(--radius-sm); background-size: cover; background-position: center; background-color: var(--bg-surface); }
   .art.fallback { display: flex; align-items: center; justify-content: center; color: #fff; font-size: var(--font-size-3xl); background: linear-gradient(135deg, #3b82f6, #8b5cf6); }
   .card-title { font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; text-align: center; }
+
+  .spotify-block { display: flex; flex-direction: column; gap: var(--space-4); margin-top: var(--space-6); }
+  .block-header { display: flex; flex-direction: column; gap: 4px; }
+  .block-header h2 { margin: 0; font-size: var(--font-size-xl); font-weight: var(--font-weight-bold); color: var(--text-primary); }
+  .block-header .sub { margin: 0; font-size: var(--font-size-sm); color: var(--text-secondary); }
+  .eyebrow.spotify { font-size: var(--font-size-xs); letter-spacing: 0.08em; text-transform: uppercase; color: var(--service-spotify); font-weight: var(--font-weight-bold); margin: 0; }
+  .rails { display: flex; flex-direction: column; gap: var(--space-4); }
 </style>

--- a/frontend/src/routes/moods/+page.svelte
+++ b/frontend/src/routes/moods/+page.svelte
@@ -120,7 +120,7 @@
   .card:hover, .card:focus-visible { background: var(--bg-hover); border-color: var(--panel-border); outline: none; }
   .card:focus-visible { border-color: var(--accent-line); }
   .art-wrap { position: relative; aspect-ratio: 1 / 1; width: 100%; border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-hover); }
-  .art { width: 100%; height: 100%; background-size: cover; background-position: center; transition: transform var(--motion-slow) ease; }
+  .art { width: 100%; height: 100%; background-size: cover; background-position: center; transition: transform var(--motion-base) ease; }
   .card:hover .art { transform: scale(1.05); }
   .art.fallback { display: flex; align-items: center; justify-content: center; font-size: var(--font-size-4xl); color: var(--text-muted); }
   .card-title { margin: 0; font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; line-height: var(--line-height-snug); }

--- a/frontend/src/routes/moods/+page.svelte
+++ b/frontend/src/routes/moods/+page.svelte
@@ -75,11 +75,13 @@
           href={`/moods/${c.slug}`}
           oncontextmenu={(e) => { e.preventDefault(); openContextMenu(e, buildMenu(c.slug, c.title), c.title); }}
         >
-          {#if c.thumbnail}
-            <div class="art" style="background-image:url('{c.thumbnail}')"></div>
-          {:else}
-            <div class="art fallback">~</div>
-          {/if}
+          <div class="art-wrap">
+            {#if c.thumbnail}
+              <div class="art" style="background-image:url('{c.thumbnail}')"></div>
+            {:else}
+              <div class="art fallback">~</div>
+            {/if}
+          </div>
           <span class="card-title">{c.title}</span>
         </a>
       {/each}
@@ -115,11 +117,27 @@
   .muted-line { margin: 0; font-size: var(--font-size-sm); color: var(--text-secondary); }
   .inline-link { background: none; border: none; padding: 0; font: inherit; color: var(--accent-line); cursor: pointer; text-decoration: underline; text-underline-offset: 2px; margin-left: var(--space-1); }
 
-  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(140px, 1fr)); gap: var(--gap); }
-  .card { display: flex; flex-direction: column; gap: var(--space-2); padding: var(--space-2); border-radius: var(--radius-md); text-decoration: none; color: inherit; cursor: pointer; transition: background var(--motion-fast) ease; }
-  .card:hover, .card:focus-visible { background: var(--bg-hover); outline: none; }
-  .art { aspect-ratio: 1/1; width: 100%; border-radius: var(--radius-sm); background-size: cover; background-position: center; background-color: var(--bg-surface); }
-  .art.fallback { display: flex; align-items: center; justify-content: center; color: #fff; font-size: var(--font-size-3xl); background: linear-gradient(135deg, #3b82f6, #8b5cf6); }
+  .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(140px, 100%), 1fr)); gap: var(--gap); }
+  .card {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    background: none;
+    border: 1px solid transparent;
+    padding: var(--space-2);
+    border-radius: var(--radius-md);
+    text-decoration: none;
+    color: inherit;
+    cursor: pointer;
+    transition: background var(--motion-fast) ease, border-color var(--motion-fast) ease;
+    box-sizing: border-box;
+  }
+  .card:hover, .card:focus-visible { background: var(--bg-hover); border-color: var(--border-subtle); outline: none; }
+  .card:focus-visible { border-color: var(--accent-line); }
+  .art-wrap { position: relative; aspect-ratio: 1 / 1; width: 100%; border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-surface); }
+  .art { width: 100%; height: 100%; background-size: cover; background-position: center; transition: transform var(--motion-base) ease; }
+  .card:hover .art { transform: scale(1.05); }
+  .art.fallback { display: flex; align-items: center; justify-content: center; font-size: var(--font-size-3xl); color: var(--text-muted); }
   .card-title { font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; text-align: center; }
 
   .spotify-block { display: flex; flex-direction: column; gap: var(--space-4); margin-top: var(--space-6); }

--- a/frontend/src/routes/moods/+page.svelte
+++ b/frontend/src/routes/moods/+page.svelte
@@ -129,13 +129,13 @@
     text-decoration: none;
     color: inherit;
     cursor: pointer;
-    transition: background var(--motion-fast) ease, border-color var(--motion-fast) ease;
+    transition: background var(--motion-base) ease, border-color var(--motion-base) ease;
     box-sizing: border-box;
   }
   .card:hover, .card:focus-visible { background: var(--bg-hover); border-color: var(--border-subtle); outline: none; }
   .card:focus-visible { border-color: var(--accent-line); }
   .art-wrap { position: relative; aspect-ratio: 1 / 1; width: 100%; border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-surface); }
-  .art { width: 100%; height: 100%; background-size: cover; background-position: center; transition: transform var(--motion-base) ease; }
+  .art { width: 100%; height: 100%; background-size: cover; background-position: center; transition: transform var(--motion-slow) ease; }
   .card:hover .art { transform: scale(1.05); }
   .art.fallback { display: flex; align-items: center; justify-content: center; font-size: var(--font-size-3xl); color: var(--text-muted); }
   .card-title { font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; text-align: center; }

--- a/frontend/src/routes/moods/+page.svelte
+++ b/frontend/src/routes/moods/+page.svelte
@@ -114,13 +114,13 @@
     text-decoration: none;
     color: inherit;
     cursor: pointer;
-    transition: background var(--motion-base) ease, border-color var(--motion-base) ease;
+    transition: background var(--motion-base), border-color var(--motion-base);
     box-sizing: border-box;
   }
   .card:hover, .card:focus-visible { background: var(--bg-hover); border-color: var(--panel-border); outline: none; }
   .card:focus-visible { border-color: var(--accent-line); }
   .art-wrap { position: relative; aspect-ratio: 1 / 1; width: 100%; border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-hover); }
-  .art { width: 100%; height: 100%; background-size: cover; background-position: center; transition: transform var(--motion-base) ease; }
+  .art { width: 100%; height: 100%; background-size: cover; background-position: center; transition: transform var(--motion-base); }
   .card:hover .art { transform: scale(1.05); }
   .art.fallback { display: flex; align-items: center; justify-content: center; font-size: var(--font-size-4xl); color: var(--text-muted); }
   .card-title { margin: 0; font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; line-height: var(--line-height-snug); }

--- a/frontend/src/routes/moods/+page.svelte
+++ b/frontend/src/routes/moods/+page.svelte
@@ -11,6 +11,7 @@
   } from '$lib/stores/tidal-moods-cache';
   import SpotifyMoodRail from '$lib/components/moods/SpotifyMoodRail.svelte';
   import { SPOTIFY_MOOD_CATEGORIES } from '$lib/components/moods/spotify-moods-data';
+  import PlayOverlay from '$lib/components/ui/PlayOverlay.svelte';
 
   type State = 'loading' | 'ready' | 'empty' | 'disconnected' | 'error';
 
@@ -81,8 +82,9 @@
             {:else}
               <div class="art fallback">~</div>
             {/if}
+            <PlayOverlay position="center" size="md" />
           </div>
-          <span class="card-title">{c.title}</span>
+          <p class="card-title">{c.title}</p>
         </a>
       {/each}
     </div>
@@ -117,7 +119,7 @@
   .muted-line { margin: 0; font-size: var(--font-size-sm); color: var(--text-secondary); }
   .inline-link { background: none; border: none; padding: 0; font: inherit; color: var(--accent-line); cursor: pointer; text-decoration: underline; text-underline-offset: 2px; margin-left: var(--space-1); }
 
-  .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(140px, 100%), 1fr)); gap: var(--gap); }
+  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(min(180px, 100%), 1fr)); gap: var(--gap); }
   .card {
     display: flex;
     flex-direction: column;
@@ -132,13 +134,14 @@
     transition: background var(--motion-base) ease, border-color var(--motion-base) ease;
     box-sizing: border-box;
   }
-  .card:hover, .card:focus-visible { background: var(--bg-hover); border-color: var(--border-subtle); outline: none; }
+  .card:hover, .card:focus-visible { background: var(--bg-hover); border-color: var(--panel-border); outline: none; }
   .card:focus-visible { border-color: var(--accent-line); }
-  .art-wrap { position: relative; aspect-ratio: 1 / 1; width: 100%; border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-surface); }
+  .card:hover :global(.play-overlay), .card:focus-visible :global(.play-overlay) { opacity: 1; transform: translateY(0); }
+  .art-wrap { position: relative; aspect-ratio: 1 / 1; width: 100%; border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-hover); }
   .art { width: 100%; height: 100%; background-size: cover; background-position: center; transition: transform var(--motion-slow) ease; }
   .card:hover .art { transform: scale(1.05); }
-  .art.fallback { display: flex; align-items: center; justify-content: center; font-size: var(--font-size-3xl); color: var(--text-muted); }
-  .card-title { font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; text-align: center; }
+  .art.fallback { display: flex; align-items: center; justify-content: center; font-size: var(--font-size-4xl); color: var(--text-muted); }
+  .card-title { margin: 0; font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; line-height: var(--line-height-snug); }
 
   .spotify-block { display: flex; flex-direction: column; gap: var(--space-4); margin-top: var(--space-6); }
   .block-header { display: flex; flex-direction: column; gap: 4px; }

--- a/frontend/src/routes/moods/+page.svelte
+++ b/frontend/src/routes/moods/+page.svelte
@@ -9,7 +9,6 @@
     putCachedMoodCategories,
     clearCachedMoods,
   } from '$lib/stores/tidal-moods-cache';
-  import PlayOverlay from '$lib/components/ui/PlayOverlay.svelte';
 
   type State = 'loading' | 'ready' | 'empty' | 'disconnected' | 'error';
 
@@ -80,7 +79,6 @@
             {:else}
               <div class="art fallback">~</div>
             {/if}
-            <PlayOverlay position="center" size="md" />
           </div>
           <p class="card-title">{c.title}</p>
         </a>
@@ -121,7 +119,6 @@
   }
   .card:hover, .card:focus-visible { background: var(--bg-hover); border-color: var(--panel-border); outline: none; }
   .card:focus-visible { border-color: var(--accent-line); }
-  .card:hover :global(.play-overlay), .card:focus-visible :global(.play-overlay) { opacity: 1; transform: translateY(0); }
   .art-wrap { position: relative; aspect-ratio: 1 / 1; width: 100%; border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-hover); }
   .art { width: 100%; height: 100%; background-size: cover; background-position: center; transition: transform var(--motion-slow) ease; }
   .card:hover .art { transform: scale(1.05); }

--- a/frontend/src/routes/moods/+page.svelte
+++ b/frontend/src/routes/moods/+page.svelte
@@ -57,7 +57,11 @@
           href={`/moods/${c.slug}`}
           oncontextmenu={(e) => { e.preventDefault(); openContextMenu(e, buildMenu(c.slug, c.title), c.title); }}
         >
-          <div class="art fallback">~</div>
+          {#if c.thumbnail}
+            <div class="art" style="background-image:url('{c.thumbnail}')"></div>
+          {:else}
+            <div class="art fallback">~</div>
+          {/if}
           <span class="card-title">{c.title}</span>
         </a>
       {/each}

--- a/frontend/src/routes/moods/+page.svelte
+++ b/frontend/src/routes/moods/+page.svelte
@@ -4,13 +4,27 @@
   import { tidalStatus } from '$lib/stores/tidal';
   import { openContextMenu } from '$lib/stores/context_menu';
   import { goto } from '$app/navigation';
+  import {
+    getCachedMoodCategories,
+    putCachedMoodCategories,
+    clearCachedMoods,
+  } from '$lib/stores/tidal-moods-cache';
 
   type State = 'loading' | 'ready' | 'empty' | 'disconnected' | 'error';
 
-  let categories = $state<TidalMoodCategory[]>([]);
-  let viewState = $state<State>('loading');
+  // Sync-read the cache on script init so revisiting /moods within the
+  // 6h TTL renders instantly without a skeleton flash. Mirrors the
+  // home-discover pattern.
+  const cachedOnMount = getCachedMoodCategories();
+  let categories = $state<TidalMoodCategory[]>(cachedOnMount ?? []);
+  let viewState = $state<State>(
+    cachedOnMount && cachedOnMount.length > 0 ? 'ready' : 'loading'
+  );
 
-  onMount(load);
+  onMount(() => {
+    if (cachedOnMount && cachedOnMount.length > 0) return;
+    void load();
+  });
 
   $effect(() => {
     if ($tidalStatus !== 'connected') return;
@@ -23,9 +37,11 @@
     try {
       const data = await api.getTidalMoods();
       categories = data.categories ?? [];
+      if (categories.length > 0) putCachedMoodCategories(categories);
       viewState = categories.length > 0 ? 'ready' : 'empty';
     } catch (e) {
       if (e instanceof ApiError && e.status === 503) {
+        clearCachedMoods();
         viewState = 'disconnected';
       } else {
         viewState = 'error';

--- a/frontend/src/routes/moods/[slug]/+page.svelte
+++ b/frontend/src/routes/moods/[slug]/+page.svelte
@@ -4,6 +4,7 @@
   import { ApiError, api, type TidalHomeModule } from '$lib/api/client';
   import { tidalStatus } from '$lib/stores/tidal';
   import TidalDiscoverShelves from '$lib/components/search/TidalDiscoverShelves.svelte';
+  import { getCachedMoodPage, putCachedMoodPage } from '$lib/stores/tidal-moods-cache';
 
   type State = 'loading' | 'ready' | 'empty' | 'disconnected' | 'error';
 
@@ -32,11 +33,19 @@
   });
 
   async function load(s: string) {
-    viewState = 'loading';
     title = humanize(s);
+    // Cache hit: render immediately without a skeleton, no network call.
+    const cached = getCachedMoodPage(s);
+    if (cached && cached.length > 0) {
+      modules = cached;
+      viewState = 'ready';
+      return;
+    }
+    viewState = 'loading';
     try {
       const data = await api.getTidalMoodPage(s);
       modules = data.modules ?? [];
+      if (modules.length > 0) putCachedMoodPage(s, modules);
       viewState = modules.length > 0 ? 'ready' : 'empty';
     } catch (e) {
       if (e instanceof ApiError && e.status === 503) {

--- a/frontend/src/routes/moods/[slug]/+page.svelte
+++ b/frontend/src/routes/moods/[slug]/+page.svelte
@@ -1,0 +1,89 @@
+<script lang="ts">
+  import { page } from '$app/stores';
+  import { onMount, untrack } from 'svelte';
+  import { ApiError, api, type TidalHomeModule } from '$lib/api/client';
+  import { tidalStatus } from '$lib/stores/tidal';
+  import TidalDiscoverShelves from '$lib/components/search/TidalDiscoverShelves.svelte';
+
+  type State = 'loading' | 'ready' | 'empty' | 'disconnected' | 'error';
+
+  const slug = $derived($page.params.slug ?? '');
+
+  let modules = $state<TidalHomeModule[]>([]);
+  let viewState = $state<State>('loading');
+  let title = $state('');
+  let requestedSlug = $state('');
+
+  onMount(() => { if (slug) void load(slug); });
+
+  $effect(() => {
+    const s = slug.trim();
+    if (!s) return;
+    if (s !== requestedSlug) {
+      requestedSlug = s;
+      void load(s);
+    }
+  });
+
+  $effect(() => {
+    if ($tidalStatus !== 'connected') return;
+    const cur = untrack(() => viewState);
+    if (cur !== 'loading' && cur !== 'ready' && slug) void load(slug);
+  });
+
+  async function load(s: string) {
+    viewState = 'loading';
+    title = humanize(s);
+    try {
+      const data = await api.getTidalMoodPage(s);
+      modules = data.modules ?? [];
+      viewState = modules.length > 0 ? 'ready' : 'empty';
+    } catch (e) {
+      if (e instanceof ApiError && e.status === 503) {
+        viewState = 'disconnected';
+      } else {
+        viewState = 'error';
+      }
+    }
+  }
+
+  function humanize(s: string): string {
+    return s
+      .replace(/^mood_/, '')
+      .replace(/^m_/, '')
+      .replace(/_/g, ' ')
+      .replace(/\b\w/g, (c) => c.toUpperCase());
+  }
+</script>
+
+<svelte:head><title>{title || 'Mood'} . NOOR</title></svelte:head>
+
+<div class="page">
+  <a class="back-link" href="/moods">&lt; All moods</a>
+  <header class="page-header">
+    <p class="eyebrow">TIDAL mood</p>
+    <h1>{title || '...'}</h1>
+  </header>
+  {#if viewState === 'loading'}
+    <p class="muted-line">Loading {title}...</p>
+  {:else if viewState === 'ready'}
+    <TidalDiscoverShelves {modules} />
+  {:else if viewState === 'empty'}
+    <p class="muted-line">No content for this mood right now. <button class="inline-link" onclick={() => slug && load(slug)}>Retry</button></p>
+  {:else if viewState === 'disconnected'}
+    <p class="muted-line">Connect TIDAL to see moods. <a class="inline-link" href="/settings#sources-tidal">Open settings</a></p>
+  {:else if viewState === 'error'}
+    <p class="muted-line">Couldn't load this mood. <button class="inline-link" onclick={() => slug && load(slug)}>Retry</button></p>
+  {/if}
+</div>
+
+<style>
+  .page { max-width: var(--content-width); margin: 0 auto; padding: 32px 28px 96px; display: flex; flex-direction: column; gap: 24px; }
+  .back-link { align-self: flex-start; font-size: var(--font-size-sm); color: var(--text-secondary); text-decoration: none; }
+  .back-link:hover { color: var(--text-primary); text-decoration: underline; }
+  .page-header { display: flex; flex-direction: column; gap: 4px; }
+  .eyebrow { font-size: var(--font-size-xs); letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-secondary); margin: 0; }
+  .page-header h1 { margin: 0; font-size: var(--font-size-3xl); font-weight: 800; }
+  .muted-line { margin: 0; font-size: var(--font-size-sm); color: var(--text-secondary); }
+  .inline-link { background: none; border: none; padding: 0; font: inherit; color: var(--accent-line); cursor: pointer; text-decoration: underline; text-underline-offset: 2px; margin-left: var(--space-1); }
+</style>

--- a/frontend/src/routes/moods/[slug]/+page.svelte
+++ b/frontend/src/routes/moods/[slug]/+page.svelte
@@ -4,11 +4,14 @@
   import { ApiError, api, type TidalHomeModule } from '$lib/api/client';
   import { tidalStatus } from '$lib/stores/tidal';
   import TidalDiscoverShelves from '$lib/components/search/TidalDiscoverShelves.svelte';
+  import SpotifyMoodRail from '$lib/components/moods/SpotifyMoodRail.svelte';
+  import { SPOTIFY_MOODS_BY_SLUG } from '$lib/components/moods/spotify-moods-data';
   import { getCachedMoodPage, putCachedMoodPage } from '$lib/stores/tidal-moods-cache';
 
   type State = 'loading' | 'ready' | 'empty' | 'disconnected' | 'error';
 
   const slug = $derived($page.params.slug ?? '');
+  const spotifyCategory = $derived(SPOTIFY_MOODS_BY_SLUG.get(slug) ?? null);
 
   let modules = $state<TidalHomeModule[]>([]);
   let viewState = $state<State>('loading');
@@ -73,6 +76,14 @@
     <p class="eyebrow">TIDAL mood</p>
     <h1>{title || '...'}</h1>
   </header>
+
+  {#if spotifyCategory}
+    <section class="spotify-block">
+      <p class="eyebrow spotify">Spotify . {spotifyCategory.label}</p>
+      <SpotifyMoodRail category={spotifyCategory} />
+    </section>
+  {/if}
+
   {#if viewState === 'loading'}
     <p class="muted-line">Loading {title}...</p>
   {:else if viewState === 'ready'}
@@ -95,4 +106,6 @@
   .page-header h1 { margin: 0; font-size: var(--font-size-3xl); font-weight: 800; }
   .muted-line { margin: 0; font-size: var(--font-size-sm); color: var(--text-secondary); }
   .inline-link { background: none; border: none; padding: 0; font: inherit; color: var(--accent-line); cursor: pointer; text-decoration: underline; text-underline-offset: 2px; margin-left: var(--space-1); }
+  .spotify-block { display: flex; flex-direction: column; gap: var(--space-2); }
+  .eyebrow.spotify { font-size: var(--font-size-xs); letter-spacing: 0.08em; text-transform: uppercase; color: var(--service-spotify); font-weight: var(--font-weight-bold); margin: 0; }
 </style>

--- a/frontend/src/routes/search/+page.svelte
+++ b/frontend/src/routes/search/+page.svelte
@@ -3,7 +3,6 @@
   import { goto, beforeNavigate } from '$app/navigation'
   import type { Snapshot } from './$types'
   import { api, type TidalSearchResults, type TidalSearchAlbum, type TidalSearchArtist, type TidalSearchTrack, type AudioSearchResult, type AudioSearchParams, type Genre, type VibeTrack, type BasicTrack, type Playlist, type TidalSearchPlaylist, type SpotifyPlaylistSearchItem, type SpotifyTrackSearchItem, type SpotifyAlbumSearchItem, type SearchResults } from '$lib/api/client'
-  import TrendingShelf from '$lib/components/charts/TrendingShelf.svelte'
   import DiscoverShelves from '$lib/components/search/DiscoverShelves.svelte'
   import { buildTidalTrackMenu, buildTrackMenu } from '$lib/player/track_menu'
   import { buildAlbumMenu } from '$lib/player/album_menu'
@@ -1056,10 +1055,6 @@
 
     <section class="results-section discover-shelves-section">
       <DiscoverShelves />
-    </section>
-
-    <section class="results-section">
-      <TrendingShelf limit={25} />
     </section>
 
     {#if recent.length === 0}

--- a/frontend/src/routes/search/+page.svelte
+++ b/frontend/src/routes/search/+page.svelte
@@ -2,7 +2,7 @@
   import { onMount } from 'svelte'
   import { goto, beforeNavigate } from '$app/navigation'
   import type { Snapshot } from './$types'
-  import { api, type TidalSearchResults, type TidalSearchAlbum, type TidalSearchArtist, type TidalSearchTrack, type AudioSearchResult, type AudioSearchParams, type Genre, type VibeTrack, type BasicTrack, type Playlist, type TidalSearchPlaylist, type SpotifyPlaylistSearchItem, type SpotifyTrackSearchItem, type SpotifyAlbumSearchItem, type SpotifyArtistSearchItem, type SearchResults } from '$lib/api/client'
+  import { api, type TidalSearchResults, type TidalSearchAlbum, type TidalSearchArtist, type TidalSearchTrack, type AudioSearchResult, type AudioSearchParams, type Genre, type VibeTrack, type BasicTrack, type Playlist, type TidalSearchPlaylist, type SpotifyPlaylistSearchItem, type SpotifyTrackSearchItem, type SpotifyAlbumSearchItem, type SearchResults } from '$lib/api/client'
   import TrendingShelf from '$lib/components/charts/TrendingShelf.svelte'
   import DiscoverShelves from '$lib/components/search/DiscoverShelves.svelte'
   import { buildTidalTrackMenu, buildTrackMenu } from '$lib/player/track_menu'
@@ -62,7 +62,6 @@
   let loadingSpotifyPlaylists = $state(false)
   let loadingSpotifyTracks = $state(false)
   let loadingSpotifyAlbums = $state(false)
-  let loadingSpotifyArtists = $state(false)
   const providerSearchDone = $derived(
     !loadingLocal
     && !loadingTidal
@@ -70,7 +69,6 @@
     && !loadingSpotifyPlaylists
     && !loadingSpotifyTracks
     && !loadingSpotifyAlbums
-    && !loadingSpotifyArtists
   )
   let error = $state<string | null>(null)
   let failedArtistImages = $state(new Set<number>())
@@ -105,7 +103,6 @@
   let spotifyPlaylistResults = $state<SpotifyPlaylistSearchItem[]>([])
   let spotifyTrackResults = $state<SpotifyTrackSearchItem[]>([])
   let spotifyAlbumResults = $state<SpotifyAlbumSearchItem[]>([])
-  let spotifyArtistResults = $state<SpotifyArtistSearchItem[]>([])
 
   type FilterMode = 'all' | 'artists' | 'albums' | 'tracks' | 'library' | 'playlists'
   let filterMode = $state<FilterMode>('all')
@@ -122,10 +119,8 @@
   let hasMoreSpotifyPlaylists = $state(true)
   let spotifyTrackOffset = $state(0)
   let spotifyAlbumOffset = $state(0)
-  let spotifyArtistOffset = $state(0)
   let hasMoreSpotifyTracks = $state(true)
   let hasMoreSpotifyAlbums = $state(true)
-  let hasMoreSpotifyArtists = $state(true)
   let loadingMore = $state(false)
   let lastQuery = $state('')
 
@@ -185,7 +180,6 @@
     loadingSpotifyPlaylists = false
     loadingSpotifyTracks = false
     loadingSpotifyAlbums = false
-    loadingSpotifyArtists = false
   }
 
   function isCurrentSearch(q: string, generation: number, signal: AbortSignal) {
@@ -255,7 +249,6 @@
           spotifyPlaylistResults = []
           spotifyTrackResults = []
           spotifyAlbumResults = []
-          spotifyArtistResults = []
         } else {
           audioResults = null
           // Reset paging — every fresh query starts at offset 0.
@@ -264,16 +257,13 @@
           spotifyPlaylistOffset = 0
           spotifyTrackOffset = 0
           spotifyAlbumOffset = 0
-          spotifyArtistOffset = 0
           hasMoreTidal = true
           hasMoreTidalPlaylists = true
           hasMoreSpotifyPlaylists = true
           hasMoreSpotifyTracks = true
           hasMoreSpotifyAlbums = true
-          hasMoreSpotifyArtists = true
           spotifyTrackResults = []
           spotifyAlbumResults = []
-          spotifyArtistResults = []
           lastQuery = q
           const cacheKey = q.toLowerCase()
           const cached = resultCache.get(cacheKey)
@@ -283,7 +273,6 @@
           loadingSpotifyPlaylists = true
           loadingSpotifyTracks = true
           loadingSpotifyAlbums = true
-          loadingSpotifyArtists = true
 
           const localPromise = api.search(q, SEARCH_PAGE_SIZE)
           const tracksPromise = cached
@@ -293,7 +282,6 @@
           const spotifyPlaylistPromise = api.searchSpotifyPlaylists(q, SEARCH_PAGE_SIZE, signal, 0)
           const spotifyTrackSearchPromise = api.searchSpotifyTracks(q, SEARCH_PAGE_SIZE, signal, 0)
           const spotifyAlbumSearchPromise = api.searchSpotifyAlbums(q, SEARCH_PAGE_SIZE, signal, 0)
-          const spotifyArtistSearchPromise = api.searchSpotifyArtists(q, SEARCH_PAGE_SIZE, signal, 0)
 
           let localSnapshot: SearchResults | null = null
           let tidalSnapshot: TidalSearchResults | null = cached ?? null
@@ -373,16 +361,6 @@
             loadingSpotifyAlbums = false
           })
 
-          void spotifyArtistSearchPromise.then((items) => {
-            if (!isCurrentSearch(q, generation, signal)) return
-            spotifyArtistResults = items
-            spotifyArtistOffset = items.length
-            if (items.length < SEARCH_PAGE_SIZE) hasMoreSpotifyArtists = false
-          }).catch(() => undefined).finally(() => {
-            if (!isCurrentSearch(q, generation, signal)) return
-            loadingSpotifyArtists = false
-          })
-
           await Promise.allSettled([
             localPromise,
             tracksPromise,
@@ -390,7 +368,6 @@
             spotifyPlaylistPromise,
             spotifyTrackSearchPromise,
             spotifyAlbumSearchPromise,
-            spotifyArtistSearchPromise,
           ])
         }
         if (isCurrentSearch(q, generation, signal)) {
@@ -431,8 +408,7 @@
       filterMode === 'playlists' && (hasMoreTidalPlaylists || hasMoreSpotifyPlaylists)
     const needsSpotifyTracks = filterMode === 'tracks' && hasMoreSpotifyTracks
     const needsSpotifyAlbums = filterMode === 'albums' && hasMoreSpotifyAlbums
-    const needsSpotifyArtists = filterMode === 'artists' && hasMoreSpotifyArtists
-    if (!needsTidal && !needsPlaylists && !needsSpotifyTracks && !needsSpotifyAlbums && !needsSpotifyArtists) return
+    if (!needsTidal && !needsPlaylists && !needsSpotifyTracks && !needsSpotifyAlbums) return
 
     loadingMore = true
     try {
@@ -523,20 +499,6 @@
               .catch(() => { hasMoreSpotifyAlbums = false }),
           )
         }
-        if (filterMode === 'artists' && hasMoreSpotifyArtists) {
-          spotifyTasks.push(
-            api
-              .searchSpotifyArtists(lastQuery, SEARCH_PAGE_SIZE, undefined, spotifyArtistOffset)
-              .then((items) => {
-                const seen = new Set(spotifyArtistResults.map((a) => a.spotifyId))
-                const fresh = items.filter((a) => !seen.has(a.spotifyId))
-                spotifyArtistResults = [...spotifyArtistResults, ...fresh]
-                spotifyArtistOffset += items.length
-                if (items.length < SEARCH_PAGE_SIZE) hasMoreSpotifyArtists = false
-              })
-              .catch(() => { hasMoreSpotifyArtists = false }),
-          )
-        }
         if (spotifyTasks.length > 0) await Promise.allSettled(spotifyTasks)
       }
     } finally {
@@ -625,7 +587,6 @@
     isEmpty &&
     spotifyTrackResults.length === 0 &&
     spotifyAlbumResults.length === 0 &&
-    spotifyArtistResults.length === 0 &&
     spotifyPlaylistResults.length === 0 &&
     tidalPlaylistResults.length === 0 &&
     filteredPlaylists.local.length === 0
@@ -639,7 +600,6 @@
     sortedArtists.length === 0 &&
     !((filterMode === 'all' || filterMode === 'tracks') && spotifyTrackResults.length > 0) &&
     !((filterMode === 'all' || filterMode === 'albums') && spotifyAlbumResults.length > 0) &&
-    !((filterMode === 'all' || filterMode === 'artists') && spotifyArtistResults.length > 0) &&
     !(showPlaylists && (filteredPlaylists.local.length > 0 || filteredPlaylists.tidal.length > 0 || filteredPlaylists.spotify.length > 0))
   )
 
@@ -1270,29 +1230,6 @@
       </section>
     {/if}
 
-    {#if (filterMode === 'all' || filterMode === 'artists') && spotifyArtistResults.length > 0}
-      <section class="results-section spotify-section">
-        <h3 class="section-label">Spotify artists</h3>
-        <div class="spotify-card-rail" use:wheelToHorizontal>
-          {#each spotifyArtistResults as a (a.spotifyId)}
-            <a
-              class="spotify-card"
-              href={`/spotify-artist/${a.spotifyId}`}
-              oncontextmenu={(e) => { e.preventDefault(); openContextMenu(e, [{ label: 'Open artist', onSelect: () => void goto(`/spotify-artist/${a.spotifyId}`) }], a.name ?? 'Spotify artist') }}
-            >
-              {#if a.thumbnail}
-                <div class="art round" style="background-image:url('{a.thumbnail}')"></div>
-              {:else}
-                <div class="art round fallback">@</div>
-              {/if}
-              <span class="card-title">{a.name ?? '-'}</span>
-              {#if a.followers !== null}<span class="card-sub">{Intl.NumberFormat().format(a.followers)} followers</span>{/if}
-            </a>
-          {/each}
-        </div>
-      </section>
-    {/if}
-
     {#if sortedAlbums.length > 0}
       <section class="results-section">
         <h3 class="section-label">Albums</h3>
@@ -1751,7 +1688,7 @@
         {:else if (
           (filterMode === 'tracks' && !hasMoreTidal && !hasMoreSpotifyTracks) ||
           (filterMode === 'albums' && !hasMoreTidal && !hasMoreSpotifyAlbums) ||
-          (filterMode === 'artists' && !hasMoreTidal && !hasMoreSpotifyArtists) ||
+          (filterMode === 'artists' && !hasMoreTidal) ||
           (filterMode === 'playlists' && !hasMoreTidalPlaylists && !hasMoreSpotifyPlaylists)
         )}
           <span class="infinite-end">- end of results -</span>
@@ -2510,7 +2447,6 @@
   .spotify-card { --card-w: clamp(120px, 11vw, 168px); flex: 0 0 var(--card-w); width: var(--card-w); display: flex; flex-direction: column; gap: var(--space-2); padding: var(--space-2); border-radius: var(--radius-md); text-decoration: none; color: inherit; cursor: pointer; }
   .spotify-card:hover, .spotify-card:focus-visible { background: var(--bg-hover); outline: none; }
   .spotify-card .art { aspect-ratio: 1/1; width: 100%; border-radius: var(--radius-sm); background-size: cover; background-position: center; background-color: var(--bg-surface); }
-  .spotify-card .art.round { border-radius: 50%; }
   .spotify-card .art.fallback { display: flex; align-items: center; justify-content: center; color: var(--text-muted); font-size: var(--font-size-3xl); }
   .spotify-card .card-title { font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
   .spotify-card .card-sub { font-size: var(--font-size-xs); color: var(--text-secondary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }

--- a/frontend/src/routes/search/discover/[id]/+page.svelte
+++ b/frontend/src/routes/search/discover/[id]/+page.svelte
@@ -298,7 +298,7 @@
 		cursor: pointer;
 		font: inherit;
 		color: inherit;
-		transition: background var(--motion-fast) ease, border-color var(--motion-fast) ease;
+		transition: background var(--motion-base), border-color var(--motion-base);
 	}
 	.track-row:hover,
 	.track-row:focus-visible {
@@ -390,7 +390,7 @@
 		cursor: pointer;
 		font: inherit;
 		color: inherit;
-		transition: background var(--motion-fast) ease, border-color var(--motion-fast) ease;
+		transition: background var(--motion-fast), border-color var(--motion-fast);
 	}
 	.card:hover,
 	.card:focus-visible {
@@ -421,7 +421,7 @@
 		height: 100%;
 		background-size: cover;
 		background-position: center;
-		transition: transform var(--motion-base) ease;
+		transition: transform var(--motion-base);
 	}
 	.card:hover .art,
 	.track-row:hover .art {

--- a/frontend/src/routes/spotify-album/[id]/+page.svelte
+++ b/frontend/src/routes/spotify-album/[id]/+page.svelte
@@ -374,7 +374,7 @@
 
   .shelf h2 { font-size: var(--font-size-lg); font-weight: var(--font-weight-bold); margin: 0 0 12px; }
   .card-rail { display: flex; gap: var(--gap-sm); overflow-x: auto; padding-bottom: var(--space-2); scroll-snap-type: x mandatory; }
-  .card { --card-w: clamp(120px, 11vw, 168px); flex: 0 0 var(--card-w); width: var(--card-w); display: flex; flex-direction: column; gap: var(--space-2); padding: var(--space-2); border-radius: var(--radius-md); text-decoration: none; color: inherit; cursor: pointer; transition: background var(--motion-fast) ease; }
+  .card { --card-w: clamp(120px, 11vw, 168px); flex: 0 0 var(--card-w); width: var(--card-w); display: flex; flex-direction: column; gap: var(--space-2); padding: var(--space-2); border-radius: var(--radius-md); text-decoration: none; color: inherit; cursor: pointer; transition: background var(--motion-fast); }
   .card:hover, .card:focus-visible { background: var(--bg-hover); outline: none; }
   .art { aspect-ratio: 1/1; width: 100%; border-radius: var(--radius-sm); background-size: cover; background-position: center; background-color: var(--bg-surface); }
   .art.fallback { display: flex; align-items: center; justify-content: center; color: var(--text-muted); font-size: var(--font-size-3xl); }

--- a/frontend/src/routes/spotify-artist/[id]/+page.svelte
+++ b/frontend/src/routes/spotify-artist/[id]/+page.svelte
@@ -327,7 +327,7 @@
   .row-btn:hover { background: rgba(255,255,255,.12); color: var(--text-primary); }
 
   .card-rail { display: flex; gap: var(--gap-sm); overflow-x: auto; padding-bottom: var(--space-2); scroll-snap-type: x mandatory; }
-  .card { --card-w: clamp(120px, 11vw, 168px); flex: 0 0 var(--card-w); width: var(--card-w); display: flex; flex-direction: column; gap: var(--space-2); padding: var(--space-2); border-radius: var(--radius-md); text-decoration: none; color: inherit; cursor: pointer; transition: background var(--motion-fast) ease; }
+  .card { --card-w: clamp(120px, 11vw, 168px); flex: 0 0 var(--card-w); width: var(--card-w); display: flex; flex-direction: column; gap: var(--space-2); padding: var(--space-2); border-radius: var(--radius-md); text-decoration: none; color: inherit; cursor: pointer; transition: background var(--motion-fast); }
   .card:hover, .card:focus-visible { background: var(--bg-hover); outline: none; }
   .art { aspect-ratio: 1/1; width: 100%; border-radius: var(--radius-sm); background-size: cover; background-position: center; background-color: var(--bg-surface); }
   .art.round { border-radius: 50%; }

--- a/frontend/src/routes/spotify-playlist/[id]/+page.svelte
+++ b/frontend/src/routes/spotify-playlist/[id]/+page.svelte
@@ -6,6 +6,7 @@
   import { formatTrackDuration } from '$lib/utils/format';
   import {
     api,
+    ApiError,
     type SpotifyPlaylistDetail,
     type SpotifyPlaylistTrack,
     type SpotifyTidalState,
@@ -102,6 +103,12 @@
     saveResult = null;
     saveErr = null;
     lazyArt = {};
+    // Sportify proxy is third-party and flaky. Retry once on 5xx so a
+    // transient upstream hiccup doesn't surface as a hard failure.
+    await attemptLoad(id, /* retryOn5xx */ true);
+  }
+
+  async function attemptLoad(id: string, retryOn5xx: boolean) {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 15_000);
     try {
@@ -112,15 +119,43 @@
       if (pendingIds.length > 0) {
         pollTimer = setTimeout(pollResolution, POLL_INTERVAL_MS);
       }
+      loading = false;
     } catch (e) {
-      error =
-        (e as Error).name === 'AbortError'
-          ? 'Timed out loading playlist metadata'
-          : ((e as Error).message ?? 'Failed to load playlist');
+      clearTimeout(timeout);
+      const is5xx = e instanceof ApiError && e.status >= 500 && e.status < 600;
+      if (is5xx && retryOn5xx) {
+        // One automatic retry after a short delay for transient proxy outages.
+        await new Promise((r) => setTimeout(r, 2_000));
+        if (spotifyId.trim() === id) {
+          await attemptLoad(id, /* retryOn5xx */ false);
+          return;
+        }
+      }
+      error = friendlyError(e);
+      loading = false;
     } finally {
       clearTimeout(timeout);
-      loading = false;
     }
+  }
+
+  function friendlyError(e: unknown): string {
+    if ((e as Error)?.name === 'AbortError') {
+      return 'Timed out loading playlist metadata. Try again in a moment.';
+    }
+    if (e instanceof ApiError) {
+      if (e.status === 503 || e.status === 502 || e.status === 504) {
+        return 'The Spotify metadata proxy is temporarily unavailable. Try again in a minute.';
+      }
+      if (e.status === 404) {
+        return 'Playlist not found on Spotify.';
+      }
+    }
+    return (e as Error).message ?? 'Failed to load playlist';
+  }
+
+  function retry() {
+    const id = spotifyId.trim();
+    if (id) void load(id);
   }
 
   $effect(() => {
@@ -343,7 +378,10 @@
   {#if loading}
     <div class="state">Loading playlist…</div>
   {:else if error}
-    <div class="state error">Couldn't load this playlist: {error}</div>
+    <div class="state error">
+      <p>Couldn't load this playlist: {error}</p>
+      <button type="button" class="retry-btn" onclick={retry}>Retry</button>
+    </div>
   {:else if detail}
     <header class="header">
       {#if detail.thumbnail}
@@ -491,7 +529,10 @@
     margin-bottom: var(--space-3);
   }
   .state { padding: 80px 0; text-align: center; color: var(--text-muted); }
-  .state.error { color: #ef4444; }
+  .state.error { color: #ef4444; display: flex; flex-direction: column; align-items: center; gap: var(--space-3); }
+  .state.error p { margin: 0; }
+  .retry-btn { padding: 8px 18px; border-radius: 999px; background: var(--bg-hover); border: 1px solid var(--panel-border); color: var(--text-primary); font: inherit; font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); cursor: pointer; transition: background var(--motion-base), border-color var(--motion-base); }
+  .retry-btn:hover, .retry-btn:focus-visible { background: var(--accent-soft); border-color: var(--accent-line); outline: none; }
 
   .header {
     display: grid;

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -8647,7 +8647,7 @@ async fn tidal_search(
         })
         .collect();
 
-    let artists: Vec<TidalSearchArtistResp> = results
+    let mut artists: Vec<TidalSearchArtistResp> = results
         .artists
         .into_iter()
         .map(|a| {
@@ -8661,6 +8661,46 @@ async fn tidal_search(
             }
         })
         .collect();
+
+    // TIDAL's catalog-search response often omits artist `picture`, so most
+    // search-result artists land here with `artwork_url = None` and render as
+    // initials in the UI. The /artists/{id} endpoint carries the canonical
+    // picture; fan out a parallel fetch for any artist still missing artwork
+    // and backfill. Tight cap (12) to bound the fan-out -- artists past that
+    // tend to be long-tail rows the user is unlikely to scroll to anyway.
+    const ARTIST_PHOTO_BACKFILL_CAP: usize = 12;
+    let backfill_targets: Vec<(usize, i64)> = artists
+        .iter()
+        .enumerate()
+        .filter(|(_, a)| a.artwork_url.is_none())
+        .take(ARTIST_PHOTO_BACKFILL_CAP)
+        .map(|(i, a)| (i, a.tidal_id))
+        .collect();
+    if !backfill_targets.is_empty() {
+        let backfill_client = client.clone();
+        let fetches = backfill_targets.iter().map(|(idx, tidal_id)| {
+            let c = backfill_client.clone();
+            let id = *tidal_id;
+            let i = *idx;
+            async move {
+                let url = c
+                    .get_artist(id)
+                    .await
+                    .ok()
+                    .and_then(|a| TidalClient::get_artwork_url(&a.picture, 640));
+                (i, url)
+            }
+        });
+        let results: Vec<(usize, Option<String>)> =
+            futures::future::join_all(fetches).await;
+        for (i, url) in results {
+            if let Some(u) = url {
+                if let Some(slot) = artists.get_mut(i) {
+                    slot.artwork_url = Some(u);
+                }
+            }
+        }
+    }
 
     let videos: Vec<TidalSearchVideoResp> = results
         .videos

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -720,10 +720,7 @@ pub fn api_routes(state: SharedState) -> Router {
         // which aren't tracks/albums/playlists, so they go through a parser
         // that just extracts category metadata. Drill-down then proxies to
         // the corresponding pages/{slug} TIDAL endpoint.
-        .route(
-            "/api/tidal/moods",
-            get(tidal_home_routes::get_tidal_moods),
-        )
+        .route("/api/tidal/moods", get(tidal_home_routes::get_tidal_moods))
         .route(
             "/api/tidal/mood-page/{slug}",
             get(tidal_home_routes::get_tidal_mood_page),
@@ -8691,8 +8688,7 @@ async fn tidal_search(
                 (i, url)
             }
         });
-        let results: Vec<(usize, Option<String>)> =
-            futures::future::join_all(fetches).await;
+        let results: Vec<(usize, Option<String>)> = futures::future::join_all(fetches).await;
         for (i, url) in results {
             if let Some(u) = url {
                 if let Some(slot) = artists.get_mut(i) {

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -716,6 +716,18 @@ pub fn api_routes(state: SharedState) -> Router {
             "/api/tidal/page/{section}/{id}",
             get(tidal_home_routes::get_tidal_page_modules_with_id),
         )
+        // Dedicated mood routes: the moods landing returns PAGE_LINKS items,
+        // which aren't tracks/albums/playlists, so they go through a parser
+        // that just extracts category metadata. Drill-down then proxies to
+        // the corresponding pages/{slug} TIDAL endpoint.
+        .route(
+            "/api/tidal/moods",
+            get(tidal_home_routes::get_tidal_moods),
+        )
+        .route(
+            "/api/tidal/mood-page/{slug}",
+            get(tidal_home_routes::get_tidal_mood_page),
+        )
         // Trending / charts (Phase 5)
         .route("/api/charts", get(chart_routes::get_charts))
         .route(
@@ -13529,8 +13541,9 @@ mod tests {
             ("GET", "/api/tidal/radio-stations"),
             ("GET", "/api/tidal/home-modules"),
             ("GET", "/api/tidal/discover-modules/1/items"),
-            ("GET", "/api/tidal/page/charts"),
             ("GET", "/api/tidal/page/mood/1"),
+            ("GET", "/api/tidal/moods"),
+            ("GET", "/api/tidal/mood-page/mood_party"),
             ("GET", "/api/charts"),
             ("GET", "/api/charts/lastfm/genres"),
             ("GET", "/api/charts/lastfm/countries"),

--- a/noor-server/src/server/routes/tidal_home_routes.rs
+++ b/noor-server/src/server/routes/tidal_home_routes.rs
@@ -415,10 +415,12 @@ pub(super) async fn get_tidal_page_modules_with_id(
 fn resolve_page_path(section: &str, id: Option<&str>) -> Result<String, StatusCode> {
     let section = section.trim_matches('/');
     // `charts` and `genres`/`new_releases` slugs aren't valid TIDAL endpoints
-    // (verified live: all 404 with subStatus 2001 "Not found"). Kept `moods`
-    // because that one does respond 200; its module shape just isn't parsed
-    // yet (see FOLLOWUPS).
-    let allowed_top = matches!(section, "moods");
+    // (verified live: all 404 with subStatus 2001 "Not found"). `moods` now
+    // has its own dedicated route at /api/tidal/moods + /api/tidal/mood-page/{slug}
+    // because its modules are PAGE_LINKS, not the usual TRACK_LIST/etc shape.
+    // Empty top-level whitelist for now — this generic route is kept for
+    // future slugs (pages/explore, pages/hires, pages/videos, etc).
+    let allowed_top = matches!(section, "");
     let allowed_with_id = matches!(section, "mood" | "genre");
     let valid = (id.is_none() && allowed_top) || (id.is_some() && allowed_with_id);
     if !valid {
@@ -521,6 +523,139 @@ async fn fetch_page_modules(
     Ok(Json(
         json!({ "modules": modules, "source": "tidal", "page": page_path }),
     ))
+}
+
+/// Returns the TIDAL mood / activity category list, parsed out of the
+/// PAGE_LINKS module on `/v1/pages/moods`. Each entry carries the upstream
+/// slug (e.g. `mood_party`) which the `/api/tidal/mood-page/{slug}` route
+/// then proxies as `pages/{slug}` for the drill-down content.
+pub(super) async fn get_tidal_moods(
+    State(state): State<SharedState>,
+) -> Result<Json<Value>, StatusCode> {
+    let (tokens, http_client, tidal_http_client) = load_tidal_session(&state).await;
+    let Some(tokens) = tokens else {
+        return Err(StatusCode::SERVICE_UNAVAILABLE);
+    };
+    let client = TidalClient::with_http(
+        tidal_http_client.clone(),
+        tokens.access_token.clone(),
+        tokens.country_code.clone(),
+    );
+    let raw = match client.get_page_raw("pages/moods").await {
+        Ok(r) => r,
+        Err(e) if super::error_looks_like_auth(&e) => {
+            let refreshed = super::recover_tidal_session(&state, &http_client, &tokens)
+                .await
+                .map_err(|_| StatusCode::BAD_GATEWAY)?;
+            let retry = TidalClient::with_http(
+                tidal_http_client,
+                refreshed.access_token.clone(),
+                refreshed.country_code.clone(),
+            );
+            retry.get_page_raw("pages/moods").await.map_err(|e| {
+                tracing::warn!("TIDAL get_tidal_moods failed after refresh: {e}");
+                StatusCode::BAD_GATEWAY
+            })?
+        }
+        Err(e) => {
+            tracing::warn!("TIDAL get_tidal_moods failed: {e}");
+            return Err(StatusCode::BAD_GATEWAY);
+        }
+    };
+    let categories = extract_page_links(&raw);
+    Ok(Json(json!({ "categories": categories, "source": "tidal" })))
+}
+
+/// Walks `rows[].modules[]` and pulls items from any module of `type ==
+/// "PAGE_LINKS"`. TIDAL uses this shape for nav-style content (moods,
+/// activity categories, sub-section links) -- the items are link metadata,
+/// not playable rows.
+fn extract_page_links(payload: &Value) -> Vec<Value> {
+    let mut out = Vec::new();
+    let Some(rows) = payload.get("rows").and_then(|v| v.as_array()) else {
+        return out;
+    };
+    for row in rows {
+        let Some(modules) = row.get("modules").and_then(|v| v.as_array()) else {
+            continue;
+        };
+        for module in modules {
+            let kind = module.get("type").and_then(|v| v.as_str()).unwrap_or("");
+            if kind != "PAGE_LINKS" {
+                continue;
+            }
+            let Some(items) = module
+                .get("pagedList")
+                .and_then(|p| p.get("items"))
+                .and_then(|v| v.as_array())
+            else {
+                continue;
+            };
+            for item in items {
+                let title = item.get("title").and_then(|v| v.as_str()).unwrap_or("");
+                let api_path = item.get("apiPath").and_then(|v| v.as_str()).unwrap_or("");
+                if title.is_empty() || api_path.is_empty() {
+                    continue;
+                }
+                let slug = api_path.strip_prefix("pages/").unwrap_or(api_path);
+                out.push(json!({
+                    "slug": slug,
+                    "title": title,
+                    "icon": item.get("icon").and_then(|v| v.as_str()),
+                    "imageId": item.get("imageId").and_then(|v| v.as_str()),
+                }));
+            }
+        }
+    }
+    out
+}
+
+/// Drill-down for one mood / activity category. `slug` is the path segment
+/// returned by `/api/tidal/moods` (e.g. `mood_party`) and is proxied to
+/// `pages/{slug}` on TIDAL. Slug pattern is restricted to lowercase
+/// alphanumeric + underscores so callers can't escape the `pages/` namespace.
+pub(super) async fn get_tidal_mood_page(
+    State(state): State<SharedState>,
+    Path(slug): Path<String>,
+) -> Result<Json<Value>, StatusCode> {
+    if slug.is_empty()
+        || slug.len() > 64
+        || !slug
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+    {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+    let wire_path = format!("pages/{}", slug);
+    fetch_page_modules(state, wire_path, false).await
+}
+
+// Shared TIDAL session loader -- mirrors the inline block other handlers use.
+async fn load_tidal_session(
+    state: &SharedState,
+) -> (
+    Option<crate::services::tidal::auth::TidalTokens>,
+    reqwest::Client,
+    reqwest::Client,
+) {
+    let in_memory = {
+        let s = state.read().await;
+        (
+            s.tidal_tokens.clone(),
+            s.http_client.clone(),
+            s.tidal_http_client.clone(),
+        )
+    };
+    match in_memory.0 {
+        Some(t) => (Some(t), in_memory.1, in_memory.2),
+        None => {
+            let persisted = super::load_persisted_tidal_tokens(state)
+                .await
+                .ok()
+                .flatten();
+            (persisted, in_memory.1, in_memory.2)
+        }
+    }
 }
 
 // ─── Last.fm scrobble auth (server-side web-auth flow) ──────────────────────

--- a/noor-server/src/server/routes/tidal_home_routes.rs
+++ b/noor-server/src/server/routes/tidal_home_routes.rs
@@ -562,7 +562,44 @@ pub(super) async fn get_tidal_moods(
             return Err(StatusCode::BAD_GATEWAY);
         }
     };
-    let categories = extract_page_links(&raw);
+    let mut categories = extract_page_links(&raw);
+
+    // TIDAL's moods landing only ships icon glyphs, no cover art for the
+    // categories. Fetch each subpage in parallel and use the first playlist's
+    // artwork as the tile thumbnail. 13 fan-out calls, all hot-cached on
+    // TIDAL's side, so the round-trip stays under a second in practice.
+    let slugs: Vec<String> = categories
+        .iter()
+        .filter_map(|c| c.get("slug").and_then(|s| s.as_str()).map(String::from))
+        .collect();
+    let thumb_client = client.clone();
+    let fetches = slugs.into_iter().map(|slug| {
+        let c = thumb_client.clone();
+        async move {
+            let path = format!("pages/{}", slug);
+            let modules = c.get_page_modules(&path).await.ok()?;
+            let first_module = modules.into_iter().next()?;
+            let first_item = first_module.items.into_iter().next()?;
+            Some((slug, first_item.artwork_url))
+        }
+    });
+    let results: Vec<Option<(String, Option<String>)>> =
+        futures::future::join_all(fetches).await;
+    let thumbs: std::collections::HashMap<String, String> = results
+        .into_iter()
+        .flatten()
+        .filter_map(|(slug, url)| url.map(|u| (slug, u)))
+        .collect();
+    for cat in categories.iter_mut() {
+        let Some(obj) = cat.as_object_mut() else { continue };
+        let Some(slug) = obj.get("slug").and_then(|s| s.as_str()).map(String::from) else {
+            continue;
+        };
+        if let Some(url) = thumbs.get(&slug) {
+            obj.insert("thumbnail".to_string(), Value::String(url.clone()));
+        }
+    }
+
     Ok(Json(json!({ "categories": categories, "source": "tidal" })))
 }
 

--- a/noor-server/src/server/routes/tidal_home_routes.rs
+++ b/noor-server/src/server/routes/tidal_home_routes.rs
@@ -472,10 +472,27 @@ async fn fetch_page_modules(
         tokens.country_code.clone(),
     );
     if debug_raw {
-        let raw = client.get_page_raw(&page_path).await.map_err(|e| {
-            tracing::warn!("TIDAL get_page_raw({page_path}) failed: {e}");
-            StatusCode::BAD_GATEWAY
-        })?;
+        let raw = match client.get_page_raw(&page_path).await {
+            Ok(r) => r,
+            Err(e) if super::error_looks_like_auth(&e) => {
+                let refreshed = super::recover_tidal_session(&state, &http_client, &tokens)
+                    .await
+                    .map_err(|_| StatusCode::BAD_GATEWAY)?;
+                let retry = TidalClient::with_http(
+                    tidal_http_client.clone(),
+                    refreshed.access_token.clone(),
+                    refreshed.country_code.clone(),
+                );
+                retry.get_page_raw(&page_path).await.map_err(|e| {
+                    tracing::warn!("TIDAL get_page_raw({page_path}) failed after refresh: {e}");
+                    StatusCode::BAD_GATEWAY
+                })?
+            }
+            Err(e) => {
+                tracing::warn!("TIDAL get_page_raw({page_path}) failed: {e}");
+                return Err(StatusCode::BAD_GATEWAY);
+            }
+        };
         return Ok(Json(
             json!({ "raw": raw, "source": "tidal", "page": page_path }),
         ));

--- a/noor-server/src/server/routes/tidal_home_routes.rs
+++ b/noor-server/src/server/routes/tidal_home_routes.rs
@@ -414,10 +414,11 @@ pub(super) async fn get_tidal_page_modules_with_id(
 // approved list so callers can't probe arbitrary TIDAL endpoints.
 fn resolve_page_path(section: &str, id: Option<&str>) -> Result<String, StatusCode> {
     let section = section.trim_matches('/');
-    let allowed_top = matches!(
-        section,
-        "charts" | "moods" | "genres" | "new-releases" | "new_releases"
-    );
+    // `charts` and `genres`/`new_releases` slugs aren't valid TIDAL endpoints
+    // (verified live: all 404 with subStatus 2001 "Not found"). Kept `moods`
+    // because that one does respond 200; its module shape just isn't parsed
+    // yet (see FOLLOWUPS).
+    let allowed_top = matches!(section, "moods");
     let allowed_with_id = matches!(section, "mood" | "genre");
     let valid = (id.is_none() && allowed_top) || (id.is_some() && allowed_with_id);
     if !valid {

--- a/noor-server/src/server/routes/tidal_home_routes.rs
+++ b/noor-server/src/server/routes/tidal_home_routes.rs
@@ -602,10 +602,7 @@ pub(super) async fn get_tidal_moods(
     let filtered: Vec<Value> = categories
         .into_iter()
         .filter_map(|mut cat| {
-            let slug = cat
-                .get("slug")
-                .and_then(|s| s.as_str())
-                .map(String::from)?;
+            let slug = cat.get("slug").and_then(|s| s.as_str()).map(String::from)?;
             if let Some((is_empty, thumb)) = probe.get(&slug) {
                 if *is_empty {
                     return None; // drop meta-nav-only categories

--- a/noor-server/src/server/routes/tidal_home_routes.rs
+++ b/noor-server/src/server/routes/tidal_home_routes.rs
@@ -562,12 +562,15 @@ pub(super) async fn get_tidal_moods(
             return Err(StatusCode::BAD_GATEWAY);
         }
     };
-    let mut categories = extract_page_links(&raw);
+    let categories = extract_page_links(&raw);
 
     // TIDAL's moods landing only ships icon glyphs, no cover art for the
-    // categories. Fetch each subpage in parallel and use the first playlist's
-    // artwork as the tile thumbnail. 13 fan-out calls, all hot-cached on
-    // TIDAL's side, so the round-trip stays under a second in practice.
+    // categories. Fetch each subpage in parallel for two reasons:
+    //   1. grab the first playlist's artwork as the tile thumbnail
+    //   2. filter out categories whose subpage has no playable music modules
+    //      (e.g. `record_labels` returns only PAGE_LINKS sub-nav)
+    // ~13 fan-out calls, hot-cached on TIDAL's side, so the round-trip stays
+    // under a second in practice.
     let slugs: Vec<String> = categories
         .iter()
         .filter_map(|c| c.get("slug").and_then(|s| s.as_str()).map(String::from))
@@ -576,31 +579,48 @@ pub(super) async fn get_tidal_moods(
     let fetches = slugs.into_iter().map(|slug| {
         let c = thumb_client.clone();
         async move {
-            let path = format!("pages/{}", slug);
-            let modules = c.get_page_modules(&path).await.ok()?;
-            let first_module = modules.into_iter().next()?;
-            let first_item = first_module.items.into_iter().next()?;
-            Some((slug, first_item.artwork_url))
+            match c.get_page_modules(&format!("pages/{}", slug)).await {
+                Ok(modules) => {
+                    let thumb = modules
+                        .first()
+                        .and_then(|m| m.items.first())
+                        .and_then(|i| i.artwork_url.clone());
+                    Some((slug, modules.is_empty(), thumb))
+                }
+                Err(_) => None,
+            }
         }
     });
-    let results: Vec<Option<(String, Option<String>)>> =
+    let results: Vec<Option<(String, bool, Option<String>)>> =
         futures::future::join_all(fetches).await;
-    let thumbs: std::collections::HashMap<String, String> = results
+    let probe: std::collections::HashMap<String, (bool, Option<String>)> = results
         .into_iter()
         .flatten()
-        .filter_map(|(slug, url)| url.map(|u| (slug, u)))
+        .map(|(slug, is_empty, thumb)| (slug, (is_empty, thumb)))
         .collect();
-    for cat in categories.iter_mut() {
-        let Some(obj) = cat.as_object_mut() else { continue };
-        let Some(slug) = obj.get("slug").and_then(|s| s.as_str()).map(String::from) else {
-            continue;
-        };
-        if let Some(url) = thumbs.get(&slug) {
-            obj.insert("thumbnail".to_string(), Value::String(url.clone()));
-        }
-    }
 
-    Ok(Json(json!({ "categories": categories, "source": "tidal" })))
+    let filtered: Vec<Value> = categories
+        .into_iter()
+        .filter_map(|mut cat| {
+            let slug = cat
+                .get("slug")
+                .and_then(|s| s.as_str())
+                .map(String::from)?;
+            if let Some((is_empty, thumb)) = probe.get(&slug) {
+                if *is_empty {
+                    return None; // drop meta-nav-only categories
+                }
+                if let Some(url) = thumb {
+                    if let Some(obj) = cat.as_object_mut() {
+                        obj.insert("thumbnail".to_string(), Value::String(url.clone()));
+                    }
+                }
+            }
+            Some(cat)
+        })
+        .collect();
+
+    Ok(Json(json!({ "categories": filtered, "source": "tidal" })))
 }
 
 /// Walks `rows[].modules[]` and pulls items from any module of `type ==
@@ -654,6 +674,7 @@ fn extract_page_links(payload: &Value) -> Vec<Value> {
 pub(super) async fn get_tidal_mood_page(
     State(state): State<SharedState>,
     Path(slug): Path<String>,
+    Query(query): Query<HashMap<String, String>>,
 ) -> Result<Json<Value>, StatusCode> {
     if slug.is_empty()
         || slug.len() > 64
@@ -664,7 +685,8 @@ pub(super) async fn get_tidal_mood_page(
         return Err(StatusCode::BAD_REQUEST);
     }
     let wire_path = format!("pages/{}", slug);
-    fetch_page_modules(state, wire_path, false).await
+    let debug_raw = query.get("debug").map(String::as_str) == Some("raw");
+    fetch_page_modules(state, wire_path, debug_raw).await
 }
 
 // Shared TIDAL session loader -- mirrors the inline block other handlers use.

--- a/noor-server/src/server/routes/tidal_home_routes.rs
+++ b/noor-server/src/server/routes/tidal_home_routes.rs
@@ -393,17 +393,21 @@ pub(super) async fn get_tidal_mix_tracks(
 pub(super) async fn get_tidal_page_modules(
     State(state): State<SharedState>,
     Path(section): Path<String>,
+    Query(query): Query<HashMap<String, String>>,
 ) -> Result<Json<Value>, StatusCode> {
     let wire_path = resolve_page_path(&section, None)?;
-    fetch_page_modules(state, wire_path).await
+    let debug_raw = query.get("debug").map(String::as_str) == Some("raw");
+    fetch_page_modules(state, wire_path, debug_raw).await
 }
 
 pub(super) async fn get_tidal_page_modules_with_id(
     State(state): State<SharedState>,
     Path((section, id)): Path<(String, String)>,
+    Query(query): Query<HashMap<String, String>>,
 ) -> Result<Json<Value>, StatusCode> {
     let wire_path = resolve_page_path(&section, Some(id.as_str()))?;
-    fetch_page_modules(state, wire_path).await
+    let debug_raw = query.get("debug").map(String::as_str) == Some("raw");
+    fetch_page_modules(state, wire_path, debug_raw).await
 }
 
 // Whitelist + wire-path normalization. Returns 404 for anything not on the
@@ -435,6 +439,7 @@ fn resolve_page_path(section: &str, id: Option<&str>) -> Result<String, StatusCo
 async fn fetch_page_modules(
     state: SharedState,
     page_path: String,
+    debug_raw: bool,
 ) -> Result<Json<Value>, StatusCode> {
     let (tokens, http_client, tidal_http_client) = {
         let in_memory = {
@@ -465,6 +470,15 @@ async fn fetch_page_modules(
         tokens.access_token.clone(),
         tokens.country_code.clone(),
     );
+    if debug_raw {
+        let raw = client.get_page_raw(&page_path).await.map_err(|e| {
+            tracing::warn!("TIDAL get_page_raw({page_path}) failed: {e}");
+            StatusCode::BAD_GATEWAY
+        })?;
+        return Ok(Json(
+            json!({ "raw": raw, "source": "tidal", "page": page_path }),
+        ));
+    }
     let modules = match client.get_page_modules(&page_path).await {
         Ok(m) => m,
         Err(e) if super::error_looks_like_auth(&e) => {

--- a/noor-server/src/services/tidal/client.rs
+++ b/noor-server/src/services/tidal/client.rs
@@ -758,48 +758,16 @@ impl TidalClient {
     pub async fn get_page_modules(&self, page_path: &str) -> Result<Vec<TidalHomeModule>> {
         let url = Self::build_page_modules_url(TIDAL_API_URL, page_path, &self.country_code, 12);
         let payload: serde_json::Value = self.get_json(&url).await?;
-        // Diagnostic: charts/moods slugs were assumptions in the original plan.
-        // Log the wire-shape so we can confirm whether the endpoint exists, the
-        // payload has a `rows[]`, and how many module-shaped entries it carries
-        // before the parser starts dropping them. Remove once slugs are firmed
-        // up (FOLLOWUPS.md).
-        let top_keys: Vec<&str> = payload
-            .as_object()
-            .map(|o| o.keys().map(String::as_str).collect())
-            .unwrap_or_default();
-        let row_count = payload
-            .get("rows")
-            .and_then(serde_json::Value::as_array)
-            .map(|r| r.len())
-            .unwrap_or(0);
-        let first_module_summary = payload
-            .get("rows")
-            .and_then(|r| r.get(0))
-            .and_then(|row| row.get("modules"))
-            .and_then(|m| m.get(0))
-            .map(|m| {
-                let title = m
-                    .get("title")
-                    .and_then(serde_json::Value::as_str)
-                    .unwrap_or("<no title>");
-                let kind = m
-                    .get("type")
-                    .and_then(serde_json::Value::as_str)
-                    .unwrap_or("<no type>");
-                let item_count = m
-                    .get("pagedList")
-                    .and_then(|p| p.get("items"))
-                    .and_then(serde_json::Value::as_array)
-                    .or_else(|| m.get("items").and_then(serde_json::Value::as_array))
-                    .map(|a| a.len())
-                    .unwrap_or(0);
-                format!("title={title:?}, type={kind:?}, items={item_count}")
-            })
-            .unwrap_or_else(|| "<no modules>".to_string());
-        tracing::warn!(
-            "TIDAL pages probe: path={page_path}, top_keys={top_keys:?}, rows={row_count}, first_module=[{first_module_summary}]"
-        );
         Ok(Self::parse_home_modules(&payload))
+    }
+
+    /// Same fetch as `get_page_modules` but returns the unparsed upstream
+    /// payload. Used by the `?debug=raw` debug query on the page route to
+    /// expose TIDAL's module-type vocabulary while we firm up which slugs and
+    /// shapes we need to handle.
+    pub async fn get_page_raw(&self, page_path: &str) -> Result<serde_json::Value> {
+        let url = Self::build_page_modules_url(TIDAL_API_URL, page_path, &self.country_code, 12);
+        self.get_json(&url).await
     }
 
     fn parse_home_modules(payload: &serde_json::Value) -> Vec<TidalHomeModule> {

--- a/noor-server/src/services/tidal/client.rs
+++ b/noor-server/src/services/tidal/client.rs
@@ -758,6 +758,47 @@ impl TidalClient {
     pub async fn get_page_modules(&self, page_path: &str) -> Result<Vec<TidalHomeModule>> {
         let url = Self::build_page_modules_url(TIDAL_API_URL, page_path, &self.country_code, 12);
         let payload: serde_json::Value = self.get_json(&url).await?;
+        // Diagnostic: charts/moods slugs were assumptions in the original plan.
+        // Log the wire-shape so we can confirm whether the endpoint exists, the
+        // payload has a `rows[]`, and how many module-shaped entries it carries
+        // before the parser starts dropping them. Remove once slugs are firmed
+        // up (FOLLOWUPS.md).
+        let top_keys: Vec<&str> = payload
+            .as_object()
+            .map(|o| o.keys().map(String::as_str).collect())
+            .unwrap_or_default();
+        let row_count = payload
+            .get("rows")
+            .and_then(serde_json::Value::as_array)
+            .map(|r| r.len())
+            .unwrap_or(0);
+        let first_module_summary = payload
+            .get("rows")
+            .and_then(|r| r.get(0))
+            .and_then(|row| row.get("modules"))
+            .and_then(|m| m.get(0))
+            .map(|m| {
+                let title = m
+                    .get("title")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("<no title>");
+                let kind = m
+                    .get("type")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("<no type>");
+                let item_count = m
+                    .get("pagedList")
+                    .and_then(|p| p.get("items"))
+                    .and_then(serde_json::Value::as_array)
+                    .or_else(|| m.get("items").and_then(serde_json::Value::as_array))
+                    .map(|a| a.len())
+                    .unwrap_or(0);
+                format!("title={title:?}, type={kind:?}, items={item_count}")
+            })
+            .unwrap_or_else(|| "<no modules>".to_string());
+        tracing::warn!(
+            "TIDAL pages probe: path={page_path}, top_keys={top_keys:?}, rows={row_count}, first_module=[{first_module_summary}]"
+        );
         Ok(Self::parse_home_modules(&payload))
     }
 

--- a/noor-server/src/services/tidal/client.rs
+++ b/noor-server/src/services/tidal/client.rs
@@ -780,14 +780,15 @@ impl TidalClient {
                 continue;
             };
             for module in modules {
+                // Module title can be empty on single-module subpages (TIDAL
+                // doesn't repeat the page title inside the module). We only
+                // skip when both the title AND the items list are empty --
+                // i.e. nothing useful to render.
                 let title = module
                     .get("title")
                     .and_then(serde_json::Value::as_str)
                     .unwrap_or_default()
                     .to_string();
-                if title.is_empty() {
-                    continue;
-                }
                 let id = module
                     .get("id")
                     .and_then(serde_json::Value::as_str)


### PR DESCRIPTION
## Summary

Follow-up polish for the discovery work merged in [#45](https://github.com/biggiesmallcap-blip/NOORwave/pull/45). 23 commits, no backend ABI changes.

### Diagnostics + investigations
- Added `?debug=raw` to `/api/tidal/page/*` (with auth refresh) to probe upstream payload shape; left in for future investigations.
- Logged module/item parser dropouts to confirm why moods/charts originally rendered empty.

### Charts page
- TIDAL `pages/charts` doesn't actually exist upstream — replaced with hardcoded Spotify chart-playlist tiles routed through the existing `/spotify-playlist/{id}` flow.
- Dropped Viral 50 Global (Sportify proxy returns hard 503 for that ID specifically; FOLLOWUPS entry added).

### Moods
- Dedicated `/moods` landing + `/moods/[slug]` drill-down powered by new `/api/tidal/moods` + `/api/tidal/mood-page/{slug}` routes that fetch each whitelisted mood subpage in parallel and backfill thumbnails from the first playlist artwork.
- Filtered out `record_labels` and other meta-nav categories.
- Curated Spotify mood playlists rail on each drill-down (matches mood -> Spotify mood IDs).
- 6h cache shared between home preview + landing + drill-down so revisits are instant.

### Home
- Removed redundant Last.fm Releases section.
- Moved TrendingShelf to /charts.
- Added moods preview rail.
- Skeleton + cache means the rail no longer blocks render on cold load.

### Search
- Backfill missing TIDAL artist photos via parallel `/artists/{id}` fan-out (cap 12).
- Removed Spotify-artist section (proxy thumbnails were broken).
- Removed Last.fm trending shelf from the empty-search state (lives on /charts now).

### Styling — every card tile now uses the canonical hover
- **Root-cause fix:** `var(--motion-base) ease` was invalid CSS (token already embeds `cubic-bezier(0.25, 0.8, 0.25, 1)`). Browsers silently dropped the entire transition so hovers snapped. Stripped trailing `ease` across 12 card files so the soft 210ms ease-out plays everywhere — matches the Last.fm trending tile feel.
- All card surfaces now use `--motion-base` for bg/border + art zoom, `--bg-hover` art-wrap bg, `--panel-border` hover border, `--font-size-4xl` muted-glyph fallback.
- Dropped misleading PlayOverlay from nav-only cards (mood tiles, chart tiles, mood rail).
- STYLING.md has a new "Motion footgun" section to prevent the regression.

### Spotify playlist detail
- Auto-retry once on 5xx (transient proxy outages).
- Friendly error message instead of dumping raw 503 JSON.
- Visible Retry button.

## Test plan

- [ ] `/charts` renders 11 Spotify chart tiles + Last.fm Trending shelf
- [ ] Click any chart tile -> `/spotify-playlist/{id}` loads, can play through TIDAL
- [ ] `/moods` renders TIDAL mood category tiles
- [ ] Click a mood tile -> drill-down shows Spotify rail + TIDAL shelves for that mood
- [ ] Home page renders moods rail without blocking on initial load
- [ ] Hover any tile (home/moods/charts/search/etc) — should feel soft, ~210ms
- [ ] Search for an artist — TIDAL artist results show photos
- [ ] /spotify-playlist/{id} for a known-broken ID shows friendly error + Retry button