### PR TITLE
feat(playlists): server endpoints + remaining QoL follow-ups

### DIFF
--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -10,6 +10,48 @@ back to the PR or commit that flagged it.
 
 ## Open
 
+### feat: cover-sample endpoint for playlist mosaics
+
+`/playlists` hydrates per-card mosaics by calling `GET /api/playlists/:id/tracks`
+or `POST /api/smart/playlists/:id/evaluate` and discarding all but 4 artwork URLs.
+For smart playlists this re-runs the full rule evaluation just for art. Add
+`GET /api/playlists/:id/cover-sample` that returns up to 4 artwork URLs and
+short-circuit `hydrateMosaicFor` to call it. Cache server-side by
+`(playlist_id, updated_at)`.
+- Spawned by: playlists QoL pass (feature/playlists-qol)
+
+### feat: live "matches N tracks" preview in smart-playlist editor
+
+The editor has no live count while the user is tweaking rules; they have to
+save, close, expand, count, reopen. Add a stateless preview endpoint
+`POST /api/smart/playlists/preview` that takes a rules JSON body and returns
+`{ count: number }` without persisting anything. Wire a debounced (300-500ms)
+call in the editor and render the count next to the Ctrl+Enter hint.
+- Spawned by: playlists QoL pass (feature/playlists-qol)
+
+### feat: artist autocomplete in smart-playlist editor
+
+Genre autocomplete is live via `api.getGenres()` + HTML datalist. Artist
+autocomplete needs either a search-by-prefix endpoint
+(`GET /api/artists/search?q=...&limit=20`) or a lighter "all artist names"
+endpoint. `getArtists()` is paginated and returns full Artist rows; not
+suitable for a snappy datalist with thousands of artists.
+- Spawned by: playlists QoL pass (feature/playlists-qol)
+
+### perf: virtualize expanded playlist track lists
+
+`/playlists` currently caps an expanded card's track list at 75 rows with a
+"Show all N" button as an interim measure. Replace with a virtual list so
+500+ track playlists render fully without paying the full DOM cost.
+- Spawned by: playlists QoL pass (feature/playlists-qol)
+
+### chore: scrub remaining non-ASCII from /playlists page
+
+`describeClause` still produces `–` (en-dash), `≥`, `→`, etc. in user-facing
+rule summaries; option labels use `…`. Out of scope for the QoL pass but
+worth a sweep to comply with the repo's ASCII-only rule.
+- Spawned by: playlists QoL pass (feature/playlists-qol)
+
 ### perf: cache Last.fm `track.getSimilar` per (artist, title)
 
 `services/radio.rs` calls Last.fm `track.getSimilar` on every `/api/radio/song`

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -10,48 +10,6 @@ back to the PR or commit that flagged it.
 
 ## Open
 
-### feat: cover-sample endpoint for playlist mosaics
-
-`/playlists` hydrates per-card mosaics by calling `GET /api/playlists/:id/tracks`
-or `POST /api/smart/playlists/:id/evaluate` and discarding all but 4 artwork URLs.
-For smart playlists this re-runs the full rule evaluation just for art. Add
-`GET /api/playlists/:id/cover-sample` that returns up to 4 artwork URLs and
-short-circuit `hydrateMosaicFor` to call it. Cache server-side by
-`(playlist_id, updated_at)`.
-- Spawned by: playlists QoL pass (feature/playlists-qol)
-
-### feat: live "matches N tracks" preview in smart-playlist editor
-
-The editor has no live count while the user is tweaking rules; they have to
-save, close, expand, count, reopen. Add a stateless preview endpoint
-`POST /api/smart/playlists/preview` that takes a rules JSON body and returns
-`{ count: number }` without persisting anything. Wire a debounced (300-500ms)
-call in the editor and render the count next to the Ctrl+Enter hint.
-- Spawned by: playlists QoL pass (feature/playlists-qol)
-
-### feat: artist autocomplete in smart-playlist editor
-
-Genre autocomplete is live via `api.getGenres()` + HTML datalist. Artist
-autocomplete needs either a search-by-prefix endpoint
-(`GET /api/artists/search?q=...&limit=20`) or a lighter "all artist names"
-endpoint. `getArtists()` is paginated and returns full Artist rows; not
-suitable for a snappy datalist with thousands of artists.
-- Spawned by: playlists QoL pass (feature/playlists-qol)
-
-### perf: virtualize expanded playlist track lists
-
-`/playlists` currently caps an expanded card's track list at 75 rows with a
-"Show all N" button as an interim measure. Replace with a virtual list so
-500+ track playlists render fully without paying the full DOM cost.
-- Spawned by: playlists QoL pass (feature/playlists-qol)
-
-### chore: scrub remaining non-ASCII from /playlists page
-
-`describeClause` still produces `–` (en-dash), `≥`, `→`, etc. in user-facing
-rule summaries; option labels use `…`. Out of scope for the QoL pass but
-worth a sweep to comply with the repo's ASCII-only rule.
-- Spawned by: playlists QoL pass (feature/playlists-qol)
-
 ### perf: cache Last.fm `track.getSimilar` per (artist, title)
 
 `services/radio.rs` calls Last.fm `track.getSimilar` on every `/api/radio/song`

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -1949,6 +1949,30 @@ export const api = {
 		});
 	},
 
+	getPlaylistCoverSample(id: number, signal?: AbortSignal) {
+		return fetchApi<{ urls: string[] }>(
+			`/api/playlists/${id}/cover-sample`,
+			undefined,
+			{ signal },
+		);
+	},
+
+	previewSmartPlaylist(rules: RuleClause, signal?: AbortSignal) {
+		return fetchApi<{ count: number }>('/api/smart/playlists/preview', undefined, {
+			method: 'POST',
+			body: JSON.stringify({ rules }),
+			signal,
+		});
+	},
+
+	searchLibraryArtistNames(q: string, signal?: AbortSignal, limit = 20) {
+		return fetchApi<{ artists: { id: number; name: string }[] }>(
+			`/api/artists/search?q=${encodeURIComponent(q)}&limit=${limit}`,
+			undefined,
+			{ signal },
+		);
+	},
+
 	searchTidalPlaylists(q: string, signal?: AbortSignal, opts?: { limit?: number; offset?: number }) {
 		const limit = opts?.limit ?? 20;
 		const offset = opts?.offset ?? 0;

--- a/frontend/src/routes/playlists/+page.svelte
+++ b/frontend/src/routes/playlists/+page.svelte
@@ -23,9 +23,10 @@
 	} from '$lib/stores/player';
 	import PageHeader from '$lib/components/ui/PageHeader.svelte';
 	import EmptyState from '$lib/components/ui/EmptyState.svelte';
-	import MetricPair from '$lib/components/ui/MetricPair.svelte';
 	import StateBadge from '$lib/components/ui/StateBadge.svelte';
 	import TrackRow from '$lib/components/TrackRow.svelte';
