### PR TITLE
[codex] Harden DiscoverSpace blend logic

### DIFF
--- a/frontend/src/lib/components/DiscoverSpace/DiscoverSpace.svelte
+++ b/frontend/src/lib/components/DiscoverSpace/DiscoverSpace.svelte
@@ -26,7 +26,7 @@
 		seedTrackId: number | null;
 		isLocked: boolean;
 		onHoverNode?: (node: DiscoverTrackNode | null, x: number, y: number) => void;
-		onSelectNode?: (node: DiscoverTrackNode) => void;
+		onSelectNode?: (node: DiscoverTrackNode | null) => void;
 		onNewNodes?: (nodes: DiscoverTrackNode[]) => void;
 	}
 	let {
@@ -60,6 +60,7 @@
 	let panStart = { x: 0, y: 0, cx: 0, cy: 0 };
 	let hoveredNode: DiscoverTrackNode | null = $state(null);
 	let selectedNode: DiscoverTrackNode | null = $state(null);
+	let lastNodeSignature = '';
 
 	// Physics settling — stops mutating node positions once kinetic energy drops
 	let simulationSettled = false;
@@ -69,6 +70,26 @@
 	let rippleNode: DiscoverTrackNode | null = null;
 	let rippleStartTick = 0;
 	const RIPPLE_TICKS = 45; // ≈ 750ms at 60fps
+
+	$effect(() => {
+		const nodes = $discoverSpaceStore.nodes;
+		const signature = nodes.map((node) => node.id).join('|');
+		if (signature === lastNodeSignature) return;
+		lastNodeSignature = signature;
+		const nodeIds = new Set(nodes.map((node) => node.id));
+		if (hoveredNode) {
+			hoveredNode = nodes.find((node) => node.id === hoveredNode?.id) ?? null;
+			if (!hoveredNode) {
+				onHoverNode?.(null, 0, 0);
+			}
+		}
+		if (selectedNode) {
+			selectedNode = nodes.find((node) => node.id === selectedNode?.id) ?? null;
+		}
+		if (rippleNode && !nodeIds.has(rippleNode.id)) {
+			rippleNode = null;
+		}
+	});
 
 	// Warp animation state
 	let warpProgress = 0;
@@ -316,6 +337,7 @@
 				rippleStartTick = tick;
 			} else {
 				selectedNode = null;
+				onSelectNode?.(null);
 			}
 		}
 		isPanning = false;

--- a/frontend/src/lib/components/DiscoverSpace/discover_space_store.test.ts
+++ b/frontend/src/lib/components/DiscoverSpace/discover_space_store.test.ts
@@ -13,6 +13,7 @@ import {
 	addBlendSeed,
 	clearBlend,
 	discoverSpaceStore,
+	loadBlendSpace,
 	loadSpace,
 	normalizeBlendSeeds,
 	removeBlendSeed,
@@ -33,6 +34,40 @@ function deferredJson(seedId: number) {
 				artists: [],
 				generated_at: new Date().toISOString(),
 				seed_track_id: seedId,
+			}),
+	};
+	return { promise, resolve: () => resolve(response) };
+}
+
+function deferredBlendJson() {
+	let resolve!: (v: unknown) => void;
+	const promise = new Promise((r) => {
+		resolve = r;
+	});
+	const response = {
+		ok: true,
+		json: () =>
+			Promise.resolve({
+				tracks: [
+					{
+						track_id: 900,
+						title: 'Stale Blend',
+						artist_name: 'Artist',
+						is_in_library: false,
+						role: 'external_candidate',
+						playability: 'resolvable',
+						score: 0.9,
+					},
+				],
+				edges: [],
+				artists: [],
+				health: {
+					playable_external_count: 1,
+					pending_external_count: 0,
+					library_guide_count: 0,
+					coverage_ratio: 1,
+				},
+				generated_at: new Date().toISOString(),
 			}),
 	};
 	return { promise, resolve: () => resolve(response) };
@@ -190,5 +225,74 @@ describe('loadSpace', () => {
 		});
 		clearBlend();
 		expect(get(discoverSpaceStore).blendSeeds).toHaveLength(0);
+	});
+
+	test('loadBlendSpace ignores fewer than two unique seeds', async () => {
+		addBlendSeed({
+			id: 'track-12',
+			trackId: 12,
+			title: 'Seed C',
+			artist: 'Artist',
+			playable: {
+				kind: 'library',
+				track_id: 12,
+				track: {} as any,
+			},
+			source: 'library',
+			role: 'library_guide',
+			playability: 'playable',
+			isInLibrary: true,
+			isColdStart: false,
+			genres: [],
+			score: 1,
+			confidence: 1,
+			supportCount: 0,
+			inDegree: 0,
+			inDegreePctile: 0,
+			primaryReason: 'unknown',
+			reasonTags: [],
+			perSeedScores: [],
+			coverageBonus: 0,
+			externalBonus: 0,
+			libraryPenalty: 0,
+			isSeed: false,
+			isPlaying: false,
+			inPlaylistBuilder: false,
+			isRouteOnly: false,
+			x: 0,
+			y: 0,
+			vx: 0,
+			vy: 0,
+			radius: 10,
+		});
+
+		await loadBlendSpace(null);
+
+		expect(authFetchMock).not.toHaveBeenCalled();
+		expect(get(discoverSpaceStore).blendHealth).toBeNull();
+		expect(get(discoverSpaceStore).blendLoading).toBe(false);
+	});
+
+	test('clearBlend invalidates an in-flight blend response', async () => {
+		discoverSpaceStore.update((s) => ({
+			...s,
+			nodes: [],
+			blendSeeds: [
+				{ kind: 'library', identity: 'library:1', track_id: 1, title: 'Seed A', weight: 0.5 },
+				{ kind: 'library', identity: 'library:2', track_id: 2, title: 'Seed B', weight: 0.5 },
+			],
+		}));
+		const blend = deferredBlendJson();
+		authFetchMock.mockImplementationOnce(() => blend.promise);
+
+		const request = loadBlendSpace(null);
+		clearBlend();
+		blend.resolve();
+		await request;
+
+		const state = get(discoverSpaceStore);
+		expect(state.blendSeeds).toHaveLength(0);
+		expect(state.blendHealth).toBeNull();
+		expect(state.nodes).toHaveLength(0);
 	});
 });

