### PR TITLE
Queue UI QOL: a11y + keyboard + undo + restructure (audit batch)

### DIFF
--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -10,6 +10,15 @@ back to the PR or commit that flagged it.
 
 ## Open
 
+### a11y: keep queue-time visible on focus without colliding with action buttons
+
+`.queue-time` currently fades on `:hover` and `:focus-within` because
+`.queue-actions` sits absolutely positioned at `right: 0; top: 50%`. Keyboard
+users lose the duration when a row gains focus. Resolving cleanly needs a row
+relayout (two-line side panel or shrunken icon set), not a one-line CSS
+toggle. Audit item 16 from the 2026-05-23 queue UI audit.
+- Spawned by: feature/queue-ui-qol (Commit 6, c21cf78 area)
+
 ### perf: cache Last.fm `track.getSimilar` per (artist, title)
 
 `services/radio.rs` calls Last.fm `track.getSimilar` on every `/api/radio/song`

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -10,6 +10,16 @@ back to the PR or commit that flagged it.
 
 ## Open
 
+### a11y: scope hidden queue actions out of the accessibility tree per row
+
+`.queue-actions` is `opacity: 0; pointer-events: none` until the row receives
+hover or focus, but the buttons stay in the a11y tree and keep their tabindex.
+Keyboard activation still works, but a screen-reader virtual cursor can list
+buttons that aren't visible. Wiring `inert` on the container needs per-row
+hover/focus state (CSS can't toggle attributes), so it's larger than the rest
+of the polish bundle. Audit item 8 from the 2026-05-23 queue UI audit.
+- Spawned by: feature/queue-ui-qol (Commit 8 area)
+
 ### a11y: keep queue-time visible on focus without colliding with action buttons
 
 `.queue-time` currently fades on `:hover` and `:focus-within` because

--- a/frontend/src/lib/components/QueueReasonCard.svelte
+++ b/frontend/src/lib/components/QueueReasonCard.svelte
@@ -99,6 +99,12 @@
 		to { opacity: 1; transform: translateY(0); }
 	}
 
+	@media (prefers-reduced-motion: reduce) {
+		.reason-card {
+			animation: none;
+		}
+	}
+
 	.header {
 		font-size: var(--font-size-2xs);
 		font-weight: var(--font-weight-bold);

--- a/frontend/src/lib/components/ShortcutHelp.svelte
+++ b/frontend/src/lib/components/ShortcutHelp.svelte
@@ -51,7 +51,13 @@
 			title: 'Queue Focus',
 			shortcuts: [
 				{ keys: ['Up'], action: 'Expand the collapsed queue when focused inside it' },
-				{ keys: ['Down'], action: 'Collapse the expanded queue when focused inside it' }
+				{ keys: ['Down'], action: 'Collapse the expanded queue when focused inside it' },
+				{ keys: ['Enter'], action: 'Play the focused row' },
+				{ keys: ['Delete'], action: 'Remove the focused row from the queue' },
+				{ keys: ['Alt', 'Up'], action: 'Move the focused row one position earlier' },
+				{ keys: ['Alt', 'Down'], action: 'Move the focused row one position later' },
+				{ keys: ['Shift', 'Alt', 'Up'], action: 'Promote the focused row to play next' },
+				{ keys: ['Z'], action: 'Undo a recent clear queue (within 6 seconds)' }
 			]
 		}
 	];

--- a/frontend/src/lib/components/remote/RemoteQueue.svelte
+++ b/frontend/src/lib/components/remote/RemoteQueue.svelte
@@ -5,8 +5,10 @@
 		moveQueueTrackNext,
 		playTrackNow,
 		refreshPlaybackState,
-		removeTrackFromQueue
+		removeTrackFromQueue,
+		restoreQueueItems
 	} from '$lib/stores/player';