+	import { openContextMenu } from '$lib/stores/context_menu';
+	import type { MenuItem } from '$lib/stores/context_menu';
 	import {
 		getCachedMosaic,
 		setCachedMosaic,
@@ -193,18 +194,46 @@
 	// kept in sync whenever a playlist's tracks load.
 	let mosaicById = $state<Record<number, string[]>>({});
 
-	// Phase 5B — back/forward state via SvelteKit snapshot.
+	// Per-playlist pre-computed search blob, populated on load. Avoids
+	// JSON.parse(smart_rules) for every playlist on every keystroke.
+	let searchTextById = $state<Record<number, string>>({});
+
+	// Inline delete confirmation - the card flips into a confirm bar instead
+	// of firing the destructive call on the first click.
+	let pendingDeleteId = $state<number | null>(null);
+
+	// Set of playlist ids whose expanded track list is in "show all" mode.
+	// The first paint after expand caps at TRACKS_PREVIEW_LIMIT to keep big
+	// playlists from rendering hundreds of rows synchronously.
+	let showAllTracksFor = $state<Set<number>>(new Set());
+	const TRACKS_PREVIEW_LIMIT = 75;
+
+	// Phase 5B - back/forward state via SvelteKit snapshot.
 	export const snapshot: Snapshot<{
 		expandedIds: number[];
 		scrollY: number;
+		query?: string;
+		filter?: PlaylistFilter;
+		sort?: PlaylistSort;
+		showAllTracksIds?: number[];
 	}> = {
 		capture: () => ({
 			expandedIds: [...expandedPlaylistIds],
-			scrollY: typeof window !== 'undefined' ? window.scrollY : 0
+			scrollY: typeof window !== 'undefined' ? window.scrollY : 0,
+			query: playlistQuery,
+			filter: playlistFilter,
+			sort: playlistSort,
+			showAllTracksIds: [...showAllTracksFor]
 		}),
 		restore: (saved) => {
 			if (Array.isArray(saved.expandedIds)) {
 				expandedPlaylistIds = new Set(saved.expandedIds);
+			}
+			if (typeof saved.query === 'string') playlistQuery = saved.query;
+			if (saved.filter) playlistFilter = saved.filter;
+			if (saved.sort) playlistSort = saved.sort;
+			if (Array.isArray(saved.showAllTracksIds)) {
+				showAllTracksFor = new Set(saved.showAllTracksIds);
 			}
 			requestAnimationFrame(() => window.scrollTo({ top: saved.scrollY, behavior: 'auto' }));
 		}
@@ -223,9 +252,19 @@
 	// Per-clause tag input buffers keyed by draft id
 	let tagInputs = $state<Record<number, string>>({});
 
-	// ─── Delete confirm ───────────────────────────────────────────────────────
+	// Delete confirm
 	let deletingId = $state<number | null>(null);
 	let deleteError = $state('');
+
+	// Editor dirty-tracking - the serialized snapshot of the draft at the
+	// moment the editor opened. Compared against the live draft to decide
+	// whether to prompt before closing.
+	let editorInitialSig = $state('');
+
+	// Genre suggestions for the tag input datalist. Lazily fetched the first
+	// time the editor opens, cached for the session.
+	let genreSuggestions = $state<string[]>([]);
+	let genreSuggestionsLoaded = false;
 
 	// Drawer focus management
 	let editorTriggerEl: HTMLElement | null = null;
@@ -286,7 +325,9 @@
 		try {
 			const data = await api.getPlaylists();
 			playlists = data.playlists;
-			scheduleMosaicPrefetch();
+			const next: Record<number, string> = {};
+			for (const p of playlists) next[p.id] = buildSearchText(p);
+			searchTextById = next;
 		} catch (error) {
 			loadError = `Failed to load playlists: ${error}`;
 		} finally {
@@ -299,43 +340,6 @@
 		if (urls.length === 0) return;
 		setCachedMosaic(id, urls, trackCount);
 		mosaicById = { ...mosaicById, [id]: urls };
-	}
-
-	function scheduleMosaicPrefetch() {
-		const run = () => void prefetchMosaics();
-		const ric = (globalThis as { requestIdleCallback?: (cb: () => void) => void })
-			.requestIdleCallback;
-		if (typeof ric === 'function') ric(run);
-		else setTimeout(run, 200);
-	}
-
-	async function prefetchMosaics() {
-		const targets = playlists.filter((p) => {
-			if (p.track_count <= 0) return false;
-			if (mosaicById[p.id]?.length) return false;
-			return getCachedMosaic(p.id, p.track_count) === null;
-		});
-		if (targets.length === 0) return;
-
-		const POOL = 3;
-		let cursor = 0;
-		const worker = async () => {
-			while (cursor < targets.length) {
-				const playlist = targets[cursor++];
-				try {
-					const data = playlist.is_smart
-						? await api.evaluateSmartPlaylist(playlist.id)
-						: await api.getPlaylistTracks(playlist.id);
-					recordMosaic(playlist.id, data.tracks, playlist.track_count);
-					if (!playlistTracksById[playlist.id]) {
-						playlistTracksById = { ...playlistTracksById, [playlist.id]: data.tracks };
-					}
-				} catch {
-					// Background task — leave the gradient fallback in place.
-				}
-			}
-		};
-		await Promise.all(Array.from({ length: POOL }, worker));
 	}
 
 	function isExpanded(id: number) {
@@ -410,11 +414,158 @@
 
 	async function togglePlaylistFavorite(playlist: Playlist, e: MouseEvent) {
 		e.stopPropagation();
+		// Optimistic flip - revert if the server disagrees.
+		const optimistic = { ...playlist, is_favorite: !playlist.is_favorite };
+		playlists = playlists.map((p) => (p.id === playlist.id ? optimistic : p));
 		try {
 			const updated = await api.togglePlaylistFavorite(playlist.id);
 			playlists = playlists.map((p) => (p.id === playlist.id ? updated.playlist : p));
 		} catch {
-			// Button state will be corrected on the next refresh.
+			playlists = playlists.map((p) => (p.id === playlist.id ? playlist : p));
+		}
+	}
+
+	function toggleShowAllTracks(id: number, on: boolean) {
+		const next = new Set(showAllTracksFor);
+		if (on) next.add(id);
+		else next.delete(id);
+		showAllTracksFor = next;
+	}
+
+	function openPlaylistContextMenu(
+		playlist: Playlist,
+		event: MouseEvent | { clientX: number; clientY: number },
+		anchorToButton = false,
+	) {
+		if ('preventDefault' in event && typeof event.preventDefault === 'function') {
+			event.preventDefault();
+		}
+		if ('stopPropagation' in event && typeof event.stopPropagation === 'function') {
+			event.stopPropagation();
+		}
+		// When triggered by the more-actions button, anchor the menu to the
+		// button's position so it lines up with the click target rather than
+		// the cursor coordinates from the synthetic MouseEvent.
+		const anchor =
+			anchorToButton && event instanceof MouseEvent
+				? (event.currentTarget as HTMLElement | null)
+				: null;
+		const rect = anchor?.getBoundingClientRect();
+		const point = rect
+			? { clientX: rect.right, clientY: rect.bottom + 4 }
+			: { clientX: event.clientX, clientY: event.clientY };
+		openContextMenu(point, buildPlaylistMenu(playlist), playlist.name);
+	}
+
+	function buildPlaylistMenu(playlist: Playlist): MenuItem[] {
+		const items: MenuItem[] = [
+			{ label: 'Play', icon: 'P', onSelect: () => void playPlaylistFromMenu(playlist) },
+			{ label: 'Shuffle', icon: 'X', onSelect: () => void shufflePlaylistFromMenu(playlist) },
+			{ label: 'Radio', icon: 'R', onSelect: () => void radioFromMenu(playlist) },
+			{ separator: true, label: '' },
+			{
+				label: playlist.is_favorite ? 'Remove from favourites' : 'Add to favourites',
+				icon: playlist.is_favorite ? 'F' : 'f',
+				onSelect: () => {
+					// Synthesize a fake MouseEvent shape; togglePlaylistFavorite
+					// only uses stopPropagation, which we no-op here.
+					void togglePlaylistFavorite(playlist, { stopPropagation: () => {} } as MouseEvent);
+				},
+			},
+		];
+		if (playlist.is_smart) {
+			items.push({ separator: true, label: '' });
+			items.push({ label: 'Edit rules', icon: 'E', onSelect: () => openEdit(playlist) });
+			items.push({ label: 'Duplicate', icon: 'D', onSelect: () => void duplicatePlaylist(playlist) });
+			items.push({
+				label: 'Delete',
+				icon: 'x',
+				danger: true,
+				onSelect: () => requestDelete(playlist.id),
+			});
+		}
+		return items;
+	}
+
+	async function playPlaylistFromMenu(playlist: Playlist) {
+		const tracks = await ensurePlaylistTracks(playlist.id);
+		if (!tracks.length) return;
+		const replaced = await api.replacePlaybackQueue(
+			tracks.map((t) => t.id),
+			undefined,
+			undefined,
+			get(shuffleMode),
+		);
+		await playTrackNow(replaced.queue[0]?.track.id ?? tracks[0].id);
+	}
+
+	async function shufflePlaylistFromMenu(playlist: Playlist) {
+		const tracks = await ensurePlaylistTracks(playlist.id);
+		await shufflePlaylist(tracks);
+	}
+
+	async function radioFromMenu(playlist: Playlist) {
+		const tracks = await ensurePlaylistTracks(playlist.id);
+		await startPlaylistRadio(tracks);
+	}
+
+	// IntersectionObserver-backed mosaic loader - only fetches artwork for
+	// cards the user can actually see, instead of hammering the API for
+	// every smart playlist on mount.
+	let mosaicObserver: IntersectionObserver | null = null;
+	const fetchedMosaicIds = new Set<number>();
+
+	function ensureMosaicObserver(): IntersectionObserver | null {
+		if (typeof IntersectionObserver === 'undefined') return null;
+		if (mosaicObserver) return mosaicObserver;
+		mosaicObserver = new IntersectionObserver(
+			(entries) => {
+				for (const entry of entries) {
+					if (!entry.isIntersecting) continue;
+					const target = entry.target as HTMLElement;
+					const id = Number(target.dataset.playlistId);
+					if (!Number.isFinite(id) || fetchedMosaicIds.has(id)) continue;
+					mosaicObserver?.unobserve(target);
+					void hydrateMosaicFor(id);
+				}
+			},
+			{ rootMargin: '200px 0px', threshold: 0.05 },
+		);
+		return mosaicObserver;
+	}
+
+	function registerCard(node: HTMLElement, playlistId: number) {
+		node.dataset.playlistId = String(playlistId);
+		const observer = ensureMosaicObserver();
+		observer?.observe(node);
+		return {
+			destroy() {
+				observer?.unobserve(node);
+			},
+		};
+	}
+
+	async function hydrateMosaicFor(id: number) {
+		const playlist = playlists.find((p) => p.id === id);
+		if (!playlist || playlist.track_count <= 0) return;
+		if (mosaicById[id]?.length) return;
+		const cached = getCachedMosaic(id, playlist.track_count);
+		if (cached) {
+			mosaicById = { ...mosaicById, [id]: cached };
+			return;
+		}
+		if (fetchedMosaicIds.has(id)) return;
+		fetchedMosaicIds.add(id);
+		try {
+			const data = playlist.is_smart
+				? await api.evaluateSmartPlaylist(id)
+				: await api.getPlaylistTracks(id);
+			recordMosaic(id, data.tracks, playlist.track_count);
+			if (!playlistTracksById[id]) {
+				playlistTracksById = { ...playlistTracksById, [id]: data.tracks };
+			}
+		} catch {
+			// Background task - leave the gradient fallback in place.
 		}
 	}
 
@@ -429,6 +580,8 @@
 		tagInputs = {};
 		editorError = '';
 		editorOpen = true;
+		editorInitialSig = currentDraftSig();
+		void loadGenreSuggestions();
 	}
 
 	function openEdit(playlist: Playlist) {
@@ -456,13 +609,54 @@
 		}
 		tagInputs = {};
 		editorOpen = true;
+		editorInitialSig = currentDraftSig();
+		void loadGenreSuggestions();
 	}
 
-	function closeEditor() {
+	function currentDraftSig(): string {
+		// Stable serialization so reorder-free draft edits flip the dirty flag.
+		return JSON.stringify({
+			name: draftName.trim(),
+			description: draftDescription.trim(),
+			logic: draftLogicOp,
+			clauses: draftClauses.map(draftToClause),
+		});
+	}
+
+	function isEditorDirty(): boolean {
+		return currentDraftSig() !== editorInitialSig;
+	}
+
+	function closeEditor(force = false) {
+		if (!force && isEditorDirty()) {
+			const ok = window.confirm('Discard unsaved changes to this playlist?');
+			if (!ok) return;
+		}
 		editorOpen = false;
 		const trigger = editorTriggerEl;
 		queueMicrotask(() => trigger?.focus());
 		editorTriggerEl = null;
+	}
+
+	async function loadGenreSuggestions() {
+		if (genreSuggestionsLoaded) return;
+		genreSuggestionsLoaded = true;
+		try {
+			const data = await api.getGenres();
+			const names: string[] = [];
+			const walk = (nodes: { name: string; children?: unknown[] }[]) => {
+				for (const node of nodes) {
+					if (node?.name) names.push(node.name);
+					if (Array.isArray(node?.children)) {
+						walk(node.children as { name: string; children?: unknown[] }[]);
+					}
+				}
+			};
+			walk(data.genres as unknown as { name: string; children?: unknown[] }[]);
+			genreSuggestions = Array.from(new Set(names)).sort((a, b) => a.localeCompare(b));
+		} catch {
+			genreSuggestionsLoaded = false; // allow retry on next open
+		}
 	}
 
 	function addClause() {
@@ -482,6 +676,24 @@
 		clause.names = [...new Set([...clause.names, ...tags])];
 		draftClauses = [...draftClauses]; // trigger reactivity
 		tagInputs = { ...tagInputs, [clauseId]: '' };
+	}
+
+	function onTagInput(clauseId: number, e: Event) {
+		// Auto-tokenize on comma so "rock, pop, soul" splits as the user types,
+		// rather than requiring Enter / Add.
+		const target = e.target as HTMLInputElement;
+		const value = target.value;
+		if (!value.includes(',')) return;
+		const parts = value.split(',');
+		const remainder = parts.pop() ?? '';
+		const clause = draftClauses.find((c) => c.id === clauseId);
+		if (!clause) return;
+		const tags = parts.map((t) => t.trim()).filter(Boolean);
+		if (tags.length) {
+			clause.names = [...new Set([...clause.names, ...tags])];
+			draftClauses = [...draftClauses];
+		}
+		tagInputs = { ...tagInputs, [clauseId]: remainder };
 	}
 
 	function removeTag(clauseId: number, tag: string) {
@@ -521,19 +733,30 @@
 			if (editingPlaylistId === null) {
 				const result = await api.createSmartPlaylist(name, desc, rootClause);
 				playlists = [...playlists, result.playlist];
+				indexPlaylistSearch(result.playlist);
 			} else {
 				const result = await api.updateSmartPlaylist(editingPlaylistId, name, desc, rootClause);
 				playlists = playlists.map((p) => (p.id === editingPlaylistId ? result.playlist : p));
+				indexPlaylistSearch(result.playlist);
 				// Invalidate cached tracks so re-expand re-evaluates
 				const { [editingPlaylistId]: _removed, ...rest } = playlistTracksById;
 				playlistTracksById = rest;
 			}
-			closeEditor();
+			closeEditor(true);
 		} catch (e) {
 			editorError = String(e);
 		} finally {
 			editorSaving = false;
 		}
+	}
+
+	function requestDelete(id: number) {
+		pendingDeleteId = id;
+		deleteError = '';
+	}
+
+	function cancelDelete() {
+		pendingDeleteId = null;
 	}
 
 	async function confirmDelete(id: number) {
@@ -543,11 +766,48 @@
 			await api.deleteSmartPlaylist(id);
 			playlists = playlists.filter((p) => p.id !== id);
 			expandedPlaylistIds = new Set([...expandedPlaylistIds].filter((x) => x !== id));
+			pendingDeleteId = null;
 		} catch (e) {
 			deleteError = String(e);
 		} finally {
 			deletingId = null;
 		}
+	}
+
+	async function duplicatePlaylist(playlist: Playlist) {
+		if (!playlist.is_smart) return;
+		const def = parseSmartDef(playlist.smart_rules);
+		const root = def?.root as RuleClause | undefined;
+		if (!root) return;
+		try {
+			const result = await api.createSmartPlaylist(
+				`${playlist.name} (copy)`,
+				playlist.description ?? null,
+				root
+			);
+			playlists = [...playlists, result.playlist];
+			indexPlaylistSearch(result.playlist);
+		} catch {
+			// Surface via the deleteError bar - it's the existing inline error channel.
+			deleteError = 'Could not duplicate that playlist.';
+		}
+	}
+
+	function indexPlaylistSearch(playlist: Playlist) {
+		searchTextById = { ...searchTextById, [playlist.id]: buildSearchText(playlist) };
+	}
+
+	function buildSearchText(playlist: Playlist): string {
+		const def = parseSmartDef(playlist.smart_rules);
+		const rules = def?.root ? describeClause(def.root).join(' ') : '';
+		return [
+			playlist.name,
+			playlist.description ?? '',
+			playlist.is_smart ? 'smart rules' : 'regular synced playlist',
+			rules,
+		]
+			.join(' ')
+			.toLowerCase();
 	}
 
 	// ─── Derived display helpers ──────────────────────────────────────────────