--- a/frontend/src/lib/components/DiscoverSpace/discover_space_store.ts
+++ b/frontend/src/lib/components/DiscoverSpace/discover_space_store.ts
@@ -130,6 +130,10 @@ export function addBlendSeed(node: DiscoverTrackNode): void {
 export function removeBlendSeed(identity: string): void {
 	discoverSpaceStore.update((s) => {
 		const nextSeeds = normalizeBlendSeeds(s.blendSeeds.filter((seed) => seed.identity !== identity));
+		if (nextSeeds.length < 2) {
+			loadBlendAborter?.abort();
+			loadBlendSeq++;
+		}
 		return {
 			...s,
 			blendSeeds: nextSeeds,
@@ -140,6 +144,7 @@ export function removeBlendSeed(identity: string): void {
 
 export function clearBlend(): void {
 	loadBlendAborter?.abort();
+	loadBlendSeq++;
 	discoverSpaceStore.update((s) => ({
 		...s,
 		blendSeeds: [],
@@ -171,6 +176,8 @@ export async function loadSpace(
 	currentTrackId: number | null
 ): Promise<void> {
 	loadSpaceAborter?.abort();
+	loadBlendAborter?.abort();
+	loadBlendSeq++;
 	const aborter = new AbortController();
 	loadSpaceAborter = aborter;
 	const seq = ++loadSpaceSeq;
@@ -243,7 +250,17 @@ export async function loadSpace(
 
 export async function loadBlendSpace(currentTrackId: number | null): Promise<void> {
 	const seeds = get(discoverSpaceStore).blendSeeds;
-	if (seeds.length === 0) return;
+	if (seeds.length < 2) {
+		loadBlendAborter?.abort();
+		loadBlendSeq++;
+		discoverSpaceStore.update((s) => ({
+			...s,
+			blendHealth: null,
+			blendLoading: false,
+			blendError: null,
+		}));
+		return;
+	}
 	loadBlendAborter?.abort();
 	const aborter = new AbortController();
 	loadBlendAborter = aborter;
@@ -253,6 +270,7 @@ export async function loadBlendSpace(currentTrackId: number | null): Promise<voi
 		...s,
 		blendLoading: true,
 		blendError: null,
+		blendHealth: null,
 		loading: true,
 		activeSeedId: null,
 		activeSeedSource: null,
@@ -311,7 +329,7 @@ async function runBlendQueueAction(
 ): Promise<void> {
 	const state = get(discoverSpaceStore);
 	const seeds = state.blendSeeds;
-	if (seeds.length === 0) return;
+	if (seeds.length < 2) return;
 	const ranked = playableBlendNodes(state.nodes);
 	if (ranked.length === 0 && endpoint !== 'add') {
 		showToast('No playable blend discoveries yet', 'info');
@@ -320,10 +338,11 @@ async function runBlendQueueAction(
 	discoverSpaceStore.update((s) => ({ ...s, blendLoading: true, blendError: null }));
 	try {
 		const apiBase = getApiBase();
+		const limit = endpoint === 'radio' ? 200 : 100;
 		const response = await authFetch(`${apiBase}/api/discovery/blend/${endpoint}`, {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' },
-			body: blendRequestBody(seeds),
+			body: blendRequestBody(seeds, limit),
 		});
 		if (!response.ok) throw new Error(`Blend action failed: ${response.status}`);
 		const result = await response.json();

--- a/frontend/src/routes/discoverspace/+page.svelte
+++ b/frontend/src/routes/discoverspace/+page.svelte
@@ -51,10 +51,29 @@
 	let searchQuery = $state('');
 	let isSearching = $state(false);
 	let blendAction = $state<'add' | 'play' | 'radio' | null>(null);
+	let lastNodeSignature = '';
 
 	let canRunBlendActions = $derived(
-		($discoverSpaceStore.blendHealth?.playable_external_count ?? 0) > 0
+		!$discoverSpaceStore.blendLoading
+		&& ($discoverSpaceStore.blendHealth?.playable_external_count ?? 0) > 0
 	);
+
+	$effect(() => {
+		const nodes = $discoverSpaceStore.nodes;
+		const signature = nodes.map((node) => node.id).join('|');
+		if (signature === lastNodeSignature) return;
+		lastNodeSignature = signature;
+		if (selectedNode) {
+			selectedNode = nodes.find((node) => node.id === selectedNode?.id) ?? null;
+		}
+		if (hoveredNode) {
+			hoveredNode = nodes.find((node) => node.id === hoveredNode?.id) ?? null;
+			if (!hoveredNode) {
+				hoverX = 0;
+				hoverY = 0;
+			}
+		}
+	});
 
 	function handleModeChange(mode: RadioMode) {
 		lastLoadedSeedId = resolvedSeedId;
@@ -71,7 +90,7 @@
 		hoverY = y;
 	}
 
-	function handleSelectNode(node: DiscoverTrackNode) {
+	function handleSelectNode(node: DiscoverTrackNode | null) {
 		selectedNode = node;
 	}
 
@@ -102,6 +121,16 @@
 		removeBlendSeed(identity);
 		if (nextCount >= 2) {
 			loadBlendSpace($currentTrack?.id ?? null);
+		}
+	}
+
+	function handleClearBlend() {
+		clearBlend();
+		hoveredNode = null;
+		selectedNode = null;
+		if (resolvedSeedId !== null) {
+			lastLoadedSeedId = resolvedSeedId;
+			loadSpace($discoverSpaceStore.mode, resolvedSeedId, undefined, resolvedSeedSource, $currentTrack?.id ?? null);
 		}
 	}
 
@@ -241,10 +270,10 @@
 				>
 					{$discoverSpaceStore.blendLoading ? 'Loading' : 'Map blend'}
 				</button>
-				<button class="blend-action" type="button" onclick={() => runBlendAction('add')} disabled={!canRunBlendActions || blendAction !== null}>Add discoveries</button>
-				<button class="blend-action primary" type="button" onclick={() => runBlendAction('play')} disabled={!canRunBlendActions || blendAction !== null}>Play discoveries</button>
-				<button class="blend-action" type="button" onclick={() => runBlendAction('radio')} disabled={!canRunBlendActions || blendAction !== null}>Make blend radio</button>
-				<button class="blend-action subtle" type="button" onclick={clearBlend}>Clear blend</button>
+				<button class="blend-action" type="button" onclick={() => runBlendAction('add')} disabled={!canRunBlendActions || blendAction !== null || $discoverSpaceStore.blendLoading}>Add discoveries</button>
+				<button class="blend-action primary" type="button" onclick={() => runBlendAction('play')} disabled={!canRunBlendActions || blendAction !== null || $discoverSpaceStore.blendLoading}>Play discoveries</button>
+				<button class="blend-action" type="button" onclick={() => runBlendAction('radio')} disabled={!canRunBlendActions || blendAction !== null || $discoverSpaceStore.blendLoading}>Make blend radio</button>
+				<button class="blend-action subtle" type="button" onclick={handleClearBlend}>Clear blend</button>
 			</div>
 		</div>
 	{/if}

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -2639,23 +2639,79 @@ fn layout_blend_candidate(
     }
 }
 
-fn resolve_tidal_blend_seeds(
+fn resolve_external_blend_seed_anchor(
+    conn: &rusqlite::Connection,
+    seed: &blend::BlendSeed,
+    model_id: Option<i64>,
+) -> rusqlite::Result<Option<i64>> {
+    if let Some(tidal_id) = seed.tidal_id.filter(|id| *id > 0) {
+        if let Some(track_id) = conn
+            .query_row(
+                "SELECT id FROM tracks WHERE tidal_id = ?1 LIMIT 1",
+                params![tidal_id],
+                |row| row.get::<_, i64>(0),
+            )
+            .optional()?
+        {
+            return Ok(Some(track_id));
+        }
+
+        return conn
+            .query_row(
+                "SELECT COALESCE(c.resolved_track_id, n.library_track_id)
+                 FROM external_track_candidates c
+                 LEFT JOIN external_track_candidate_neighbors n
+                   ON n.candidate_id = c.id
+                  AND (?2 IS NULL OR n.model_id = ?2)
+                 WHERE c.tidal_id = ?1
+                   AND COALESCE(c.resolved_track_id, n.library_track_id) IS NOT NULL
+                 ORDER BY
+                   CASE WHEN c.resolved_track_id IS NOT NULL THEN 0 ELSE 1 END,
+                   n.score DESC,
+                   n.rank ASC
+                 LIMIT 1",
+                params![tidal_id, model_id],
+                |row| row.get::<_, i64>(0),
+            )
+            .optional();
+    }
+
+    let artist = seed.artist.as_deref().unwrap_or("").trim();
+    let title = seed.title.as_deref().unwrap_or("").trim();
+    if artist.is_empty() || title.is_empty() {
+        return Ok(None);
+    }
+
+    conn.query_row(
+        "SELECT COALESCE(c.resolved_track_id, n.library_track_id)
+         FROM external_track_candidates c
+         LEFT JOIN external_track_candidate_neighbors n
+           ON n.candidate_id = c.id
+          AND (?3 IS NULL OR n.model_id = ?3)
+         WHERE lower(trim(c.title)) = lower(trim(?1))
+           AND lower(trim(c.artist_name)) = lower(trim(?2))
+           AND COALESCE(c.resolved_track_id, n.library_track_id) IS NOT NULL
+         ORDER BY
+           CASE WHEN c.resolved_track_id IS NOT NULL THEN 0 ELSE 1 END,
+           n.score DESC,
+           n.rank ASC
+         LIMIT 1",
+        params![title, artist, model_id],
+        |row| row.get::<_, i64>(0),
+    )
+    .optional()
+}
+
+fn resolve_blend_seed_anchors(
     conn: &rusqlite::Connection,
     seeds: &mut [blend::BlendSeed],
+    model_id: Option<i64>,
 ) -> rusqlite::Result<()> {
     for seed in seeds {
-        if seed.kind != blend::BlendSeedKind::Tidal || seed.track_id.is_some() {
-            continue;
-        }
-        if let Some(tidal_id) = seed.tidal_id {
-            let track_id = conn
-                .query_row(
-                    "SELECT id FROM tracks WHERE tidal_id = ?1 LIMIT 1",
-                    params![tidal_id],
-                    |row| row.get::<_, i64>(0),
-                )
-                .optional()?;
-            seed.track_id = track_id;
+        if seed.kind == blend::BlendSeedKind::Library {
+            seed.anchor_track_id = seed.track_id;
+        } else if seed.anchor_track_id.is_none() {
+            seed.anchor_track_id = resolve_external_blend_seed_anchor(conn, seed, model_id)?;
         }
     }
     Ok(())
@@ -2691,7 +2747,7 @@ fn seed_node_from_track(
         playability: blend::Playability::Playable,
         per_seed_scores: vec![blend::SeedScore {
             seed_identity: seed.identity.clone(),
-            seed_track_id: seed.track_id,
+            seed_track_id: seed.anchor_track_id.or(seed.track_id),
             score: 1.0,
         }],
         covered_seed_count: 1,
@@ -2735,7 +2791,7 @@ fn seed_node_from_external_seed(
         },
         per_seed_scores: vec![blend::SeedScore {
             seed_identity: seed.identity.clone(),
-            seed_track_id: seed.track_id,
+            seed_track_id: seed.anchor_track_id.or(seed.track_id),
             score: 1.0,
         }],
         covered_seed_count: 1,
@@ -2756,17 +2812,20 @@ fn build_discovery_blend_space(
     limit: i64,
     library_cap_ratio: f64,
 ) -> anyhow::Result<(Vec<blend::ScoredBlendCandidate>, Value)> {
-    resolve_tidal_blend_seeds(conn, seeds)?;
+    let model = queries::get_selected_discovery_embedding_model(conn)?;
+    resolve_blend_seed_anchors(conn, seeds, model.as_ref().map(|model| model.id))?;
     let seed_count = seeds.len();
     let library_seed_ids = seeds
         .iter()
-        .filter_map(|seed| seed.track_id)
+        .filter_map(|seed| seed.anchor_track_id.or(seed.track_id))
+        .collect::<HashSet<_>>()
+        .into_iter()
         .collect::<Vec<_>>();
-    let model = queries::get_selected_discovery_embedding_model(conn)?;
 
     let mut seed_nodes = Vec::new();
     for (index, seed) in seeds.iter().enumerate() {
-        if let Some(track_id) = seed.track_id {
+        if seed.kind == blend::BlendSeedKind::Library && seed.track_id.is_some() {
+            let track_id = seed.track_id.unwrap_or_default();
             let row = conn
                 .query_row(
                     "SELECT t.id, t.title, ar.name, al.title, al.artwork_url, t.duration_ms
@@ -2799,6 +2858,10 @@ fn build_discovery_blend_space(
     if let Some(model) = model {
         let per_seed_limit = limit.max(1).min(200);
         let seed_id_set = library_seed_ids.iter().copied().collect::<HashSet<_>>();
+        let seed_identity_set = seeds
+            .iter()
+            .map(|seed| seed.identity.clone())
+            .collect::<HashSet<_>>();
         let library_neighbors = queries::get_track_neighbors_for_seeds(
             conn,
             model.id,
@@ -2811,6 +2874,9 @@ fn build_discovery_blend_space(
                     continue;
                 }
                 let identity = format!("library:{}", row.track_id);
+                if seed_identity_set.contains(&identity) {
+                    continue;
+                }
                 let reason_tags =
                     parse_discovery_reason_tags(row.reason_json.as_deref(), "library_match");
                 let entry = candidate_inputs.entry(identity.clone()).or_insert_with(|| {
@@ -2847,7 +2913,10 @@ fn build_discovery_blend_space(
                     .tidal_id
                     .filter(|id| *id > 0)
                     .map(|id| format!("tidal:{id}"))
-                    .unwrap_or_else(|| format!("pending:{}", row.candidate_id));
+                    .unwrap_or_else(|| blend::pending_seed_identity(&row.artist_name, &row.title));
+                if seed_identity_set.contains(&identity) {
+                    continue;
+                }
                 let reason_tags =
                     parse_discovery_reason_tags(row.reason_json.as_deref(), "external_match");
                 let entry = candidate_inputs.entry(identity.clone()).or_insert_with(|| {
@@ -2995,7 +3064,7 @@ fn blend_edge_json(
     candidate
         .per_seed_scores
         .iter()
-        .filter(|score| score.seed_track_id == seed.track_id && score.score > 0.0)
+        .filter(|score| score.seed_identity == seed.identity && score.score > 0.0)
         .map(|score| {
             json!({
                 "id": format!("blend-{from_track_id}-{to_track_id}"),
@@ -3855,7 +3924,9 @@ async fn add_discovery_blend_to_queue(
             Ok(crate::server::radio_pipeline::append_radio_queue_from_candidates(conn, tracks)?)
         })
         .map_err(internal)?;
-    let pending_count = build.pending_item_ids.len();
+    let pending_item_ids = build.pending_item_ids;
+    let pending_count = pending_item_ids.len();
+    spawn_pending_resolvers_for_queue_items(&state, &db, pending_item_ids, "blend_add").await;
     {
         let state_guard = state.read().await;
         let _ = state_guard.event_tx.send(AppEvent::QueueUpdated);
@@ -3888,8 +3959,9 @@ async fn play_discovery_blend(
 
 async fn make_discovery_blend_radio(
     State(state): State<SharedState>,
-    Json(payload): Json<DiscoveryBlendRequest>,
+    Json(mut payload): Json<DiscoveryBlendRequest>,
 ) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    payload.limit = Some(payload.limit.unwrap_or(200).max(120).min(200));
     play_discovery_blend_inner(state, payload, "blend_radio").await
 }
 
@@ -5181,40 +5253,7 @@ async fn build_radio_queue_and_spawn_resolvers(
         }
     };
 
-    if !pending_item_ids.is_empty() {
-        let tokens_opt: Option<crate::services::tidal::auth::TidalTokens> = {
-            let s = state.read().await;
-            if let Some(t) = s.tidal_tokens.clone() {
-                Some(t)
-            } else {
-                drop(s);
-                load_persisted_tidal_tokens(state).await.ok().flatten()
-            }
-        };
-
-        if let Some(tokens) = tokens_opt {
-            let semaphore = Arc::new(tokio::sync::Semaphore::new(RESOLVER_POOL_SIZE));
-            let (event_tx, tidal_http_client) = {
-                let s = state.read().await;
-                (s.event_tx.clone(), s.tidal_http_client.clone())
-            };
-            for item_id in pending_item_ids {
-                let sem = semaphore.clone();
-                let db_bg = db.clone();
-                let tok = tokens.clone();
-                let tx = event_tx.clone();
-                let http = tidal_http_client.clone();
-                tokio::spawn(async move {
-                    let _permit = sem.acquire_owned().await.ok();
-                    resolve_pending_row(db_bg, tok, item_id, tx, http).await;
-                });
-            }
-        } else {
-            tracing::warn!(
-                "{context}: Tidal tokens unavailable - pending rows will rely on lazy resolution"
-            );
-        }
-    }
+    spawn_pending_resolvers_for_queue_items(state, db, pending_item_ids, context).await;
 
     {
         let s = state.read().await;
@@ -5222,6 +5261,50 @@ async fn build_radio_queue_and_spawn_resolvers(
     }
 
     Ok((first_playable, pending_count))
+}
+
+async fn spawn_pending_resolvers_for_queue_items(
+    state: &SharedState,
+    db: &crate::db::Database,
+    pending_item_ids: Vec<i64>,
+    context: &'static str,
+) {
+    if pending_item_ids.is_empty() {
+        return;
+    }
+
+    let tokens_opt: Option<crate::services::tidal::auth::TidalTokens> = {
+        let s = state.read().await;
+        if let Some(t) = s.tidal_tokens.clone() {
+            Some(t)
+        } else {
+            drop(s);
+            load_persisted_tidal_tokens(state).await.ok().flatten()
+        }
+    };
+
+    if let Some(tokens) = tokens_opt {
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(RESOLVER_POOL_SIZE));
+        let (event_tx, tidal_http_client) = {
+            let s = state.read().await;
+            (s.event_tx.clone(), s.tidal_http_client.clone())
+        };
+        for item_id in pending_item_ids {
+            let sem = semaphore.clone();
+            let db_bg = db.clone();
+            let tok = tokens.clone();
+            let tx = event_tx.clone();
+            let http = tidal_http_client.clone();
+            tokio::spawn(async move {
+                let _permit = sem.acquire_owned().await.ok();
+                resolve_pending_row(db_bg, tok, item_id, tx, http).await;
+            });
+        }
+    } else {
+        tracing::warn!(
+            "{context}: Tidal tokens unavailable - pending rows will rely on lazy resolution"
+        );
+    }
 }
 
 async fn start_first_radio_queue_item(
@@ -13758,6 +13841,156 @@ mod tests {
         assert_eq!(pending["role"], "external_candidate");
         assert_eq!(pending["playability"], "pending");
         assert_eq!(body["health"]["pending_external_count"], 1);
+        assert_eq!(body["health"]["playable_external_count"], 1);
+        assert!(body["health"]["coverage_ratio"].as_f64().unwrap() > 0.0);
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[tokio::test]
+    async fn discovery_blend_space_uses_external_seed_anchors() {
+        let (db, db_path) = fresh_migrated_db();
+        db.with_conn(|conn| {
+            conn.execute(
+                "INSERT INTO artists (id, name) VALUES (1, 'Guide Artist')",
+                [],
+            )?;
+            conn.execute(
+                "INSERT INTO tracks (id, title, artist_id, duration_ms, tidal_id)
+                 VALUES
+                    (1, 'Guide One', 1, 200000, 1001),
+                    (2, 'Guide Two', 1, 201000, 1002)",
+                [],
+            )?;
+            let model = queries::create_embedding_model(
+                conn,
+                "discovery-fusion-v2:blend-external-seeds",
+                "discovery-fusion-v2",
+                2,
+                "ready",
+                None,
+            )?;
+            queries::activate_embedding_model(conn, model.id)?;
+            let external_seed_one = queries::upsert_external_track_candidate(
+                conn,
+                &queries::ExternalTrackCandidateUpsert {
+                    tidal_id: Some(991_001),
+                    mbid: None,
+                    dedupe_key: "tidal:991001".to_string(),
+                    title: "External Seed One".to_string(),
+                    artist_name: "Outside".to_string(),
+                    genre_tags_json: None,
+                    duration_ms: Some(180_000),
+                    expires_at: "2099-01-01 00:00:00".to_string(),
+                },
+            )?;
+            let external_seed_two = queries::upsert_external_track_candidate(
+                conn,
+                &queries::ExternalTrackCandidateUpsert {
+                    tidal_id: Some(991_002),
+                    mbid: None,
+                    dedupe_key: "tidal:991002".to_string(),
+                    title: "External Seed Two".to_string(),
+                    artist_name: "Outside".to_string(),
+                    genre_tags_json: None,
+                    duration_ms: Some(181_000),
+                    expires_at: "2099-01-01 00:00:00".to_string(),
+                },
+            )?;
+            let shared_discovery = queries::upsert_external_track_candidate(
+                conn,
+                &queries::ExternalTrackCandidateUpsert {
+                    tidal_id: Some(991_003),
+                    mbid: None,
+                    dedupe_key: "tidal:991003".to_string(),
+                    title: "Shared Discovery".to_string(),
+                    artist_name: "Outside".to_string(),
+                    genre_tags_json: None,
+                    duration_ms: Some(182_000),
+                    expires_at: "2099-01-01 00:00:00".to_string(),
+                },
+            )?;
+            queries::replace_external_candidate_neighbors(
+                conn,
+                model.id,
+                1,
+                &[
+                    queries::ExternalCandidateNeighborWriteRow {
+                        candidate_id: external_seed_one.id,
+                        rank: 1,
+                        score: 0.99,
+                        audio_score: 0.99,
+                        metadata_score: 0.0,
+                        reason_json: Some(r#"[{"key":"external_audio_proxy"}]"#.to_string()),
+                    },
+                    queries::ExternalCandidateNeighborWriteRow {
+                        candidate_id: shared_discovery.id,
+                        rank: 2,
+                        score: 0.91,
+                        audio_score: 0.91,
+                        metadata_score: 0.0,
+                        reason_json: Some(r#"[{"key":"external_audio_proxy"}]"#.to_string()),
+                    },
+                ],
+            )?;
+            queries::replace_external_candidate_neighbors(
+                conn,
+                model.id,
+                2,
+                &[
+                    queries::ExternalCandidateNeighborWriteRow {
+                        candidate_id: external_seed_two.id,
+                        rank: 1,
+                        score: 0.99,
+                        audio_score: 0.99,
+                        metadata_score: 0.0,
+                        reason_json: Some(r#"[{"key":"external_audio_proxy"}]"#.to_string()),
+                    },
+                    queries::ExternalCandidateNeighborWriteRow {
+                        candidate_id: shared_discovery.id,
+                        rank: 2,
+                        score: 0.89,
+                        audio_score: 0.89,
+                        metadata_score: 0.0,
+                        reason_json: Some(r#"[{"key":"external_audio_proxy"}]"#.to_string()),
+                    },
+                ],
+            )?;
+            Ok(())
+        })
+        .expect("seed external blend anchors");
+
+        let app = api_routes(Arc::new(tokio::sync::RwLock::new(fresh_test_state(
+            db.clone(),
+        ))));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/discovery/blend/space")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"seeds":[{"kind":"tidal","tidal_id":991001,"title":"External Seed One","artist":"Outside"},{"kind":"tidal","tidal_id":991002,"title":"External Seed Two","artist":"Outside"}],"limit":20}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: Value = serde_json::from_slice(
+            &axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        let tracks = body["tracks"].as_array().expect("tracks array");
+        assert!(
+            tracks
+                .iter()
+                .any(|track| track["title"] == "Shared Discovery"),
+            "external blend seeds should produce anchored discoveries"
+        );
         assert_eq!(body["health"]["playable_external_count"], 1);
         assert!(body["health"]["coverage_ratio"].as_f64().unwrap() > 0.0);
 

--- a/noor-server/src/services/discovery_blend.rs
+++ b/noor-server/src/services/discovery_blend.rs
@@ -34,6 +34,7 @@ pub struct BlendSeed {
     pub kind: BlendSeedKind,
     pub identity: String,
     pub track_id: Option<i64>,
+    pub anchor_track_id: Option<i64>,
     pub tidal_id: Option<i64>,
     pub artist: Option<String>,
     pub title: Option<String>,
@@ -155,6 +156,7 @@ pub fn validate_and_normalize_seeds(
             kind: seed.kind,
             identity,
             track_id: seed.track_id.filter(|id| *id > 0),
+            anchor_track_id: seed.track_id.filter(|id| *id > 0),
             tidal_id: seed.tidal_id.filter(|id| *id > 0),
             artist: seed.artist.clone(),
             title: seed.title.clone(),
@@ -203,17 +205,27 @@ fn normalize_identity_part(value: &str) -> String {
         .join(" ")
 }
 
+pub fn pending_seed_identity(artist: &str, title: &str) -> String {
+    format!(
+        "pending:{}:{}",
+        normalize_identity_part(artist),
+        normalize_identity_part(title)
+    )
+}
+
 pub fn score_blend_candidate(
     candidate: &BlendCandidateInput,
     seeds: &[BlendSeed],
 ) -> ScoredBlendCandidate {
+    let mut seen_anchor_track_ids = HashSet::new();
     let mut per_seed_scores = Vec::new();
     let mut covered_seed_count = 0usize;
     let mut weighted_seed_proximity = 0.0;
 
     for seed in seeds {
-        let score = seed
-            .track_id
+        let seed_track_id = seed.anchor_track_id.or(seed.track_id);
+        let score = seed_track_id
+            .filter(|track_id| seen_anchor_track_ids.insert(*track_id))
             .and_then(|track_id| {
                 candidate
                     .per_seed_scores
@@ -228,7 +240,7 @@ pub fn score_blend_candidate(
         weighted_seed_proximity += seed.weight * score;
         per_seed_scores.push(SeedScore {
             seed_identity: seed.identity.clone(),
-            seed_track_id: seed.track_id,
+            seed_track_id,
             score,
         });
     }
@@ -497,5 +509,19 @@ mod tests {
             .filter(|candidate| candidate.role == CandidateRole::LibraryGuide)
             .count();
         assert_eq!(libraries, 1);
+    }
+
+    #[test]
+    fn duplicate_external_anchors_do_not_count_as_multi_seed_coverage() {
+        let mut seeds =
+            validate_and_normalize_seeds(&[library_seed(1, Some(0.5)), library_seed(2, Some(0.5))])
+                .expect("valid seeds");
+        seeds[1].anchor_track_id = Some(1);
+        let scored =
+            score_blend_candidate(&candidate("shared-anchor", false, vec![(1, 0.9)]), &seeds);
+
+        assert_eq!(scored.covered_seed_count, 1);
+        assert_eq!(scored.per_seed_scores[0].score, 0.9);
+        assert_eq!(scored.per_seed_scores[1].score, 0.0);
     }
 }


### PR DESCRIPTION
## Summary

- Fix DiscoverSpace blend mapping for external discovery seeds by resolving hidden library anchors while preserving the visible external seed nodes.
- Prevent stale blend responses and stale selected/hovered node state from sticking after clear, remove, normal map reload, or empty-canvas selection.
- Make blend queue actions safer: require at least two unique seeds, disable actions while remapping, spawn pending TIDAL resolvers for Add discoveries, and request a larger backend route for Make blend radio.
- Avoid inflated blend coverage when multiple external seeds collapse to the same library anchor.

## Root Cause

The initial blend implementation assumed seeds had local library track IDs. External/pending seeds often did not, so the backend could render only the seed nodes with zero health. The frontend also kept old blend health and selected node objects across async map transitions.

## Validation

- cargo test -p noor-server discovery_blend
- cargo fmt --all -- --check
- cargo check -p noor-server
- pnpm test -- discover_space_store
- pnpm lint
- pnpm check