+	import { pendingUndo, consumeUndo } from '$lib/stores/queue_undo';
 	import { upscaleTidalArtwork } from '$lib/utils/artwork';
 	import { formatTrackDuration } from '$lib/utils/format';
 	import {
@@ -109,6 +111,13 @@
 	function onClear() {
 		hapticAccent();
 		void clearQueue();
+	}
+
+	async function onUndoClear() {
+		const restorable = consumeUndo();
+		if (!restorable) return;
+		hapticCommit();
+		await restoreQueueItems(restorable);
 	}
 
 	async function onPlayRow(item: QueueItem) {
@@ -220,6 +229,17 @@
 			</button>
 		</div>
 	</header>
+
+	{#if $pendingUndo}
+		<div class="remote-queue-undo" role="status">
+			<span>Cleared {$pendingUndo.count} {$pendingUndo.count === 1 ? 'track' : 'tracks'}</span>
+			<button
+				class="remote-queue-undo-btn"
+				type="button"
+				onclick={() => void onUndoClear()}
+			>Undo</button>
+		</div>
+	{/if}
 
 	{#if displayQueue.length === 0}
 		<p class="remote-empty">Nothing is lined up.</p>
@@ -495,5 +515,28 @@
 
 	.remote-queue-clear:disabled {
 		opacity: 0.4;
+	}
+
+	.remote-queue-undo {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 12px;
+		margin: 8px 0 12px;
+		padding: 10px 14px;
+		border-radius: 12px;
+		background: color-mix(in srgb, var(--accent-soft) 70%, transparent);
+		border: 1px solid var(--accent-line);
+		font-size: var(--font-size-sm);
+	}
+
+	.remote-queue-undo-btn {
+		padding: 6px 14px;
+		border-radius: 999px;
+		border: 1px solid var(--accent-line);
+		background: var(--accent-strong);
+		color: var(--bg-base);
+		font-weight: var(--font-weight-semibold);
+		font-size: var(--font-size-sm);
 	}
 </style>

--- a/frontend/src/lib/stores/player.restore_queue.test.ts
+++ b/frontend/src/lib/stores/player.restore_queue.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { QueueItem } from '$lib/api/client';
+
+// Mock the api client so we can drive restoreQueueItems without a server.
+// vi.mock is hoisted, so the factory has to declare its own spies, then we
+// re-import them from the module to assert against.
+vi.mock('$lib/api/client', async () => {
+	const addQueueTrack = vi.fn(async () => ({ queue: [], playback_state: null }));
+	const queueAppend = vi.fn(async () => ({ queue: [], playback_state: null }));
+	const getPlaybackState = vi.fn(async () => ({ queue: [] }));
+	return {
+		api: { addQueueTrack, queueAppend, getPlaybackState },
+		ApiError: class ApiError extends Error {},
+	};
+});
+
+import { api } from '$lib/api/client';
+import { restoreQueueItems } from './player';
+
+function libraryRow(id: number, trackId: number): QueueItem {
+	return {
+		id,
+		position: id,
+		source: 'library',
+		track: {
+			id: trackId,
+			title: `Library ${trackId}`,
+			tidal_id: null,
+			source: 'tidal_stream',
+		} as QueueItem['track'],
+	};
+}
+
+function ephemeralTidalRow(queueId: number, tidalId: number): QueueItem {
+	return {
+		id: queueId,
+		position: queueId,
+		source: 'tidal_mix',
+		track: {
+			id: -tidalId,
+			title: `Tidal ${tidalId}`,
+			tidal_id: tidalId,
+			source: 'tidal_stream',
+			artist_name: null,
+			album_title: null,
+			artwork_url: null,
+			duration_ms: 200_000,
+		} as QueueItem['track'],
+	};
+}
+
+function pendingRow(queueId: number): QueueItem {
+	return {
+		id: queueId,
+		position: queueId,
+		source: 'radio_pending',
+		is_pending: true,
+		track: {
+			id: 0,
+			title: 'Pending Title',
+			tidal_id: null,
+		} as QueueItem['track'],
+	};
+}
+
+describe('restoreQueueItems', () => {
+	beforeEach(() => {
+		vi.mocked(api.addQueueTrack).mockClear();
+		vi.mocked(api.queueAppend).mockClear();
+		vi.mocked(api.getPlaybackState).mockClear();
+	});
+
+	it('restores a library-only queue via addQueueTrack', async () => {
+		const summary = await restoreQueueItems([libraryRow(1, 100), libraryRow(2, 101)]);
+		expect(summary.restored).toBe(2);
+		expect(summary.skipped).toBe(0);
+		expect(api.addQueueTrack).toHaveBeenCalledTimes(2);
+		expect(api.queueAppend).not.toHaveBeenCalled();
+	});
+
+	it('restores an ephemeral TIDAL row via queueAppend, preserving the tidal_id', async () => {
+		const summary = await restoreQueueItems([ephemeralTidalRow(50, 999)]);
+		expect(summary.restored).toBe(1);
+		expect(api.queueAppend).toHaveBeenCalledTimes(1);
+		const callArg = vi.mocked(api.queueAppend).mock.calls[0][0] as {
+			tidal_id: number;
+		};
+		expect(callArg.tidal_id).toBe(999);
+		expect(api.addQueueTrack).not.toHaveBeenCalled();
+	});
+
+	it('preserves original order across a mixed library + TIDAL queue', async () => {
+		const mixed = [
+			libraryRow(1, 100),
+			ephemeralTidalRow(2, 200),
+			libraryRow(3, 101),
+			ephemeralTidalRow(4, 201),
+		];
+		const summary = await restoreQueueItems(mixed);
+		expect(summary.restored).toBe(4);
+		expect(summary.skipped).toBe(0);
+
+		// Each row is restored exactly once.
+		expect(api.addQueueTrack).toHaveBeenCalledTimes(2);
+		expect(api.queueAppend).toHaveBeenCalledTimes(2);
+
+		// Verify the issue order matches the input order. addQueueTrack and
+		// queueAppend are interleaved; we check the relative ordering of all
+		// four mock calls via their invocation order on the spy timeline.
+		const orderTrace: string[] = [];
+		vi.mocked(api.addQueueTrack).mock.invocationCallOrder.forEach((n) =>
+			orderTrace.push(`add@${n}`)
+		);
+		vi.mocked(api.queueAppend).mock.invocationCallOrder.forEach((n) =>
+			orderTrace.push(`tidal@${n}`)
+		);
+		orderTrace.sort((a, b) => Number(a.split('@')[1]) - Number(b.split('@')[1]));
+		expect(orderTrace.map((t) => t.split('@')[0])).toEqual([
+			'add',
+			'tidal',
+			'add',
+			'tidal',
+		]);
+	});
+
+	it('skips pending rows but still restores resolved rows in the same batch', async () => {
+		const summary = await restoreQueueItems([
+			libraryRow(1, 100),
+			pendingRow(2),
+			ephemeralTidalRow(3, 300),
+		]);
+		expect(summary.restored).toBe(2);
+		expect(summary.skipped).toBe(1);
+		expect(api.addQueueTrack).toHaveBeenCalledTimes(1);
+		expect(api.queueAppend).toHaveBeenCalledTimes(1);
+	});
+
+	it('no-ops on empty input without hitting the API', async () => {
+		const summary = await restoreQueueItems([]);
+		expect(summary).toEqual({ restored: 0, skipped: 0 });
+		expect(api.addQueueTrack).not.toHaveBeenCalled();
+		expect(api.queueAppend).not.toHaveBeenCalled();
+	});
+});

--- a/frontend/src/lib/stores/player.ts
+++ b/frontend/src/lib/stores/player.ts
@@ -14,6 +14,7 @@ import {
 } from '$lib/api/client';
 import { setExclusiveEngaged, setExclusiveReleased } from '$lib/stores/exclusive_status';
 import { showToast, dismissToast } from '$lib/stores/toast';
+import { announceQueue, announceResolved } from '$lib/stores/queue_announcer';
 import { wsConnected } from '$lib/api/ws';
 import { updateLibraryTrackFavorite } from '$lib/stores/library';
 import { clamp01 } from '$lib/utils/math';
@@ -93,7 +94,29 @@ function setCurrentTrack(track: Track | null) {
 }
 
 function setPlaybackQueue(queue: QueueItem[]) {
-	playbackQueue.set(enrichQueue(queue));
+	const enriched = enrichQueue(queue);
+	const previous = get(playbackQueue);
+	const resolvedDelta = countResolvedTransitions(previous, enriched);
+	playbackQueue.set(enriched);
+	if (resolvedDelta > 0) announceResolved(resolvedDelta);
+}
+
+// Count rows whose persisted queue id existed in `previous` as pending and now
+// resolved in `next`. Newly added rows and removed rows are ignored: the live
+// region only surfaces *transitions* so initial hydration and reorderings stay
+// quiet.
+export function countResolvedTransitions(previous: QueueItem[], next: QueueItem[]): number {
+	if (previous.length === 0) return 0;
+	const wasPending = new Set<number>();
+	for (const item of previous) {
+		if (item.is_pending === true) wasPending.add(item.id);
+	}
+	if (wasPending.size === 0) return 0;
+	let resolved = 0;
+	for (const item of next) {
+		if (item.is_pending !== true && wasPending.has(item.id)) resolved += 1;
+	}
+	return resolved;
 }
 
 // ─── Error model ──────────────────────────────────────────────────────────────
@@ -655,6 +678,7 @@ export async function addTrackToQueue(trackId: number) {
 		playerError.set(null);
 		noteSuccess();
 		showToast('Added to queue', 'success');
+		announceQueue('Added to queue');
 	} catch (error) {
 		setError('add to queue', error);
 		throw error;
@@ -715,6 +739,7 @@ export async function removeTrackFromQueue(queueItemId: number) {
 		const result = await api.removeQueueTrack(queueItemId);
 		setPlaybackQueue(result.queue);
 		noteSuccess();
+		announceQueue('Removed from queue');
 	} catch (error) {
 		setError('remove from queue', error, () => removeTrackFromQueue(queueItemId));
 	}
@@ -756,8 +781,9 @@ export async function clearQueue(): Promise<QueueItem[]> {
 			(item) => !result.queue.some((q) => q.id === item.id)
 		);
 		if (restorable.length > 0) {
-			showToast(`Queue cleared — Undo (${restorable.length})`, 'info', 6000);
-			// We register the undo handler externally — caller (layout) wires the toast click.
+			showToast(`Queue cleared - Undo (${restorable.length})`, 'info', 6000);
+			// We register the undo handler externally - caller (layout) wires the toast click.
+			announceQueue(`Queue cleared, ${restorable.length} ${restorable.length === 1 ? 'track' : 'tracks'} removed. Press Z to undo.`);
 		}
 		return restorable;
 	} catch (error) {

--- a/frontend/src/lib/stores/player.ts
+++ b/frontend/src/lib/stores/player.ts
@@ -15,6 +15,8 @@ import {
 import { setExclusiveEngaged, setExclusiveReleased } from '$lib/stores/exclusive_status';
 import { showToast, dismissToast } from '$lib/stores/toast';
 import { announceQueue, announceResolved } from '$lib/stores/queue_announcer';
+import { offerUndo } from '$lib/stores/queue_undo';
+import { queueItemToTidalPlayable } from '$lib/utils/track';
 import { wsConnected } from '$lib/api/ws';
 import { updateLibraryTrackFavorite } from '$lib/stores/library';
 import { clamp01 } from '$lib/utils/math';
@@ -781,8 +783,8 @@ export async function clearQueue(): Promise<QueueItem[]> {
 			(item) => !result.queue.some((q) => q.id === item.id)
 		);
 		if (restorable.length > 0) {
-			showToast(`Queue cleared - Undo (${restorable.length})`, 'info', 6000);
-			// We register the undo handler externally - caller (layout) wires the toast click.
+			offerUndo(restorable, 6000);
+			showToast(`Queue cleared (${restorable.length})`, 'info', 3000);
 			announceQueue(`Queue cleared, ${restorable.length} ${restorable.length === 1 ? 'track' : 'tracks'} removed. Press Z to undo.`);
 		}
 		return restorable;
@@ -792,21 +794,59 @@ export async function clearQueue(): Promise<QueueItem[]> {
 	}
 }
 
-export async function restoreQueueItems(items: QueueItem[]): Promise<void> {
-	if (!items.length) return;
+/**
+ * Restore queue rows after a clear-queue. Re-adds each row in its original
+ * order, dispatching by row type so a mixed library + TIDAL + pending queue
+ * is restored correctly:
+ *  - Library rows (`track.id > 0`) re-add via `api.addQueueTrack`.
+ *  - Ephemeral TIDAL rows (negative id, has a `TidalPlayable`) re-add via
+ *    `api.queueAppend(tidalQueueRequest(...))`.
+ *  - Pending rows (`track.id === 0`, never resolved) are skipped because the
+ *    library has no `track_id` to re-append; the pending producer would have
+ *    to be re-run, which is out of scope here.
+ *
+ * Returns counts so callers can announce a meaningful summary. Rows that
+ * failed to restore are surfaced as a count, not silently dropped.
+ */
+export interface RestoreSummary {
+	restored: number;
+	skipped: number;
+}
+
+export async function restoreQueueItems(items: QueueItem[]): Promise<RestoreSummary> {
+	const summary: RestoreSummary = { restored: 0, skipped: 0 };
+	if (!items.length) return summary;
 	try {
-		// Re-add each track in order. addQueueTrack appends to the end.
 		for (const item of items) {
 			if (item.track.id > 0) {
 				await api.addQueueTrack(item.track.id);
+				summary.restored += 1;
+				continue;
 			}
+			const tidal = queueItemToTidalPlayable(item);
+			if (tidal && tidal.tidal_id > 0) {
+				await api.queueAppend(tidalQueueRequest(tidal));
+				summary.restored += 1;
+				continue;
+			}
+			// Pending rows (track.id === 0, is_pending) or rows we can't
+			// reconstruct (no positive library id, no tidal_id) get skipped.
+			summary.skipped += 1;
 		}
 		const snapshot = await api.getPlaybackState();
 		setPlaybackQueue(snapshot.queue);
 		playerError.set(null);
+		if (summary.restored > 0) {
+			announceQueue(
+				summary.skipped === 0
+					? `Restored ${summary.restored} ${summary.restored === 1 ? 'track' : 'tracks'}`
+					: `Restored ${summary.restored}, skipped ${summary.skipped} unresolved`
+			);
+		}
 	} catch (error) {
 		setError('restore queue', error);
 	}
+	return summary;
 }
 
 export async function saveQueueAsPlaylist(

--- a/frontend/src/lib/stores/queue_announcer.test.ts
+++ b/frontend/src/lib/stores/queue_announcer.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { get } from 'svelte/store';
+import {
+	announceQueue,
+	announceResolved,
+	queueAnnouncement,
+	_resetForTests,
+} from './queue_announcer';
+
+function readAnnouncement(): string {
+	return get(queueAnnouncement);
+}
+
+describe('queue_announcer', () => {
+	beforeEach(() => {
+		_resetForTests();
+		vi.useFakeTimers();
+	});
+
+	it('publishes a user-driven announcement on the next microtask', async () => {
+		announceQueue('Added to queue');
+		expect(readAnnouncement()).toBe('');
+		await vi.advanceTimersByTimeAsync(0);
+		expect(readAnnouncement()).toBe('Added to queue');
+	});
+
+	it('clears the announcement after the dwell window so a repeat message re-fires', async () => {
+		announceQueue('Removed from queue');
+		await vi.advanceTimersByTimeAsync(0);
+		expect(readAnnouncement()).toBe('Removed from queue');
+		await vi.advanceTimersByTimeAsync(2500);
+		expect(readAnnouncement()).toBe('');
+		announceQueue('Removed from queue');
+		await vi.advanceTimersByTimeAsync(0);
+		expect(readAnnouncement()).toBe('Removed from queue');
+	});
+
+	it('coalesces a burst of resolutions into a single summary', async () => {
+		for (let i = 0; i < 30; i += 1) announceResolved(1);
+		await vi.advanceTimersByTimeAsync(0);
+		expect(readAnnouncement()).toBe('');
+		await vi.advanceTimersByTimeAsync(1500);
+		// One queued macrotask publishes the summary, then microtask flushes the store.
+		await vi.advanceTimersByTimeAsync(0);
+		expect(readAnnouncement()).toBe('30 tracks resolved on TIDAL');
+	});
+
+	it('keeps rolling the coalesce window while resolutions keep arriving', async () => {
+		announceResolved(2);
+		await vi.advanceTimersByTimeAsync(1400);
+		expect(readAnnouncement()).toBe('');
+		announceResolved(3);
+		await vi.advanceTimersByTimeAsync(1400);
+		expect(readAnnouncement()).toBe('');
+		await vi.advanceTimersByTimeAsync(100);
+		await vi.advanceTimersByTimeAsync(0);
+		expect(readAnnouncement()).toBe('5 tracks resolved on TIDAL');
+	});
+
+	it('uses singular grammar for a single resolution', async () => {
+		announceResolved(1);
+		await vi.advanceTimersByTimeAsync(1500);
+		await vi.advanceTimersByTimeAsync(0);
+		expect(readAnnouncement()).toBe('1 track resolved on TIDAL');
+	});
+
+	it('drops zero or negative deltas', async () => {
+		announceResolved(0);
+		announceResolved(-3);
+		await vi.advanceTimersByTimeAsync(2000);
+		expect(readAnnouncement()).toBe('');
+	});
+});

--- a/frontend/src/lib/stores/queue_announcer.ts
+++ b/frontend/src/lib/stores/queue_announcer.ts
@@ -1,0 +1,59 @@
+import { writable, type Readable, derived } from 'svelte/store';
+
+const message = writable<string>('');
+
+let clearHandle: ReturnType<typeof setTimeout> | null = null;
+let coalesceHandle: ReturnType<typeof setTimeout> | null = null;
+let coalescedResolvedCount = 0;
+
+const COALESCE_WINDOW_MS = 1500;
+const CLEAR_AFTER_MS = 2500;
+
+function publish(text: string) {
+	if (clearHandle) {
+		clearTimeout(clearHandle);
+		clearHandle = null;
+	}
+	// Force the live region to re-fire even when the new text equals the previous
+	// value: blank it for a microtask, then set. Some screen readers ignore
+	// identical writes without this reset.
+	message.set('');
+	queueMicrotask(() => {
+		message.set(text);
+		clearHandle = setTimeout(() => {
+			message.set('');
+			clearHandle = null;
+		}, CLEAR_AFTER_MS);
+	});
+}
+
+function flushResolved() {
+	const n = coalescedResolvedCount;
+	coalescedResolvedCount = 0;
+	coalesceHandle = null;
+	if (n <= 0) return;
+	publish(`${n} ${n === 1 ? 'track' : 'tracks'} resolved on TIDAL`);
+}
+
+export function announceQueue(text: string) {
+	if (!text) return;
+	publish(text);
+}
+
+export function announceResolved(delta: number) {
+	if (delta <= 0) return;
+	coalescedResolvedCount += delta;
+	if (coalesceHandle) clearTimeout(coalesceHandle);
+	coalesceHandle = setTimeout(flushResolved, COALESCE_WINDOW_MS);
+}
+
+export const queueAnnouncement: Readable<string> = derived(message, ($m) => $m);
+
+export function _resetForTests() {
+	if (clearHandle) clearTimeout(clearHandle);
+	if (coalesceHandle) clearTimeout(coalesceHandle);
+	clearHandle = null;
+	coalesceHandle = null;
+	coalescedResolvedCount = 0;
+	message.set('');
+}

--- a/frontend/src/lib/stores/queue_undo.test.ts
+++ b/frontend/src/lib/stores/queue_undo.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { get } from 'svelte/store';
+import {
+	pendingUndo,
+	offerUndo,
+	consumeUndo,
+	dismissUndo,
+	_resetForTests,
+} from './queue_undo';
+import type { QueueItem } from '$lib/api/client';
+
+function fakeItem(id: number, trackId: number, source = 'library'): QueueItem {
+	return {
+		id,
+		position: id,
+		source,
+		track: {
+			id: trackId,
+			title: `t${id}`,
+			tidal_id: trackId < 0 ? -trackId : null,
+		} as QueueItem['track'],
+	};
+}
+
+describe('queue_undo store', () => {
+	beforeEach(() => {
+		_resetForTests();
+		vi.useFakeTimers();
+	});
+
+	it('offerUndo with non-empty items publishes a pending undo', () => {
+		offerUndo([fakeItem(1, 100), fakeItem(2, 101)], 6000);
+		const value = get(pendingUndo);
+		expect(value?.count).toBe(2);
+		expect(value?.items.length).toBe(2);
+		expect(value?.expiresAt).toBeGreaterThan(Date.now());
+	});
+
+	it('offerUndo with empty items clears the store', () => {
+		offerUndo([fakeItem(1, 100)], 6000);
+		offerUndo([], 6000);
+		expect(get(pendingUndo)).toBeNull();
+	});
+
+	it('auto-clears after the TTL', () => {
+		offerUndo([fakeItem(1, 100)], 6000);
+		expect(get(pendingUndo)).not.toBeNull();
+		vi.advanceTimersByTime(6001);
+		expect(get(pendingUndo)).toBeNull();
+	});
+
+	it('consumeUndo returns the items and clears the store', () => {
+		const items = [fakeItem(1, 100), fakeItem(2, -200, 'tidal_mix')];
+		offerUndo(items, 6000);
+		const taken = consumeUndo();
+		expect(taken).toEqual(items);
+		expect(get(pendingUndo)).toBeNull();
+	});
+
+	it('consumeUndo returns null when nothing pending', () => {
+		expect(consumeUndo()).toBeNull();
+	});
+
+	it('dismissUndo clears the store and cancels the TTL', () => {
+		offerUndo([fakeItem(1, 100)], 6000);
+		dismissUndo();
+		expect(get(pendingUndo)).toBeNull();
+		vi.advanceTimersByTime(7000);
+		expect(get(pendingUndo)).toBeNull();
+	});
+
+	it('a second offerUndo cancels the first TTL', () => {
+		offerUndo([fakeItem(1, 100)], 6000);
+		vi.advanceTimersByTime(3000);
+		offerUndo([fakeItem(2, 101), fakeItem(3, 102)], 6000);
+		vi.advanceTimersByTime(4000);
+		// At t=7000ms, first TTL would have expired but the second offer
+		// reset it, so the new items should still be present.
+		const value = get(pendingUndo);
+		expect(value?.count).toBe(2);
+	});
+});

--- a/frontend/src/lib/stores/queue_undo.ts
+++ b/frontend/src/lib/stores/queue_undo.ts
@@ -1,0 +1,62 @@
+import { writable, get } from 'svelte/store';
+import type { QueueItem } from '$lib/api/client';
+
+/**
+ * Pending undo offer surfaced by `clearQueue`. Both the desktop layout and
+ * the `/remote` queue subscribe to render the affordance, so the undo lives
+ * at the store boundary instead of being wired per-call-site.
+ *
+ * `expiresAt` is a wall-clock millisecond stamp so UIs can render a
+ * countdown without holding their own timer. The store auto-clears at the
+ * TTL.
+ */
+export interface PendingUndo {
+	count: number;
+	items: QueueItem[];
+	expiresAt: number;
+}
+
+export const pendingUndo = writable<PendingUndo | null>(null);
+
+let clearHandle: ReturnType<typeof setTimeout> | null = null;
+
+export function offerUndo(items: QueueItem[], ttlMs: number = 6000): void {
+	if (clearHandle) {
+		clearTimeout(clearHandle);
+		clearHandle = null;
+	}
+	if (items.length === 0) {
+		pendingUndo.set(null);
+		return;
+	}
+	pendingUndo.set({ count: items.length, items, expiresAt: Date.now() + ttlMs });
+	clearHandle = setTimeout(() => {
+		pendingUndo.set(null);
+		clearHandle = null;
+	}, ttlMs);
+}
+
+export function consumeUndo(): QueueItem[] | null {
+	const current = get(pendingUndo);
+	if (!current) return null;
+	pendingUndo.set(null);
+	if (clearHandle) {
+		clearTimeout(clearHandle);
+		clearHandle = null;
+	}
+	return current.items;
+}
+
+export function dismissUndo(): void {
+	if (clearHandle) {
+		clearTimeout(clearHandle);
+		clearHandle = null;
+	}
+	pendingUndo.set(null);
+}
+
+export function _resetForTests(): void {
+	if (clearHandle) clearTimeout(clearHandle);
+	clearHandle = null;
+	pendingUndo.set(null);
+}

--- a/frontend/src/lib/utils/reason.test.ts
+++ b/frontend/src/lib/utils/reason.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { parseReason, formatReasonForScreenReader } from './reason';
+
+describe('parseReason', () => {
+	it('returns null for null or empty input', () => {
+		expect(parseReason(null)).toBeNull();
+		expect(parseReason(undefined)).toBeNull();
+		expect(parseReason('')).toBeNull();
+		expect(parseReason('   ')).toBeNull();
+	});
+
+	it('returns just the prefix when no JSON suffix is present', () => {
+		expect(parseReason('Liked artist Massive Attack')).toEqual({
+			prefix: 'Liked artist Massive Attack',
+		});
+	});
+
+	it('parses prefix + json into a breakdown', () => {
+		expect(
+			parseReason('Genre match | {"genre_jaccard":0.42,"affinity_mult":1.1}')
+		).toEqual({
+			prefix: 'Genre match',
+			genre_jaccard: 0.42,
+			affinity_mult: 1.1,
+		});
+	});
+
+	it('treats malformed JSON as a prefix-only reason', () => {
+		const r = parseReason('Genre match | {bad json');
+		expect(r?.prefix).toBe('Genre match | {bad json');
+		expect(r?.genre_jaccard).toBeUndefined();
+	});
+});
+
+describe('formatReasonForScreenReader', () => {
+	it('returns null when there is nothing to read', () => {
+		expect(formatReasonForScreenReader(null)).toBeNull();
+		expect(formatReasonForScreenReader('')).toBeNull();
+	});
+
+	it('reads the prefix when no metrics are present', () => {
+		expect(formatReasonForScreenReader('Liked artist Massive Attack')).toBe(
+			'Liked artist Massive Attack'
+		);
+	});
+
+	it('appends formatted genre overlap and affinity to the prefix', () => {
+		expect(
+			formatReasonForScreenReader(
+				'Genre match | {"genre_jaccard":0.42,"affinity_mult":1.08}'
+			)
+		).toBe('Genre match. Genre overlap 42%. Affinity +8%');
+	});
+
+	it('skips affinity when it rounds to zero', () => {
+		expect(
+			formatReasonForScreenReader('Library | {"genre_jaccard":0.67,"affinity_mult":1.001}')
+		).toBe('Library. Genre overlap 67%');
+	});
+
+	it('handles negative affinity', () => {
+		expect(
+			formatReasonForScreenReader('Recent skip | {"affinity_mult":0.7}')
+		).toBe('Recent skip. Affinity -30%');
+	});
+});

--- a/frontend/src/lib/utils/reason.ts
+++ b/frontend/src/lib/utils/reason.ts
@@ -87,3 +87,25 @@ export function formatJaccardPct(jaccard: number | undefined): string | null {
 	if (jaccard === undefined || !Number.isFinite(jaccard)) return null;
 	return `${Math.round(jaccard * 100)}%`;
 }
+
+/**
+ * Render a queue row's reason as a single plain-text sentence for
+ * screen readers. The hover card is `pointer-events: none` and
+ * positioned globally, so SR cannot reach it via aria-describedby on
+ * the floating element. We mirror the parsed breakdown inline next to
+ * the row's ⓘ trigger and point aria-describedby at that span.
+ *
+ * Returns null when there's nothing useful to read (no reason at all).
+ */
+export function formatReasonForScreenReader(raw: string | null | undefined): string | null {
+	const parsed = parseReason(raw);
+	if (!parsed) return null;
+	const parts: string[] = [];
+	if (parsed.prefix) parts.push(parsed.prefix);
+	const jaccard = formatJaccardPct(parsed.genre_jaccard);
+	if (jaccard !== null) parts.push(`Genre overlap ${jaccard}`);
+	const affinity = formatAffinityDelta(parsed.affinity_mult);
+	if (affinity !== null) parts.push(`Affinity ${affinity}`);
+	if (parts.length === 0) return null;
+	return parts.join('. ');
+}

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -53,6 +53,7 @@
 	import Toast from '$lib/components/Toast.svelte';
 	import CommandPalette from '$lib/components/CommandPalette.svelte';
 	import QueueReasonCard from '$lib/components/QueueReasonCard.svelte';
+	import { formatReasonForScreenReader } from '$lib/utils/reason';
 	import ShortcutHelp from '$lib/components/ShortcutHelp.svelte';
 	import PlayerBar from '$lib/shell/PlayerBar.svelte';
 	import SidebarNav from '$lib/shell/SidebarNav.svelte';
@@ -1464,9 +1465,12 @@
 								<span class="queue-time">{formatTrackDuration(item.track.duration_ms)}</span>
 								<div class="queue-actions">
 									{#if item.reason}
+										{@const reasonDesc = formatReasonForScreenReader(item.reason)}
+										{@const reasonId = `queue-reason-${item.id}`}
 										<button
 											class="queue-action icon reason"
 											aria-label="Why is this here?"
+											aria-describedby={reasonDesc ? reasonId : undefined}
 											title="Why is this here?"
 											onmouseenter={(event) => showQueueReason(item.reason, event)}
 											onmousemove={moveQueueReason}
@@ -1475,6 +1479,9 @@
 											onblur={hideQueueReason}
 											onclick={stopPropagation}
 										>ⓘ</button>
+										{#if reasonDesc}
+											<span id={reasonId} class="queue-sr-status">{reasonDesc}</span>
+										{/if}
 									{/if}
 									<button
 										class="queue-action icon"

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -46,6 +46,7 @@
 	import type { QueueItem, TidalPlayable, Track } from '$lib/api/client';
 	import { showToast } from '$lib/stores/toast';
 	import { queueAnnouncement } from '$lib/stores/queue_announcer';
+	import { pendingUndo, consumeUndo } from '$lib/stores/queue_undo';
 	import { formatTrackDuration, getQualityClass } from '$lib/utils/format';
 	import { api, getStoredToken, setStoredToken, clearStoredToken } from '$lib/api/client';
 	import ContextMenu from '$lib/components/ContextMenu.svelte';
@@ -496,6 +497,13 @@
 				event.preventDefault();
 				void cyclePlayerRepeatMode();
 				break;
+			case 'z':
+			case 'Z':
+				if ($pendingUndo) {
+					event.preventDefault();
+					void handleUndoClear();
+				}
+				break;
 		}
 	}
 
@@ -853,23 +861,16 @@
 
 	async function handleClearQueue() {
 		if (upcomingQueue.length === 0) return;
-		const restorable = await clearQueueAction();
-		if (restorable.length > 0) {
-			// Replace the auto-toast with a richer one that has a real undo button.
-			// We can't bind a click handler to the simple text toast, so expose
-			// undo via the keyboard shortcut Z within 6s.
-			const onKey = (event: KeyboardEvent) => {
-				if (isTypingTarget(event.target)) return;
-				if (event.key === 'z' || event.key === 'Z') {
-					event.preventDefault();
-					window.removeEventListener('keydown', onKey);
-					void restoreQueueItems(restorable);
-					showToast(`Restored ${restorable.length} tracks`, 'success');
-				}
-			};
-			window.addEventListener('keydown', onKey);
-			setTimeout(() => window.removeEventListener('keydown', onKey), 6000);
-		}
+		await clearQueueAction();
+		// The store offers an undo: the queue-section renders an Undo chip
+		// bound to `pendingUndo`. Z is the power-user shortcut to fire the
+		// same path without reaching for the mouse.
+	}
+
+	async function handleUndoClear() {
+		const restorable = consumeUndo();
+		if (!restorable) return;
+		await restoreQueueItems(restorable);
 	}
 
 	function stopPropagation(event: Event) {
@@ -1357,6 +1358,19 @@
 					</div>
 				</div>
 			</div>
+
+			{#if $pendingUndo}
+				<div class="queue-undo-bar" role="status">
+					<span class="queue-undo-text">
+						Cleared {$pendingUndo.count} {$pendingUndo.count === 1 ? 'track' : 'tracks'}
+					</span>
+					<button
+						class="queue-undo-btn"
+						type="button"
+						onclick={() => void handleUndoClear()}
+					>Undo<span class="queue-undo-hint" aria-hidden="true">Z</span></button>
+				</div>
+			{/if}
 
 			{#if saveQueueOpen}
 				<form
@@ -2255,6 +2269,62 @@
 		clip: rect(0, 0, 0, 0);
 		white-space: nowrap;
 		border: 0;
+	}
+
+	.queue-undo-bar {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 12px;
+		margin: 0 0 10px;
+		padding: 8px 12px;
+		border-radius: var(--radius-sm);
+		background: color-mix(in srgb, var(--accent-soft) 70%, transparent);
+		border: 1px solid var(--accent-line);
+		animation: queue-undo-slide-in 180ms ease-out;
+	}
+
+	@keyframes queue-undo-slide-in {
+		from { opacity: 0; transform: translateY(-4px); }
+		to { opacity: 1; transform: translateY(0); }
+	}
+
+	.queue-undo-text {
+		color: var(--text-primary);
+		font-size: var(--font-size-xs);
+		font-weight: var(--font-weight-medium);
+	}
+
+	.queue-undo-btn {
+		display: inline-flex;
+		align-items: center;
+		gap: 8px;
+		padding: 5px 12px;
+		border-radius: 999px;
+		border: 1px solid var(--accent-line);
+		background: var(--accent-strong);
+		color: var(--bg-base);
+		font-size: var(--font-size-xs);
+		font-weight: var(--font-weight-semibold);
+		cursor: pointer;
+		transition: background var(--motion-fast), transform var(--motion-fast);
+	}
+
+	.queue-undo-btn:hover {
+		transform: translateY(-1px);
+	}
+
+	.queue-undo-hint {
+		display: inline-grid;
+		place-items: center;
+		min-width: 18px;
+		height: 18px;
+		padding: 0 4px;
+		border-radius: 4px;
+		background: color-mix(in srgb, var(--bg-base) 22%, transparent);
+		font-size: var(--font-size-2xs);
+		font-weight: var(--font-weight-bold);
+		letter-spacing: 0.04em;
 	}
 
 	.queue-header {

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -620,7 +620,46 @@
 	}
 
 	function handleQueueTrackKeydown(item: QueueItemType, event: KeyboardEvent) {
-		runOnActivation(event, () => void handleQueueTrackPlay(item));
+		const isPending = item.is_pending === true;
+		if (!isPending && (event.key === 'Enter' || event.key === ' ')) {
+			event.preventDefault();
+			void handleQueueTrackPlay(item);
+			return;
+		}
+		if (event.key === 'Delete' || event.key === 'Backspace') {
+			event.preventDefault();
+			void removeTrackFromQueue(item.id);
+			return;
+		}
+		if (event.altKey && event.key === 'ArrowUp') {
+			event.preventDefault();
+			if (event.shiftKey) {
+				void moveQueueTrackNext(item.id);
+			} else {
+				void reorderQueueRow(item, -1);
+			}
+			return;
+		}
+		if (event.altKey && event.key === 'ArrowDown') {
+			event.preventDefault();
+			void reorderQueueRow(item, 1);
+		}
+	}
+
+	async function reorderQueueRow(item: QueueItemType, delta: -1 | 1) {
+		const fullQueue = get(playbackQueue);
+		const currentIdx = fullQueue.findIndex((q) => q.id === item.id);
+		if (currentIdx === -1) return;
+		const newIdx = currentIdx + delta;
+		if (newIdx < 0 || newIdx >= fullQueue.length) return;
+		// Refuse to move a row above the currently-playing item. The play head
+		// is rendered as the "current" row and is not user-reorderable.
+		const playingId = $currentTrack?.id ?? null;
+		if (playingId != null) {
+			const playingIdx = fullQueue.findIndex((q) => q.track.id === playingId);
+			if (playingIdx >= 0 && newIdx <= playingIdx) return;
+		}
+		await moveQueueItem(item.id, newIdx);
 	}
 
 	async function handleQueueRemove(queueItemId: number, event: MouseEvent) {
@@ -1422,13 +1461,13 @@
 							class:pending={isPending}
 							class="queue-row"
 							role="button"
-							tabindex={isPending ? undefined : 0}
+							tabindex={0}
 							aria-disabled={isPending}
 							title={isPending ? 'Resolving on TIDAL...' : undefined}
 							draggable={true}
 							data-track-id={item.track.id}
 							onclick={isPending ? undefined : () => void handleQueueTrackPlay(item)}
-							onkeydown={isPending ? undefined : (event) => handleQueueTrackKeydown(item, event)}
+							onkeydown={(event) => handleQueueTrackKeydown(item, event)}
 							oncontextmenu={(event) => openQueueRowMenu(item, event)}
 							ondragstart={(event) => handleQueueDragStart(event, item)}
 							ondragover={(event) => handleQueueDragOver(event, item)}
@@ -1760,11 +1799,11 @@
 								: $currentTrack?.id === item.track.id}
 							class:pending={isPending}
 							role="button"
-							tabindex={isPending ? undefined : 0}
+							tabindex={0}
 							aria-disabled={isPending}
 							title={isPending ? 'Resolving on TIDAL...' : undefined}
 							onclick={isPending ? undefined : () => void handleQueueTrackPlay(item)}
-							onkeydown={isPending ? undefined : (event) => handleQueueTrackKeydown(item, event)}
+							onkeydown={(event) => handleQueueTrackKeydown(item, event)}
 							oncontextmenu={(event) => openQueueRowMenu(item, event)}
 						>
 							<div class="queue-art-wrap" title={formatQueueSource(item.source)}>

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1562,11 +1562,12 @@
 			{/if}
 
 			{#if upcomingQueue.length > 0}
-				<div class="queue-list" id="queue-list" bind:this={queueListEl} onscroll={handleQueueScroll}>
+				<div class="queue-list" id="queue-list" role="list" bind:this={queueListEl} onscroll={handleQueueScroll}>
 					{#each upcomingQueue.slice(0, queueVisibleCount) as item, i (`${item.id}-${i}`)}
 						{@const aid = item.track.artist_id}
 						{@const isPending = item.is_pending === true}
 						<div
+							role="listitem"
 							class:active={$currentQueueItemId != null
 								? $currentQueueItemId === item.id
 								: $currentTrack?.id === item.track.id}
@@ -1574,14 +1575,9 @@
 							class:drag-over={dragOverItemId === item.id && dragItemId !== item.id}
 							class:pending={isPending}
 							class="queue-row"
-							role="button"
-							tabindex={0}
-							aria-disabled={isPending}
 							title={isPending ? 'Resolving on TIDAL...' : undefined}
 							draggable={true}
 							data-track-id={item.track.id}
-							onclick={isPending ? undefined : () => void handleQueueTrackPlay(item)}
-							onkeydown={(event) => handleQueueTrackKeydown(item, event)}
 							oncontextmenu={(event) => openQueueRowMenu(item, event)}
 							ondragstart={(event) => handleQueueDragStart(event, item)}
 							ondragover={(event) => handleQueueDragOver(event, item)}
@@ -1604,7 +1600,19 @@
 							</div>
 
 							<div class="queue-meta">
-								<p class="queue-title">{item.track.title}</p>
+								<button
+									class="queue-row-play"
+									type="button"
+									aria-label={isPending
+										? `Pending: ${item.track.title}`
+										: `Play ${item.track.title}`}
+									aria-disabled={isPending}
+									disabled={isPending}
+									onclick={isPending ? undefined : () => void handleQueueTrackPlay(item)}
+									onkeydown={(event) => handleQueueTrackKeydown(item, event)}
+								>
+									<span class="queue-title">{item.track.title}</span>
+								</button>
 								{#if isPending}
 									<span class="queue-artist pending-label">
 										<span class="queue-inline-spinner" aria-hidden="true"></span>
@@ -1905,22 +1913,18 @@
 			</div>
 
 			{#if upcomingQueue.length > 0}
-				<div class="mobile-np-queue-list">
+				<div class="mobile-np-queue-list" role="list">
 					{#each upcomingQueue.slice(0, queueVisibleCount) as item, i (`${item.id}-${i}`)}
 						{@const aid = item.track.artist_id}
 						{@const isPending = item.is_pending === true}
 						<div
+							role="listitem"
 							class="queue-row"
 							class:active={$currentQueueItemId != null
 								? $currentQueueItemId === item.id
 								: $currentTrack?.id === item.track.id}
 							class:pending={isPending}
-							role="button"
-							tabindex={0}
-							aria-disabled={isPending}
 							title={isPending ? 'Resolving on TIDAL...' : undefined}
-							onclick={isPending ? undefined : () => void handleQueueTrackPlay(item)}
-							onkeydown={(event) => handleQueueTrackKeydown(item, event)}
 							oncontextmenu={(event) => openQueueRowMenu(item, event)}
 						>
 							<div class="queue-art-wrap" title={formatQueueSource(item.source)}>
@@ -1936,7 +1940,19 @@
 								<span class="queue-source-dot source-{queueSourceSlug(item.source)}" aria-hidden="true"></span>
 							</div>
 							<div class="queue-meta">
-								<p class="queue-title">{item.track.title}</p>
+								<button
+									class="queue-row-play"
+									type="button"
+									aria-label={isPending
+										? `Pending: ${item.track.title}`
+										: `Play ${item.track.title}`}
+									aria-disabled={isPending}
+									disabled={isPending}
+									onclick={isPending ? undefined : () => void handleQueueTrackPlay(item)}
+									onkeydown={(event) => handleQueueTrackKeydown(item, event)}
+								>
+									<span class="queue-title">{item.track.title}</span>
+								</button>
 								{#if isPending}
 									<span class="queue-artist pending-label">
 										<span class="queue-inline-spinner" aria-hidden="true"></span>
@@ -2763,7 +2779,6 @@
 		border: 1px solid color-mix(in srgb, var(--instrument-border) 46%, transparent);
 		border-radius: var(--radius-sm);
 		background: color-mix(in srgb, var(--instrument-surface) 78%, transparent);
-		cursor: pointer;
 		transition:
 			border-color var(--motion-fast),
 			background var(--motion-fast),
@@ -2901,6 +2916,29 @@
 		display: flex;
 		flex-direction: column;
 		gap: 2px;
+	}
+
+	.queue-row-play {
+		display: block;
+		width: 100%;
+		padding: 0;
+		margin: 0;
+		border: none;
+		background: transparent;
+		color: inherit;
+		text-align: left;
+		font: inherit;
+		cursor: pointer;
+		border-radius: 4px;
+	}
+
+	.queue-row-play:disabled {
+		cursor: default;
+	}
+
+	.queue-row-play:focus-visible {
+		outline: 2px solid var(--accent-line);
+		outline-offset: 2px;
 	}
 
 	.queue-title {

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1014,6 +1014,27 @@
 
 	let queueTotalLabel = $derived(formatQueueTotal(queueTotalMs));
 
+	// Default visible-row cap for both desktop and mobile queue lists. The
+	// cap exists so a 500-row library/radio session doesn't paint thousands
+	// of DOM nodes at boot; users grow it with a "Load more" button so the
+	// rest of the queue isn't silently truncated.
+	const QUEUE_INITIAL_CAP = 40;
+	const QUEUE_LOAD_MORE_STEP = 40;
+	let queueVisibleCount = $state(QUEUE_INITIAL_CAP);
+
+	$effect(() => {
+		// Reset the cap when the queue gets smaller than what we are currently
+		// showing (clear, big remove, snapshot shrink). Without this the
+		// "Load more" button would linger at a count larger than the queue.
+		if (upcomingQueue.length < queueVisibleCount) {
+			queueVisibleCount = Math.max(QUEUE_INITIAL_CAP, Math.min(queueVisibleCount, upcomingQueue.length || QUEUE_INITIAL_CAP));
+		}
+	});
+
+	function loadMoreQueue() {
+		queueVisibleCount = Math.min(upcomingQueue.length, queueVisibleCount + QUEUE_LOAD_MORE_STEP);
+	}
+
 	const QUEUE_EXPANDED_KEY = 'noor.queueExpanded';
 
 	function loadQueueExpanded(): boolean {
@@ -1502,7 +1523,7 @@
 
 			{#if upcomingQueue.length > 0}
 				<div class="queue-list" id="queue-list" bind:this={queueListEl} onscroll={handleQueueScroll}>
-					{#each upcomingQueue.slice(0, 40) as item, i (`${item.id}-${i}`)}
+					{#each upcomingQueue.slice(0, queueVisibleCount) as item, i (`${item.id}-${i}`)}
 						{@const aid = item.track.artist_id}
 						{@const isPending = item.is_pending === true}
 						<div
@@ -1622,8 +1643,11 @@
 				</div>
 			{/if}
 
-			{#if upcomingQueue.length > 40}
-				<p class="queue-overflow">+ {upcomingQueue.length - 40} more tracks waiting in the queue</p>
+			{#if upcomingQueue.length > queueVisibleCount}
+				<button class="queue-load-more" type="button" onclick={loadMoreQueue}>
+					Load {Math.min(QUEUE_LOAD_MORE_STEP, upcomingQueue.length - queueVisibleCount)} more
+					<span class="queue-load-more-rest">({upcomingQueue.length - queueVisibleCount} waiting)</span>
+				</button>
 			{/if}
 		</section>
 	</aside>
@@ -1842,7 +1866,7 @@
 
 			{#if upcomingQueue.length > 0}
 				<div class="mobile-np-queue-list">
-					{#each upcomingQueue.slice(0, 40) as item, i (`${item.id}-${i}`)}
+					{#each upcomingQueue.slice(0, queueVisibleCount) as item, i (`${item.id}-${i}`)}
 						{@const aid = item.track.artist_id}
 						{@const isPending = item.is_pending === true}
 						<div
@@ -1922,8 +1946,11 @@
 				</div>
 			{/if}
 
-			{#if upcomingQueue.length > 40}
-				<p class="queue-overflow">+ {upcomingQueue.length - 40} more tracks in the queue</p>
+			{#if upcomingQueue.length > queueVisibleCount}
+				<button class="queue-load-more" type="button" onclick={loadMoreQueue}>
+					Load {Math.min(QUEUE_LOAD_MORE_STEP, upcomingQueue.length - queueVisibleCount)} more
+					<span class="queue-load-more-rest">({upcomingQueue.length - queueVisibleCount} waiting)</span>
+				</button>
 			{/if}
 		</div>
 	{/if}
@@ -2882,8 +2909,7 @@
 	}
 
 	.queue-time,
-	.queue-empty span,
-	.queue-overflow {
+	.queue-empty span {
 		color: var(--text-secondary);
 		font-size: var(--font-size-xs);
 	}
@@ -2985,9 +3011,29 @@
 		font-weight: var(--font-weight-semibold);
 	}
 
-	.queue-overflow {
-		padding-top: 12px;
-		border-top: 1px solid var(--border-subtle);
+	.queue-load-more {
+		margin-top: 12px;
+		padding: 8px 16px;
+		border-radius: 999px;
+		border: 1px dashed var(--border-strong);
+		background: color-mix(in srgb, var(--instrument-surface) 60%, transparent);
+		color: var(--text-secondary);
+		font-size: var(--font-size-xs);
+		font-weight: var(--font-weight-medium);
+		cursor: pointer;
+		transition: background var(--motion-fast), color var(--motion-fast), border-color var(--motion-fast);
+		align-self: center;
+	}
+
+	.queue-load-more:hover {
+		background: var(--bg-hover);
+		color: var(--text-primary);
+		border-color: var(--accent-line);
+	}
+
+	.queue-load-more-rest {
+		margin-left: 6px;
+		color: var(--text-tertiary);
 	}
 
 	@media (max-width: 1320px) {

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -45,6 +45,7 @@
 	import { get } from 'svelte/store';
 	import type { QueueItem, TidalPlayable, Track } from '$lib/api/client';
 	import { showToast } from '$lib/stores/toast';
+	import { queueAnnouncement } from '$lib/stores/queue_announcer';
 	import { formatTrackDuration, getQualityClass } from '$lib/utils/format';
 	import { api, getStoredToken, setStoredToken, clearStoredToken } from '$lib/api/client';
 	import ContextMenu from '$lib/components/ContextMenu.svelte';
@@ -1273,6 +1274,7 @@
 		/>
 
 		<section class="queue-section">
+			<div class="queue-sr-status" role="status" aria-live="polite" aria-atomic="true">{$queueAnnouncement}</div>
 			<div class="queue-header">
 				<button
 					class="queue-banner"
@@ -2241,6 +2243,18 @@
 		border-top: 1px solid var(--border-subtle);
 		margin-top: 16px;
 		padding: 16px;
+	}
+
+	.queue-sr-status {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+		white-space: nowrap;
+		border: 0;
 	}
 
 	.queue-header {

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -693,8 +693,13 @@
 	}
 
 	// Source slug drives the `.source-*` CSS class that paints the 4px dot on
-	// queue artwork. Keep in sync with formatQueueSource above.
+	// queue artwork. Keep in sync with formatQueueSource above. The one
+	// exception: `automix-new` (the only hyphenated source label in the repo)
+	// keeps its own slug so the dot can wear a ring distinguishing
+	// discover-injected rows from plain automix.
 	function queueSourceSlug(source: string): string {
+		const normalized = source.trim().toLowerCase();
+		if (normalized === 'automix-new') return 'automix-new';
 		return formatQueueSource(source).toLowerCase();
 	}
 
@@ -1021,6 +1026,18 @@
 	const QUEUE_INITIAL_CAP = 40;
 	const QUEUE_LOAD_MORE_STEP = 40;
 	let queueVisibleCount = $state(QUEUE_INITIAL_CAP);
+	let legendOpen = $state(false);
+
+	type LegendEntry = { slug: string; label: string };
+	const SOURCE_LEGEND: LegendEntry[] = [
+		{ slug: 'library', label: 'Library' },
+		{ slug: 'playlist', label: 'Playlist' },
+		{ slug: 'genre', label: 'Genre' },
+		{ slug: 'automix', label: 'Automix' },
+		{ slug: 'automix-new', label: 'Discover automix' },
+		{ slug: 'discover', label: 'Discover' },
+		{ slug: 'manual', label: 'Manual' },
+	];
 
 	$effect(() => {
 		// Reset the cap when the queue gets smaller than what we are currently
@@ -1444,7 +1461,7 @@
 						aria-label="Save queue as playlist"
 						onclick={openSaveQueue}
 						disabled={upcomingQueue.length === 0 && !$currentTrack}
-					>＋</button>
+					>★</button>
 					</div>
 					<div class="queue-action-group cleanup-controls" role="group" aria-label="Cleanup controls">
 					<button
@@ -1467,6 +1484,29 @@
 					>▲</button>
 					</div>
 				</div>
+			</div>
+
+			<div class="queue-legend-row">
+				<button
+					class="queue-legend-toggle"
+					type="button"
+					aria-expanded={legendOpen}
+					aria-controls="queue-source-legend"
+					onclick={() => { legendOpen = !legendOpen; }}
+				>
+					Source legend
+					<span aria-hidden="true">{legendOpen ? '▴' : '▾'}</span>
+				</button>
+				{#if legendOpen}
+					<ul class="queue-legend" id="queue-source-legend">
+						{#each SOURCE_LEGEND as entry}
+							<li>
+								<span class="queue-source-dot source-{entry.slug}" aria-hidden="true"></span>
+								<span>{entry.label}</span>
+							</li>
+						{/each}
+					</ul>
+				{/if}
 			</div>
 
 			{#if !currentRowVisible && $currentTrack && upcomingQueue.length > 0}
@@ -1639,7 +1679,7 @@
 			{:else}
 				<div class="queue-empty">
 					<p>Nothing is lined up yet.</p>
-					<span>Start from the library, genres, playlists, or discovery.</span>
+					<span>Pick a track from <a class="queue-empty-link" href="/library">your library</a>, <a class="queue-empty-link" href="/genres">a genre</a>, or <a class="queue-empty-link" href="/playlists">a playlist</a>. Press <kbd class="queue-empty-key">Q</kbd> to collapse the queue.</span>
 				</div>
 			{/if}
 
@@ -1942,7 +1982,7 @@
 			{:else}
 				<div class="queue-empty">
 					<p>Nothing is lined up yet.</p>
-					<span>Start from the library, genres, playlists, or discovery.</span>
+					<span>Pick a track from <a class="queue-empty-link" href="/library">your library</a>, <a class="queue-empty-link" href="/genres">a genre</a>, or <a class="queue-empty-link" href="/playlists">a playlist</a>. Press <kbd class="queue-empty-key">Q</kbd> to collapse the queue.</span>
 				</div>
 			{/if}
 
@@ -2841,6 +2881,13 @@
 	}
 
 	.queue-source-dot.source-automix { background: var(--accent-strong, #6366f1); }
+	.queue-source-dot.source-automix-new {
+		/* Discover-injected automix rows get the automix indigo plus a ring
+		   so users can spot which queue picks came from a TIDAL search vs the
+		   library-only automix path. */
+		background: var(--accent-strong, #6366f1);
+		box-shadow: 0 0 0 2px color-mix(in srgb, #a855f7 70%, transparent);
+	}
 	.queue-source-dot.source-discover { background: #a855f7; }
 	.queue-source-dot.source-genre { background: #22d3ee; }
 	.queue-source-dot.source-playlist { background: #f59e0b; }
@@ -3009,6 +3056,86 @@
 
 	.queue-empty p {
 		font-weight: var(--font-weight-semibold);
+	}
+
+	.queue-empty-link {
+		color: var(--text-secondary);
+		text-decoration: underline;
+		text-underline-offset: 2px;
+	}
+
+	.queue-empty-link:hover {
+		color: var(--text-primary);
+	}
+
+	.queue-empty-key {
+		display: inline-grid;
+		place-items: center;
+		min-width: 16px;
+		padding: 0 4px;
+		margin: 0 2px;
+		border-radius: 4px;
+		background: var(--bg-elevated, rgba(255, 255, 255, 0.06));
+		border: 1px solid var(--border-subtle);
+		color: var(--text-secondary);
+		font-family: var(--font-mono, monospace);
+		font-size: var(--font-size-2xs);
+		font-weight: var(--font-weight-bold);
+	}
+
+	.queue-legend-row {
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+		margin-bottom: 6px;
+	}
+
+	.queue-legend-toggle {
+		align-self: flex-start;
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		padding: 4px 8px;
+		border-radius: 999px;
+		border: 1px solid transparent;
+		background: transparent;
+		color: var(--text-tertiary);
+		font-size: var(--font-size-2xs);
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+		cursor: pointer;
+	}
+
+	.queue-legend-toggle:hover {
+		color: var(--text-secondary);
+		border-color: var(--border-subtle);
+	}
+
+	.queue-legend {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 10px 14px;
+		margin: 0;
+		padding: 8px 10px;
+		list-style: none;
+		border-radius: var(--radius-sm);
+		background: color-mix(in srgb, var(--instrument-surface) 70%, transparent);
+		border: 1px solid var(--border-subtle);
+	}
+
+	.queue-legend li {
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		font-size: var(--font-size-xs);
+		color: var(--text-secondary);
+	}
+
+	.queue-legend .queue-source-dot {
+		position: static;
+		width: 8px;
+		height: 8px;
+		border-width: 0;
 	}
 
 	.queue-load-more {

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -832,9 +832,41 @@
 	// ─── Scroll active queue row into view ───────────────────────────────────
 	let lastUserScrollAt = $state(0);
 	let queueListEl: HTMLElement | null = $state(null);
+	let currentRowVisible = $state(true);
+
+	function refreshCurrentRowVisibility() {
+		const id = $currentTrack?.id;
+		if (!id || !queueListEl) {
+			currentRowVisible = true;
+			return;
+		}
+		const row = queueListEl.querySelector(`[data-track-id="${id}"]`);
+		if (!row) {
+			currentRowVisible = true;
+			return;
+		}
+		const rect = (row as HTMLElement).getBoundingClientRect();
+		const containerRect = queueListEl.getBoundingClientRect();
+		currentRowVisible = !(rect.bottom < containerRect.top || rect.top > containerRect.bottom);
+	}
 
 	function handleQueueScroll() {
 		lastUserScrollAt = Date.now();
+		refreshCurrentRowVisibility();
+	}
+
+	function jumpToCurrentRow() {
+		const id = $currentTrack?.id;
+		if (!id || !queueListEl) return;
+		const row = queueListEl.querySelector(`[data-track-id="${id}"]`);
+		if (!row) return;
+		(row as HTMLElement).scrollIntoView({
+			block: 'center',
+			behavior: prefersReducedMotion() ? 'auto' : 'smooth',
+		});
+		// Re-enable the auto-jump effect so subsequent track changes follow.
+		lastUserScrollAt = 0;
+		refreshCurrentRowVisibility();
 	}
 
 	function prefersReducedMotion(): boolean {
@@ -844,19 +876,28 @@
 
 	$effect(() => {
 		const id = $currentTrack?.id;
-		if (!id || !queueListEl) return;
-		// Bail if the user scrolled recently - don't yank focus from their browse.
-		if (Date.now() - lastUserScrollAt < 5000) return;
+		if (!id || !queueListEl) {
+			currentRowVisible = true;
+			return;
+		}
 		const row = queueListEl.querySelector(`[data-track-id="${id}"]`);
-		if (!row) return;
+		if (!row) {
+			currentRowVisible = true;
+			return;
+		}
 		const rect = row.getBoundingClientRect();
 		const containerRect = queueListEl.getBoundingClientRect();
 		const offscreen = rect.bottom < containerRect.top || rect.top > containerRect.bottom;
-		if (offscreen) {
+		// Bail on the auto-scroll if the user scrolled recently - don't yank
+		// focus from their browse. The jump-to-current chip still shows.
+		if (offscreen && Date.now() - lastUserScrollAt >= 5000) {
 			row.scrollIntoView({
 				block: 'nearest',
 				behavior: prefersReducedMotion() ? 'auto' : 'smooth',
 			});
+			currentRowVisible = true;
+		} else {
+			currentRowVisible = !offscreen;
 		}
 	});
 
@@ -1406,6 +1447,18 @@
 					</div>
 				</div>
 			</div>
+
+			{#if !currentRowVisible && $currentTrack && upcomingQueue.length > 0}
+				<button
+					class="queue-jump-chip"
+					type="button"
+					onclick={jumpToCurrentRow}
+					title="Scroll to the track that is currently playing"
+				>
+					<span aria-hidden="true">↓</span>
+					Jump to now playing
+				</button>
+			{/if}
 
 			{#if $pendingUndo}
 				<div class="queue-undo-bar" role="status">
@@ -2325,6 +2378,28 @@
 		border: 0;
 	}
 
+	.queue-jump-chip {
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		align-self: center;
+		margin: 0 0 10px;
+		padding: 6px 14px;
+		border-radius: 999px;
+		border: 1px solid var(--accent-line);
+		background: color-mix(in srgb, var(--accent-soft) 80%, transparent);
+		color: var(--accent-strong);
+		font-size: var(--font-size-xs);
+		font-weight: var(--font-weight-semibold);
+		cursor: pointer;
+		transition: background var(--motion-fast), transform var(--motion-fast);
+	}
+
+	.queue-jump-chip:hover {
+		background: var(--accent-soft);
+		transform: translateY(-1px);
+	}
+
 	.queue-undo-bar {
 		display: flex;
 		align-items: center;
@@ -2392,6 +2467,7 @@
 		.queue-action:hover,
 		.queue-icon-btn:hover:not(:disabled),
 		.queue-undo-btn:hover,
+		.queue-jump-chip:hover,
 		.queue-expand-btn:hover:not(:disabled) {
 			transform: none;
 		}
@@ -2687,7 +2763,7 @@
 		line-height: 1;
 		color: var(--text-tertiary);
 		cursor: grab;
-		opacity: 0;
+		opacity: 0.35;
 		transition: opacity var(--motion-fast);
 		user-select: none;
 	}

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -798,10 +798,15 @@
 		lastUserScrollAt = Date.now();
 	}
 
+	function prefersReducedMotion(): boolean {
+		if (typeof window === 'undefined' || !window.matchMedia) return false;
+		return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+	}
+
 	$effect(() => {
 		const id = $currentTrack?.id;
 		if (!id || !queueListEl) return;
-		// Bail if the user scrolled recently — don't yank focus from their browse.
+		// Bail if the user scrolled recently - don't yank focus from their browse.
 		if (Date.now() - lastUserScrollAt < 5000) return;
 		const row = queueListEl.querySelector(`[data-track-id="${id}"]`);
 		if (!row) return;
@@ -809,7 +814,10 @@
 		const containerRect = queueListEl.getBoundingClientRect();
 		const offscreen = rect.bottom < containerRect.top || rect.top > containerRect.bottom;
 		if (offscreen) {
-			row.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+			row.scrollIntoView({
+				block: 'nearest',
+				behavior: prefersReducedMotion() ? 'auto' : 'smooth',
+			});
 		}
 	});
 
@@ -2332,6 +2340,32 @@
 		font-size: var(--font-size-2xs);
 		font-weight: var(--font-weight-bold);
 		letter-spacing: 0.04em;
+	}
+
+	/* Honor OS-level motion-reduction. We still allow opacity transitions
+	   (they're conveying state changes that the user actively triggered),
+	   but flatten translates, rotations, and the spinner so vestibular
+	   users don't get unwanted motion in the queue surface. */
+	@media (prefers-reduced-motion: reduce) {
+		.queue-row,
+		.queue-row:hover,
+		.queue-row:focus-within,
+		.queue-action:hover,
+		.queue-icon-btn:hover:not(:disabled),
+		.queue-undo-btn:hover,
+		.queue-expand-btn:hover:not(:disabled) {
+			transform: none;
+		}
+		.now-playing-panel.queue-expanded .queue-expand-btn {
+			transform: none;
+		}
+		.queue-spinner,
+		.queue-inline-spinner {
+			animation: none;
+		}
+		.queue-undo-bar {
+			animation: none;
+		}
 	}
 
 	.queue-header {


### PR DESCRIPTION
## Summary

Implements the 2026-05-23 queue UI audit findings: 16 of 18 items shipped in 9 commits; 2 items (queue-time on focus, inert hidden actions) deferred to `FOLLOWUPS.md` because each needs row-layout work beyond an a11y polish pass.

Plan was vetted through `/codex:adversarial-review` before any code changes - findings flagged the Undo TIDAL-row drop, the Toast-extension risk, the RemoteQueue blind spot, the live-region resolution storm, and the mobile slice oversight. Each was folded into the per-commit plan before implementation.

## Commits

1. `7bd513c` feat(queue): coalesced aria-live announcements - polite live region, user-driven announcements for add/remove/clear, debounced summaries for passive TIDAL resolution storms.
2. `99ee04f` feat(queue): visible undo via pendingUndo store + type-aware restore - new chip in desktop and `/remote`, `restoreQueueItems` no longer silently drops ephemeral TIDAL rows.
3. `f14dea5` a11y(queue): announce row reason via aria-describedby - SR users hear the prefix + Genre overlap + Affinity values when ⓘ receives focus.
4. `c21cf78` a11y(queue): honor prefers-reduced-motion - flattens translates/rotations/spinners/`scrollIntoView` smoothness.
5. `77f2e50` feat(queue): keyboard reorder, delete, and pending-row context menu - Delete/Backspace removes, Alt+↑/↓ reorders, Shift+Alt+↑ plays next; pending rows are now reachable via Tab.
6. `d131a4c` feat(queue): jump-to-current chip + grip baseline visibility - jump chip appears when the active row scrolls off; drag grip is no longer fully invisible.
7. `ce279d1` feat(queue): load-more for both desktop and mobile lists - rows past 40 are reachable on both viewports (Codex flagged the mobile loop as a half-fix).
8. `9e8485a` chore(queue): source legend, automix-new ring, save icon, empty CTA - collapsible source legend, ring on discover-injected dots, ＋ → ★ save icon, empty state CTA + Q hint.
9. `fa1b2b2` refactor(queue): row semantics - non-interactive wrapper + play button - resolves the role=button + nested interactive antipattern; queue is now a proper `role=list` of `role=listitem` rows with a dedicated play button per row.

## Test plan
- [x] `pnpm check` - 0 errors, 0 warnings (610 files)
- [x] `pnpm lint` - clean
- [x] `pnpm test` - 274 tests pass (57 files), including new coverage for `queue_announcer` (resolution storm coalescing), `queue_undo` (TTL + dismiss), `restoreQueueItems` (mixed library + TIDAL ordering), and `formatReasonForScreenReader`
- [x] `pnpm run build` - clean production build
- [ ] Manual keyboard-only walkthrough: Tab → row's play button, Enter to play, Alt+↑/↓ to reorder, Delete to remove, Z to undo a clear
- [ ] Manual reduced-motion toggle: confirm transforms/spinners/jump scroll go static
- [ ] Mixed library + TIDAL queue: clear, then Undo, verify all rows restored in original order (including ephemeral TIDAL rows)
- [ ] `/remote` clear behavior: the same Undo chip should appear when clearing from the mobile remote
- [ ] Mobile NP-sheet queue with > 40 rows: confirm the Load-more button surfaces
- [ ] Reader pass with VoiceOver / NVDA on the queue: confirm row reason and resolution-storm summaries are announced

## Deferred (filed in FOLLOWUPS.md)
- Item 8 (a11y: scope hidden queue actions out of the accessibility tree per row) - needs `inert` toggling tied to per-row hover/focus state.
- Item 16 (a11y: keep queue-time visible on focus without colliding with action buttons) - needs a side-panel relayout, not a one-line CSS change.