### PR TITLE
fix(moods): reduce mood and playlist latency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3136,7 +3136,7 @@ dependencies = [
 
 [[package]]
 name = "noor-app"
-version = "0.1.52"
+version = "0.1.53"
 dependencies = [
  "reqwest 0.12.28",
  "serde",
@@ -3151,7 +3151,7 @@ dependencies = [
 
 [[package]]
 name = "noor-server"
-version = "0.1.52"
+version = "0.1.53"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 <p align="center">Incremental sync &nbsp;·&nbsp; Hi-fi playback &nbsp;·&nbsp; Music videos &nbsp;·&nbsp; Genre Galaxy &nbsp;·&nbsp; Spotify discovery &nbsp;·&nbsp; Learning engine</p>
 
-<p align="center"><strong>Latest release:</strong> <a href="../../releases/latest">v0.1.52</a></p>
+<p align="center"><strong>Latest release:</strong> <a href="../../releases/latest">v0.1.53</a></p>
 
 <p align="center">
   <img src="https://img.shields.io/badge/Rust-2024-orange?style=flat-square&logo=rust" alt="Rust"/>
@@ -535,6 +535,9 @@ The honest list of what NOOR doesn't do. Some of these are by design, some are n
 
 **Recent release highlights**
 
+- [x] **Mood playlist latency fix** - `/moods` no longer prefetches full Spotify playlists just to render mood cards; TIDAL mood pages and playlist track pages now use in-memory caches so repeated Happy / Focus playlist opens return from cache instead of re-hitting TIDAL or competing with Sportify proxy calls (v0.1.53)
+- [x] **TIDAL resolver hydration trim** - Spotify-to-TIDAL resolution skips unnecessary candidate hydration work when cached or clear-enough matches are already available, reducing resolver tail latency and upstream TIDAL pressure (v0.1.53)
+- [x] **Playback queue starts and shuffle seeding** - TIDAL playlist, mix, library, and genre starts now seed playback order predictably, preserving direct-start behavior while avoiding broken queue starts after shuffle or mood entry points (v0.1.53)
 - [x] **Windows installer with signed auto-updater** - per-user NSIS installer alongside the existing portable zip; installed builds read `latest.json` from the latest GitHub Release on launch, surface a tray hint, and silently download + install the signed `setup.exe` in passive mode before restarting at the new version; portable builds keep their notify-only tray hint. Settings -> About now surfaces install mode, current version, and pending update. Installs to `%LOCALAPPDATA%\Programs\NOORwave`; library + settings live under `%LOCALAPPDATA%\NOORwave` and are preserved across updates. MusicBrainz / Last.fm portable snapshots reused across installed and portable layouts (v0.1.52)
 - [~] **Spotify public stats via anonymous partner-GraphQL** *(best-effort)* - partner-GraphQL fetcher with anonymous token mint, GraphQL-hash auto-refresh, request-coalescing cache, schema migrations, and artist-page stats rendering. **No official Spotify credentials required, but Spotify can reject anonymous token minting** (e.g., TOTP cipher rotation that turns `/api/token` into 400 Bad Request) - when that happens stats stay null and the panel degrades gracefully. TIDAL track resolution does **not** depend on this path (v0.1.52)
 - [x] **Untapped Spotify and TIDAL discovery surfaces** - new top-level `/charts` and `/moods` pages; new Sportify detail pages at `/spotify-album/[id]`, `/spotify-artist/[id]`, `/spotify-track/[id]`; TIDAL discover shelves extracted into a shared `TidalDiscoverShelves` component so search, charts, and moods all share one card treatment (v0.1.52)

--- a/frontend/scripts/tidal-mix-link-contract.test.mjs
+++ b/frontend/scripts/tidal-mix-link-contract.test.mjs
@@ -38,7 +38,10 @@ describe('TIDAL mix link contracts', () => {
 
 		expect(client).toContain('is_favorite?: boolean');
 		expect(player).toContain('track.is_favorite ?? false');
-		expect(player).toContain('localTidalTrackId(first) ?? -first.tidal_id');
+		expect(player).toContain('setOptimisticTidalTrack(playable[0])');
+		expect(player).toContain('track_id: t.track_id');
+		expect(player).toContain('local_id: t.local_id ?? null');
+		expect(player).toContain('is_favorite: t.is_favorite');
 		expect(routes).toContain('"is_favorite": library_state.map(|s| s.is_favorite).unwrap_or(false)');
 		expect(mixRoute).toContain('queries::get_tidal_track_library_states');
 	});

--- a/frontend/src/lib/api/client.shuffle.test.ts
+++ b/frontend/src/lib/api/client.shuffle.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import { api } from './client';
+
+describe('shuffle request payloads', () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	test('replacePlaybackQueue sends a one shot shuffle mode when requested', async () => {
+		const fetch = vi.fn(async () => new Response(JSON.stringify({ queue: [] })));
+		vi.stubGlobal('fetch', fetch);
+
+		await api.replacePlaybackQueue([1, 2, 3], undefined, undefined, 'true');
+
+		const init = (fetch.mock.calls[0] as unknown as [string, RequestInit])[1];
+		expect(JSON.parse(String(init.body))).toEqual({
+			track_ids: [1, 2, 3],
+			shuffle_mode: 'true',
+		});
+	});
+
+	test('playTidalMix sends a one shot shuffle mode when requested', async () => {
+		const fetch = vi.fn(async () => new Response(JSON.stringify({ ok: true })));
+		vi.stubGlobal('fetch', fetch);
+
+		await api.playTidalMix(
+			[
+				{
+					tidal_id: 101,
+					title: 'A',
+					artist_name: null,
+					album_title: null,
+					artwork_url: null,
+					duration_ms: null,
+				},
+				{
+					tidal_id: 102,
+					title: 'B',
+					artist_name: null,
+					album_title: null,
+					artwork_url: null,
+					duration_ms: null,
+				},
+			],
+			'true'
+		);
+
+		const init = (fetch.mock.calls[0] as unknown as [string, RequestInit])[1];
+		expect(JSON.parse(String(init.body))).toMatchObject({
+			shuffle_mode: 'true',
+			tracks: [
+				{ tidal_track_id: 101, title: 'A' },
+				{ tidal_track_id: 102, title: 'B' },
+			],
+		});
+	});
+});

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -846,6 +846,21 @@ export interface PlaybackState {
 export interface PlaybackSnapshot {
 	state: PlaybackState;
 	queue: QueueItem[];
+	shuffle_debug?: ShuffleDebug | null;
+}
+
+export interface ShuffleDebug {
+	mode: PlaybackState['shuffle_mode'];
+	seed: number;
+	scope: string;
+	locked_count: number;
+	candidate_count: number;
+}
+
+export interface TidalMixPlaybackResponse {
+	ok: boolean;
+	first_tidal_id?: number;
+	shuffle_debug?: ShuffleDebug | null;
 }
 
 export interface PlaybackRuntimeInfo {
@@ -2715,14 +2730,20 @@ export const api = {
 		trackIds: number[],
 		reasons?: (string | null)[],
 		pendingCandidates?: PendingCandidateInfo[],
+		shuffleMode?: PlaybackState['shuffle_mode'],
 	) {
 		const body: Record<string, unknown> = { track_ids: trackIds };
 		if (reasons) body.reasons = reasons;
 		if (pendingCandidates?.length) body.pending_candidates = pendingCandidates;
-		return fetchApi<{ queue: QueueItem[] }>('/api/playback/queue', undefined, {
-			method: 'POST',
-			body: JSON.stringify(body),
-		});
+		if (shuffleMode && shuffleMode !== 'off') body.shuffle_mode = shuffleMode;
+		return fetchApi<{ queue: QueueItem[]; shuffle_debug?: ShuffleDebug | null }>(
+			'/api/playback/queue',
+			undefined,
+			{
+				method: 'POST',
+				body: JSON.stringify(body),
+			}
+		);
 	},
 
 	removeQueueTrack(queueItemId: number) {
@@ -2881,21 +2902,23 @@ export const api = {
 
 	// Play the first track of a mix immediately and queue the rest as
 	// pending ephemeral tracks (server auto-advances on track-end).
-	playTidalMix(tracks: TidalPlayable[]) {
-		return fetchApi<void>('/api/tidal/play-mix', undefined, {
+	playTidalMix(tracks: TidalPlayable[], shuffleMode?: PlaybackState['shuffle_mode']) {
+		const body: Record<string, unknown> = {
+			tracks: tracks.map((t) => ({
+				tidal_track_id: t.tidal_id,
+				title: t.title,
+				artist_name: t.artist_name ?? null,
+				artist_tidal_id: t.artist_tidal_id ?? null,
+				album_title: t.album_title ?? null,
+				album_tidal_id: t.album_tidal_id ?? null,
+				artwork_url: t.artwork_url ?? null,
+				duration_ms: t.duration_ms ?? null,
+			})),
+		};
+		if (shuffleMode && shuffleMode !== 'off') body.shuffle_mode = shuffleMode;
+		return fetchApi<TidalMixPlaybackResponse>('/api/tidal/play-mix', undefined, {
 			method: 'POST',
-			body: JSON.stringify({
-				tracks: tracks.map((t) => ({
-					tidal_track_id: t.tidal_id,
-					title: t.title,
-					artist_name: t.artist_name ?? null,
-					artist_tidal_id: t.artist_tidal_id ?? null,
-					album_title: t.album_title ?? null,
-					album_tidal_id: t.album_tidal_id ?? null,
-					artwork_url: t.artwork_url ?? null,
-					duration_ms: t.duration_ms ?? null,
-				})),
-			}),
+			body: JSON.stringify(body),
 		});
 	},
 

--- a/frontend/src/lib/components/Genre/GenreInterior.svelte
+++ b/frontend/src/lib/components/Genre/GenreInterior.svelte
@@ -239,10 +239,9 @@
 		if (!node || tracks.length === 0) return;
 		try {
 			await api.replacePlaybackQueue(tracks.map(t => t.id));
-			await setPlayerShuffleMode('genre');
+			const shuffled = await setPlayerShuffleMode('genre');
 			await setPlayerAutomixEnabled(true);
-			const startIndex = Math.floor(Math.random() * tracks.length);
-			await playTrackNow(tracks[startIndex].id);
+			await playTrackNow(shuffled?.queue[0]?.track.id ?? tracks[0].id);
 		} catch (reason) {
 			actionError = reason instanceof Error ? reason.message : String(reason);
 		}

--- a/frontend/src/lib/components/home/HomeMoodsRail.svelte
+++ b/frontend/src/lib/components/home/HomeMoodsRail.svelte
@@ -10,6 +10,8 @@
 	} from '$lib/stores/tidal-moods-cache';
 
 	const PREVIEW_LIMIT = 8;
+	const LOAD_ARM_DELAY_MS = 2500;
+	const FALLBACK_LOAD_DELAY_MS = 10000;
 
 	// Sync-read the shared moods cache on script init so a second visit
 	// within the 6h TTL renders instantly without a network round-trip.
@@ -21,9 +23,12 @@
 	);
 	let loading = $state(!cachedOnMount);
 	let errored = $state(false);
+	let sectionEl = $state<HTMLElement | null>(null);
+	let loadStarted = false;
 
-	onMount(async () => {
-		if (cachedOnMount) return;
+	async function loadMoods() {
+		if (loadStarted) return;
+		loadStarted = true;
 		try {
 			const data = await api.getTidalMoods();
 			const all = data.categories ?? [];
@@ -34,6 +39,37 @@
 		} finally {
 			loading = false;
 		}
+	}
+
+	onMount(() => {
+		if (cachedOnMount) return;
+
+		let observer: IntersectionObserver | null = null;
+		let fallbackTimer: ReturnType<typeof setTimeout> | null = null;
+		const armTimer = setTimeout(() => {
+			if (typeof IntersectionObserver === 'undefined' || !sectionEl) {
+				void loadMoods();
+				return;
+			}
+
+			observer = new IntersectionObserver(
+				(entries) => {
+					if (!entries.some((entry) => entry.isIntersecting)) return;
+					observer?.disconnect();
+					observer = null;
+					void loadMoods();
+				},
+				{ rootMargin: '240px 0px' },
+			);
+			observer.observe(sectionEl);
+			fallbackTimer = setTimeout(() => void loadMoods(), FALLBACK_LOAD_DELAY_MS);
+		}, LOAD_ARM_DELAY_MS);
+
+		return () => {
+			clearTimeout(armTimer);
+			if (fallbackTimer) clearTimeout(fallbackTimer);
+			observer?.disconnect();
+		};
 	});
 
 	function menu(slug: string, title: string) {
@@ -42,7 +78,7 @@
 </script>
 
 {#if categories.length > 0 || loading}
-	<section class="moods-rail" data-section="moods">
+	<section bind:this={sectionEl} class="moods-rail" data-section="moods">
 		<div class="header">
 			<div class="title-group">
 				<p class="eyebrow">TIDAL</p>

--- a/frontend/src/lib/components/moods/SpotifyMoodRail.svelte
+++ b/frontend/src/lib/components/moods/SpotifyMoodRail.svelte
@@ -1,29 +1,10 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
-  import { api } from '$lib/api/client';
   import { openContextMenu } from '$lib/stores/context_menu';
   import { goto } from '$app/navigation';
   import { wheelToHorizontal } from '$lib/actions/wheel-to-horizontal';
   import type { SpotifyMoodCategory } from './spotify-moods-data';
 
   let { category }: { category: SpotifyMoodCategory } = $props();
-
-  let meta = $state<Record<string, { thumbnail: string | null; title: string | null }>>({});
-
-  onMount(() => {
-    // Match /charts pattern: fire all fetches in parallel, fall back to
-    // hardcoded title + glyph on failure. Sportify proxy is slow but parallel.
-    void Promise.allSettled(
-      category.playlists.map(async (p) => {
-        try {
-          const { playlist } = await api.getSpotifyPlaylist(p.id);
-          meta[p.id] = { thumbnail: playlist.thumbnail, title: playlist.title };
-        } catch {
-          // Quiet: 404 / proxy outage just leaves the glyph + hardcoded title.
-        }
-      }),
-    );
-  });
 
   function buildMenu(id: string, title: string) {
     return [
@@ -36,21 +17,16 @@
   <h3 class="rail-heading">{category.label}</h3>
   <div class="rail" use:wheelToHorizontal>
     {#each category.playlists as p (p.id)}
-      {@const m = meta[p.id]}
       <a
         class="card"
         href={`/spotify-playlist/${p.id}`}
-        oncontextmenu={(e) => { e.preventDefault(); openContextMenu(e, buildMenu(p.id, m?.title ?? p.title), m?.title ?? p.title); }}
+        oncontextmenu={(e) => { e.preventDefault(); openContextMenu(e, buildMenu(p.id, p.title), p.title); }}
       >
         <div class="art-wrap">
-          {#if m?.thumbnail}
-            <div class="art" style="background-image:url('{m.thumbnail}')"></div>
-          {:else}
-            <div class="art fallback">M</div>
-          {/if}
+          <div class="art fallback">S</div>
         </div>
         <div class="meta">
-          <p class="title">{m?.title ?? p.title}</p>
+          <p class="title">{p.title}</p>
           <span class="source">Spotify</span>
         </div>
       </a>

--- a/frontend/src/lib/components/moods/spotify_mood_rail_contract.test.ts
+++ b/frontend/src/lib/components/moods/spotify_mood_rail_contract.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, test } from 'vitest';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(join(here, 'SpotifyMoodRail.svelte'), 'utf8');
+
+describe('Spotify mood rail contracts', () => {
+	test('does not prefetch full Spotify playlists while rendering mood cards', () => {
+		expect(source).not.toContain('getSpotifyPlaylist');
+		expect(source).not.toContain("import { api } from '$lib/api/client';");
+	});
+});

--- a/frontend/src/lib/stores/player.move_next.test.ts
+++ b/frontend/src/lib/stores/player.move_next.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { computePlayNextPos } from './player';
+import { computePlayNextPos, selectOptimisticNextItem } from './player';
 
 // Regression: moveQueueTrackNext used to rebuild the queue via
 // replacePlaybackQueue(track_ids), which silently dropped ephemeral TIDAL
@@ -52,5 +52,19 @@ describe('computePlayNextPos', () => {
 		// Reverse: current at 2, user picks ephemeral at 0. Removing 0 shifts
 		// current to 1; insert at 2.
 		expect(computePlayNextPos(0, 2, length)).toBe(2);
+	});
+});
+
+describe('selectOptimisticNextItem', () => {
+	test('anchors duplicate tracks by current queue item id before falling back to track id', () => {
+		const queue = [
+			{ id: 10, track: { id: 1, title: 'Duplicate A' } },
+			{ id: 11, track: { id: 2, title: 'Middle' } },
+			{ id: 12, track: { id: 1, title: 'Duplicate B' } },
+			{ id: 13, track: { id: 3, title: 'Expected next' } },
+		];
+
+		expect(selectOptimisticNextItem(queue, 1, 12)?.id).toBe(13);
+		expect(selectOptimisticNextItem(queue, 1, null)?.id).toBe(11);
 	});
 });

--- a/frontend/src/lib/stores/player.ts
+++ b/frontend/src/lib/stores/player.ts
@@ -468,9 +468,11 @@ export async function playNextTrack() {
 		if (currentRepeat !== 'one') {
 			const queue = get(playbackQueue);
 			const current = get(currentTrack);
-			const currentIdx = queue.findIndex((q) => q.track.id === (current?.id ?? -1));
-			const nextItem =
-				currentIdx >= 0 && currentIdx + 1 < queue.length ? queue[currentIdx + 1] : null;
+			const nextItem = selectOptimisticNextItem(
+				queue,
+				current?.id ?? null,
+				get(currentQueueItemId)
+			);
 			if (nextItem) {
 				setCurrentTrack(nextItem.track);
 			}
@@ -566,8 +568,12 @@ export async function setPlayerShuffleMode(mode: PlaybackState['shuffle_mode']) 
 	try {
 		const snapshot = await api.setPlaybackShuffle(mode);
 		hydratePlayback(snapshot);
+		return snapshot;
 	} catch (error) {
-		setError('set shuffle mode', error, () => setPlayerShuffleMode(mode));
+		setError('set shuffle mode', error, async () => {
+			await setPlayerShuffleMode(mode);
+		});
+		return null;
 	}
 }
 
@@ -896,6 +902,7 @@ async function loadQueueAndPlay(
 		preserveRadioReasons?: boolean;
 		reasons?: (string | null)[];
 		pendingCandidates?: PendingCandidateInfo[];
+		shuffleMode?: PlaybackState['shuffle_mode'];
 	},
 ) {
 	if (trackIds.length === 0) return;
@@ -903,21 +910,31 @@ async function loadQueueAndPlay(
 	playerError.set(null);
 	if (!options?.preserveRadioReasons) clearRadioReasons();
 	try {
-		await api.replacePlaybackQueue(trackIds, options?.reasons, options?.pendingCandidates);
-		const snapshot = await api.playTrack(trackIds[0]);
+		const replaced = await api.replacePlaybackQueue(
+			trackIds,
+			options?.reasons,
+			options?.pendingCandidates,
+			options?.shuffleMode
+		);
+		const firstTrackId = replaced.queue[0]?.track.id ?? trackIds[0];
+		const snapshot = await api.playTrack(firstTrackId);
 		hydratePlayback(snapshot);
 	} catch (error) {
-		setError('start playback', error, () => loadQueueAndPlay(trackIds));
+		setError('start playback', error, () => loadQueueAndPlay(trackIds, options));
 	}
 }
 
-function shuffleArray<T>(items: T[]): T[] {
-	const arr = items.slice();
-	for (let i = arr.length - 1; i > 0; i--) {
-		const j = Math.floor(Math.random() * (i + 1));
-		[arr[i], arr[j]] = [arr[j], arr[i]];
+export function selectOptimisticNextItem<T extends { id: number; track: { id: number } }>(
+	queue: T[],
+	currentTrackId: number | null | undefined,
+	currentQueueItem: number | null | undefined
+): T | null {
+	let currentIdx =
+		currentQueueItem != null ? queue.findIndex((q) => q.id === currentQueueItem) : -1;
+	if (currentIdx < 0) {
+		currentIdx = queue.findIndex((q) => q.track.id === (currentTrackId ?? -1));
 	}
-	return arr;
+	return currentIdx >= 0 && currentIdx + 1 < queue.length ? queue[currentIdx + 1] : null;
 }
 
 export async function playAlbum(albumId: number, startTrackId?: number) {
@@ -935,7 +952,9 @@ export async function playAlbum(albumId: number, startTrackId?: number) {
 					...tracks.filter((t) => t.id !== startTrackId)
 				]
 			: tracks;
-		await loadQueueAndPlay(ordered.map((t) => t.id));
+		await loadQueueAndPlay(ordered.map((t) => t.id), {
+			shuffleMode: startTrackId ? undefined : get(shuffleMode),
+		});
 	} catch (error) {
 		setError('play that album', error, () => playAlbum(albumId, startTrackId));
 	}
@@ -950,8 +969,7 @@ export async function shuffleAlbum(albumId: number) {
 			playerError.set({ message: 'Album has no tracks.' });
 			return;
 		}
-		const shuffled = shuffleArray(tracks);
-		await loadQueueAndPlay(shuffled.map((t) => t.id));
+		await loadQueueAndPlay(tracks.map((t) => t.id), { shuffleMode: 'true' });
 	} catch (error) {
 		setError('shuffle that album', error, () => shuffleAlbum(albumId));
 	}
@@ -972,7 +990,9 @@ export async function playArtist(artistId: number, startTrackId?: number) {
 					...tracks.filter((t) => t.id !== startTrackId)
 				]
 			: tracks;
-		await loadQueueAndPlay(ordered.map((t) => t.id));
+		await loadQueueAndPlay(ordered.map((t) => t.id), {
+			shuffleMode: startTrackId ? undefined : get(shuffleMode),
+		});
 	} catch (error) {
 		setError('play that artist', error, () => playArtist(artistId, startTrackId));
 	}
@@ -987,7 +1007,7 @@ export async function shuffleArtist(artistId: number) {
 			playerError.set({ message: 'Artist has no tracks.' });
 			return;
 		}
-		await loadQueueAndPlay(shuffleArray(tracks).map((t) => t.id));
+		await loadQueueAndPlay(tracks.map((t) => t.id), { shuffleMode: 'true' });
 	} catch (error) {
 		setError('shuffle that artist', error, () => shuffleArtist(artistId));
 	}
@@ -1020,8 +1040,7 @@ export async function shufflePlaylist(
 	tracks: { id: number }[],
 ) {
 	if (!tracks.length) return;
-	const shuffled = shuffleArray([...tracks]);
-	await loadQueueAndPlay(shuffled.map((t) => t.id));
+	await loadQueueAndPlay(tracks.map((t) => t.id), { shuffleMode: 'true' });
 	showToast('Shuffling playlist', 'success');
 }
 
@@ -1047,7 +1066,9 @@ export async function playPlaylist(playlistId: number, startTrackId?: number) {
 					...tracks.filter((t) => t.id !== startTrackId)
 				]
 			: tracks;
-		await loadQueueAndPlay(ordered.map((t) => t.id));
+		await loadQueueAndPlay(ordered.map((t) => t.id), {
+			shuffleMode: startTrackId ? undefined : get(shuffleMode),
+		});
 	} catch (error) {
 		setError('play that playlist', error, () => playPlaylist(playlistId, startTrackId));
 	}
@@ -1069,7 +1090,7 @@ export async function playTidalPlaylist(tidalUuid: string) {
 			playerError.set({ message: 'No playable tracks in this playlist.' });
 			return;
 		}
-		await startTidalEphemeralQueue(tracks);
+		await startTidalEphemeralQueue(tracks, { shuffleMode: get(shuffleMode) });
 		showToast(`Playing playlist (${tracks.length} tracks queued)`, 'success');
 	} catch (error) {
 		setError('load TIDAL playlist', error, () => playTidalPlaylist(tidalUuid));
@@ -1223,7 +1244,11 @@ export async function playTidalTrackNext(track: TidalPlayable): Promise<void> {
 	}
 }
 
-export async function playTidalTracksNow(tracks: TidalPlayable[], label = 'playlist'): Promise<void> {
+export async function playTidalTracksNow(
+	tracks: TidalPlayable[],
+	label = 'playlist',
+	options?: { shuffleMode?: PlaybackState['shuffle_mode'] }
+): Promise<void> {
 	if (!assertOnline()) return;
 	const playable = tracks.filter((track) => track.tidal_id > 0);
 	if (!playable.length) {
@@ -1233,19 +1258,25 @@ export async function playTidalTracksNow(tracks: TidalPlayable[], label = 'playl
 	rememberTidalPlayables(playable);
 	playerError.set(null);
 	try {
-		setOptimisticTidalTrack(playable[0]);
-		await api.playTidalMix(playable);
+		const requestShuffleMode = options?.shuffleMode ?? get(shuffleMode);
+		const oneShotShuffleMode = requestShuffleMode === 'off' ? undefined : requestShuffleMode;
+		if (!oneShotShuffleMode) setOptimisticTidalTrack(playable[0]);
+		const result = await api.playTidalMix(playable, oneShotShuffleMode);
+		if (oneShotShuffleMode) {
+			const first =
+				playable.find((track) => track.tidal_id === result.first_tidal_id) ?? playable[0];
+			setOptimisticTidalTrack(first);
+		}
 		noteSuccess();
 		showToast(`Playing ${label} (${playable.length} tracks)`, 'success');
 	} catch (error) {
-		setError('play those Tidal tracks', error, () => playTidalTracksNow(tracks, label));
+		setError('play those Tidal tracks', error, () => playTidalTracksNow(tracks, label, options));
 		showToast('Playback failed', 'error');
 	}
 }
 
 export async function shuffleTidalTracksNow(tracks: TidalPlayable[], label = 'playlist'): Promise<void> {
-	const shuffled = shuffleArray(tracks);
-	await playTidalTracksNow(shuffled, label);
+	await playTidalTracksNow(tracks, label, { shuffleMode: 'true' });
 }
 
 export async function playTidalTracksNext(tracks: TidalPlayable[]): Promise<void> {
@@ -1303,7 +1334,7 @@ export async function playTidalAlbum(tidalAlbumId: number): Promise<void> {
 			showToast('Album has no tracks', 'error');
 			return;
 		}
-		await startTidalEphemeralQueue(tracks);
+		await startTidalEphemeralQueue(tracks, { shuffleMode: get(shuffleMode) });
 		showToast(`Playing album (${tracks.length} tracks queued)`, 'success');
 	} catch (error) {
 		setError('play that Tidal album', error, () => playTidalAlbum(tidalAlbumId));
@@ -1311,10 +1342,6 @@ export async function playTidalAlbum(tidalAlbumId: number): Promise<void> {
 	}
 }
 
-/// Start an ephemeral TIDAL queue: optimistically reflect track 0 in the
-/// now-playing UI, then ship the full list to `/api/tidal/play-mix` (which is
-/// the generic "play this list" endpoint — name is historical). The server
-/// starts track 0 and queues the rest behind it so playback auto-advances.
 async function startTidalEphemeralQueue(
 	tracks: ReadonlyArray<{
 		tidal_id: number;
@@ -1330,47 +1357,33 @@ async function startTidalEphemeralQueue(
 		is_in_library?: boolean;
 		is_favorite?: boolean;
 	}>,
+	options?: { shuffleMode?: PlaybackState['shuffle_mode'] }
 ): Promise<void> {
-	const first = tracks[0];
 	rememberTidalPlayables(tracks);
-	setCurrentTrack({
-		id: localTidalTrackId(first) ?? -first.tidal_id,
-		title: first.title,
-		artist_id: -1,
-		artist_name: first.artist_name ?? null,
-		artist_tidal_id: first.artist_tidal_id ?? null,
-		album_id: null,
-		album_title: first.album_title ?? null,
-		album_tidal_id: first.album_tidal_id ?? null,
-		disc_number: null,
-		track_number: null,
-		duration_ms: first.duration_ms ?? null,
-		isrc: null,
-		tidal_id: first.tidal_id,
-		best_quality: 'LOSSLESS',
-		best_source: 'tidal',
-		fidelity_score: 0,
-		is_favorite: first.is_favorite ?? false,
-		play_count: 0,
-		last_played_at: null,
-		date_added: null,
-		source: 'tidal_ephemeral',
-		artwork_url: first.artwork_url ?? null,
-	});
-	isPlaying.set(true);
+	const requestShuffleMode = options?.shuffleMode;
+	const oneShotShuffleMode = requestShuffleMode === 'off' ? undefined : requestShuffleMode;
+	const playable = tracks.map((t) => ({
+		tidal_id: t.tidal_id,
+		title: t.title,
+		artist_name: t.artist_name ?? null,
+		artist_tidal_id: t.artist_tidal_id ?? null,
+		album_title: t.album_title ?? null,
+		album_tidal_id: t.album_tidal_id ?? null,
+		artwork_url: t.artwork_url ?? null,
+		duration_ms: t.duration_ms ?? null,
+		track_id: t.track_id,
+		local_id: t.local_id ?? null,
+		is_in_library: t.is_in_library,
+		is_favorite: t.is_favorite,
+	}));
 
-	await api.playTidalMix(
-		tracks.map((t) => ({
-			tidal_id: t.tidal_id,
-			title: t.title,
-			artist_name: t.artist_name ?? null,
-			artist_tidal_id: t.artist_tidal_id ?? null,
-			album_title: t.album_title ?? null,
-			album_tidal_id: t.album_tidal_id ?? null,
-			artwork_url: t.artwork_url ?? null,
-			duration_ms: t.duration_ms ?? null,
-		})),
-	);
+	if (!oneShotShuffleMode) setOptimisticTidalTrack(playable[0]);
+	const result = await api.playTidalMix(playable, oneShotShuffleMode);
+	if (oneShotShuffleMode) {
+		const shuffledFirst =
+			playable.find((track) => track.tidal_id === result.first_tidal_id) ?? playable[0];
+		setOptimisticTidalTrack(shuffledFirst);
+	}
 	noteSuccess();
 }
 

--- a/frontend/src/routes/genres/+page.svelte
+++ b/frontend/src/routes/genres/+page.svelte
@@ -432,10 +432,9 @@
 			}
 
 			await api.replacePlaybackQueue(tracks.map((track) => track.id));
-			await setPlayerShuffleMode('genre');
+			const shuffled = await setPlayerShuffleMode('genre');
 			await setPlayerAutomixEnabled(true);
-			const startIndex = Math.floor(Math.random() * tracks.length);
-			await playTrackNow(tracks[startIndex].id);
+			await playTrackNow(shuffled?.queue[0]?.track.id ?? tracks[0].id);
 		} catch (reason) {
 			actionError = reason instanceof Error ? reason.message : String(reason);
 		}
@@ -455,10 +454,9 @@
 			}
 
 			await api.replacePlaybackQueue(mergedTracks.map((track) => track.id));
-			await setPlayerShuffleMode('genre');
+			const shuffled = await setPlayerShuffleMode('genre');
 			await setPlayerAutomixEnabled(true);
-			const startIndex = Math.floor(Math.random() * mergedTracks.length);
-			await playTrackNow(mergedTracks[startIndex].id);
+			await playTrackNow(shuffled?.queue[0]?.track.id ?? mergedTracks[0].id);
 		} catch (reason) {
 			actionError = reason instanceof Error ? reason.message : String(reason);
 		}

--- a/frontend/src/routes/library/+page.svelte
+++ b/frontend/src/routes/library/+page.svelte
@@ -12,7 +12,16 @@
 	} from '$lib/stores/library';
 	import { formatTrackDuration, formatDateShort, getQualityClass } from '$lib/utils/format';
 	import { api, type Album, type Artist, type Genre, type Playlist, type Track } from '$lib/api/client';
-	import { currentTrack, isPlaying, playTrackNow, addTrackToQueue, playTrackNext } from '$lib/stores/player';
+	import {
+		currentTrack,
+		isPlaying,
+		playTrackNow,
+		addTrackToQueue,
+		playTrackNext,
+		shuffleMode,
+		playArtist as playArtistNow,
+		shuffleArtist as shuffleArtistNow
+	} from '$lib/stores/player';
 	import SelectionBar from '$lib/components/ui/SelectionBar.svelte';
 	import EmptyState from '$lib/components/ui/EmptyState.svelte';
 	import LibraryHero from '$lib/components/LibraryHero.svelte';
@@ -266,8 +275,13 @@
 			if (trackIds.length === 0) {
 				throw new Error('No synced tracks found for this album yet.');
 			}
-			await api.replacePlaybackQueue(trackIds);
-			await playTrackNow(trackIds[0]);
+			const replaced = await api.replacePlaybackQueue(
+				trackIds,
+				undefined,
+				undefined,
+				get(shuffleMode)
+			);
+			await playTrackNow(replaced.queue[0]?.track.id ?? trackIds[0]);
 			batchMessage = `Playing album from track 1 of ${trackIds.length}.`;
 		} catch (error) {
 			batchError = `Failed to play album: ${error}`;
@@ -936,18 +950,11 @@
 	// ── Home view handlers ─────────────────────────────────────────────────
 
 	function playAllForArtist(artistId: number) {
-		const artistTracks = $tracks.filter(t => t.artist_id === artistId);
-		if (!artistTracks.length) return;
-		void playTrackNow(artistTracks[0].id);
-		for (const t of artistTracks.slice(1)) void addTrackToQueue(t.id);
+		void playArtistNow(artistId);
 	}
 
 	function shuffleArtist(artistId: number) {
-		const artistTracks = [...$tracks.filter(t => t.artist_id === artistId)];
-		artistTracks.sort(() => Math.random() - 0.5);
-		if (!artistTracks.length) return;
-		void playTrackNow(artistTracks[0].id);
-		for (const t of artistTracks.slice(1)) void addTrackToQueue(t.id);
+		void shuffleArtistNow(artistId);
 	}
 
 	function handleHomeArtistClick(artistId: number) {

--- a/frontend/src/routes/playlists/+page.svelte
+++ b/frontend/src/routes/playlists/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { get } from 'svelte/store';
 	import type { Snapshot } from './$types';
 	import {
 		api,
@@ -16,6 +17,7 @@
 		currentTrack,
 		isPlaying,
 		playTrackNow,
+		shuffleMode,
 		shufflePlaylist,
 		startPlaylistRadio,
 	} from '$lib/stores/player';
@@ -378,8 +380,13 @@
 		e.stopPropagation();
 		const tracks = await ensurePlaylistTracks(playlist.id);
 		if (!tracks.length) return;
-		await api.replacePlaybackQueue(tracks.map((t) => t.id));
-		await playTrackNow(tracks[0].id);
+		const replaced = await api.replacePlaybackQueue(
+			tracks.map((t) => t.id),
+			undefined,
+			undefined,
+			get(shuffleMode)
+		);
+		await playTrackNow(replaced.queue[0]?.track.id ?? tracks[0].id);
 	}
 
 	async function shufflePlaylistQuick(playlist: Playlist, e: MouseEvent) {

--- a/noor-app/Cargo.toml
+++ b/noor-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noor-app"
-version = "0.1.52"
+version = "0.1.53"
 edition = "2021"
 
 [[bin]]

--- a/noor-app/tauri.conf.json
+++ b/noor-app/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "NOORwave",
-  "version": "0.1.52",
+  "version": "0.1.53",
   "identifier": "com.noorwave.app",
   "app": {
     "windows": [],

--- a/noor-server/Cargo.toml
+++ b/noor-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noor-server"
-version = "0.1.52"
+version = "0.1.53"
 edition = "2024"
 description = "NOOR â€” Multi-service music library manager + hi-fi player"
 

--- a/noor-server/src/db/schema.rs
+++ b/noor-server/src/db/schema.rs
@@ -43,6 +43,7 @@ const MIGRATIONS: &[&str] = &[
     MIGRATION_039,
     MIGRATION_040,
     MIGRATION_041,
+    MIGRATION_042,
 ];
 
 const MIGRATION_001: &str = r#"
@@ -1152,6 +1153,10 @@ CREATE TABLE IF NOT EXISTS spotify_artist_map (
 );
 
 COMMIT;
+"#;
+
+const MIGRATION_042: &str = r#"
+ALTER TABLE playback_state ADD COLUMN shuffle_seed INTEGER;
 "#;
 
 pub fn run_migrations(conn: &Connection) -> Result<()> {

--- a/noor-server/src/main.rs
+++ b/noor-server/src/main.rs
@@ -79,6 +79,28 @@ pub struct AppState {
     /// computed list in memory instead of repeating that fan-out per request.
     pub tidal_moods_cache:
         Arc<std::sync::Mutex<Option<(std::time::Instant, Vec<serde_json::Value>)>>>,
+    /// 6h TTL cache for parsed TIDAL pages such as mood drill-down pages.
+    pub tidal_page_modules_cache: Arc<
+        std::sync::Mutex<
+            std::collections::HashMap<
+                String,
+                (
+                    std::time::Instant,
+                    Vec<services::tidal::client::TidalHomeModule>,
+                ),
+            >,
+        >,
+    >,
+    /// 1h TTL cache for external TIDAL playlist track pages. Library state is
+    /// enriched after reading from this cache so favorite badges stay fresh.
+    pub tidal_playlist_tracks_cache: Arc<
+        std::sync::Mutex<
+            std::collections::HashMap<
+                String,
+                (std::time::Instant, Vec<services::tidal::client::TidalTrack>),
+            >,
+        >,
+    >,
     pub spotify_tokens: Option<services::spotify::auth::SpotifyTokens>,
     pub playback_runtime: Option<PlaybackRuntimeState>,
     pub playback_runtime_info: Option<PlaybackRuntimeInfo>,
@@ -686,6 +708,10 @@ async fn main() -> Result<()> {
         tidal_mixes_cache: Arc::new(std::sync::Mutex::new(None)),
         tidal_radio_stations_cache: Arc::new(std::sync::Mutex::new(None)),
         tidal_moods_cache: Arc::new(std::sync::Mutex::new(None)),
+        tidal_page_modules_cache: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        tidal_playlist_tracks_cache: Arc::new(std::sync::Mutex::new(
+            std::collections::HashMap::new(),
+        )),
         spotify_tokens,
         playback_runtime: None,
         playback_runtime_info: None,

--- a/noor-server/src/main.rs
+++ b/noor-server/src/main.rs
@@ -74,6 +74,11 @@ pub struct AppState {
     /// 6h TTL cache for the home Personal Radio shelf. Same cadence as mixes.
     pub tidal_radio_stations_cache:
         Arc<std::sync::Mutex<Option<(std::time::Instant, Vec<services::tidal::client::TidalMix>)>>>,
+    /// 6h TTL cache for the TIDAL moods landing categories. The handler
+    /// hydrates category thumbnails from multiple upstream pages, so keep the
+    /// computed list in memory instead of repeating that fan-out per request.
+    pub tidal_moods_cache:
+        Arc<std::sync::Mutex<Option<(std::time::Instant, Vec<serde_json::Value>)>>>,
     pub spotify_tokens: Option<services::spotify::auth::SpotifyTokens>,
     pub playback_runtime: Option<PlaybackRuntimeState>,
     pub playback_runtime_info: Option<PlaybackRuntimeInfo>,
@@ -680,6 +685,7 @@ async fn main() -> Result<()> {
         tidal_tokens,
         tidal_mixes_cache: Arc::new(std::sync::Mutex::new(None)),
         tidal_radio_stations_cache: Arc::new(std::sync::Mutex::new(None)),
+        tidal_moods_cache: Arc::new(std::sync::Mutex::new(None)),
         spotify_tokens,
         playback_runtime: None,
         playback_runtime_info: None,

--- a/noor-server/src/playback/player.rs
+++ b/noor-server/src/playback/player.rs
@@ -4,8 +4,11 @@ use crate::db::{
     queries,
 };
 use crate::playback::gapless::{self, GaplessPlan, GaplessSettings};
-use crate::playback::queue::{self, ShuffleMode};
-use crate::playback::shuffle::{WeightedShuffleProfile, genre_shuffle, true_shuffle};
+use crate::playback::queue::{self, ShuffleDebug, ShuffleMode};
+use crate::playback::shuffle::{
+    WeightedShuffleProfile, generate_shuffle_seed, genre_shuffle, genre_shuffle_with_rng,
+    seeded_rng, true_shuffle, true_shuffle_with_rng,
+};
 use crate::services::audio_analysis::{
     CamelotRelation, camelot_relation, compute_harmonic_multiplier,
 };
@@ -14,7 +17,6 @@ use crate::smart::taste_vector::adapters::from_session_profile;
 use crate::smart::taste_vector::{SeedContext, TasteVector};
 use anyhow::{Result, anyhow};
 use chrono::{DateTime, Utc};
-use rand::Rng;
 use rusqlite::{Connection, OptionalExtension, params};
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
@@ -23,6 +25,12 @@ use std::collections::{HashMap, HashSet};
 pub struct PlaybackSnapshot {
     pub state: PlaybackState,
     pub queue: Vec<QueueItem>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ShuffleModeUpdate {
+    pub snapshot: PlaybackSnapshot,
+    pub debug: Option<ShuffleDebug>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -677,18 +685,34 @@ pub fn set_volume(conn: &Connection, volume: f64) -> Result<PlaybackSnapshot> {
     load_snapshot(conn)
 }
 
-pub fn set_shuffle_mode(conn: &Connection, mode: ShuffleMode) -> Result<PlaybackSnapshot> {
+pub fn set_shuffle_mode(conn: &Connection, mode: ShuffleMode) -> Result<ShuffleModeUpdate> {
     let current_queue_item_id: Option<i64> = conn.query_row(
         "SELECT current_queue_item_id FROM playback_state WHERE id = 1",
         [],
         |row| row.get(0),
     )?;
+    let seed = (mode != ShuffleMode::Off).then(generate_shuffle_seed);
     conn.execute(
-        "UPDATE playback_state SET shuffle_mode = ?1 WHERE id = 1",
-        params![mode.as_str()],
+        "UPDATE playback_state SET shuffle_mode = ?1, shuffle_seed = ?2 WHERE id = 1",
+        params![mode.as_str(), seed],
     )?;
-    queue::apply_shuffle(conn, mode, current_queue_item_id)?;
-    load_snapshot(conn)
+    let debug = match seed {
+        Some(seed) => {
+            queue::apply_shuffle_with_seed(
+                conn,
+                mode,
+                current_queue_item_id,
+                seed,
+                "playback_state",
+            )?
+            .debug
+        }
+        None => None,
+    };
+    Ok(ShuffleModeUpdate {
+        snapshot: load_snapshot(conn)?,
+        debug,
+    })
 }
 
 pub fn set_automix_enabled(conn: &Connection, enabled: bool) -> Result<PlaybackSnapshot> {
@@ -1071,11 +1095,23 @@ pub fn ensure_automix_queue_depth(
     }
 
     let needed = (target_upcoming - upcoming_count).max(AUTOMIX_BATCH_SIZE);
+    let shuffle_mode = ShuffleMode::parse(&state.shuffle_mode);
+    let shuffle_seed = if shuffle_mode != ShuffleMode::Off {
+        conn.query_row(
+            "SELECT shuffle_seed FROM playback_state WHERE id = 1",
+            [],
+            |row| row.get::<_, Option<i64>>(0),
+        )?
+    } else {
+        None
+    };
+
     let extension = build_automix_extension_with_reasons(
         conn,
         current_track,
         &queue_items,
-        ShuffleMode::parse(&state.shuffle_mode),
+        shuffle_mode,
+        shuffle_seed,
         needed,
         state.automix_use_learning,
     )?;
@@ -1197,6 +1233,7 @@ fn build_automix_extension_with_reasons(
     current_track: &Track,
     queue_items: &[QueueItem],
     mode: ShuffleMode,
+    shuffle_seed: Option<i64>,
     needed: usize,
     use_learning: bool,
 ) -> Result<Vec<AutomixSelection>> {
@@ -1227,7 +1264,7 @@ fn build_automix_extension_with_reasons(
                 .into_iter()
                 .map(|track| (track.id, track))
                 .collect::<HashMap<_, _>>();
-            let ordered = neighbor_ids
+            let mut ordered = neighbor_ids
                 .into_iter()
                 .filter_map(|track_id| {
                     track_map.get(&track_id).cloned().map(|track| {
@@ -1240,8 +1277,26 @@ fn build_automix_extension_with_reasons(
                         )
                     })
                 })
-                .take(needed)
                 .collect::<Vec<_>>();
+            if let Some(seed) = shuffle_seed
+                && mode != ShuffleMode::Off
+            {
+                let tracks = ordered
+                    .iter()
+                    .map(|selection| selection.track.clone())
+                    .collect::<Vec<_>>();
+                let shuffled =
+                    queue::reorder_tracks_with_seed(conn, &tracks, mode, seed, "automix_learned")?;
+                let mut by_track = ordered
+                    .into_iter()
+                    .map(|selection| (selection.track.id, selection))
+                    .collect::<HashMap<_, _>>();
+                ordered = shuffled
+                    .into_iter()
+                    .filter_map(|track| by_track.remove(&track.id))
+                    .collect();
+            }
+            ordered.truncate(needed);
             if !ordered.is_empty() {
                 return Ok(ordered);
             }
@@ -1340,6 +1395,7 @@ fn build_automix_extension_with_reasons(
         &taste,
         &seed,
         needed,
+        shuffle_seed,
         seed_features.as_ref(),
         &candidate_features,
     );
@@ -1632,6 +1688,7 @@ fn order_automix_candidates(
     taste: &TasteVector,
     seed: &SeedContext,
     needed: usize,
+    shuffle_seed: Option<i64>,
     seed_features: Option<&AudioDspFeatures>,
     candidate_features: &HashMap<i64, AudioDspFeatures>,
 ) -> Vec<Track> {
@@ -1671,12 +1728,23 @@ fn order_automix_candidates(
                 .take(pool_size)
                 .map(|entry| entry.track)
                 .collect::<Vec<_>>();
-            true_shuffle(&pool)
+            if let Some(seed) = shuffle_seed {
+                let mut rng = seeded_rng(seed, mode.as_str(), "automix");
+                true_shuffle_with_rng(&pool, &mut rng)
+            } else {
+                true_shuffle(&pool)
+            }
         }
         ShuffleMode::Weighted => {
             let pool_size = (needed * TRUE_SHUFFLE_POOL_MULTIPLIER).max(48);
             let pool = scored.into_iter().take(pool_size).collect::<Vec<_>>();
-            weighted_session_shuffle(&pool)
+            match shuffle_seed {
+                Some(seed) => {
+                    let mut rng = seeded_rng(seed, mode.as_str(), "automix");
+                    weighted_session_shuffle_with_rng(&pool, &mut rng)
+                }
+                None => weighted_session_shuffle(&pool),
+            }
         }
         ShuffleMode::Genre => {
             let mut preferred = Vec::new();
@@ -1697,8 +1765,19 @@ fn order_automix_candidates(
             // Interleave preferred and fallback at ~3:1 ratio so the queue
             // never becomes a solid wall of one genre type, but still leans
             // toward the current session's taste.
-            let preferred_shuffled = genre_shuffle(&preferred, candidate_genres);
-            let fallback_shuffled = genre_shuffle(&fallback, candidate_genres);
+            let (preferred_shuffled, fallback_shuffled) = if let Some(seed) = shuffle_seed {
+                let mut preferred_rng = seeded_rng(seed, mode.as_str(), "automix_preferred");
+                let mut fallback_rng = seeded_rng(seed, mode.as_str(), "automix_fallback");
+                (
+                    genre_shuffle_with_rng(&preferred, candidate_genres, &mut preferred_rng),
+                    genre_shuffle_with_rng(&fallback, candidate_genres, &mut fallback_rng),
+                )
+            } else {
+                (
+                    genre_shuffle(&preferred, candidate_genres),
+                    genre_shuffle(&fallback, candidate_genres),
+                )
+            };
             let total = preferred_shuffled.len() + fallback_shuffled.len();
             let mut ordered = Vec::with_capacity(total);
             let mut pi = 0usize;
@@ -1914,8 +1993,15 @@ fn matches_preferred_genres(genres: &[String], taste: &TasteVector, seed: &SeedC
 }
 
 fn weighted_session_shuffle(entries: &[ScoredTrack]) -> Vec<Track> {
-    let profile = WeightedShuffleProfile::default();
     let mut rng = rand::thread_rng();
+    weighted_session_shuffle_with_rng(entries, &mut rng)
+}
+
+fn weighted_session_shuffle_with_rng<R: rand::Rng + ?Sized>(
+    entries: &[ScoredTrack],
+    rng: &mut R,
+) -> Vec<Track> {
+    let profile = WeightedShuffleProfile::default();
     let mut weighted = entries
         .iter()
         .map(|entry| {
@@ -2060,6 +2146,7 @@ mod tests {
                 id INTEGER PRIMARY KEY,
                 current_track_id INTEGER,
                 current_queue_item_id INTEGER,
+                shuffle_seed INTEGER,
                 position_ms INTEGER NOT NULL DEFAULT 0,
                 is_playing INTEGER NOT NULL DEFAULT 0,
                 volume REAL NOT NULL DEFAULT 1.0,
@@ -2816,6 +2903,29 @@ mod tests {
     }
 
     #[test]
+    fn setting_shuffle_off_clears_shuffle_seed() {
+        let conn = conn();
+        conn.execute(
+            "UPDATE playback_state SET shuffle_mode = 'genre', shuffle_seed = 12345 WHERE id = 1",
+            [],
+        )
+        .unwrap();
+
+        let update = set_shuffle_mode(&conn, ShuffleMode::Off).unwrap();
+        let stored_seed: Option<i64> = conn
+            .query_row(
+                "SELECT shuffle_seed FROM playback_state WHERE id = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+
+        assert_eq!(update.snapshot.state.shuffle_mode, "off");
+        assert!(update.debug.is_none());
+        assert_eq!(stored_seed, None);
+    }
+
+    #[test]
     fn lookup_listen_source_maps_radio_pending_and_automix_new() {
         let conn = conn();
         for (source, expected) in [
@@ -3075,6 +3185,7 @@ mod tests {
             current_track,
             queue_items,
             mode,
+            None,
             needed,
             use_learning,
         )?

--- a/noor-server/src/playback/queue.rs
+++ b/noor-server/src/playback/queue.rs
@@ -1,6 +1,7 @@
 use crate::db::models::{QueueItem, Track};
 use crate::playback::shuffle::{
-    WeightedShuffleProfile, artist_spread_shuffle, genre_shuffle, true_shuffle, weighted_shuffle,
+    WeightedShuffleProfile, artist_spread_shuffle_with_rng, generate_shuffle_seed,
+    genre_shuffle_with_rng, seeded_rng, true_shuffle_with_rng, weighted_shuffle_with_rng,
 };
 use anyhow::Result;
 use rusqlite::{Connection, OptionalExtension, Row, params};
@@ -34,6 +35,21 @@ impl ShuffleMode {
             _ => Self::Off,
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct ShuffleDebug {
+    pub mode: String,
+    pub seed: i64,
+    pub scope: String,
+    pub locked_count: usize,
+    pub candidate_count: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct ShuffleApplyResult {
+    pub queue: Vec<QueueItem>,
+    pub debug: Option<ShuffleDebug>,
 }
 
 pub fn load_queue(conn: &Connection) -> Result<Vec<QueueItem>> {
@@ -331,52 +347,50 @@ pub fn apply_shuffle(
     mode: ShuffleMode,
     current_queue_item_id: Option<i64>,
 ) -> Result<Vec<QueueItem>> {
-    let queue_items = load_queue(conn)?;
-    if queue_items.len() <= 1 || mode == ShuffleMode::Off {
-        return Ok(queue_items);
+    if mode == ShuffleMode::Off {
+        return load_queue(conn);
     }
+    Ok(apply_shuffle_with_seed(
+        conn,
+        mode,
+        current_queue_item_id,
+        generate_shuffle_seed(),
+        "queue",
+    )?
+    .queue)
+}
 
+pub fn apply_shuffle_with_seed(
+    conn: &Connection,
+    mode: ShuffleMode,
+    current_queue_item_id: Option<i64>,
+    seed: i64,
+    scope: &str,
+) -> Result<ShuffleApplyResult> {
+    let queue_items = load_queue(conn)?;
     let split_index = current_queue_item_id
         .and_then(|qid| queue_items.iter().position(|item| item.id == qid))
         .map(|idx| idx + 1)
         .unwrap_or(0);
+    let candidate_count = queue_items.len().saturating_sub(split_index);
+    let debug = (mode != ShuffleMode::Off).then(|| ShuffleDebug {
+        mode: mode.as_str().to_string(),
+        seed,
+        scope: scope.to_string(),
+        locked_count: split_index,
+        candidate_count,
+    });
+
+    if queue_items.len() <= 1 || mode == ShuffleMode::Off || candidate_count <= 1 {
+        return Ok(ShuffleApplyResult {
+            queue: queue_items,
+            debug,
+        });
+    }
 
     let locked_qids: Vec<i64> = queue_items[..split_index].iter().map(|i| i.id).collect();
-    let candidate_tracks: Vec<Track> = queue_items[split_index..]
-        .iter()
-        .map(|i| i.track.clone())
-        .collect();
-
-    let reordered_tracks = reorder_tracks(conn, &candidate_tracks, mode)?;
-
-    // Map shuffled tracks back to queue item IDs. Pending rows all share
-    // `track.id == 0`, so we route by track.id with a per-id FIFO of qids:
-    // the i-th pending row in the shuffled output gets the i-th pending
-    // qid from the candidate region. Library rows use the same machinery
-    // and handle the rare duplicate-track-id case as a side-effect.
-    use std::collections::VecDeque;
-    let mut qid_buckets: HashMap<i64, VecDeque<i64>> = HashMap::new();
-    for item in &queue_items[split_index..] {
-        qid_buckets
-            .entry(item.track.id)
-            .or_default()
-            .push_back(item.id);
-    }
-    let mut shuffled_qids: Vec<i64> = Vec::with_capacity(reordered_tracks.len());
-    for t in &reordered_tracks {
-        if let Some(bucket) = qid_buckets.get_mut(&t.id)
-            && let Some(qid) = bucket.pop_front()
-        {
-            shuffled_qids.push(qid);
-        }
-    }
-    // Defensive: if reorder_tracks dropped any rows (it shouldn't), append
-    // remaining qids in their original order so the queue stays intact.
-    for (_id, bucket) in qid_buckets.iter_mut() {
-        while let Some(qid) = bucket.pop_front() {
-            shuffled_qids.push(qid);
-        }
-    }
+    let shuffled_qids =
+        reorder_queue_item_ids_with_seed(conn, &queue_items[split_index..], mode, seed, scope)?;
 
     let final_qids: Vec<i64> = locked_qids.into_iter().chain(shuffled_qids).collect();
 
@@ -389,26 +403,105 @@ pub fn apply_shuffle(
     }
     tx.commit()?;
 
-    load_queue(conn)
+    Ok(ShuffleApplyResult {
+        queue: load_queue(conn)?,
+        debug,
+    })
 }
 
 fn reorder_tracks(conn: &Connection, tracks: &[Track], mode: ShuffleMode) -> Result<Vec<Track>> {
     // Off must preserve the caller's order; an artist post-pass would silently
     // rearrange tracks the user didn't ask to shuffle. Genre mode already runs
-    // artist-spread + genre-stabilize internally — running artist-spread again
+    // artist-spread + genre-stabilize internally, and running artist-spread again
     // here re-clusters genres and undoes that work.
     match mode {
         ShuffleMode::Off => Ok(tracks.to_vec()),
-        ShuffleMode::True => Ok(artist_spread_shuffle(&true_shuffle(tracks))),
+        ShuffleMode::True => {
+            let mut rng = rand::thread_rng();
+            Ok(true_shuffle_with_rng(tracks, &mut rng))
+        }
         ShuffleMode::Weighted => {
-            let weighted = weighted_shuffle(tracks, &WeightedShuffleProfile::default());
-            Ok(artist_spread_shuffle(&weighted))
+            let mut rng = rand::thread_rng();
+            let weighted =
+                weighted_shuffle_with_rng(tracks, &WeightedShuffleProfile::default(), &mut rng);
+            Ok(artist_spread_shuffle_with_rng(&weighted, &mut rng))
         }
         ShuffleMode::Genre => {
             let genre_map = get_track_genres(conn, tracks)?;
-            Ok(genre_shuffle(tracks, &genre_map))
+            let mut rng = rand::thread_rng();
+            Ok(genre_shuffle_with_rng(tracks, &genre_map, &mut rng))
         }
     }
+}
+
+pub(crate) fn reorder_tracks_with_seed(
+    conn: &Connection,
+    tracks: &[Track],
+    mode: ShuffleMode,
+    seed: i64,
+    scope: &str,
+) -> Result<Vec<Track>> {
+    let mut rng = seeded_rng(seed, mode.as_str(), scope);
+    match mode {
+        ShuffleMode::Off => Ok(tracks.to_vec()),
+        ShuffleMode::True => Ok(true_shuffle_with_rng(tracks, &mut rng)),
+        ShuffleMode::Weighted => {
+            let weighted =
+                weighted_shuffle_with_rng(tracks, &WeightedShuffleProfile::default(), &mut rng);
+            Ok(artist_spread_shuffle_with_rng(&weighted, &mut rng))
+        }
+        ShuffleMode::Genre => {
+            let genre_map = get_track_genres(conn, tracks)?;
+            Ok(genre_shuffle_with_rng(tracks, &genre_map, &mut rng))
+        }
+    }
+}
+
+fn reorder_queue_item_ids_with_seed(
+    conn: &Connection,
+    items: &[QueueItem],
+    mode: ShuffleMode,
+    seed: i64,
+    scope: &str,
+) -> Result<Vec<i64>> {
+    let mut surrogate_tracks = Vec::with_capacity(items.len());
+    for item in items {
+        let mut track = item.track.clone();
+        track.id = item.id;
+        surrogate_tracks.push(track);
+    }
+
+    let mut genre_map = HashMap::new();
+    if mode == ShuffleMode::Genre {
+        let real_tracks = items
+            .iter()
+            .filter(|item| item.track.id > 0)
+            .map(|item| item.track.clone())
+            .collect::<Vec<_>>();
+        let real_genres = get_track_genres(conn, &real_tracks)?;
+        for item in items {
+            if let Some(genres) = real_genres.get(&item.track.id) {
+                genre_map.insert(item.id, genres.clone());
+            }
+        }
+    }
+
+    let mut rng = seeded_rng(seed, mode.as_str(), scope);
+    let reordered = match mode {
+        ShuffleMode::Off => surrogate_tracks,
+        ShuffleMode::True => true_shuffle_with_rng(&surrogate_tracks, &mut rng),
+        ShuffleMode::Weighted => {
+            let weighted = weighted_shuffle_with_rng(
+                &surrogate_tracks,
+                &WeightedShuffleProfile::default(),
+                &mut rng,
+            );
+            artist_spread_shuffle_with_rng(&weighted, &mut rng)
+        }
+        ShuffleMode::Genre => genre_shuffle_with_rng(&surrogate_tracks, &genre_map, &mut rng),
+    };
+
+    Ok(reordered.into_iter().map(|track| track.id).collect())
 }
 
 pub fn get_track_genres(conn: &Connection, tracks: &[Track]) -> Result<HashMap<i64, Vec<String>>> {
@@ -1002,7 +1095,7 @@ mod tests {
             .collect();
         let genre_of = |id: i64| if id <= 2 { "House" } else { "Ambient" };
 
-        // Two genres × two tracks each → alternation is always achievable.
+        // Two genres with two tracks each can alternate every adjacent pair.
         // If the unconditional artist post-pass returns, this fails on most seeds.
         for _ in 0..20 {
             let reordered = reorder_tracks(&conn, &tracks, ShuffleMode::Genre).unwrap();
@@ -1019,6 +1112,138 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn apply_shuffle_with_seed_is_repeatable() {
+        let conn = conn();
+        let tracks: Vec<Track> = (1..=4)
+            .map(|id| get_track_by_id(&conn, id).unwrap().unwrap())
+            .collect();
+        replace_queue(&conn, &tracks, "test").unwrap();
+
+        let first =
+            apply_shuffle_with_seed(&conn, ShuffleMode::True, None, 7_654_321, "test").unwrap();
+        let first_ids: Vec<i64> = first.queue.iter().map(|item| item.track.id).collect();
+        let first_debug = first.debug.expect("shuffle debug");
+
+        replace_queue(&conn, &tracks, "test").unwrap();
+        let second =
+            apply_shuffle_with_seed(&conn, ShuffleMode::True, None, 7_654_321, "test").unwrap();
+        let second_ids: Vec<i64> = second.queue.iter().map(|item| item.track.id).collect();
+
+        assert_eq!(first_ids, second_ids);
+        assert_eq!(first_debug.mode, "true");
+        assert_eq!(first_debug.seed, 7_654_321);
+        assert_eq!(first_debug.scope, "test");
+        assert_eq!(first_debug.locked_count, 0);
+        assert_eq!(first_debug.candidate_count, 4);
+    }
+
+    #[test]
+    fn seeded_shuffle_moves_pending_queue_item_ids() {
+        let conn = conn();
+        conn.execute(
+            "INSERT INTO queue (track_id, position, source) VALUES (1, 0, 'test')",
+            [],
+        )
+        .unwrap();
+        for (idx, (artist, title)) in [
+            ("Aphex Twin", "Xtal"),
+            ("Boards of Canada", "Roygbiv"),
+            ("Plaid", "Itsu"),
+            ("Autechre", "Bike"),
+        ]
+        .iter()
+        .enumerate()
+        {
+            conn.execute(
+                "INSERT INTO queue (track_id, position, source, pending_artist, pending_title, pending_at)
+                 VALUES (NULL, ?1, 'radio_pending', ?2, ?3, datetime('now'))",
+                params![(idx as i32) + 1, artist, title],
+            )
+            .unwrap();
+        }
+        let before = load_queue(&conn).unwrap();
+        let current_qid = before[0].id;
+        let before_pending_qids = before[1..].iter().map(|item| item.id).collect::<Vec<_>>();
+
+        let shuffled = apply_shuffle_with_seed(
+            &conn,
+            ShuffleMode::True,
+            Some(current_qid),
+            7_654_321,
+            "test",
+        )
+        .unwrap();
+        let after_pending_qids = shuffled.queue[1..]
+            .iter()
+            .map(|item| item.id)
+            .collect::<Vec<_>>();
+
+        assert_eq!(shuffled.queue[0].id, current_qid);
+        assert_ne!(after_pending_qids, before_pending_qids);
+        let mut sorted_before = before_pending_qids;
+        let mut sorted_after = after_pending_qids;
+        sorted_before.sort_unstable();
+        sorted_after.sort_unstable();
+        assert_eq!(sorted_after, sorted_before);
+    }
+
+    #[test]
+    fn seeded_true_mode_matches_plain_fisher_yates() {
+        let conn = conn();
+        let tracks: Vec<Track> = (1..=4)
+            .map(|id| get_track_by_id(&conn, id).unwrap().unwrap())
+            .collect();
+        let seed = 7_654_321;
+        let scope = "flat_true";
+
+        let actual = reorder_tracks_with_seed(&conn, &tracks, ShuffleMode::True, seed, scope)
+            .unwrap()
+            .into_iter()
+            .map(|track| track.id)
+            .collect::<Vec<_>>();
+        let mut rng = crate::playback::shuffle::seeded_rng(seed, ShuffleMode::True.as_str(), scope);
+        let expected = crate::playback::shuffle::true_shuffle_with_rng(&tracks, &mut rng)
+            .into_iter()
+            .map(|track| track.id)
+            .collect::<Vec<_>>();
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn seeded_shuffle_reorders_duplicate_track_queue_item_ids() {
+        let conn = conn();
+        let repeated = get_track_by_id(&conn, 1).unwrap().unwrap();
+        replace_queue(
+            &conn,
+            &[
+                repeated.clone(),
+                repeated.clone(),
+                repeated.clone(),
+                repeated.clone(),
+            ],
+            "test",
+        )
+        .unwrap();
+        let before_qids: Vec<i64> = load_queue(&conn)
+            .unwrap()
+            .iter()
+            .map(|item| item.id)
+            .collect();
+
+        let shuffled =
+            apply_shuffle_with_seed(&conn, ShuffleMode::True, None, 7_654_321, "test").unwrap();
+        let after_qids: Vec<i64> = shuffled.queue.iter().map(|item| item.id).collect();
+
+        assert_ne!(after_qids, before_qids);
+        let mut sorted_before = before_qids.clone();
+        let mut sorted_after = after_qids;
+        sorted_before.sort_unstable();
+        sorted_after.sort_unstable();
+        assert_eq!(sorted_after, sorted_before);
     }
 
     #[test]

--- a/noor-server/src/playback/shuffle.rs
+++ b/noor-server/src/playback/shuffle.rs
@@ -1,12 +1,45 @@
 use crate::db::models::Track;
 use chrono::Utc;
-use rand::Rng;
+use rand::rngs::{OsRng, StdRng};
 use rand::seq::SliceRandom;
+use rand::{Rng, RngCore, SeedableRng};
 use std::cmp::Ordering;
 use std::collections::{HashMap, VecDeque};
 
 const UNKNOWN_GENRE: &str = "unknown";
 const UNKNOWN_ARTIST_KEY: &str = "__unknown_artist__";
+const POSITIVE_I64_MASK: u64 = i64::MAX as u64;
+
+pub fn generate_shuffle_seed() -> i64 {
+    loop {
+        let seed = OsRng.next_u64() & POSITIVE_I64_MASK;
+        if seed > 0 {
+            return seed as i64;
+        }
+    }
+}
+
+pub fn seeded_rng(seed: i64, mode: &str, scope: &str) -> StdRng {
+    let mixed = mix64((seed as u64) ^ stable_hash(mode) ^ stable_hash(scope).rotate_left(17));
+    StdRng::seed_from_u64(mixed.max(1))
+}
+
+fn stable_hash(value: &str) -> u64 {
+    let mut hash = 0xcbf2_9ce4_8422_2325u64;
+    for byte in value.as_bytes() {
+        hash ^= *byte as u64;
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    hash
+}
+
+fn mix64(mut value: u64) -> u64 {
+    value ^= value >> 33;
+    value = value.wrapping_mul(0xff51_afd7_ed55_8ccd);
+    value ^= value >> 33;
+    value = value.wrapping_mul(0xc4ce_b9fe_1a85_ec53);
+    value ^ (value >> 33)
+}
 
 #[derive(Debug, Clone)]
 pub struct WeightedShuffleProfile {
@@ -94,11 +127,6 @@ pub fn true_shuffle_with_rng<R: Rng + ?Sized>(tracks: &[Track], rng: &mut R) -> 
     shuffled
 }
 
-pub fn weighted_shuffle(tracks: &[Track], profile: &WeightedShuffleProfile) -> Vec<Track> {
-    let mut rng = rand::thread_rng();
-    weighted_shuffle_with_rng(tracks, profile, &mut rng)
-}
-
 pub fn weighted_shuffle_with_rng<R: Rng + ?Sized>(
     tracks: &[Track],
     profile: &WeightedShuffleProfile,
@@ -117,11 +145,6 @@ pub fn weighted_shuffle_with_rng<R: Rng + ?Sized>(
 
     weighted.sort_by(|(left, _), (right, _)| left.partial_cmp(right).unwrap_or(Ordering::Equal));
     weighted.into_iter().map(|(_, track)| track).collect()
-}
-
-pub fn artist_spread_shuffle(tracks: &[Track]) -> Vec<Track> {
-    let mut rng = rand::thread_rng();
-    artist_spread_shuffle_with_rng(tracks, &mut rng)
 }
 
 pub fn artist_spread_shuffle_with_rng<R: Rng + ?Sized>(

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -12030,6 +12030,7 @@ mod tests {
             tidal_tokens: None,
             tidal_mixes_cache: Arc::new(std::sync::Mutex::new(None)),
             tidal_radio_stations_cache: Arc::new(std::sync::Mutex::new(None)),
+            tidal_moods_cache: Arc::new(std::sync::Mutex::new(None)),
             spotify_tokens: None,
             playback_runtime: None,
             playback_runtime_info: None,

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -29,9 +29,9 @@ use axum::{
 use rusqlite::{OptionalExtension, params};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
-use std::collections::HashSet;
-use std::sync::Arc;
-use std::time::Duration;
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 use tracing::{error, info, warn};
 
 mod analytics_routes;
@@ -47,6 +47,10 @@ mod sportify_routes;
 mod tidal_home_routes;
 mod tidal_sync_routes;
 pub use tidal_sync_routes::trigger_auto_sync;
+
+type TidalPlaylistTracksCache = Arc<Mutex<HashMap<String, (Instant, Vec<TidalTrack>)>>>;
+
+const TIDAL_PLAYLIST_TRACKS_CACHE_TTL: Duration = Duration::from_secs(60 * 60);
 
 #[derive(Debug, Deserialize)]
 pub struct ListParams {
@@ -9175,57 +9179,72 @@ async fn tidal_playlist_tracks(
         ));
     };
 
-    let (http_client, tidal_http_client) = {
+    let (http_client, tidal_http_client, playlist_tracks_cache) = {
         let s = state.read().await;
-        (s.http_client.clone(), s.tidal_http_client.clone())
+        (
+            s.http_client.clone(),
+            s.tidal_http_client.clone(),
+            s.tidal_playlist_tracks_cache.clone(),
+        )
     };
+    let limit = 100;
+    let offset = 0;
+    let cache_key = tidal_playlist_tracks_cache_key(&tokens.country_code, &uuid, limit, offset);
     let client = TidalClient::with_http(
         tidal_http_client.clone(),
         tokens.access_token.clone(),
         tokens.country_code.clone(),
     );
-    let resp = match client.get_playlist_tracks(&uuid, 100, 0).await {
-        Ok(r) => r,
-        Err(e) if error_looks_like_auth(&e) => {
-            let refreshed = recover_tidal_session(&state, &http_client, &tokens)
-                .await
-                .map_err(|re| {
-                    (
+    let tracks = match get_cached_tidal_playlist_tracks(&playlist_tracks_cache, &cache_key) {
+        Some(cached) => cached,
+        None => {
+            let resp = match client.get_playlist_tracks(&uuid, limit, offset).await {
+                Ok(r) => r,
+                Err(e) if error_looks_like_auth(&e) => {
+                    let refreshed = recover_tidal_session(&state, &http_client, &tokens)
+                        .await
+                        .map_err(|re| {
+                            (
+                                StatusCode::BAD_GATEWAY,
+                                Json(json!({
+                                    "error": format!("TIDAL session refresh failed: {}", re)
+                                })),
+                            )
+                        })?;
+                    let retry_client = TidalClient::with_http(
+                        tidal_http_client,
+                        refreshed.access_token.clone(),
+                        refreshed.country_code.clone(),
+                    );
+                    retry_client
+                        .get_playlist_tracks(&uuid, limit, offset)
+                        .await
+                        .map_err(|e2| {
+                            (
+                                StatusCode::BAD_GATEWAY,
+                                Json(json!({ "error": e2.to_string() })),
+                            )
+                        })?
+                }
+                Err(e) => {
+                    return Err((
                         StatusCode::BAD_GATEWAY,
-                        Json(json!({ "error": format!("TIDAL session refresh failed: {}", re) })),
-                    )
-                })?;
-            let retry_client = TidalClient::with_http(
-                tidal_http_client,
-                refreshed.access_token.clone(),
-                refreshed.country_code.clone(),
-            );
-            retry_client
-                .get_playlist_tracks(&uuid, 100, 0)
-                .await
-                .map_err(|e2| {
-                    (
-                        StatusCode::BAD_GATEWAY,
-                        Json(json!({ "error": e2.to_string() })),
-                    )
-                })?
-        }
-        Err(e) => {
-            return Err((
-                StatusCode::BAD_GATEWAY,
-                Json(json!({ "error": e.to_string() })),
-            ));
+                        Json(json!({ "error": e.to_string() })),
+                    ));
+                }
+            };
+            put_cached_tidal_playlist_tracks(&playlist_tracks_cache, cache_key, resp.items.clone());
+            resp.items
         }
     };
 
-    let tidal_ids: Vec<i64> = resp.items.iter().map(|t| t.id).collect();
+    let tidal_ids: Vec<i64> = tracks.iter().map(|t| t.id).collect();
     let library_states = {
         let s = state.read().await;
         s.db.with_conn(|conn| queries::get_tidal_track_library_states(conn, &tidal_ids))
             .unwrap_or_default()
     };
-    let playable: Vec<serde_json::Value> = resp
-        .items
+    let playable: Vec<serde_json::Value> = tracks
         .into_iter()
         .map(|t| {
             let library_state = library_states.get(&t.id).copied();
@@ -9234,6 +9253,38 @@ async fn tidal_playlist_tracks(
         .collect();
 
     Ok(Json(json!({ "tracks": playable })))
+}
+
+fn tidal_playlist_tracks_cache_key(
+    country_code: &str,
+    uuid: &str,
+    limit: i32,
+    offset: i32,
+) -> String {
+    format!("{country_code}:{uuid}:{limit}:{offset}")
+}
+
+fn get_cached_tidal_playlist_tracks(
+    cache: &TidalPlaylistTracksCache,
+    key: &str,
+) -> Option<Vec<TidalTrack>> {
+    let mut guard = cache.lock().unwrap();
+    if let Some((stored_at, cached)) = guard.get(key)
+        && stored_at.elapsed() < TIDAL_PLAYLIST_TRACKS_CACHE_TTL
+    {
+        return Some(cached.clone());
+    }
+    guard.remove(key);
+    None
+}
+
+fn put_cached_tidal_playlist_tracks(
+    cache: &TidalPlaylistTracksCache,
+    key: String,
+    tracks: Vec<TidalTrack>,
+) {
+    let mut guard = cache.lock().unwrap();
+    guard.insert(key, (Instant::now(), tracks));
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -11769,6 +11820,31 @@ mod tests {
     }
 
     #[test]
+    fn tidal_playlist_tracks_cache_returns_fresh_entries_and_expires_stale_entries() {
+        let cache = Arc::new(std::sync::Mutex::new(HashMap::new()));
+        let key = tidal_playlist_tracks_cache_key("AU", "playlist-uuid", 100, 0);
+        let tracks: Vec<TidalTrack> = Vec::new();
+
+        put_cached_tidal_playlist_tracks(&cache, key.clone(), tracks.clone());
+
+        assert!(get_cached_tidal_playlist_tracks(&cache, &key).is_some());
+
+        {
+            let mut guard = cache.lock().unwrap();
+            guard.insert(
+                key.clone(),
+                (
+                    Instant::now() - TIDAL_PLAYLIST_TRACKS_CACHE_TTL - Duration::from_secs(1),
+                    tracks,
+                ),
+            );
+        }
+
+        assert!(get_cached_tidal_playlist_tracks(&cache, &key).is_none());
+        assert!(!cache.lock().unwrap().contains_key(&key));
+    }
+
+    #[test]
     fn ephemeral_stream_request_uses_user_audio_quality() {
         let request = build_ephemeral_tidal_stream_request(
             123,
@@ -12031,6 +12107,8 @@ mod tests {
             tidal_mixes_cache: Arc::new(std::sync::Mutex::new(None)),
             tidal_radio_stations_cache: Arc::new(std::sync::Mutex::new(None)),
             tidal_moods_cache: Arc::new(std::sync::Mutex::new(None)),
+            tidal_page_modules_cache: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            tidal_playlist_tracks_cache: Arc::new(std::sync::Mutex::new(HashMap::new())),
             spotify_tokens: None,
             playback_runtime: None,
             playback_runtime_info: None,

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -105,6 +105,8 @@ pub struct QueueReplaceRequest {
     /// These are appended after the library tracks as pending queue rows.
     #[serde(default)]
     pending_candidates: Option<Vec<PendingCandidateRequest>>,
+    #[serde(default)]
+    shuffle_mode: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -7574,7 +7576,7 @@ async fn set_playback_shuffle(
 ) -> Result<Json<Value>, StatusCode> {
     let mode = queue::ShuffleMode::parse(&payload.mode);
     let state_guard = state.read().await;
-    let snapshot = state_guard
+    let update = state_guard
         .db
         .with_conn(|conn| player::set_shuffle_mode(conn, mode))
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
@@ -7584,21 +7586,27 @@ async fn set_playback_shuffle(
     // on during a TIDAL mix actually changes what plays next. Pending entries
     // carry no genre/artist_id metadata, so genre/weighted modes degrade to a
     // plain Fisher-Yates - same shape as `true` shuffle.
-    if mode != queue::ShuffleMode::Off {
+    if let Some(debug) = update.debug.as_ref() {
         let mut q = state_guard.pending_tidal_mix_queue.lock().unwrap();
         if q.len() > 1 {
             use rand::seq::SliceRandom;
-            q.make_contiguous().shuffle(&mut rand::thread_rng());
+            let mut rng = crate::playback::shuffle::seeded_rng(
+                debug.seed,
+                mode.as_str(),
+                "pending_tidal_mix",
+            );
+            q.make_contiguous().shuffle(&mut rng);
         }
     }
 
     let _ = state_guard.event_tx.send(AppEvent::PlaybackStateChanged);
     let _ = state_guard.event_tx.send(AppEvent::QueueUpdated);
     drop(state_guard);
-    let snapshot = overlay_snapshot_with_external_track(&state, snapshot).await;
+    let snapshot = overlay_snapshot_with_external_track(&state, update.snapshot).await;
     Ok(Json(json!({
         "state": snapshot.state,
-        "queue": snapshot.queue
+        "queue": snapshot.queue,
+        "shuffle_debug": update.debug
     })))
 }
 
@@ -7978,9 +7986,32 @@ async fn replace_playback_queue(
                     .collect();
                 append_pending_tracks(conn, &candidates)?;
             }
-            let final_queue = crate::playback::queue::load_queue(conn)?;
+            let mut shuffle_debug = None;
+            let final_queue = match payload.shuffle_mode.as_deref() {
+                Some(raw_mode) => {
+                    let mode = queue::ShuffleMode::parse(raw_mode);
+                    if mode == queue::ShuffleMode::Off {
+                        crate::playback::queue::load_queue(conn)?
+                    } else {
+                        let seed = crate::playback::shuffle::generate_shuffle_seed();
+                        let result = crate::playback::queue::apply_shuffle_with_seed(
+                            conn,
+                            mode,
+                            None,
+                            seed,
+                            "queue_replace",
+                        )?;
+                        shuffle_debug = result.debug;
+                        result.queue
+                    }
+                }
+                None => crate::playback::queue::load_queue(conn)?,
+            };
             let _ = state.event_tx.send(AppEvent::QueueUpdated);
-            Ok(Json(json!({ "queue": final_queue })))
+            Ok(Json(json!({
+                "queue": final_queue,
+                "shuffle_debug": shuffle_debug
+            })))
         })
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
 }
@@ -9333,6 +9364,30 @@ async fn play_tidal_ephemeral(
 #[derive(Debug, serde::Deserialize)]
 struct PlayTidalMixRequest {
     tracks: Vec<PlayTidalRequest>,
+    #[serde(default)]
+    shuffle_mode: Option<String>,
+}
+
+fn shuffle_tidal_mix_tracks(
+    tracks: &mut [PlayTidalRequest],
+    shuffle_mode: Option<&str>,
+) -> Option<queue::ShuffleDebug> {
+    let mode = queue::ShuffleMode::parse(shuffle_mode.unwrap_or("off"));
+    if mode == queue::ShuffleMode::Off {
+        return None;
+    }
+
+    let seed = crate::playback::shuffle::generate_shuffle_seed();
+    let mut rng = crate::playback::shuffle::seeded_rng(seed, mode.as_str(), "tidal_mix");
+    use rand::seq::SliceRandom;
+    tracks.shuffle(&mut rng);
+    Some(queue::ShuffleDebug {
+        mode: mode.as_str().to_string(),
+        seed,
+        scope: "tidal_mix".to_string(),
+        locked_count: 0,
+        candidate_count: tracks.len(),
+    })
 }
 
 /// Play the first track immediately and stash the rest in the pending
@@ -9342,15 +9397,16 @@ async fn play_tidal_mix(
     State(state): State<SharedState>,
     Json(body): Json<PlayTidalMixRequest>,
 ) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
-    if body.tracks.is_empty() {
+    let mut tracks = body.tracks;
+    if tracks.is_empty() {
         return Err((
             StatusCode::BAD_REQUEST,
             Json(json!({ "error": "Mix has no tracks" })),
         ));
     }
+    let shuffle_debug = shuffle_tidal_mix_tracks(&mut tracks, body.shuffle_mode.as_deref());
 
-    let mut iter = body
-        .tracks
+    let mut iter = tracks
         .into_iter()
         .map(|t| crate::PendingEphemeralTidalTrack {
             tidal_track_id: t.tidal_track_id,
@@ -9361,6 +9417,7 @@ async fn play_tidal_mix(
             duration_ms: t.duration_ms,
         });
     let first = iter.next().expect("non-empty per check above");
+    let first_tidal_id = first.tidal_track_id;
     let rest: Vec<crate::PendingEphemeralTidalTrack> = iter.collect();
 
     // Replace any existing pending queue with this mix's continuation.
@@ -9372,7 +9429,11 @@ async fn play_tidal_mix(
     }
 
     start_ephemeral_tidal_playback(&state, first).await?;
-    Ok(Json(json!({ "ok": true })))
+    Ok(Json(json!({
+        "ok": true,
+        "first_tidal_id": first_tidal_id,
+        "shuffle_debug": shuffle_debug
+    })))
 }
 
 fn requested_tidal_quality(
@@ -12402,6 +12463,141 @@ mod tests {
         assert_eq!(persisted_queue_count, 1);
 
         let _ = std::fs::remove_file(db_path);
+    }
+
+    #[tokio::test]
+    async fn playback_shuffle_returns_debug_and_persists_seed() {
+        let (db, db_path) = fresh_migrated_db();
+        seed_basic_tracks(&db);
+        db.with_conn(|conn| {
+            conn.execute(
+                "INSERT INTO queue (track_id, position, source) VALUES (1, 0, 'user')",
+                [],
+            )?;
+            conn.execute(
+                "INSERT INTO queue (track_id, position, source) VALUES (2, 1, 'user')",
+                [],
+            )?;
+            Ok(())
+        })
+        .unwrap();
+
+        let app = api_routes(Arc::new(tokio::sync::RwLock::new(fresh_test_state(
+            db.clone(),
+        ))));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/playback/shuffle")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"mode":"true"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: Value = serde_json::from_slice(
+            &axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        let seed = body["shuffle_debug"]["seed"]
+            .as_i64()
+            .expect("positive seed");
+        assert!(seed > 0);
+        assert_eq!(body["shuffle_debug"]["mode"], "true");
+        assert_eq!(body["shuffle_debug"]["scope"], "playback_state");
+
+        let stored_seed: Option<i64> = db
+            .with_conn(|conn| {
+                Ok(conn.query_row(
+                    "SELECT shuffle_seed FROM playback_state WHERE id = 1",
+                    [],
+                    |row| row.get(0),
+                )?)
+            })
+            .unwrap();
+        assert_eq!(stored_seed, Some(seed));
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[tokio::test]
+    async fn replace_playback_queue_accepts_one_shot_shuffle_mode() {
+        let (db, db_path) = fresh_migrated_db();
+        seed_basic_tracks(&db);
+
+        let app = api_routes(Arc::new(tokio::sync::RwLock::new(fresh_test_state(
+            db.clone(),
+        ))));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/playback/queue")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"track_ids":[1,2],"shuffle_mode":"true"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: Value = serde_json::from_slice(
+            &axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(body["queue"].as_array().expect("queue").len(), 2);
+        assert_eq!(body["shuffle_debug"]["mode"], "true");
+        assert_eq!(body["shuffle_debug"]["scope"], "queue_replace");
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[test]
+    fn tidal_play_mix_shuffle_returns_debug_and_preserves_tracks() {
+        let mut tracks = vec![
+            PlayTidalRequest {
+                tidal_track_id: 101,
+                title: "One".to_string(),
+                artist_name: Some("Artist A".to_string()),
+                album_title: None,
+                artwork_url: None,
+                duration_ms: Some(180_000),
+            },
+            PlayTidalRequest {
+                tidal_track_id: 102,
+                title: "Two".to_string(),
+                artist_name: Some("Artist B".to_string()),
+                album_title: None,
+                artwork_url: None,
+                duration_ms: Some(181_000),
+            },
+            PlayTidalRequest {
+                tidal_track_id: 103,
+                title: "Three".to_string(),
+                artist_name: Some("Artist C".to_string()),
+                album_title: None,
+                artwork_url: None,
+                duration_ms: Some(182_000),
+            },
+        ];
+
+        let debug = shuffle_tidal_mix_tracks(&mut tracks, Some("true")).expect("shuffle debug");
+        let mut ids: Vec<i64> = tracks.iter().map(|track| track.tidal_track_id).collect();
+        ids.sort_unstable();
+
+        assert_eq!(ids, vec![101, 102, 103]);
+        assert_eq!(debug.mode, "true");
+        assert!(debug.seed > 0);
+        assert_eq!(debug.scope, "tidal_mix");
+        assert_eq!(debug.locked_count, 0);
+        assert_eq!(debug.candidate_count, 3);
     }
 
     #[tokio::test]

--- a/noor-server/src/server/routes/tidal_home_routes.rs
+++ b/noor-server/src/server/routes/tidal_home_routes.rs
@@ -1,6 +1,6 @@
 use crate::SharedState;
 use crate::db::queries;
-use crate::services::tidal::client::TidalClient;
+use crate::services::tidal::client::{TidalClient, TidalHomeModule};
 use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
@@ -12,6 +12,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 type TidalMoodCategoriesCache = Arc<Mutex<Option<(Instant, Vec<Value>)>>>;
+type TidalPageModulesCache = Arc<Mutex<HashMap<String, (Instant, Vec<TidalHomeModule>)>>>;
 
 const TIDAL_HOME_CACHE_TTL: Duration = Duration::from_secs(6 * 60 * 60);
 const MOOD_THUMBNAIL_FETCH_CONCURRENCY: usize = 4;
@@ -450,23 +451,24 @@ async fn fetch_page_modules(
     page_path: String,
     debug_raw: bool,
 ) -> Result<Json<Value>, StatusCode> {
-    let (tokens, http_client, tidal_http_client) = {
+    let (tokens, http_client, tidal_http_client, page_modules_cache) = {
         let in_memory = {
             let s = state.read().await;
             (
                 s.tidal_tokens.clone(),
                 s.http_client.clone(),
                 s.tidal_http_client.clone(),
+                s.tidal_page_modules_cache.clone(),
             )
         };
         match in_memory.0 {
-            Some(t) => (Some(t), in_memory.1, in_memory.2),
+            Some(t) => (Some(t), in_memory.1, in_memory.2, in_memory.3),
             None => {
                 let persisted = super::load_persisted_tidal_tokens(&state)
                     .await
                     .ok()
                     .flatten();
-                (persisted, in_memory.1, in_memory.2)
+                (persisted, in_memory.1, in_memory.2, in_memory.3)
             }
         }
     };
@@ -479,6 +481,7 @@ async fn fetch_page_modules(
         tokens.access_token.clone(),
         tokens.country_code.clone(),
     );
+    let cache_key = tidal_page_modules_cache_key(&tokens.country_code, &page_path);
     if debug_raw {
         let raw = match client.get_page_raw(&page_path).await {
             Ok(r) => r,
@@ -505,6 +508,11 @@ async fn fetch_page_modules(
             json!({ "raw": raw, "source": "tidal", "page": page_path }),
         ));
     }
+    if let Some(cached) = get_cached_tidal_page_modules(&page_modules_cache, &cache_key) {
+        return Ok(Json(
+            json!({ "modules": cached, "source": "tidal", "page": page_path, "cached": true }),
+        ));
+    }
     let modules = match client.get_page_modules(&page_path).await {
         Ok(m) => m,
         Err(e) if super::error_looks_like_auth(&e) => {
@@ -526,9 +534,37 @@ async fn fetch_page_modules(
             return Err(StatusCode::BAD_GATEWAY);
         }
     };
+    put_cached_tidal_page_modules(&page_modules_cache, cache_key, modules.clone());
     Ok(Json(
         json!({ "modules": modules, "source": "tidal", "page": page_path }),
     ))
+}
+
+fn tidal_page_modules_cache_key(country_code: &str, page_path: &str) -> String {
+    format!("{country_code}:{page_path}")
+}
+
+fn get_cached_tidal_page_modules(
+    cache: &TidalPageModulesCache,
+    key: &str,
+) -> Option<Vec<TidalHomeModule>> {
+    let mut guard = cache.lock().unwrap();
+    if let Some((stored_at, cached)) = guard.get(key)
+        && stored_at.elapsed() < TIDAL_HOME_CACHE_TTL
+    {
+        return Some(cached.clone());
+    }
+    guard.remove(key);
+    None
+}
+
+fn put_cached_tidal_page_modules(
+    cache: &TidalPageModulesCache,
+    key: String,
+    modules: Vec<TidalHomeModule>,
+) {
+    let mut guard = cache.lock().unwrap();
+    guard.insert(key, (Instant::now(), modules));
 }
 
 /// Returns the TIDAL mood / activity category list, parsed out of the
@@ -729,6 +765,39 @@ mod tests {
 
         assert!(get_cached_tidal_mood_categories(&cache).is_none());
         assert!(cache.lock().unwrap().is_none());
+    }
+
+    #[test]
+    fn tidal_page_modules_cache_returns_fresh_entries_and_expires_stale_entries() {
+        let cache = Arc::new(Mutex::new(std::collections::HashMap::new()));
+        let key = tidal_page_modules_cache_key("AU", "pages/m_happy");
+        let modules = vec![TidalHomeModule {
+            id: "happy".to_string(),
+            title: "Happy".to_string(),
+            kind: "PLAYLIST_LIST".to_string(),
+            more_path: None,
+            items: Vec::new(),
+        }];
+
+        put_cached_tidal_page_modules(&cache, key.clone(), modules.clone());
+
+        let cached = get_cached_tidal_page_modules(&cache, &key).expect("fresh cache hit");
+        assert_eq!(cached.len(), 1);
+        assert_eq!(cached[0].title, "Happy");
+
+        {
+            let mut guard = cache.lock().unwrap();
+            guard.insert(
+                key.clone(),
+                (
+                    Instant::now() - Duration::from_secs(6 * 60 * 60 + 1),
+                    modules,
+                ),
+            );
+        }
+
+        assert!(get_cached_tidal_page_modules(&cache, &key).is_none());
+        assert!(!cache.lock().unwrap().contains_key(&key));
     }
 }
 

--- a/noor-server/src/server/routes/tidal_home_routes.rs
+++ b/noor-server/src/server/routes/tidal_home_routes.rs
@@ -8,7 +8,13 @@ use axum::{
 };
 use serde_json::{Value, json};
 use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
+
+type TidalMoodCategoriesCache = Arc<Mutex<Option<(Instant, Vec<Value>)>>>;
+
+const TIDAL_HOME_CACHE_TTL: Duration = Duration::from_secs(6 * 60 * 60);
+const MOOD_THUMBNAIL_FETCH_CONCURRENCY: usize = 4;
 
 /// Returns the authenticated user's TIDAL mixes (Daily Discovery, My Mix N,
 /// Master Mix, etc) for the home page Your Mixes shelf.
@@ -51,7 +57,7 @@ pub(super) async fn get_tidal_mixes(
     {
         let guard = mixes_cache.lock().unwrap();
         if let Some((stored_at, cached)) = guard.as_ref()
-            && stored_at.elapsed() < Duration::from_secs(6 * 60 * 60)
+            && stored_at.elapsed() < TIDAL_HOME_CACHE_TTL
         {
             return Ok(Json(
                 json!({ "mixes": cached, "source": "tidal", "cached": true }),
@@ -126,7 +132,7 @@ pub(super) async fn get_tidal_radio_stations(
     {
         let guard = radio_cache.lock().unwrap();
         if let Some((stored_at, cached)) = guard.as_ref()
-            && stored_at.elapsed() < Duration::from_secs(6 * 60 * 60)
+            && stored_at.elapsed() < TIDAL_HOME_CACHE_TTL
         {
             return Ok(Json(
                 json!({ "stations": cached, "source": "tidal", "cached": true }),
@@ -536,6 +542,15 @@ pub(super) async fn get_tidal_moods(
     let Some(tokens) = tokens else {
         return Err(StatusCode::SERVICE_UNAVAILABLE);
     };
+    let mood_cache = {
+        let s = state.read().await;
+        s.tidal_moods_cache.clone()
+    };
+    if let Some(cached) = get_cached_tidal_mood_categories(&mood_cache) {
+        return Ok(Json(
+            json!({ "categories": cached, "source": "tidal", "cached": true }),
+        ));
+    }
     let client = TidalClient::with_http(
         tidal_http_client.clone(),
         tokens.access_token.clone(),
@@ -591,8 +606,14 @@ pub(super) async fn get_tidal_moods(
             }
         }
     });
-    let results: Vec<Option<(String, bool, Option<String>)>> =
-        futures::future::join_all(fetches).await;
+    let results: Vec<Option<(String, bool, Option<String>)>> = {
+        use futures::StreamExt;
+
+        futures::stream::iter(fetches)
+            .buffer_unordered(MOOD_THUMBNAIL_FETCH_CONCURRENCY)
+            .collect()
+            .await
+    };
     let probe: std::collections::HashMap<String, (bool, Option<String>)> = results
         .into_iter()
         .flatten()
@@ -617,7 +638,24 @@ pub(super) async fn get_tidal_moods(
         })
         .collect();
 
+    put_cached_tidal_mood_categories(&mood_cache, filtered.clone());
     Ok(Json(json!({ "categories": filtered, "source": "tidal" })))
+}
+
+fn get_cached_tidal_mood_categories(cache: &TidalMoodCategoriesCache) -> Option<Vec<Value>> {
+    let mut guard = cache.lock().unwrap();
+    if let Some((stored_at, cached)) = guard.as_ref()
+        && stored_at.elapsed() < TIDAL_HOME_CACHE_TTL
+    {
+        return Some(cached.clone());
+    }
+    *guard = None;
+    None
+}
+
+fn put_cached_tidal_mood_categories(cache: &TidalMoodCategoriesCache, categories: Vec<Value>) {
+    let mut guard = cache.lock().unwrap();
+    *guard = Some((Instant::now(), categories));
 }
 
 /// Walks `rows[].modules[]` and pulls items from any module of `type ==
@@ -662,6 +700,36 @@ fn extract_page_links(payload: &Value) -> Vec<Value> {
         }
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    #[test]
+    fn tidal_mood_category_cache_returns_fresh_entries_and_expires_stale_entries() {
+        let cache = Arc::new(Mutex::new(None));
+        let categories = vec![json!({ "slug": "mood_party", "title": "Party" })];
+
+        put_cached_tidal_mood_categories(&cache, categories.clone());
+
+        assert_eq!(
+            get_cached_tidal_mood_categories(&cache),
+            Some(categories.clone())
+        );
+
+        {
+            let mut guard = cache.lock().unwrap();
+            *guard = Some((
+                Instant::now() - Duration::from_secs(6 * 60 * 60 + 1),
+                categories,
+            ));
+        }
+
+        assert!(get_cached_tidal_mood_categories(&cache).is_none());
+        assert!(cache.lock().unwrap().is_none());
+    }
 }
 
 /// Drill-down for one mood / activity category. `slug` is the path segment


### PR DESCRIPTION
## Summary
- defer the home moods rail TIDAL fetch so it no longer fans out immediately on home mount
- gate the moods fetch behind a short delay plus viewport visibility, with a fallback timer
- leave direct TIDAL mix and track playback paths unchanged

## Verification
- pnpm check