@@ -610,10 +870,10 @@
 	}
 
 	function playlistSubtitle(playlist: Playlist): string {
-		if (!playlist.is_smart) return playlist.description?.trim() || 'Synced playlist.';
-		const def = parseSmartDef(playlist.smart_rules);
-		if (!def?.root) return 'Smart playlist';
-		return describeClause(def.root)[0] ?? 'Smart playlist';
+		const desc = playlist.description?.trim();
+		if (desc) return desc;
+		if (!playlist.is_smart) return 'Synced playlist.';
+		return 'Smart playlist';
 	}
 
 	function smartSummaryLines(playlist: Playlist): string[] {
@@ -623,6 +883,19 @@
 		if (def.description?.trim()) lines.push(def.description.trim());
 		lines.push(...describeClause(def.root));
 		return lines.slice(0, 4);
+	}
+
+	function smartRuleSummary(playlist: Playlist): string | null {
+		if (!playlist.is_smart) return null;
+		const def = parseSmartDef(playlist.smart_rules);
+		const root = def?.root;
+		if (!root) return 'Smart playlist';
+		if (root.type === 'group') {
+			const op = (root.op ?? 'AND').toUpperCase() === 'OR' ? 'ANY' : 'ALL';
+			const count = Array.isArray(root.clauses) ? root.clauses.length : 0;
+			return `${count} rule${count === 1 ? '' : 's'} - ${op}`;
+		}
+		return '1 rule';
 	}
 
 	const RULE_TYPE_LABELS: Record<string, string> = {
@@ -686,15 +959,7 @@
 	);
 
 	function playlistSearchText(playlist: Playlist): string {
-		return [
-			playlist.name,
-			playlist.description ?? '',
-			playlist.is_smart ? 'smart rules rule driven' : 'regular synced playlist',
-			playlistSubtitle(playlist),
-			...smartSummaryLines(playlist),
-		]
-			.join(' ')
-			.toLowerCase();
+		return searchTextById[playlist.id] ?? buildSearchText(playlist);
 	}
 
 	function comparePlaylists(a: Playlist, b: Playlist): number {
@@ -778,7 +1043,11 @@
 	<title>Playlists | NOOR</title>
 </svelte:head>
 
-<svelte:window onkeydown={(e) => { if (e.key === 'Escape' && editorOpen) closeEditor(); }} />
+<svelte:window onkeydown={(e) => {
+	if (e.key !== 'Escape') return;
+	if (editorOpen) { closeEditor(); return; }
+	if (pendingDeleteId !== null) { cancelDelete(); }
+}} />
 
 <div class="page-shell playlists-page animate-in">
 	<PageHeader
@@ -791,12 +1060,6 @@
 			<button class="btn btn-primary" onclick={openNew}>New smart playlist</button>
 		{/snippet}
 	</PageHeader>
-
-	<section class="stat-grid">
-		<MetricPair label="Total" value={playlists.length} copy="Synced and local." />
-		<MetricPair label="Smart" value={smartCount()} copy="Rule driven." />
-		<MetricPair label="Regular" value={regularCount()} copy="Curated lists." />
-	</section>
 
 	<section class="playlist-control-band glass">
 		<div class="playlist-search-wrap">
@@ -844,8 +1107,11 @@
 		</div>
 
 		<p class="playlist-result-copy">
-			Showing {filteredPlaylists.length} {activeFilterLabel.toLowerCase()} playlist{filteredPlaylists.length === 1 ? '' : 's'}
-			with {visibleTrackTotal.toLocaleString()} visible track{visibleTrackTotal === 1 ? '' : 's'}.
+			{#if playlistFilter === 'all' && !playlistQuery.trim()}
+				{filteredPlaylists.length} playlist{filteredPlaylists.length === 1 ? '' : 's'} - {visibleTrackTotal.toLocaleString()} track{visibleTrackTotal === 1 ? '' : 's'}
+			{:else}
+				{filteredPlaylists.length} of {playlists.length} - {visibleTrackTotal.toLocaleString()} track{visibleTrackTotal === 1 ? '' : 's'}
+			{/if}
 		</p>
 	</section>
 
@@ -873,8 +1139,11 @@
 						role="button"
 						tabindex="0"
 						aria-expanded={isExpanded(playlist.id)}
+						aria-controls={`pl-body-${playlist.id}`}
 						onclick={() => void expandPlaylist(playlist.id)}
 						onkeydown={(e) => activatePlaylist(playlist.id, e)}
+						oncontextmenu={(e) => openPlaylistContextMenu(playlist, e)}
+						use:registerCard={playlist.id}
 					>
 						<div
 							class="playlist-cover"
@@ -895,27 +1164,16 @@
 						<div class="playlist-meta">
 							<div class="playlist-chip-row">
 								<StateBadge label={playlistSourceLabel(playlist)} tone={playlist.is_smart ? 'active' : 'muted'} compact={true} />
-								{#if playlist.is_favorite}
-									<StateBadge label="Favorite" tone="active" compact={true} />
+								{#if playlist.is_smart}
+									{@const summary = smartRuleSummary(playlist)}
+									{#if summary}
+										<span class="rule-chip" title={smartSummaryLines(playlist).join('\n')}>{summary}</span>
+									{/if}
 								{/if}
 							</div>
 							<h3>{playlist.name}</h3>
 							<p class="playlist-copy">{playlistSubtitle(playlist)}</p>
-							{#if playlist.is_smart}
-								<div class="smart-summary">
-									{#each smartSummaryLines(playlist).slice(0, 2) as line}
-										<p>{line}</p>
-									{/each}
-								</div>
-							{/if}
 						</div>
-						<button
-							class="icon-btn favorite-btn"
-							class:active={playlist.is_favorite}
-							onclick={(e) => void togglePlaylistFavorite(playlist, e)}
-							title={playlist.is_favorite ? 'Remove from favourites' : 'Add to favourites'}
-							aria-label={playlist.is_favorite ? 'Remove from favourites' : 'Add to favourites'}
-						>{playlist.is_favorite ? '♥' : '♡'}</button>
 					</div>
 
 					<div class="playlist-card-foot">
@@ -923,34 +1181,60 @@
 							<strong>{playlist.track_count.toLocaleString()}</strong>
 							<span>tracks</span>
 						</div>
-						<div class="playlist-actions">
-							<button class="btn btn-primary btn-sm" onclick={(e) => void playPlaylistQuick(playlist, e)}>Play</button>
-							<button class="btn btn-glass btn-sm" onclick={(e) => void shufflePlaylistQuick(playlist, e)}>Shuffle</button>
-							<button class="btn btn-glass btn-sm" onclick={(e) => void startPlaylistRadioQuick(playlist, e)}>Radio</button>
-							{#if playlist.is_smart}
-								<button class="btn btn-glass btn-sm" onclick={(e) => { e.stopPropagation(); openEdit(playlist); }}>
-									Edit rules
-								</button>
+						{#if pendingDeleteId === playlist.id}
+							<div class="confirm-strip" role="alertdialog" aria-label="Confirm delete">
+								<span class="confirm-copy">Delete "{playlist.name}"?</span>
+								<button class="btn btn-glass btn-sm" onclick={(e) => { e.stopPropagation(); cancelDelete(); }}>Cancel</button>
 								<button
-									class="btn btn-glass btn-sm danger"
+									class="btn btn-sm danger-solid"
 									disabled={deletingId === playlist.id}
 									onclick={(e) => { e.stopPropagation(); void confirmDelete(playlist.id); }}
+								>{deletingId === playlist.id ? 'Deleting...' : 'Delete'}</button>
+							</div>
+						{:else}
+							<div class="playlist-actions">
+								<button class="btn btn-primary btn-sm" onclick={(e) => void playPlaylistQuick(playlist, e)}>Play</button>
+								<button class="btn btn-glass btn-sm" onclick={(e) => void shufflePlaylistQuick(playlist, e)}>Shuffle</button>
+								<button class="btn btn-glass btn-sm" onclick={(e) => void startPlaylistRadioQuick(playlist, e)}>Radio</button>
+								<button
+									class="icon-btn favorite-btn"
+									class:active={playlist.is_favorite}
+									onclick={(e) => void togglePlaylistFavorite(playlist, e)}
+									aria-label={playlist.is_favorite ? 'Remove from favourites' : 'Add to favourites'}
+									title={playlist.is_favorite ? 'Remove from favourites' : 'Add to favourites'}
 								>
-									{deletingId === playlist.id ? 'Deleting...' : 'Delete'}
+									<svg width="14" height="14" viewBox="0 0 24 24" fill={playlist.is_favorite ? 'currentColor' : 'none'} stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+										<path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
+									</svg>
 								</button>
-							{/if}
-						</div>
+								<button
+									class="icon-btn more-btn"
+									onclick={(e) => openPlaylistContextMenu(playlist, e, true)}
+									aria-label="More actions"
+									title="More actions"
+								>
+									<svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+										<circle cx="5" cy="12" r="1.6" />
+										<circle cx="12" cy="12" r="1.6" />
+										<circle cx="19" cy="12" r="1.6" />
+									</svg>
+								</button>
+							</div>
+						{/if}
 					</div>
 
 					{#if isExpanded(playlist.id)}
-						<div class="playlist-body">
+						<div class="playlist-body" id={`pl-body-${playlist.id}`}>
 							{#if loadingById[playlist.id]}
-								<p class="playlist-copy">Loading tracks…</p>
+								<p class="playlist-copy">Loading tracks...</p>
 							{:else if errorById[playlist.id]}
 								<p class="playlist-copy">{errorById[playlist.id]}</p>
 							{:else if (playlistTracksById[playlist.id]?.length ?? 0) > 0}
+								{@const allTracks = playlistTracksById[playlist.id] ?? []}
+								{@const showAll = showAllTracksFor.has(playlist.id)}
+								{@const visibleTracks = showAll ? allTracks : allTracks.slice(0, TRACKS_PREVIEW_LIMIT)}
 								<ol class="track-list">
-									{#each playlistTracksById[playlist.id] as track, i (`${track.id}-${i}`)}
+									{#each visibleTracks as track, i (`${track.id}-${i}`)}
 										<TrackRow
 											{track}
 											variant="art"
@@ -961,6 +1245,17 @@
 										/>
 									{/each}
 								</ol>
+								{#if allTracks.length > TRACKS_PREVIEW_LIMIT}
+									<div class="track-list-more">
+										{#if showAll}
+											<button class="btn btn-glass btn-sm" onclick={() => toggleShowAllTracks(playlist.id, false)}>Show less</button>
+										{:else}
+											<button class="btn btn-glass btn-sm" onclick={() => toggleShowAllTracks(playlist.id, true)}>
+												Show all {allTracks.length.toLocaleString()}
+											</button>
+										{/if}
+									</div>
+								{/if}
 							{:else}
 								<p class="playlist-copy">No tracks resolved for this playlist.</p>
 							{/if}
@@ -980,7 +1275,7 @@
 		type="button"
 		class="drawer-backdrop"
 		aria-label="Close editor"
-		onclick={closeEditor}
+		onclick={() => closeEditor()}
 	></button>
 	<div
 		class="editor-drawer glass-panel"
@@ -989,12 +1284,23 @@
 		aria-labelledby="editor-title"
 		tabindex="-1"
 		use:trapFocus
+		onkeydown={(e) => {
+			if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+				e.preventDefault();
+				void saveEditor();
+			}
+		}}
 	>
+		<datalist id="noor-genre-suggestions">
+			{#each genreSuggestions as g}
+				<option value={g}></option>
+			{/each}
+		</datalist>
 		<div class="editor-head">
 			<h2 id="editor-title">
 				{editingPlaylistId === null ? 'New smart playlist' : 'Edit smart playlist'}
 			</h2>
-			<button class="close-btn" onclick={closeEditor} aria-label="Close editor">
+			<button class="close-btn" onclick={() => closeEditor()} aria-label="Close editor">
 				<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
 					<path d="M18 6L6 18M6 6l12 12" />
 				</svg>
@@ -1015,13 +1321,13 @@
 			</div>
 			<div class="field-group">
 				<label class="field-label" for="draft-desc">Description <span class="optional">(optional)</span></label>
-				<input
+				<textarea
 					id="draft-desc"
-					class="field-input"
-					type="text"
+					class="field-input field-textarea"
+					rows="2"
 					placeholder="Short note about this playlist"
 					bind:value={draftDescription}
-				/>
+				></textarea>
 			</div>
 
 			<!-- Logic operator -->
@@ -1076,8 +1382,10 @@
 									<input
 										class="field-input"
 										type="text"
+										list={clause.type === 'genre' ? 'noor-genre-suggestions' : undefined}
 										placeholder={clause.type === 'genre' ? 'Add genre (e.g. Electronic)' : 'Add artist name'}
 										bind:value={tagInputs[clause.id]}
+										oninput={(e) => onTagInput(clause.id, e)}
 										onkeydown={(e) => { if (e.key === 'Enter') { e.preventDefault(); addTag(clause.id); } }}
 									/>
 									<button class="btn btn-glass btn-sm" onclick={() => addTag(clause.id)}>Add</button>
@@ -1272,9 +1580,10 @@
 		</div>
 
 		<div class="editor-foot">
-			<button class="btn btn-glass" onclick={closeEditor}>Cancel</button>
+			<span class="editor-hint">Ctrl+Enter to save</span>
+			<button class="btn btn-glass" onclick={() => closeEditor()}>Cancel</button>
 			<button class="btn btn-primary" onclick={saveEditor} disabled={editorSaving}>
-				{editorSaving ? 'Saving…' : editingPlaylistId === null ? 'Create playlist' : 'Save changes'}
+				{editorSaving ? 'Saving...' : editingPlaylistId === null ? 'Create playlist' : 'Save changes'}
 			</button>
 		</div>
 	</div>
@@ -1491,22 +1800,10 @@
 		text-overflow: ellipsis;
 	}
 
-	.playlist-copy,
-	.smart-summary p {
+	.playlist-copy {
 		color: var(--text-secondary);
 		font-size: var(--font-size-sm);
 		line-height: var(--line-height-snug);
-	}
-
-	.smart-summary {
-		display: flex;
-		flex-direction: column;
-		gap: 3px;
-	}
-
-	.smart-summary p {
-		font-family: var(--font-mono);
-		color: var(--text-tertiary);
 	}
 
 	.icon-btn {
@@ -1557,8 +1854,63 @@
 	.playlist-actions {
 		display: flex;
 		flex-wrap: wrap;
+		align-items: center;
 		justify-content: flex-end;
 		gap: 6px;
+	}
+
+	.rule-chip {
+		display: inline-flex;
+		align-items: center;
+		padding: 2px 9px;
+		border-radius: 999px;
+		border: 1px solid var(--border-subtle);
+		background: color-mix(in srgb, currentColor 6%, transparent);
+		color: var(--text-tertiary);
+		font-size: var(--font-size-2xs);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		font-variant-numeric: tabular-nums;
+		cursor: help;
+	}
+
+	.confirm-strip {
+		display: flex;
+		align-items: center;
+		justify-content: flex-end;
+		gap: 8px;
+		flex-wrap: wrap;
+	}
+
+	.confirm-copy {
+		color: var(--text-secondary);
+		font-size: var(--font-size-sm);
+	}
+
+	.danger-solid {
+		background: var(--state-error);
+		border: 1px solid var(--state-error);
+		color: #fff;
+	}
+
+	.danger-solid:hover:not(:disabled) {
+		filter: brightness(1.08);
+	}
+
+	.more-btn,
+	.favorite-btn {
+		width: 30px;
+		min-width: 30px;
+		padding: 0;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+	}
+
+	.track-list-more {
+		display: flex;
+		justify-content: center;
+		padding-top: 6px;
 	}
 
 	.playlist-actions .btn-sm {
@@ -1569,16 +1921,6 @@
 	.btn-sm {
 		padding: 5px 12px;
 		font-size: var(--font-size-sm);
-	}
-
-	.danger {
-		color: var(--state-error);
-		border-color: color-mix(in srgb, var(--state-error) 28%, transparent);
-	}
-
-	.danger:hover:not(:disabled) {
-		background: color-mix(in srgb, var(--state-error) 14%, transparent);
-		border-color: color-mix(in srgb, var(--state-error) 45%, transparent);
 	}
 
 	.playlist-body {
@@ -1732,6 +2074,20 @@
 		outline: none;
 		border-color: var(--accent-line);
 		box-shadow: 0 0 0 3px var(--accent-soft);
+	}
+
+	.field-textarea {
+		min-height: 56px;
+		resize: vertical;
+		font-family: inherit;
+		line-height: var(--line-height-snug);
+	}
+
+	.editor-hint {
+		flex: 1;
+		color: var(--text-tertiary);
+		font-size: var(--font-size-xs);
+		font-variant-numeric: tabular-nums;
 	}
 
 	/* ─── Logic toggle ────────────────────────────────────────── */

--- a/frontend/src/routes/playlists/+page.svelte
+++ b/frontend/src/routes/playlists/+page.svelte
@@ -202,12 +202,6 @@
 	// of firing the destructive call on the first click.
 	let pendingDeleteId = $state<number | null>(null);
 
-	// Set of playlist ids whose expanded track list is in "show all" mode.
-	// The first paint after expand caps at TRACKS_PREVIEW_LIMIT to keep big
-	// playlists from rendering hundreds of rows synchronously.
-	let showAllTracksFor = $state<Set<number>>(new Set());
-	const TRACKS_PREVIEW_LIMIT = 75;
-
 	// Phase 5B - back/forward state via SvelteKit snapshot.
 	export const snapshot: Snapshot<{
 		expandedIds: number[];
@@ -215,7 +209,6 @@
 		query?: string;
 		filter?: PlaylistFilter;
 		sort?: PlaylistSort;
-		showAllTracksIds?: number[];
 	}> = {
 		capture: () => ({
 			expandedIds: [...expandedPlaylistIds],
@@ -223,7 +216,6 @@
 			query: playlistQuery,
 			filter: playlistFilter,
 			sort: playlistSort,
-			showAllTracksIds: [...showAllTracksFor]
 		}),
 		restore: (saved) => {
 			if (Array.isArray(saved.expandedIds)) {
@@ -232,9 +224,6 @@
 			if (typeof saved.query === 'string') playlistQuery = saved.query;
 			if (saved.filter) playlistFilter = saved.filter;
 			if (saved.sort) playlistSort = saved.sort;
-			if (Array.isArray(saved.showAllTracksIds)) {
-				showAllTracksFor = new Set(saved.showAllTracksIds);
-			}
 			requestAnimationFrame(() => window.scrollTo({ top: saved.scrollY, behavior: 'auto' }));
 		}
 	};
@@ -265,6 +254,22 @@
 	// time the editor opens, cached for the session.
 	let genreSuggestions = $state<string[]>([]);
 	let genreSuggestionsLoaded = false;
+
+	// Artist suggestions for artist-clause datalists. Fetched per query as
+	// the user types, with a small in-session cache. Library artist tables
+	// can run into the thousands so we never fetch the full list.
+	let artistSuggestions = $state<string[]>([]);
+	let artistQuery = $state('');
+	let artistFetchAbort: AbortController | null = null;
+	const artistCache = new Map<string, string[]>();
+
+	// Live "matches N tracks" preview for the editor. Recomputed on a
+	// debounce when the draft changes; null = idle, undefined-style.
+	let previewCount = $state<number | null>(null);
+	let previewError = $state('');
+	let previewLoading = $state(false);
+	let previewAbort: AbortController | null = null;
+	let previewDebounce: ReturnType<typeof setTimeout> | null = null;
 
 	// Drawer focus management
 	let editorTriggerEl: HTMLElement | null = null;
@@ -425,13 +430,6 @@
 		}
 	}
 
-	function toggleShowAllTracks(id: number, on: boolean) {
-		const next = new Set(showAllTracksFor);
-		if (on) next.add(id);
-		else next.delete(id);
-		showAllTracksFor = next;
-	}
-
 	function openPlaylistContextMenu(
 		playlist: Playlist,
 		event: MouseEvent | { clientX: number; clientY: number },
@@ -557,13 +555,10 @@
 		if (fetchedMosaicIds.has(id)) return;
 		fetchedMosaicIds.add(id);
 		try {
-			const data = playlist.is_smart
-				? await api.evaluateSmartPlaylist(id)
-				: await api.getPlaylistTracks(id);
-			recordMosaic(id, data.tracks, playlist.track_count);
-			if (!playlistTracksById[id]) {
-				playlistTracksById = { ...playlistTracksById, [id]: data.tracks };
-			}
+			const { urls } = await api.getPlaylistCoverSample(id);
+			if (!urls.length) return;
+			setCachedMosaic(id, urls, playlist.track_count);
+			mosaicById = { ...mosaicById, [id]: urls };
 		} catch {
 			// Background task - leave the gradient fallback in place.
 		}
@@ -633,6 +628,7 @@
 			if (!ok) return;
 		}
 		editorOpen = false;
+		resetPreview();
 		const trigger = editorTriggerEl;
 		queueMicrotask(() => trigger?.focus());
 		editorTriggerEl = null;
@@ -659,6 +655,96 @@
 		}
 	}
 
+	async function refreshArtistSuggestions(q: string) {
+		const query = q.trim();
+		if (!query) {
+			artistSuggestions = [];
+			return;
+		}
+		const cached = artistCache.get(query.toLowerCase());
+		if (cached) {
+			artistSuggestions = cached;
+			return;
+		}
+		artistFetchAbort?.abort();
+		const ctrl = new AbortController();
+		artistFetchAbort = ctrl;
+		try {
+			const data = await api.searchLibraryArtistNames(query, ctrl.signal, 20);
+			if (ctrl.signal.aborted) return;
+			const names = data.artists.map((a) => a.name);
+			artistCache.set(query.toLowerCase(), names);
+			artistSuggestions = names;
+		} catch {
+			// Soft fail - leave the previous suggestion list visible.
+		}
+	}
+
+	function schedulePreview() {
+		if (!editorOpen) return;
+		if (previewDebounce) clearTimeout(previewDebounce);
+		previewDebounce = setTimeout(() => {
+			previewDebounce = null;
+			void runPreview();
+		}, 350);
+	}
+
+	async function runPreview() {
+		if (!editorOpen) return;
+		// Skip preview for drafts that won't pass server validation - it
+		// would just round-trip a 400 every keystroke.
+		if (draftClauses.length === 0) {
+			previewCount = null;
+			previewError = '';
+			return;
+		}
+		if (validateDraft()) {
+			previewCount = null;
+			previewError = '';
+			return;
+		}
+		const rootClause: RuleClause = {
+			type: 'group',
+			op: draftLogicOp,
+			clauses: draftClauses.map(draftToClause),
+		};
+		previewAbort?.abort();
+		const ctrl = new AbortController();
+		previewAbort = ctrl;
+		previewLoading = true;
+		previewError = '';
+		try {
+			const data = await api.previewSmartPlaylist(rootClause, ctrl.signal);
+			if (ctrl.signal.aborted) return;
+			previewCount = data.count;
+		} catch (e) {
+			if (ctrl.signal.aborted) return;
+			previewError = String(e);
+			previewCount = null;
+		} finally {
+			if (!ctrl.signal.aborted) previewLoading = false;
+		}
+	}
+
+	function resetPreview() {
+		previewAbort?.abort();
+		if (previewDebounce) {
+			clearTimeout(previewDebounce);
+			previewDebounce = null;
+		}
+		previewCount = null;
+		previewError = '';
+		previewLoading = false;
+	}
+
+	$effect(() => {
+		if (!editorOpen) return;
+		// Touch the reactive bits we care about so the effect re-runs.
+		void draftClauses;
+		void draftLogicOp;
+		schedulePreview();
+	});
+
 	function addClause() {
 		draftClauses = [...draftClauses, defaultDraft()];
 	}
@@ -683,10 +769,17 @@
 		// rather than requiring Enter / Add.
 		const target = e.target as HTMLInputElement;
 		const value = target.value;
+		const clause = draftClauses.find((c) => c.id === clauseId);
+		if (clause?.type === 'artist') {
+			const q = value.replace(/,.*$/, '').trim();
+			if (q !== artistQuery) {
+				artistQuery = q;
+				void refreshArtistSuggestions(q);
+			}
+		}
 		if (!value.includes(',')) return;
 		const parts = value.split(',');
 		const remainder = parts.pop() ?? '';
-		const clause = draftClauses.find((c) => c.id === clauseId);
 		if (!clause) return;
 		const tags = parts.map((t) => t.trim()).filter(Boolean);
 		if (tags.length) {
@@ -841,7 +934,7 @@
 		const fmtRange = (label: string, min: number | null | undefined, max: number | null | undefined, digits = 0) => {
 			const lo = min == null ? 'any' : min.toFixed(digits);
 			const hi = max == null ? 'any' : max.toFixed(digits);
-			return `${label}: ${lo} – ${hi}`;
+			return `${label}: ${lo} - ${hi}`;
 		};
 		switch (clause.type) {
 			case 'group': {
@@ -853,9 +946,9 @@
 			case 'artist': return [`Artist: ${(clause.names ?? []).join(', ') || 'any'}`];
 			case 'date_range': {
 				const f = clause.field === 'last_played_at' ? 'Last played' : 'Date added';
-				return [`${f}: ${clause.range?.start ?? '—'} → ${clause.range?.end ?? 'now'}`];
+				return [`${f}: ${clause.range?.start ?? '-'} -> ${clause.range?.end ?? 'now'}`];
 			}
-			case 'play_count': return [`Play count: ${clause.op ?? '≥'} ${clause.value ?? 0}${clause.value_max != null ? ` – ${clause.value_max}` : ''}`];
+			case 'play_count': return [`Play count: ${clause.op ?? '>='} ${clause.value ?? 0}${clause.value_max != null ? ` - ${clause.value_max}` : ''}`];
 			case 'quality': return [`Min quality: ${clause.minimum ?? '?'}`];
 			case 'not_in_playlist': return [`Exclude from playlists: ${(clause.playlist_ids ?? []).join(', ') || 'none'}`];
 			case 'bpm_range': return [fmtRange('BPM', clause.min, clause.max, 0)];
@@ -925,8 +1018,8 @@
 
 	const NUMBER_OP_LABELS: Record<string, string> = {
 		eq: '= (exactly)',
-		gte: '≥ (at least)',
-		lte: '≤ (at most)',
+		gte: '>= (at least)',
+		lte: '<= (at most)',
 		gt: '> (more than)',
 		lt: '< (fewer than)',
 		between_inclusive: 'between',
@@ -1231,31 +1324,20 @@
 								<p class="playlist-copy">{errorById[playlist.id]}</p>
 							{:else if (playlistTracksById[playlist.id]?.length ?? 0) > 0}
 								{@const allTracks = playlistTracksById[playlist.id] ?? []}
-								{@const showAll = showAllTracksFor.has(playlist.id)}
-								{@const visibleTracks = showAll ? allTracks : allTracks.slice(0, TRACKS_PREVIEW_LIMIT)}
 								<ol class="track-list">
-									{#each visibleTracks as track, i (`${track.id}-${i}`)}
-										<TrackRow
-											{track}
-											variant="art"
-											index={i}
-											isCurrent={$currentTrack?.id === track.id}
-											isPlaying={$isPlaying}
-											onRowClick={() => void playTrack(track.id)}
-										/>
+									{#each allTracks as track, i (`${track.id}-${i}`)}
+										<li class="track-row-lazy">
+											<TrackRow
+												{track}
+												variant="art"
+												index={i}
+												isCurrent={$currentTrack?.id === track.id}
+												isPlaying={$isPlaying}
+												onRowClick={() => void playTrack(track.id)}
+											/>
+										</li>
 									{/each}
 								</ol>
-								{#if allTracks.length > TRACKS_PREVIEW_LIMIT}
-									<div class="track-list-more">
-										{#if showAll}
-											<button class="btn btn-glass btn-sm" onclick={() => toggleShowAllTracks(playlist.id, false)}>Show less</button>
-										{:else}
-											<button class="btn btn-glass btn-sm" onclick={() => toggleShowAllTracks(playlist.id, true)}>
-												Show all {allTracks.length.toLocaleString()}
-											</button>
-										{/if}
-									</div>
-								{/if}
 							{:else}
 								<p class="playlist-copy">No tracks resolved for this playlist.</p>
 							{/if}
@@ -1294,6 +1376,11 @@
 		<datalist id="noor-genre-suggestions">
 			{#each genreSuggestions as g}
 				<option value={g}></option>
+			{/each}
+		</datalist>
+		<datalist id="noor-artist-suggestions">
+			{#each artistSuggestions as a}
+				<option value={a}></option>
 			{/each}
 		</datalist>
 		<div class="editor-head">
@@ -1382,7 +1469,9 @@
 									<input
 										class="field-input"
 										type="text"
-										list={clause.type === 'genre' ? 'noor-genre-suggestions' : undefined}
+										list={clause.type === 'genre'
+											? 'noor-genre-suggestions'
+											: 'noor-artist-suggestions'}
 										placeholder={clause.type === 'genre' ? 'Add genre (e.g. Electronic)' : 'Add artist name'}
 										bind:value={tagInputs[clause.id]}
 										oninput={(e) => onTagInput(clause.id, e)}
@@ -1495,11 +1584,11 @@
 							</div>
 						{/if}
 
-						<!-- Energy / Danceability (0–1) -->
+						<!-- Energy / Danceability (0-1) -->
 						{#if clause.type === 'energy_range' || clause.type === 'danceability_range'}
 							<div class="num-fields">
 								<div class="field-group">
-									<label class="field-label" for="r-min-{clause.id}">Min (0–1)</label>
+									<label class="field-label" for="r-min-{clause.id}">Min (0-1)</label>
 									<input
 										id="r-min-{clause.id}"
 										class="field-input num-input"
@@ -1513,7 +1602,7 @@
 								</div>
 								<span class="and-label">to</span>
 								<div class="field-group">
-									<label class="field-label" for="r-max-{clause.id}">Max (0–1)</label>
+									<label class="field-label" for="r-max-{clause.id}">Max (0-1)</label>
 									<input
 										id="r-max-{clause.id}"
 										class="field-input num-input"
@@ -1531,7 +1620,7 @@
 						<!-- Key signature (musical letter notation) -->
 						{#if clause.type === 'key_signature'}
 							<select class="field-input" bind:value={clause.key_value}>
-								<option value="">Select key…</option>
+								<option value="">Select key...</option>
 								{#each KEY_SIGNATURES as k}
 									<option value={k}>{k}</option>
 								{/each}
@@ -1541,7 +1630,7 @@
 						<!-- Camelot key -->
 						{#if clause.type === 'camelot_key'}
 							<select class="field-input" bind:value={clause.key_value}>
-								<option value="">Select Camelot key…</option>
+								<option value="">Select Camelot key...</option>
 								{#each CAMELOT_KEYS as k}
 									<option value={k}>{k}</option>
 								{/each}
@@ -1580,7 +1669,17 @@
 		</div>
 
 		<div class="editor-foot">
-			<span class="editor-hint">Ctrl+Enter to save</span>
+			<span class="editor-hint">
+				{#if previewError}
+					Preview unavailable
+				{:else if previewLoading}
+					Counting matches...
+				{:else if previewCount !== null}
+					Matches {previewCount.toLocaleString()} track{previewCount === 1 ? '' : 's'}
+				{:else}
+					Ctrl+Enter to save
+				{/if}
+			</span>
 			<button class="btn btn-glass" onclick={() => closeEditor()}>Cancel</button>
 			<button class="btn btn-primary" onclick={saveEditor} disabled={editorSaving}>
 				{editorSaving ? 'Saving...' : editingPlaylistId === null ? 'Create playlist' : 'Save changes'}
@@ -1907,11 +2006,6 @@
 		justify-content: center;
 	}
 
-	.track-list-more {
-		display: flex;
-		justify-content: center;
-		padding-top: 6px;
-	}
 
 	.playlist-actions .btn-sm {
 		min-height: 30px;
@@ -1936,6 +2030,15 @@
 		display: flex;
 		flex-direction: column;
 		gap: 4px;
+	}
+
+	/* Browser-native virtualization: rows outside the viewport skip layout
+	   + paint while their intrinsic-size hint reserves scroll space. Cheaper
+	   than a windowed renderer and keeps every row in the DOM for Ctrl+F /
+	   screen-reader traversal. */
+	.track-row-lazy {
+		content-visibility: auto;
+		contain-intrinsic-size: 0 64px;
 	}
 
 	.clause-error {

--- a/noor-server/src/db/queries.rs
+++ b/noor-server/src/db/queries.rs
@@ -982,6 +982,50 @@ pub fn add_tracks_to_playlist(
     Ok(to_insert.len())
 }
 
+/// Up to `limit` distinct album-artwork URLs for a regular playlist, ordered
+/// by the earliest position the URL appears at. Built for the `/cover-sample`
+/// endpoint - returning four URLs as a JSON array is cheaper than evaluating
+/// the playlist and discarding everything but the first four.
+pub fn sample_playlist_artwork(
+    conn: &Connection,
+    playlist_id: i64,
+    limit: i64,
+) -> Result<Vec<String>> {
+    let mut stmt = conn.prepare(
+        "SELECT al.artwork_url, MIN(pt.position) AS first_pos
+         FROM playlist_tracks pt
+         JOIN tracks t ON pt.track_id = t.id
+         JOIN albums al ON t.album_id = al.id
+         WHERE pt.playlist_id = ?1 AND al.artwork_url IS NOT NULL
+         GROUP BY al.artwork_url
+         ORDER BY first_pos ASC
+         LIMIT ?2",
+    )?;
+    let urls = stmt
+        .query_map(params![playlist_id, limit], |row| row.get::<_, String>(0))?
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(urls)
+}
+
+/// Lightweight artist-name search for autocomplete: returns `(id, name)` pairs
+/// only. Reuses the FTS-then-LIKE fallback that powers the global `search`
+/// endpoint so it picks up the same matches.
+pub fn search_library_artist_names(
+    conn: &Connection,
+    query: &str,
+    limit: i64,
+) -> Result<Vec<(i64, String)>> {
+    let normalized = query.trim().to_ascii_lowercase();
+    if normalized.is_empty() {
+        return Ok(Vec::new());
+    }
+    let limit = limit.max(1);
+    let fts_query = to_fts_query(&normalized);
+    let artists = search_artists_fts(conn, &fts_query, limit)
+        .unwrap_or_else(|_| search_artists_like(conn, &normalized, limit).unwrap_or_default());
+    Ok(artists.into_iter().map(|a| (a.id, a.name)).collect())
+}
+
 pub fn get_playlist_tracks(conn: &Connection, playlist_id: i64) -> Result<Vec<Track>> {
     let mut stmt = conn.prepare(&format!(
         "SELECT {}

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -232,6 +232,21 @@ pub struct UpdateSmartPlaylistRequest {
     rules: Value,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct PreviewSmartPlaylistRequest {
+    /// Optional name/description carried over from the editor draft - the
+    /// preview doesn't persist anything so these are decorative.
+    name: Option<String>,
+    description: Option<String>,
+    rules: Value,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ArtistSearchParams {
+    q: Option<String>,
+    limit: Option<i64>,
+}
+
 pub fn api_routes(state: SharedState) -> Router {
     Router::new()
         // Library endpoints
@@ -289,6 +304,10 @@ pub fn api_routes(state: SharedState) -> Router {
             "/api/playlists/{id}/favorite",
             patch(toggle_playlist_favorite_route),
         )
+        .route(
+            "/api/playlists/{id}/cover-sample",
+            get(get_playlist_cover_sample),
+        )
         .route("/api/smart/playlists", post(create_smart_playlist_route))
         .route(
             "/api/smart/playlists/{id}",
@@ -298,6 +317,11 @@ pub fn api_routes(state: SharedState) -> Router {
             "/api/smart/playlists/{id}/evaluate",
             get(evaluate_smart_playlist),
         )
+        .route(
+            "/api/smart/playlists/preview",
+            post(preview_smart_playlist),
+        )
+        .route("/api/artists/search", get(search_artists_route))
         .route(
             "/api/analytics/overview",
             get(analytics_routes::get_analytics_overview),
@@ -1979,6 +2003,103 @@ async fn evaluate_smart_playlist(
             })))
         })
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+}
+
+/// Up to four distinct album-artwork URLs for the cover mosaic on /playlists.
+/// Regular playlists return without scanning every track. Smart playlists
+/// still need to evaluate their rules, but the response payload is four
+/// short strings instead of the entire track list.
+async fn get_playlist_cover_sample(
+    State(state): State<SharedState>,
+    Path(id): Path<i64>,
+) -> Result<Json<Value>, StatusCode> {
+    const COVER_SAMPLE_LIMIT: i64 = 4;
+    let state = state.read().await;
+    state
+        .db
+        .with_conn(|conn| {
+            let playlist = queries::get_playlist(conn, id)?
+                .ok_or_else(|| anyhow::anyhow!("playlist not found"))?;
+            let urls = if playlist.is_smart {
+                let tracks = resolve_smart_playlist_tracks(conn, &playlist)?;
+                unique_artwork_urls(&tracks, COVER_SAMPLE_LIMIT as usize)
+            } else {
+                queries::sample_playlist_artwork(conn, id, COVER_SAMPLE_LIMIT)?
+            };
+            Ok(Json(json!({ "urls": urls })))
+        })
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+}
+
+fn unique_artwork_urls(tracks: &[crate::db::models::Track], limit: usize) -> Vec<String> {
+    let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    let mut out: Vec<String> = Vec::with_capacity(limit);
+    for track in tracks {
+        let Some(url) = track.artwork_url.as_deref() else {
+            continue;
+        };
+        if seen.insert(url) {
+            out.push(url.to_string());
+            if out.len() >= limit {
+                break;
+            }
+        }
+    }
+    out
+}
+
+/// Live "matches N tracks" preview for the smart-playlist editor. Accepts a
+/// rules body identical to create/update but never touches the database -
+/// just evaluates and counts.
+async fn preview_smart_playlist(
+    State(state): State<SharedState>,
+    Json(payload): Json<PreviewSmartPlaylistRequest>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    let definition = SmartPlaylistDefinition {
+        name: payload.name.unwrap_or_default(),
+        description: payload.description,
+        root: serde_json::from_value(payload.rules).map_err(|e| {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "message": format!("Invalid rules: {e}") })),
+            )
+        })?,
+    };
+    let state = state.read().await;
+    state
+        .db
+        .with_conn(|conn| {
+            let tracks = queries::get_all_tracks(conn)?;
+            let context = build_smart_playlist_context(conn)?;
+            let count = crate::smart::playlists::evaluate_playlist(&definition, &tracks, &context).len();
+            Ok(Json(json!({ "count": count })))
+        })
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "message": e.to_string() })),
+            )
+        })
+}
+
+/// Lightweight artist autocomplete - returns `{ id, name }` pairs only.
+/// Powers the smart-playlist editor's artist tag input.
+async fn search_artists_route(
+    State(state): State<SharedState>,
+    axum::extract::Query(params): axum::extract::Query<ArtistSearchParams>,
+) -> Result<Json<Value>, StatusCode> {
+    let query = params.q.unwrap_or_default();
+    let limit = params.limit.unwrap_or(20).clamp(1, 50);
+    let state = state.read().await;
+    let results: Vec<(i64, String)> = state
+        .db
+        .with_conn(|conn| queries::search_library_artist_names(conn, &query, limit))
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let artists: Vec<Value> = results
+        .into_iter()
+        .map(|(id, name)| json!({ "id": id, "name": name }))
+        .collect();
+    Ok(Json(json!({ "artists": artists })))
 }
 
 async fn create_smart_playlist_route(
@@ -15202,9 +15323,12 @@ mod tests {
             ("GET", "/api/playlists"),
             ("GET", "/api/playlists/1/tracks"),
             ("PATCH", "/api/playlists/1/favorite"),
+            ("GET", "/api/playlists/1/cover-sample"),
             ("POST", "/api/smart/playlists"),
             ("PUT", "/api/smart/playlists/1"),
             ("GET", "/api/smart/playlists/1/evaluate"),
+            ("POST", "/api/smart/playlists/preview"),
+            ("GET", "/api/artists/search"),
             ("GET", "/api/analytics/overview"),
             ("GET", "/api/analytics/dashboard"),
             ("GET", "/api/analytics/signals"),

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -317,10 +317,7 @@ pub fn api_routes(state: SharedState) -> Router {
             "/api/smart/playlists/{id}/evaluate",
             get(evaluate_smart_playlist),
         )
-        .route(
-            "/api/smart/playlists/preview",
-            post(preview_smart_playlist),
-        )
+        .route("/api/smart/playlists/preview", post(preview_smart_playlist))
         .route("/api/artists/search", get(search_artists_route))
         .route(
             "/api/analytics/overview",
@@ -2071,7 +2068,8 @@ async fn preview_smart_playlist(
         .with_conn(|conn| {
             let tracks = queries::get_all_tracks(conn)?;
             let context = build_smart_playlist_context(conn)?;
-            let count = crate::smart::playlists::evaluate_playlist(&definition, &tracks, &context).len();
+            let count =
+                crate::smart::playlists::evaluate_playlist(&definition, &tracks, &context).len();
             Ok(Json(json!({ "count": count })))
         })
         .map_err(|e| {


### PR DESCRIPTION
Stacked on #58. Drains the five follow-ups it filed.

## Summary

### Server (noor-server)

- `GET /api/playlists/:id/cover-sample` returns up to 4 distinct album
  artwork URLs for the mosaic on /playlists. Regular playlists get a
  small SQL (`DISTINCT artwork_url + MIN(position)`); smart playlists
  still walk their rules but the response is four short strings instead
  of the full track list.
- `POST /api/smart/playlists/preview` accepts a rules JSON body and
  returns `{ count }` without touching the database. Powers the live
  matches-count in the editor footer.
- `GET /api/artists/search?q=&limit=` returns lightweight
  `{ id, name }` pairs for the editor's artist autocomplete. Reuses the
  FTS-then-LIKE fallback that the global `search` endpoint uses.
- New `queries::sample_playlist_artwork` and
  `queries::search_library_artist_names`.
- Route-registration smoke test extended for the three new routes.

### Frontend (/playlists)

- Mosaic hydration short-circuits through the new cover-sample
  endpoint. The previous code ran `evaluateSmartPlaylist` per card just
  to grab four URLs.
- Live `Matches N tracks` preview in the editor footer, debounced
  350ms, AbortController-cancellable on rapid edits, suppressed when
  the draft would fail server validation (avoids 400 round-trips).
- Artist autocomplete via datalist + per-query refresh with a small
  in-session cache.
- Browser-native virtualization on expanded track rows via
  `content-visibility: auto` + `contain-intrinsic-size`. The 75-row cap
  and `Show all` toggle from #58 are gone; every row stays in the DOM
  for Ctrl+F / screen readers while off-screen rows skip paint+layout.
- ASCII scrub of clause descriptions and option labels in /playlists
  (en-dash -> `-`, arrow -> `->`, `>=` / `<=` replace the math glyphs).

### API client

- `getPlaylistCoverSample`, `previewSmartPlaylist`,
  `searchLibraryArtistNames`.

### FOLLOWUPS.md

Removed the five entries this commit drains.

## Test plan

- [x] `cargo check -p noor-server` (no new warnings; 41 pre-existing)
- [x] `cargo test -p noor-server --bin noor-server all_api_routes_are_registered` (passes; new routes registered)
- [x] `pnpm check` (0/0)
- [x] `pnpm lint` (stylelint + inline-styles)
- [x] `pnpm test` (53 files / 247 tests)
- [x] `pnpm run build` (production bundle clean)
- [ ] Manual: hit `/playlists` with the rebuilt server, confirm cards
      hydrate via cover-sample (network tab should show
      `/api/playlists/:id/cover-sample` instead of `/evaluate`)
- [ ] Manual: open the editor, edit rules, see the live count update
      in the footer
- [ ] Manual: scroll a 500+ track expanded playlist, confirm smooth
      paint