### PR TITLE
feat(dj): stabilize timing telemetry and enable FilterSweep

### DIFF
--- a/.scratch/dj-bassswap-renderable/PRD.md
+++ b/.scratch/dj-bassswap-renderable/PRD.md
@@ -1,0 +1,144 @@
+# DJ BassSwap16 Renderable Plan
+
+Status: Draft
+
+## Goal
+
+Make `BassSwap16` the next renderable DJ transition template after `FilterSweep`, while keeping `SafeCrossfade` as the timing authority and keeping `SlamCut` downgraded.
+
+## Current Baseline
+
+Current committed DJ work is PR-ready on `feature/build-dj-engine-architecture`.
+
+- `SafeCrossfade` renders.
+- `FilterSweep` renders with fallback visibility and timing instability gating.
+- `SlamCut` is still downgraded.
+- DJ profile rebuild analysis uses LOW quality.
+- Normal playback decode no longer queues heavy DJ profile analysis.
+- Near-end manual seek suppresses accidental auto transition.
+
+## Product Rationale
+
+User testing showed FilterSweep can be useful for DnB and electronic material, but rough transitions still come from low-end handoff and percussion clash. `BassSwap16` targets the main audible failure: both tracks fighting for the bass range during the overlap.
+
+This should sound less like a generic crossfade than FilterSweep because the low end changes ownership at a phrase boundary while mids and highs continue blending.
+
+## Scope
+
+Implement `BassSwap16` only.
+
+- Keep `BassSwap32` non-renderable.
+- Keep `LongHarmonicBlend` non-renderable.
+- Keep `SlamCut` non-renderable.
+- Keep current SafeCrossfade timing path.
+- Keep existing fallback and downgrade reporting model.
+- Do not tune fire-ahead in this PR.
+- Do not add a true high-pass or low-pass filter path in this PR.
+
+## Behavior
+
+`BassSwap16` should render only when:
+
+- The planner chose `BassSwap16`.
+- Both profiles are current enough to plan.
+- Timing evidence is stable enough, using the same instability posture as FilterSweep unless a stricter gate is needed.
+- Renderer can produce a valid `TransitionProgram`.
+
+If any condition fails:
+
+- Planned template remains visible as `BassSwap16`.
+- Actual renderer falls back to `SafeCrossfade`.
+- Downgrade reason is visible, for example `template_not_renderable` or `timing_unstable`.
+- Planning reason remains separate from downgrade reason.
+
+## Render Shape
+
+Use the existing `noor-mix` EQ and gain automation.
+
+Initial conservative render shape:
+
+- Deck B gain fades in across the full transition.
+- Deck B low band starts cut.
+- Deck A low band stays full early.
+- Low-band ownership swaps around the midpoint phrase boundary.
+- Deck A mids and highs taper after the bass swap.
+- Deck B mids and highs stay mostly present so the incoming track can be recognized before its bass arrives.
+- Avoid EQ boosts above unity for V1.
+
+The first version should favor cleanliness over drama.
+
+## Timing
+
+Use the same runtime timing path as `SafeCrossfade`.
+
+Candidate duration:
+
+- `BassSwap16`: phrase-derived 16 bar planner duration when available.
+- If runtime needs a fixed V1 cap, start around 12 to 16 seconds and keep fallback visible.
+
+Do not make `BassSwap32` renderable until `BassSwap16` is proven stable.
+
+## Tests
+
+`noor-mix`:
+
+- `BassSwap16` validates.
+- `BassSwap16` contains low-band swap automation.
+- Rendered output is limiter-safe.
+- Mixer render path does not allocate.
+- Bass handoff has only one deck owning the low band at the midpoint.
+
+`noor-server`:
+
+- `BassSwap16` passes through as renderable.
+- `BassSwap32`, `LongHarmonicBlend`, and `SlamCut` still downgrade.
+- `BassSwap16` uses the SafeCrossfade timing path.
+- Timing instability downgrades `BassSwap16`.
+- Status reports planned and renderer template correctly.
+
+Frontend:
+
+- Cockpit contract accepts `BassSwap16` as an actual renderer template.
+- Non-renderable templates are not shown as active renderers.
+
+Commands:
+
+- `cargo test -p noor-mix`
+- `cargo test -p noor-server playback::player::tests::dj`
+- `cargo test -p noor-server server::routes::dj_routes::tests`
+- `pnpm test -- dj_page_contract`
+- `pnpm check`
+
+## Manual Audio Checks
+
+Use several queue pairs:
+
+- Electronic or DnB pair with compatible phrase structure.
+- House or four-on-the-floor pair with clear basslines.
+- Jazz, guitar, or clap-heavy pair that previously sounded rough.
+
+Record:
+
+- Planned template.
+- Renderer template.
+- Planned start.
+- Actual start.
+- Delta.
+- Whether the bass handoff sounded cleaner than FilterSweep.
+- Whether hats or claps felt out of sync.
+
+## Non-Goals
+
+- No SlamCut activation.
+- No ML template selection.
+- No generative transition programs.
+- No new runtime language.
+- No licensing-sensitive DSP dependency.
+- No adaptive fire-ahead tuning.
+
+## PR Sequence
+
+1. Open current committed DJ branch as the stabilization PR.
+2. Start `BassSwap16` as the next PR from that baseline.
+3. Only after `BassSwap16` is tested, consider `LongHarmonicBlend`.
+4. Keep `SlamCut` blocked until downbeat confidence is stronger.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3150,6 +3150,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "noor-mix"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "hound",
+ "rubato",
+ "rustfft",
+ "serde",
+ "symphonia",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
 name = "noor-server"
 version = "0.1.56"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3179,6 +3179,7 @@ dependencies = [
  "hmac",
  "madmom_beats_port_core",
  "md5",
+ "noor-mix",
  "num-complex",
  "rand 0.8.6",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["noor-server", "noor-app"]
+members = ["noor-server", "noor-app", "noor-mix"]
 resolver = "2"
 
 [profile.dev]

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -914,14 +914,51 @@ export type DjStatusResponse = {
 	current?: DjDeckStatus;
 	next?: DjDeckStatus;
 	selected_program?: string;
+	planned_template?: string;
+	renderer_template?: string;
+	renderer_mode?: 'legacy_overlap' | 'dj_gain_program' | 'dj_full_program';
+	downgrade_reason?: string;
+	sync_target?: string;
+	planned_start_ms?: number;
+	actual_start_ms?: number;
+	timing_delta_ms?: number;
+	timing_source?: string;
+	timing_status?: string;
 	fallback_reason?: string;
 	profile_confidence_floor: number;
 	last_transition_event_id?: number;
+	recent_timing_events: DjTimingHistoryEvent[];
+	timing_history_summary: DjTimingHistorySummary;
 	safe_crossfade_suggestion?: {
 		media_ref_kind: string;
 		media_ref_id: string;
 		bad_feedback_count: number;
 	};
+};
+
+export type DjTimingHistoryEvent = {
+	event_id: number;
+	planned_template: string;
+	renderer_template?: string;
+	planned_start_ms?: number;
+	actual_start_ms?: number;
+	timing_delta_ms?: number;
+	timing_source?: string;
+	timing_status?: 'fired' | 'late' | 'missed';
+	timing_quality: 'tight' | 'usable' | 'loose' | 'bad';
+	started_at: string;
+};
+
+export type DjTimingHistorySummary = {
+	event_count: number;
+	average_delta_ms?: number;
+	average_abs_delta_ms?: number;
+	tight_count: number;
+	usable_count: number;
+	loose_count: number;
+	bad_count: number;
+	late_count: number;
+	missed_count: number;
 };
 
 export type DjProfileCorrectionRequest = {

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -903,7 +903,7 @@ export type DjDeckStatus = {
 	title: string;
 	artist?: string;
 	profile_ready: boolean;
-	profile_status: 'ready' | 'missing' | 'decode_failed' | string;
+	profile_status: 'ready' | 'missing' | 'analyzing' | 'decode_failed' | string;
 	profile_error?: string;
 	profile_confidence?: number;
 	beat_count?: number;
@@ -916,6 +916,16 @@ export type DjStatusResponse = {
 	enabled: boolean;
 	current?: DjDeckStatus;
 	next?: DjDeckStatus;
+	planning_status:
+		| 'disabled'
+		| 'pair_missing'
+		| 'waiting_for_profiles'
+		| 'profile_failed'
+		| 'waiting_for_window'
+		| 'ready_to_plan'
+		| 'armed'
+		| 'missed'
+		| string;
 	selected_program?: string;
 	planned_template?: string;
 	renderer_template?: string;

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -903,6 +903,8 @@ export type DjDeckStatus = {
 	title: string;
 	artist?: string;
 	profile_ready: boolean;
+	profile_status: 'ready' | 'missing' | 'decode_failed' | string;
+	profile_error?: string;
 	profile_confidence?: number;
 	beat_count?: number;
 	downbeat_count?: number;

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -871,6 +871,7 @@ export interface PlaybackRuntimeInfo {
 	last_error: string | null;
 	exclusive_engaged: boolean;
 	exclusive_transport_format: string | null;
+	dj_engine_enabled: boolean;
 }
 
 export type DjEnabledResponse = { enabled: boolean };

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -873,6 +873,73 @@ export interface PlaybackRuntimeInfo {
 	exclusive_transport_format: string | null;
 }
 
+export type DjEnabledResponse = { enabled: boolean };
+
+export type DjTransitionSpeedBias = 'slower' | 'neutral' | 'faster';
+
+export type DjProfileResponse = {
+	track_id: number;
+	profile_version: string;
+	beat_count: number;
+	downbeat_count: number;
+	phrase_count: number;
+};
+
+export type DjMixIntent = 'safe' | 'balanced' | 'bold';
+
+export type DjMixIntentResponse = {
+	intent: DjMixIntent;
+};
+
+export type DjPolicyResponse = {
+	mix_intent: DjMixIntent;
+	transition_speed_bias: DjTransitionSpeedBias;
+};
+
+export type DjDeckStatus = {
+	media_ref_kind: string;
+	media_ref_id: string;
+	title: string;
+	artist?: string;
+	profile_ready: boolean;
+	profile_confidence?: number;
+	beat_count?: number;
+	downbeat_count?: number;
+	phrase_count?: number;
+	safe_crossfade_only: boolean;
+};
+
+export type DjStatusResponse = {
+	enabled: boolean;
+	current?: DjDeckStatus;
+	next?: DjDeckStatus;
+	selected_program?: string;
+	fallback_reason?: string;
+	profile_confidence_floor: number;
+	last_transition_event_id?: number;
+	safe_crossfade_suggestion?: {
+		media_ref_kind: string;
+		media_ref_id: string;
+		bad_feedback_count: number;
+	};
+};
+
+export type DjProfileCorrectionRequest = {
+	media_ref_kind: string;
+	media_ref_id: string;
+	bpm_multiplier?: number;
+	downbeat_offset_beats?: number;
+	phrase_offset_bars?: number;
+	safe_crossfade_only?: boolean;
+	transition_speed_bias?: DjTransitionSpeedBias;
+	notes?: string;
+};
+
+export type DjFeedbackRequest = {
+	transition_event_id?: number;
+	rating: 'good' | 'bad' | 'too_safe' | 'too_bold';
+	reason?: string;
+};
 export interface StreamDisplayInfo {
 	audio_quality: string;
 	sample_rate: number | null;
@@ -2620,6 +2687,69 @@ export const api = {
 		);
 	},
 
+	getDjEnabled(): Promise<DjEnabledResponse> {
+		return fetchApi<DjEnabledResponse>('/api/dj/enabled');
+	},
+
+	setDjEnabled(enabled: boolean): Promise<DjEnabledResponse> {
+		return fetchApi<DjEnabledResponse>('/api/dj/enabled', undefined, {
+			method: 'PUT',
+			body: JSON.stringify({ enabled }),
+		});
+	},
+
+	getDjStatus(): Promise<DjStatusResponse> {
+		return fetchApi<DjStatusResponse>('/api/dj/status');
+	},
+
+	getDjProfile(trackId: number): Promise<DjProfileResponse> {
+		return fetchApi<DjProfileResponse>(`/api/dj/profile/${trackId}`);
+	},
+
+	getDjMixIntent(): Promise<DjMixIntentResponse> {
+		return fetchApi<DjMixIntentResponse>('/api/dj/mix-intent');
+	},
+
+	setDjMixIntent(intent: DjMixIntent): Promise<DjMixIntentResponse> {
+		return fetchApi<DjMixIntentResponse>('/api/dj/mix-intent', undefined, {
+			method: 'PUT',
+			body: JSON.stringify({ intent }),
+		});
+	},
+
+	getDjPolicy(): Promise<DjPolicyResponse> {
+		return fetchApi<DjPolicyResponse>('/api/dj/policy');
+	},
+
+	setDjPolicy(policy: Partial<DjPolicyResponse>): Promise<DjPolicyResponse> {
+		return fetchApi<DjPolicyResponse>('/api/dj/policy', undefined, {
+			method: 'PUT',
+			body: JSON.stringify(policy),
+		});
+	},
+
+	async setDjProfileCorrection(correction: DjProfileCorrectionRequest): Promise<void> {
+		await fetchApi<unknown>('/api/dj/profile-correction', undefined, {
+			method: 'POST',
+			body: JSON.stringify(correction),
+		});
+	},
+
+	rebuildDjProfile(
+		request: Pick<DjProfileCorrectionRequest, 'media_ref_kind' | 'media_ref_id'>,
+	): Promise<{ accepted: boolean; status: string }> {
+		return fetchApi<{ accepted: boolean; status: string }>('/api/dj/profile-rebuild', undefined, {
+			method: 'POST',
+			body: JSON.stringify(request),
+		});
+	},
+
+	async recordDjFeedback(feedback: DjFeedbackRequest): Promise<void> {
+		await fetchApi<unknown>('/api/dj/feedback', undefined, {
+			method: 'POST',
+			body: JSON.stringify(feedback),
+		});
+	},
 	getMusicBrainzStatus() {
 		return fetchApi<MusicBrainzStatus>('/api/library/enrich/musicbrainz/status');
 	},

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -919,6 +919,7 @@ export type DjStatusResponse = {
 	renderer_template?: string;
 	renderer_mode?: 'legacy_overlap' | 'dj_gain_program' | 'dj_full_program';
 	downgrade_reason?: string;
+	planning_reason?: string;
 	sync_target?: string;
 	planned_start_ms?: number;
 	actual_start_ms?: number;
@@ -947,6 +948,7 @@ export type DjTimingHistoryEvent = {
 	to_artist?: string;
 	planned_template: string;
 	renderer_template?: string;
+	planning_reason?: string;
 	planned_start_ms?: number;
 	actual_start_ms?: number;
 	timing_delta_ms?: number;

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -925,6 +925,8 @@ export type DjStatusResponse = {
 	timing_delta_ms?: number;
 	timing_source?: string;
 	timing_status?: string;
+	timing_quality: 'tight' | 'usable' | 'loose' | 'bad' | 'unknown';
+	timing_direction: 'on_time' | 'early' | 'late' | 'missed' | 'pending' | 'unknown';
 	fallback_reason?: string;
 	profile_confidence_floor: number;
 	last_transition_event_id?: number;
@@ -939,6 +941,10 @@ export type DjStatusResponse = {
 
 export type DjTimingHistoryEvent = {
 	event_id: number;
+	from_title?: string;
+	from_artist?: string;
+	to_title?: string;
+	to_artist?: string;
 	planned_template: string;
 	renderer_template?: string;
 	planned_start_ms?: number;
@@ -947,6 +953,7 @@ export type DjTimingHistoryEvent = {
 	timing_source?: string;
 	timing_status?: 'fired' | 'late' | 'missed';
 	timing_quality: 'tight' | 'usable' | 'loose' | 'bad';
+	timing_direction: 'on_time' | 'early' | 'late' | 'missed' | 'unknown';
 	started_at: string;
 };
 

--- a/frontend/src/lib/components/dj-cockpit/DjCockpit.svelte
+++ b/frontend/src/lib/components/dj-cockpit/DjCockpit.svelte
@@ -19,8 +19,8 @@
 
 	let transitionArmed = $derived(Boolean(status?.selected_program || status?.last_transition_event_id));
 
-	async function refresh() {
-		loading = true;
+	async function refresh(showLoading = false) {
+		if (showLoading) loading = true;
 		try {
 			const [enabledResponse, policyResponse, statusResponse] = await Promise.all([
 				api.getDjEnabled(),
@@ -39,7 +39,11 @@
 	}
 
 	onMount(() => {
-		void refresh();
+		void refresh(true);
+		const interval = window.setInterval(() => {
+			void refresh();
+		}, 2_000);
+		return () => window.clearInterval(interval);
 	});
 
 	async function setEnabled(next: boolean) {
@@ -104,12 +108,22 @@
 		rebuildStatus = 'Requesting profile rebuild';
 		try {
 			const response = await api.rebuildDjProfile(ref);
-			rebuildStatus = response.accepted ? 'Profile rebuild accepted' : 'Profile is not in the current pair';
+			rebuildStatus = rebuildProfileStatusMessage(response.status, response.accepted);
 			await refresh();
 		} catch {
 			rebuildStatus = 'Profile rebuild failed';
 			showToast('Could not rebuild DJ profile.', 'error');
 		}
+	}
+
+	function rebuildProfileStatusMessage(status: string, accepted: boolean) {
+		if (accepted && status === 'already_running') return 'Profile rebuild already running';
+		if (accepted) return 'Profile rebuild accepted';
+		if (status === 'already_current') return 'Profile already current';
+		if (status === 'dj_disabled') return 'DJ engine disabled';
+		if (status === 'source_unavailable') return 'Profile source unavailable';
+		if (status === 'decode_failed') return 'Profile decode failed';
+		return 'Profile is not in the current pair';
 	}
 
 	async function recordFeedback(rating: 'good' | 'bad' | 'too_safe' | 'too_bold') {

--- a/frontend/src/lib/components/dj-cockpit/DjCockpit.svelte
+++ b/frontend/src/lib/components/dj-cockpit/DjCockpit.svelte
@@ -1,0 +1,321 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { api, type DjMixIntent, type DjProfileCorrectionRequest, type DjStatusResponse, type DjTransitionSpeedBias } from '$lib/api/client';
+	import { showToast } from '$lib/stores/toast';
+	import MixIntentControl from './MixIntentControl.svelte';
+	import ProfileCorrectionPanel from './ProfileCorrectionPanel.svelte';
+	import QueuePairPanel from './QueuePairPanel.svelte';
+	import SafetyGuardrailPanel from './SafetyGuardrailPanel.svelte';
+	import TransitionLane from './TransitionLane.svelte';
+
+	let status = $state<DjStatusResponse | null>(null);
+	let enabled = $state(false);
+	let mixIntent = $state<DjMixIntent>('balanced');
+	let speedBias = $state<DjTransitionSpeedBias>('neutral');
+	let loading = $state(true);
+	let saving = $state(false);
+	let debugOpen = $state(false);
+	let rebuildStatus = $state('');
+
+	let transitionArmed = $derived(Boolean(status?.selected_program || status?.last_transition_event_id));
+
+	async function refresh() {
+		loading = true;
+		try {
+			const [enabledResponse, policyResponse, statusResponse] = await Promise.all([
+				api.getDjEnabled(),
+				api.getDjPolicy(),
+				api.getDjStatus(),
+			]);
+			enabled = enabledResponse.enabled;
+			mixIntent = policyResponse.mix_intent;
+			speedBias = policyResponse.transition_speed_bias;
+			status = statusResponse;
+		} catch {
+			showToast('Could not load DJ cockpit.', 'error');
+		} finally {
+			loading = false;
+		}
+	}
+
+	onMount(() => {
+		void refresh();
+	});
+
+	async function setEnabled(next: boolean) {
+		saving = true;
+		try {
+			const response = await api.setDjEnabled(next);
+			enabled = response.enabled;
+			await refresh();
+		} catch {
+			showToast('Could not update DJ engine.', 'error');
+		} finally {
+			saving = false;
+		}
+	}
+
+	async function setIntent(next: DjMixIntent) {
+		mixIntent = next;
+		try {
+			await api.setDjMixIntent(next);
+			await refresh();
+		} catch {
+			showToast('Could not update mix intent.', 'error');
+		}
+	}
+
+	async function setSpeed(next: DjTransitionSpeedBias) {
+		speedBias = next;
+		try {
+			await api.setDjPolicy({ transition_speed_bias: next });
+			await refresh();
+		} catch {
+			showToast('Could not update transition speed.', 'error');
+		}
+	}
+
+	async function saveCorrection(correction: DjProfileCorrectionRequest) {
+		saving = true;
+		try {
+			await api.setDjProfileCorrection(correction);
+			showToast('DJ correction saved.', 'success');
+			await refresh();
+		} catch {
+			showToast('Could not save DJ correction.', 'error');
+		} finally {
+			saving = false;
+		}
+	}
+
+	function clearCorrection(ref: Pick<DjProfileCorrectionRequest, 'media_ref_kind' | 'media_ref_id'>) {
+		void saveCorrection({
+			...ref,
+			bpm_multiplier: undefined,
+			downbeat_offset_beats: undefined,
+			phrase_offset_bars: undefined,
+			safe_crossfade_only: false,
+			transition_speed_bias: undefined,
+			notes: undefined,
+		});
+	}
+
+	async function rebuildProfile(ref: Pick<DjProfileCorrectionRequest, 'media_ref_kind' | 'media_ref_id'>) {
+		rebuildStatus = 'Requesting profile rebuild';
+		try {
+			const response = await api.rebuildDjProfile(ref);
+			rebuildStatus = response.accepted ? 'Profile rebuild accepted' : 'Profile is not in the current pair';
+			await refresh();
+		} catch {
+			rebuildStatus = 'Profile rebuild failed';
+			showToast('Could not rebuild DJ profile.', 'error');
+		}
+	}
+
+	async function recordFeedback(rating: 'good' | 'bad' | 'too_safe' | 'too_bold') {
+		try {
+			await api.recordDjFeedback({
+				transition_event_id: status?.last_transition_event_id,
+				rating,
+			});
+			showToast('DJ feedback recorded.', 'success');
+			await refresh();
+		} catch {
+			showToast('Could not record DJ feedback.', 'error');
+		}
+	}
+
+	function acceptSafeOnlySuggestion() {
+		const suggestion = status?.safe_crossfade_suggestion;
+		if (!suggestion) return;
+		void saveCorrection({
+			media_ref_kind: suggestion.media_ref_kind,
+			media_ref_id: suggestion.media_ref_id,
+			safe_crossfade_only: true,
+			notes: 'Accepted safe-only suggestion',
+		});
+	}
+</script>
+
+<section class="dj-cockpit" aria-labelledby="dj-cockpit-heading">
+	<header class="topbar">
+		<div>
+			<p class="eyebrow">DJ cockpit</p>
+			<h1 id="dj-cockpit-heading">Transition control</h1>
+		</div>
+		<div class="engine-toggle">
+			<span>{enabled ? 'DJ engine on' : 'Legacy playback path'}</span>
+			<button type="button" aria-pressed={enabled} disabled={saving} onclick={() => void setEnabled(!enabled)}>
+				{enabled ? 'Disable DJ' : 'Enable DJ'}
+			</button>
+		</div>
+	</header>
+
+	{#if !enabled}
+		<p class="disabled-note">
+			Playback is using the legacy path. DJ lookahead and transition planning are stopped.
+		</p>
+	{/if}
+
+	<MixIntentControl
+		intent={mixIntent}
+		speed={speedBias}
+		disabled={loading || saving}
+		onIntentChange={(next) => void setIntent(next)}
+		onSpeedChange={(next) => void setSpeed(next)}
+	/>
+
+	<div class="workspace">
+		<div class="primary-column">
+			<TransitionLane
+				{status}
+				debugOpen={debugOpen}
+				onToggleDebug={() => { debugOpen = !debugOpen; }}
+				onFeedback={(rating) => void recordFeedback(rating)}
+			/>
+			<QueuePairPanel current={status?.current} next={status?.next} />
+		</div>
+
+		<aside class="side-column">
+			<ProfileCorrectionPanel
+				current={status?.current}
+				next={status?.next}
+				transitionArmed={transitionArmed}
+				busy={saving}
+				onSave={(correction) => void saveCorrection(correction)}
+				onClear={clearCorrection}
+				onRebuild={(ref) => void rebuildProfile(ref)}
+			/>
+			{#if rebuildStatus}
+				<p class="rebuild-status" role="status">{rebuildStatus}</p>
+			{/if}
+			<SafetyGuardrailPanel {status} onAcceptSafeOnly={acceptSafeOnlySuggestion} />
+		</aside>
+	</div>
+</section>
+
+<style>
+	.dj-cockpit {
+		width: min(100%, var(--content-width));
+		margin: 0 auto;
+		padding: var(--space-5);
+		display: grid;
+		gap: var(--space-4);
+	}
+
+	.topbar {
+		display: flex;
+		align-items: end;
+		justify-content: space-between;
+		gap: var(--space-4);
+	}
+
+	.eyebrow,
+	h1,
+	p {
+		margin: 0;
+	}
+
+	.eyebrow {
+		color: var(--text-tertiary);
+		font-size: var(--font-size-2xs);
+		font-weight: var(--font-weight-bold);
+		line-height: var(--line-height-tight);
+		text-transform: uppercase;
+		letter-spacing: 0;
+	}
+
+	h1 {
+		margin-top: var(--space-1);
+		font-size: var(--font-size-3xl);
+		line-height: var(--line-height-tight);
+	}
+
+	.engine-toggle {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		color: var(--text-secondary);
+		font-size: var(--font-size-sm);
+	}
+
+	button {
+		min-height: 2.75rem;
+		padding: 0 var(--space-3);
+		border: 1px solid var(--accent-line);
+		border-radius: var(--radius-sm);
+		background: var(--accent-soft);
+		color: var(--accent-strong);
+		font-size: var(--font-size-sm);
+		font-weight: var(--font-weight-semibold);
+		line-height: 1;
+		cursor: pointer;
+	}
+
+	button:focus-visible {
+		outline: 2px solid var(--accent);
+		outline-offset: 2px;
+	}
+
+	button:disabled {
+		cursor: not-allowed;
+		opacity: 0.55;
+	}
+
+	.disabled-note,
+	.rebuild-status {
+		padding: var(--space-3);
+		border: 1px solid color-mix(in srgb, var(--state-warning) 36%, transparent);
+		border-radius: var(--radius-sm);
+		background: color-mix(in srgb, var(--state-warning) 10%, transparent);
+		color: var(--state-warning);
+		font-size: var(--font-size-sm);
+		line-height: var(--line-height-snug);
+	}
+
+	.workspace {
+		display: grid;
+		grid-template-columns: minmax(0, 1.55fr) minmax(19rem, 0.85fr);
+		gap: var(--space-4);
+		align-items: start;
+	}
+
+	.primary-column,
+	.side-column {
+		display: grid;
+		gap: var(--space-4);
+		min-width: 0;
+	}
+
+	.side-column {
+		padding: var(--space-4);
+		border: 1px solid var(--border-subtle);
+		border-radius: var(--radius-md);
+		background: color-mix(in srgb, var(--bg-elevated) 88%, transparent);
+	}
+
+	@media (max-width: 980px) {
+		.workspace {
+			grid-template-columns: 1fr;
+		}
+	}
+
+	@media (max-width: 760px) {
+		.dj-cockpit {
+			padding: var(--space-3);
+		}
+
+		.topbar,
+		.engine-toggle {
+			display: grid;
+			align-items: stretch;
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		* {
+			transition-duration: 1ms !important;
+			animation-duration: 1ms !important;
+		}
+	}
+</style>

--- a/frontend/src/lib/components/dj-cockpit/MixIntentControl.svelte
+++ b/frontend/src/lib/components/dj-cockpit/MixIntentControl.svelte
@@ -1,0 +1,135 @@
+<script lang="ts">
+	import type { DjMixIntent, DjTransitionSpeedBias } from '$lib/api/client';
+
+	let {
+		intent,
+		speed,
+		disabled = false,
+		onIntentChange,
+		onSpeedChange,
+	}: {
+		intent: DjMixIntent;
+		speed: DjTransitionSpeedBias;
+		disabled?: boolean;
+		onIntentChange: (intent: DjMixIntent) => void;
+		onSpeedChange: (speed: DjTransitionSpeedBias) => void;
+	} = $props();
+
+	const intents: Array<{ value: DjMixIntent; label: string }> = [
+		{ value: 'safe', label: 'Safe' },
+		{ value: 'balanced', label: 'Balanced' },
+		{ value: 'bold', label: 'Bold' },
+	];
+
+	const speeds: Array<{ value: DjTransitionSpeedBias; label: string }> = [
+		{ value: 'slower', label: 'Slower' },
+		{ value: 'neutral', label: 'Neutral' },
+		{ value: 'faster', label: 'Faster' },
+	];
+</script>
+
+<div class="policy-controls">
+	<div class="control-block">
+		<span class="control-label">Mix intent</span>
+		<div class="segmented" role="group" aria-label="Mix intent">
+			{#each intents as item}
+				<button
+					type="button"
+					class:active={intent === item.value}
+					aria-pressed={intent === item.value}
+					disabled={disabled}
+					onclick={() => onIntentChange(item.value)}
+				>
+					{item.label}
+				</button>
+			{/each}
+		</div>
+	</div>
+
+	<div class="control-block">
+		<span class="control-label">Transition speed</span>
+		<div class="segmented" role="group" aria-label="Transition speed">
+			{#each speeds as item}
+				<button
+					type="button"
+					class:active={speed === item.value}
+					aria-pressed={speed === item.value}
+					disabled={disabled}
+					onclick={() => onSpeedChange(item.value)}
+				>
+					{item.label}
+				</button>
+			{/each}
+		</div>
+	</div>
+</div>
+
+<style>
+	.policy-controls {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--space-3);
+		align-items: end;
+	}
+
+	.control-block {
+		display: grid;
+		gap: var(--space-1);
+		min-width: min(100%, 17rem);
+	}
+
+	.control-label {
+		color: var(--text-tertiary);
+		font-size: var(--font-size-xs);
+		font-weight: var(--font-weight-semibold);
+		line-height: var(--line-height-tight);
+	}
+
+	.segmented {
+		display: grid;
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+		gap: var(--space-1);
+		padding: var(--space-1);
+		border: 1px solid var(--border-subtle);
+		border-radius: var(--radius-sm);
+		background: color-mix(in srgb, var(--bg-surface) 88%, transparent);
+	}
+
+	button {
+		min-height: 2.75rem;
+		border: 1px solid transparent;
+		border-radius: var(--radius-xs);
+		background: transparent;
+		color: var(--text-secondary);
+		font-size: var(--font-size-sm);
+		font-weight: var(--font-weight-semibold);
+		line-height: 1;
+		cursor: pointer;
+		transition:
+			background var(--motion-fast),
+			border-color var(--motion-fast),
+			color var(--motion-fast);
+	}
+
+	button:hover,
+	button:focus-visible {
+		border-color: var(--border-muted);
+		color: var(--text-primary);
+	}
+
+	button:focus-visible {
+		outline: 2px solid var(--accent);
+		outline-offset: 2px;
+	}
+
+	button.active {
+		border-color: var(--accent-line);
+		background: var(--accent-soft);
+		color: var(--accent-strong);
+	}
+
+	button:disabled {
+		cursor: not-allowed;
+		opacity: 0.55;
+	}
+</style>

--- a/frontend/src/lib/components/dj-cockpit/ProfileCorrectionPanel.svelte
+++ b/frontend/src/lib/components/dj-cockpit/ProfileCorrectionPanel.svelte
@@ -1,0 +1,262 @@
+<script lang="ts">
+	import type {
+		DjDeckStatus,
+		DjProfileCorrectionRequest,
+		DjTransitionSpeedBias,
+	} from '$lib/api/client';
+
+	let {
+		current = undefined,
+		next = undefined,
+		transitionArmed = false,
+		busy = false,
+		onSave,
+		onClear,
+		onRebuild,
+	}: {
+		current?: DjDeckStatus;
+		next?: DjDeckStatus;
+		transitionArmed?: boolean;
+		busy?: boolean;
+		onSave: (correction: DjProfileCorrectionRequest) => void;
+		onClear: (mediaRef: Pick<DjProfileCorrectionRequest, 'media_ref_kind' | 'media_ref_id'>) => void;
+		onRebuild: (mediaRef: Pick<DjProfileCorrectionRequest, 'media_ref_kind' | 'media_ref_id'>) => void;
+	} = $props();
+
+	let selectedRef = $state<'current' | 'next'>('next');
+	let bpmMultiplier = $state(1);
+	let downbeatOffset = $state(0);
+	let phraseOffset = $state(0);
+	let speedBias = $state<DjTransitionSpeedBias>('neutral');
+	let safeOnly = $state(false);
+	let notes = $state('');
+
+	let selectedDeck = $derived(selectedRef === 'current' ? current : next);
+
+	function mediaRef(deck?: DjDeckStatus) {
+		if (!deck) return null;
+		return {
+			media_ref_kind: deck.media_ref_kind,
+			media_ref_id: deck.media_ref_id,
+		};
+	}
+
+	function save() {
+		const ref = mediaRef(selectedDeck);
+		if (!ref) return;
+		onSave({
+			...ref,
+			bpm_multiplier: bpmMultiplier,
+			downbeat_offset_beats: downbeatOffset,
+			phrase_offset_bars: phraseOffset,
+			safe_crossfade_only: safeOnly,
+			transition_speed_bias: speedBias,
+			notes: notes.trim() || undefined,
+		});
+	}
+</script>
+
+<section class="correction-panel" aria-labelledby="dj-corrections-heading">
+	<header>
+		<div>
+			<p class="eyebrow">Corrections</p>
+			<h2 id="dj-corrections-heading">Profile overrides</h2>
+		</div>
+	</header>
+
+	{#if transitionArmed}
+		<p class="armed-note">Changes apply to the next transition.</p>
+	{/if}
+
+	<div class="target-tabs" role="group" aria-label="Correction target">
+		<button type="button" class:active={selectedRef === 'current'} onclick={() => { selectedRef = 'current'; }}>
+			Current
+		</button>
+		<button type="button" class:active={selectedRef === 'next'} onclick={() => { selectedRef = 'next'; }}>
+			Next
+		</button>
+	</div>
+
+	{#if selectedDeck}
+		<p class="target-label" title={selectedDeck.title}>{selectedDeck.title}</p>
+		<div class="field-grid">
+			<label>
+				<span>BPM multiplier</span>
+				<input type="number" min="0.5" max="1.5" step="0.01" bind:value={bpmMultiplier} />
+			</label>
+			<label>
+				<span>Downbeat nudge</span>
+				<input type="number" min="-16" max="16" step="1" bind:value={downbeatOffset} />
+			</label>
+			<label>
+				<span>Phrase nudge</span>
+				<input type="number" min="-16" max="16" step="1" bind:value={phraseOffset} />
+			</label>
+			<label>
+				<span>Speed override</span>
+				<select bind:value={speedBias}>
+					<option value="slower">Slower</option>
+					<option value="neutral">Neutral</option>
+					<option value="faster">Faster</option>
+				</select>
+			</label>
+		</div>
+
+		<label class="check-row">
+			<input type="checkbox" bind:checked={safeOnly} />
+			<span>Safe-crossfade only</span>
+		</label>
+
+		<label>
+			<span>Notes</span>
+			<textarea rows="3" bind:value={notes}></textarea>
+		</label>
+
+		<div class="actions">
+			<button type="button" disabled={busy} onclick={save}>Save correction</button>
+			<button type="button" disabled={busy} onclick={() => mediaRef(selectedDeck) && onClear(mediaRef(selectedDeck)!)}>Clear override</button>
+			<button type="button" disabled={busy} onclick={() => mediaRef(selectedDeck) && onRebuild(mediaRef(selectedDeck)!)}>Rebuild profile</button>
+		</div>
+	{:else}
+		<p class="empty">No deck selected for correction.</p>
+	{/if}
+</section>
+
+<style>
+	.correction-panel {
+		display: grid;
+		gap: var(--space-3);
+	}
+
+	.eyebrow,
+	h2,
+	p {
+		margin: 0;
+	}
+
+	.eyebrow {
+		color: var(--text-tertiary);
+		font-size: var(--font-size-2xs);
+		font-weight: var(--font-weight-bold);
+		line-height: var(--line-height-tight);
+		text-transform: uppercase;
+		letter-spacing: 0;
+	}
+
+	h2 {
+		font-size: var(--font-size-xl);
+		line-height: var(--line-height-tight);
+	}
+
+	.armed-note {
+		padding: var(--space-2) var(--space-3);
+		border: 1px solid color-mix(in srgb, var(--state-warning) 34%, transparent);
+		border-radius: var(--radius-sm);
+		color: var(--state-warning);
+		font-size: var(--font-size-sm);
+		line-height: var(--line-height-snug);
+	}
+
+	.target-tabs,
+	.actions {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--space-2);
+	}
+
+	button {
+		min-height: 2.75rem;
+		padding: 0 var(--space-3);
+		border: 1px solid var(--border-subtle);
+		border-radius: var(--radius-sm);
+		background: color-mix(in srgb, var(--bg-surface) 86%, transparent);
+		color: var(--text-primary);
+		font-size: var(--font-size-sm);
+		font-weight: var(--font-weight-semibold);
+		line-height: 1;
+		cursor: pointer;
+	}
+
+	button.active {
+		border-color: var(--accent-line);
+		background: var(--accent-soft);
+		color: var(--accent-strong);
+	}
+
+	button:focus-visible,
+	input:focus-visible,
+	select:focus-visible,
+	textarea:focus-visible {
+		outline: 2px solid var(--accent);
+		outline-offset: 2px;
+	}
+
+	button:disabled {
+		cursor: not-allowed;
+		opacity: 0.55;
+	}
+
+	.target-label {
+		overflow: hidden;
+		color: var(--text-secondary);
+		font-size: var(--font-size-sm);
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.field-grid {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: var(--space-3);
+	}
+
+	label {
+		display: grid;
+		gap: var(--space-1);
+		color: var(--text-secondary);
+		font-size: var(--font-size-sm);
+	}
+
+	label span {
+		font-weight: var(--font-weight-semibold);
+	}
+
+	input,
+	select,
+	textarea {
+		width: 100%;
+		min-height: 2.75rem;
+		border: 1px solid var(--border-subtle);
+		border-radius: var(--radius-sm);
+		background: color-mix(in srgb, var(--bg-surface) 90%, transparent);
+		color: var(--text-primary);
+		font: inherit;
+		padding: var(--space-2);
+	}
+
+	textarea {
+		min-height: 5.5rem;
+		resize: vertical;
+	}
+
+	.check-row {
+		grid-template-columns: auto minmax(0, 1fr);
+		align-items: center;
+	}
+
+	.check-row input {
+		width: 1.25rem;
+		min-height: 1.25rem;
+	}
+
+	.empty {
+		color: var(--text-tertiary);
+		font-size: var(--font-size-sm);
+	}
+
+	@media (max-width: 760px) {
+		.field-grid {
+			grid-template-columns: 1fr;
+		}
+	}
+</style>

--- a/frontend/src/lib/components/dj-cockpit/QueuePairPanel.svelte
+++ b/frontend/src/lib/components/dj-cockpit/QueuePairPanel.svelte
@@ -11,6 +11,7 @@
 
 	function confidenceLabel(deck?: DjDeckStatus) {
 		if (deck?.profile_status === 'decode_failed') return 'Analysis failed';
+		if (deck?.profile_status === 'analyzing') return 'Analyzing';
 		if (!deck?.profile_ready) return 'Profile missing';
 		if (deck.profile_confidence == null) return 'Profile ready';
 		return `${Math.round(deck.profile_confidence * 100)}% confidence`;

--- a/frontend/src/lib/components/dj-cockpit/QueuePairPanel.svelte
+++ b/frontend/src/lib/components/dj-cockpit/QueuePairPanel.svelte
@@ -10,6 +10,7 @@
 	} = $props();
 
 	function confidenceLabel(deck?: DjDeckStatus) {
+		if (deck?.profile_status === 'decode_failed') return 'Analysis failed';
 		if (!deck?.profile_ready) return 'Profile missing';
 		if (deck.profile_confidence == null) return 'Profile ready';
 		return `${Math.round(deck.profile_confidence * 100)}% confidence`;
@@ -32,9 +33,17 @@
 					<h3 title={item.deck.title}>{item.deck.title}</h3>
 					<p title={item.deck.artist ?? 'Unknown artist'}>{item.deck.artist ?? 'Unknown artist'}</p>
 					<div class="deck-status">
-						<span class:ready={item.deck.profile_ready}>{confidenceLabel(item.deck)}</span>
+						<span
+							class:ready={item.deck.profile_ready}
+							class:failed={item.deck.profile_status === 'decode_failed'}
+						>
+							{confidenceLabel(item.deck)}
+						</span>
 						{#if item.deck.safe_crossfade_only}
 							<span class="safe-only">Safe only</span>
+						{/if}
+						{#if item.deck.profile_error}
+							<span class="error-detail" title={item.deck.profile_error}>{item.deck.profile_error}</span>
 						{/if}
 					</div>
 					<dl>
@@ -156,6 +165,18 @@
 	.deck-status .ready {
 		border-color: color-mix(in srgb, var(--state-success) 42%, transparent);
 		color: var(--state-success);
+	}
+
+	.deck-status .failed {
+		border-color: color-mix(in srgb, var(--state-error) 46%, transparent);
+		color: var(--state-error);
+	}
+
+	.deck-status .error-detail {
+		max-width: 100%;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
 	}
 
 	.deck-status .safe-only {

--- a/frontend/src/lib/components/dj-cockpit/QueuePairPanel.svelte
+++ b/frontend/src/lib/components/dj-cockpit/QueuePairPanel.svelte
@@ -1,0 +1,199 @@
+<script lang="ts">
+	import type { DjDeckStatus } from '$lib/api/client';
+
+	let {
+		current = undefined,
+		next = undefined,
+	}: {
+		current?: DjDeckStatus;
+		next?: DjDeckStatus;
+	} = $props();
+
+	function confidenceLabel(deck?: DjDeckStatus) {
+		if (!deck?.profile_ready) return 'Profile missing';
+		if (deck.profile_confidence == null) return 'Profile ready';
+		return `${Math.round(deck.profile_confidence * 100)}% confidence`;
+	}
+</script>
+
+<section class="pair-panel" aria-labelledby="dj-pair-heading">
+	<header>
+		<div>
+			<p class="eyebrow">Queue pair</p>
+			<h2 id="dj-pair-heading">Current and next</h2>
+		</div>
+	</header>
+
+	<div class="deck-grid">
+		{#each [{ label: 'Outgoing', deck: current }, { label: 'Incoming', deck: next }] as item}
+			<article class="deck-card" class:missing={!item.deck}>
+				<span class="deck-label">{item.label}</span>
+				{#if item.deck}
+					<h3 title={item.deck.title}>{item.deck.title}</h3>
+					<p title={item.deck.artist ?? 'Unknown artist'}>{item.deck.artist ?? 'Unknown artist'}</p>
+					<div class="deck-status">
+						<span class:ready={item.deck.profile_ready}>{confidenceLabel(item.deck)}</span>
+						{#if item.deck.safe_crossfade_only}
+							<span class="safe-only">Safe only</span>
+						{/if}
+					</div>
+					<dl>
+						<div>
+							<dt>Beats</dt>
+							<dd>{item.deck.beat_count ?? 0}</dd>
+						</div>
+						<div>
+							<dt>Downbeats</dt>
+							<dd>{item.deck.downbeat_count ?? 0}</dd>
+						</div>
+						<div>
+							<dt>Phrases</dt>
+							<dd>{item.deck.phrase_count ?? 0}</dd>
+						</div>
+					</dl>
+					<small>{item.deck.media_ref_kind}:{item.deck.media_ref_id}</small>
+				{:else}
+					<h3>No deck</h3>
+					<p>The queue pair is not resolved yet.</p>
+				{/if}
+			</article>
+		{/each}
+	</div>
+</section>
+
+<style>
+	.pair-panel {
+		display: grid;
+		gap: var(--space-3);
+	}
+
+	header {
+		display: flex;
+		justify-content: space-between;
+		gap: var(--space-3);
+	}
+
+	.eyebrow {
+		margin: 0 0 var(--space-1);
+		color: var(--text-tertiary);
+		font-size: var(--font-size-2xs);
+		font-weight: var(--font-weight-bold);
+		line-height: var(--line-height-tight);
+		text-transform: uppercase;
+		letter-spacing: 0;
+	}
+
+	h2,
+	h3,
+	p {
+		margin: 0;
+	}
+
+	h2 {
+		font-size: var(--font-size-xl);
+		line-height: var(--line-height-tight);
+	}
+
+	.deck-grid {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: var(--space-3);
+	}
+
+	.deck-card {
+		display: grid;
+		gap: var(--space-2);
+		min-width: 0;
+		padding: var(--space-3);
+		border: 1px solid var(--border-subtle);
+		border-radius: var(--radius-sm);
+		background: color-mix(in srgb, var(--bg-surface) 86%, transparent);
+	}
+
+	.deck-card.missing {
+		opacity: 0.72;
+	}
+
+	.deck-label,
+	small {
+		color: var(--text-tertiary);
+		font-size: var(--font-size-xs);
+		line-height: var(--line-height-snug);
+	}
+
+	h3,
+	p {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	h3 {
+		font-size: var(--font-size-lg);
+		line-height: var(--line-height-tight);
+	}
+
+	p {
+		color: var(--text-secondary);
+		font-size: var(--font-size-sm);
+	}
+
+	.deck-status {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--space-1);
+	}
+
+	.deck-status span {
+		padding: var(--space-1) var(--space-2);
+		border: 1px solid var(--border-subtle);
+		border-radius: 999px;
+		color: var(--text-secondary);
+		font-size: var(--font-size-xs);
+		line-height: 1;
+	}
+
+	.deck-status .ready {
+		border-color: color-mix(in srgb, var(--state-success) 42%, transparent);
+		color: var(--state-success);
+	}
+
+	.deck-status .safe-only {
+		border-color: color-mix(in srgb, var(--state-warning) 42%, transparent);
+		color: var(--state-warning);
+	}
+
+	dl {
+		display: grid;
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+		gap: var(--space-2);
+		margin: 0;
+	}
+
+	dl div {
+		display: grid;
+		gap: var(--space-1);
+	}
+
+	dt {
+		color: var(--text-tertiary);
+		font-size: var(--font-size-2xs);
+		font-weight: var(--font-weight-semibold);
+		line-height: var(--line-height-tight);
+		text-transform: uppercase;
+		letter-spacing: 0;
+	}
+
+	dd {
+		margin: 0;
+		font-size: var(--font-size-lg);
+		font-weight: var(--font-weight-semibold);
+		line-height: var(--line-height-tight);
+	}
+
+	@media (max-width: 760px) {
+		.deck-grid {
+			grid-template-columns: 1fr;
+		}
+	}
+</style>

--- a/frontend/src/lib/components/dj-cockpit/SafetyGuardrailPanel.svelte
+++ b/frontend/src/lib/components/dj-cockpit/SafetyGuardrailPanel.svelte
@@ -1,0 +1,142 @@
+<script lang="ts">
+	import type { DjStatusResponse } from '$lib/api/client';
+
+	let {
+		status,
+		onAcceptSafeOnly,
+	}: {
+		status: DjStatusResponse | null;
+		onAcceptSafeOnly: () => void;
+	} = $props();
+</script>
+
+<section class="guardrail-panel" aria-labelledby="dj-guardrails-heading">
+	<header>
+		<div>
+			<p class="eyebrow">Guardrails</p>
+			<h2 id="dj-guardrails-heading">Safety state</h2>
+		</div>
+	</header>
+
+	<dl>
+		<div>
+			<dt>Confidence floor</dt>
+			<dd>{status?.profile_confidence_floor ?? 0}</dd>
+		</div>
+		<div>
+			<dt>Decode state</dt>
+			<dd>{status?.fallback_reason === 'decode_late' ? 'Late' : 'Ready'}</dd>
+		</div>
+		<div>
+			<dt>Analysis state</dt>
+			<dd>{status?.fallback_reason === 'analysis_late' ? 'Late' : 'Ready'}</dd>
+		</div>
+		<div>
+			<dt>Pair freshness</dt>
+			<dd>{status?.fallback_reason === 'queue_changed' ? 'Stale pair' : 'Current pair'}</dd>
+		</div>
+	</dl>
+
+	{#if status?.safe_crossfade_suggestion}
+		<div class="suggestion">
+			<p>
+				Repeated bad feedback reached {status.safe_crossfade_suggestion.bad_feedback_count} events for
+				{status.safe_crossfade_suggestion.media_ref_kind}:{status.safe_crossfade_suggestion.media_ref_id}.
+			</p>
+			<button type="button" onclick={onAcceptSafeOnly}>Accept safe-only suggestion</button>
+		</div>
+	{/if}
+</section>
+
+<style>
+	.guardrail-panel {
+		display: grid;
+		gap: var(--space-3);
+	}
+
+	.eyebrow,
+	h2,
+	p,
+	dl {
+		margin: 0;
+	}
+
+	.eyebrow {
+		color: var(--text-tertiary);
+		font-size: var(--font-size-2xs);
+		font-weight: var(--font-weight-bold);
+		line-height: var(--line-height-tight);
+		text-transform: uppercase;
+		letter-spacing: 0;
+	}
+
+	h2 {
+		font-size: var(--font-size-xl);
+		line-height: var(--line-height-tight);
+	}
+
+	dl {
+		display: grid;
+		gap: var(--space-2);
+	}
+
+	dl div,
+	.suggestion {
+		padding: var(--space-3);
+		border: 1px solid var(--border-subtle);
+		border-radius: var(--radius-sm);
+		background: color-mix(in srgb, var(--bg-surface) 86%, transparent);
+	}
+
+	dl div {
+		display: flex;
+		justify-content: space-between;
+		gap: var(--space-3);
+	}
+
+	dt,
+	dd {
+		font-size: var(--font-size-sm);
+		line-height: var(--line-height-snug);
+	}
+
+	dt {
+		color: var(--text-tertiary);
+	}
+
+	dd {
+		margin: 0;
+		color: var(--text-primary);
+		font-weight: var(--font-weight-semibold);
+		text-align: right;
+	}
+
+	.suggestion {
+		display: grid;
+		gap: var(--space-2);
+		border-color: color-mix(in srgb, var(--state-warning) 34%, transparent);
+	}
+
+	.suggestion p {
+		color: var(--text-secondary);
+		font-size: var(--font-size-sm);
+		line-height: var(--line-height-snug);
+	}
+
+	button {
+		min-height: 2.75rem;
+		border: 1px solid var(--accent-line);
+		border-radius: var(--radius-sm);
+		background: var(--accent-soft);
+		color: var(--accent-strong);
+		font-size: var(--font-size-sm);
+		font-weight: var(--font-weight-semibold);
+		line-height: 1;
+		cursor: pointer;
+	}
+
+	button:focus-visible {
+		outline: 2px solid var(--accent);
+		outline-offset: 2px;
+	}
+</style>

--- a/frontend/src/lib/components/dj-cockpit/SafetyGuardrailPanel.svelte
+++ b/frontend/src/lib/components/dj-cockpit/SafetyGuardrailPanel.svelte
@@ -8,6 +8,29 @@
 		status: DjStatusResponse | null;
 		onAcceptSafeOnly: () => void;
 	} = $props();
+
+	function formatPlanningStatus(value: string | null | undefined) {
+		switch (value) {
+			case 'waiting_for_profiles':
+				return 'Waiting for profiles';
+			case 'profile_failed':
+				return 'Profile failed';
+			case 'waiting_for_window':
+				return 'Waiting for window';
+			case 'ready_to_plan':
+				return 'Ready to plan';
+			case 'pair_missing':
+				return 'Pair missing';
+			case 'armed':
+				return 'Armed';
+			case 'missed':
+				return 'Missed';
+			case 'disabled':
+				return 'Disabled';
+			default:
+				return 'Unknown';
+		}
+	}
 </script>
 
 <section class="guardrail-panel" aria-labelledby="dj-guardrails-heading">
@@ -34,6 +57,10 @@
 		<div>
 			<dt>Pair freshness</dt>
 			<dd>{status?.fallback_reason === 'queue_changed' ? 'Stale pair' : 'Current pair'}</dd>
+		</div>
+		<div>
+			<dt>Planning state</dt>
+			<dd>{formatPlanningStatus(status?.planning_status)}</dd>
 		</div>
 	</dl>
 

--- a/frontend/src/lib/components/dj-cockpit/TransitionLane.svelte
+++ b/frontend/src/lib/components/dj-cockpit/TransitionLane.svelte
@@ -19,6 +19,9 @@
 	let hasPair = $derived(Boolean(status?.current && status?.next));
 	let currentReady = $derived(status?.current?.profile_ready === true);
 	let nextReady = $derived(status?.next?.profile_ready === true);
+	let currentFailed = $derived(status?.current?.profile_status === 'decode_failed');
+	let nextFailed = $derived(status?.next?.profile_status === 'decode_failed');
+	let profileFailed = $derived(currentFailed || nextFailed);
 	let profileMissing = $derived(hasPair && (!currentReady || !nextReady));
 	let rendererLabel = $derived(
 		status?.renderer_template ??
@@ -37,6 +40,8 @@
 				? rendererLabel
 				: !hasPair
 					? 'Pair not detected'
+					: profileFailed
+						? 'Profile analysis failed'
 					: profileMissing
 						? 'Analyzing profiles'
 						: 'Ready to plan',
@@ -50,6 +55,12 @@
 					: 'Transition armed for the current pair.'
 				: !hasPair
 					? 'Waiting for current and next tracks.'
+					: currentFailed && nextFailed
+						? 'Current and next profile decodes failed.'
+						: currentFailed
+							? 'The current profile decode failed.'
+							: nextFailed
+								? 'The next profile decode failed.'
 					: !currentReady && !nextReady
 						? 'Building current and next DJ profiles.'
 						: !currentReady
@@ -63,7 +74,8 @@
 			fallback &&
 				!['disabled', 'pair_missing', 'missing_current_profile', 'missing_next_profile'].includes(
 					fallback,
-				),
+				) &&
+				!['current_profile_decode_failed', 'next_profile_decode_failed'].includes(fallback),
 		),
 	);
 	let recentTimingEvents = $derived(status?.recent_timing_events ?? []);

--- a/frontend/src/lib/components/dj-cockpit/TransitionLane.svelte
+++ b/frontend/src/lib/components/dj-cockpit/TransitionLane.svelte
@@ -80,6 +80,14 @@
 		return `${value > 0 ? '+' : ''}${value} ms`;
 	}
 
+	function formatActualTiming(event: DjStatusResponse['recent_timing_events'][number]) {
+		return event.timing_status === 'missed' ? 'missed' : formatTimingMs(event.actual_start_ms);
+	}
+
+	function formatEventDelta(event: DjStatusResponse['recent_timing_events'][number]) {
+		return event.timing_status === 'missed' ? 'missed' : formatTimingDelta(event.timing_delta_ms);
+	}
+
 	function formatTimingDirection(value: string | null | undefined) {
 		switch (value) {
 			case 'on_time':
@@ -249,8 +257,8 @@
 							<span>{event.planning_reason ?? 'none'}</span>
 							<span>{event.timing_source ?? 'none'}</span>
 							<span>{formatTimingMs(event.planned_start_ms)}</span>
-							<span>{formatTimingMs(event.actual_start_ms)}</span>
-							<span>{formatTimingDelta(event.timing_delta_ms)}</span>
+							<span>{formatActualTiming(event)}</span>
+							<span>{formatEventDelta(event)}</span>
 						</li>
 					{/each}
 				</ul>

--- a/frontend/src/lib/components/dj-cockpit/TransitionLane.svelte
+++ b/frontend/src/lib/components/dj-cockpit/TransitionLane.svelte
@@ -14,15 +14,17 @@
 	} = $props();
 
 	let fallback = $derived(status?.fallback_reason ?? null);
+	let planningStatus = $derived(status?.planning_status ?? 'disabled');
 	let transitionId = $derived(status?.last_transition_event_id ?? null);
-	let transitionArmed = $derived(Boolean(transitionId || status?.renderer_template || status?.selected_program));
-	let hasPair = $derived(Boolean(status?.current && status?.next));
+	let transitionArmed = $derived(
+		planningStatus === 'armed' ||
+			(planningStatus !== 'missed' &&
+				Boolean(transitionId || status?.renderer_template || status?.selected_program)),
+	);
 	let currentReady = $derived(status?.current?.profile_ready === true);
 	let nextReady = $derived(status?.next?.profile_ready === true);
 	let currentFailed = $derived(status?.current?.profile_status === 'decode_failed');
 	let nextFailed = $derived(status?.next?.profile_status === 'decode_failed');
-	let profileFailed = $derived(currentFailed || nextFailed);
-	let profileMissing = $derived(hasPair && (!currentReady || !nextReady));
 	let rendererLabel = $derived(
 		status?.renderer_template ??
 			(status?.renderer_mode === 'legacy_overlap'
@@ -34,40 +36,48 @@
 						: 'Transition armed'),
 	);
 	let laneTitle = $derived(
-		!status?.enabled
+		planningStatus === 'disabled'
 			? 'Legacy path'
-			: transitionArmed
+			: planningStatus === 'armed'
 				? rendererLabel
-				: !hasPair
+				: planningStatus === 'pair_missing'
 					? 'Pair not detected'
-					: profileFailed
+					: planningStatus === 'profile_failed'
 						? 'Profile analysis failed'
-					: profileMissing
+					: planningStatus === 'waiting_for_profiles'
 						? 'Analyzing profiles'
-						: 'Ready to plan',
+						: planningStatus === 'waiting_for_window'
+							? 'Waiting for mix window'
+							: planningStatus === 'missed'
+								? 'Transition missed'
+								: 'Ready to plan',
 	);
 	let laneCopy = $derived(
-		!status?.enabled
+		planningStatus === 'disabled'
 			? 'Playback is using the legacy path.'
-			: transitionArmed
+			: planningStatus === 'armed'
 				? status?.renderer_mode === 'legacy_overlap'
 					? 'DJ planned this pair, but audio is using the overlap fallback.'
 					: 'Transition armed for the current pair.'
-				: !hasPair
+				: planningStatus === 'pair_missing'
 					? 'Waiting for current and next tracks.'
-					: currentFailed && nextFailed
+					: planningStatus === 'profile_failed' && currentFailed && nextFailed
 						? 'Current and next profile decodes failed.'
-						: currentFailed
+						: planningStatus === 'profile_failed' && currentFailed
 							? 'The current profile decode failed.'
-							: nextFailed
+							: planningStatus === 'profile_failed' && nextFailed
 								? 'The next profile decode failed.'
-					: !currentReady && !nextReady
+								: planningStatus === 'waiting_for_profiles' && !currentReady && !nextReady
 						? 'Building current and next DJ profiles.'
-						: !currentReady
+						: planningStatus === 'waiting_for_profiles' && !currentReady
 							? 'Building the current DJ profile.'
-							: !nextReady
+							: planningStatus === 'waiting_for_profiles' && !nextReady
 								? 'Building the next DJ profile.'
-								: 'Both DJ profiles are ready. Waiting for a transition plan to arm.',
+								: planningStatus === 'waiting_for_window'
+									? 'Both DJ profiles are ready. Waiting for the mix window.'
+									: planningStatus === 'missed'
+										? 'The last armed transition missed its fire point.'
+										: 'Both DJ profiles are ready. Waiting for a transition plan to arm.',
 	);
 	let showFallback = $derived(
 		Boolean(
@@ -212,6 +222,10 @@
 				<div>
 					<dt>Readiness block</dt>
 					<dd>{status?.fallback_reason ?? 'none'}</dd>
+				</div>
+				<div>
+					<dt>Planning status</dt>
+					<dd>{status?.planning_status ?? 'none'}</dd>
 				</div>
 				<div>
 					<dt>Confidence floor</dt>

--- a/frontend/src/lib/components/dj-cockpit/TransitionLane.svelte
+++ b/frontend/src/lib/components/dj-cockpit/TransitionLane.svelte
@@ -79,6 +79,33 @@
 		}
 		return `${value > 0 ? '+' : ''}${value} ms`;
 	}
+
+	function formatTimingDirection(value: string | null | undefined) {
+		switch (value) {
+			case 'on_time':
+				return 'on time';
+			case 'early':
+			case 'late':
+			case 'missed':
+			case 'pending':
+				return value;
+			default:
+				return 'unknown';
+		}
+	}
+
+	function formatTrackLabel(title: string | undefined, artist: string | undefined, fallback: string) {
+		if (!title) {
+			return fallback;
+		}
+		return artist ? `${title} - ${artist}` : title;
+	}
+
+	function formatTimingPair(event: DjStatusResponse['recent_timing_events'][number]) {
+		const from = formatTrackLabel(event.from_title, event.from_artist, `Event ${event.event_id}`);
+		const to = formatTrackLabel(event.to_title, event.to_artist, 'unknown');
+		return `${from} -> ${to}`;
+	}
 </script>
 
 <section class="transition-lane" aria-labelledby="dj-transition-heading">
@@ -151,6 +178,14 @@
 					<dd>{status?.timing_status ?? 'none'}</dd>
 				</div>
 				<div>
+					<dt>Timing direction</dt>
+					<dd>{formatTimingDirection(status?.timing_direction)}</dd>
+				</div>
+				<div>
+					<dt>Timing quality</dt>
+					<dd>{status?.timing_quality ?? 'unknown'}</dd>
+				</div>
+				<div>
 					<dt>Fallback</dt>
 					<dd>{status?.fallback_reason ?? 'none'}</dd>
 				</div>
@@ -159,7 +194,7 @@
 					<dd>{status?.profile_confidence_floor ?? 0}</dd>
 				</div>
 			</dl>
-			<p class="debug-heading">Recent fires</p>
+			<p class="debug-heading">Recent timing</p>
 			{#if timingSummary && timingSummary.event_count > 0}
 				<div class="timing-summary" aria-label="Recent DJ timing summary">
 					<div>
@@ -190,8 +225,9 @@
 			{/if}
 			{#if recentTimingEvents.length > 0}
 				<div class="timing-history-header" aria-hidden="true">
-					<span>Event</span>
+					<span>Pair</span>
 					<span>Status</span>
+					<span>Timing</span>
 					<span>Quality</span>
 					<span>Source</span>
 					<span>Planned</span>
@@ -201,8 +237,9 @@
 				<ul class="timing-history" aria-label="Recent DJ transition timing">
 					{#each recentTimingEvents as event}
 						<li>
-							<span>Event {event.event_id}</span>
+							<span>{formatTimingPair(event)}</span>
 							<span>{event.timing_status ?? 'none'}</span>
+							<span>{formatTimingDirection(event.timing_direction)}</span>
 							<span>{event.timing_quality}</span>
 							<span>{event.timing_source ?? 'none'}</span>
 							<span>{formatTimingMs(event.planned_start_ms)}</span>
@@ -387,7 +424,7 @@
 
 	.timing-history-header {
 		display: grid;
-		grid-template-columns: 1fr repeat(6, minmax(4.5rem, auto));
+		grid-template-columns: minmax(10rem, 1fr) repeat(7, minmax(4.25rem, auto));
 		gap: var(--space-2);
 		color: var(--text-tertiary);
 		font-size: var(--font-size-2xs);
@@ -409,7 +446,7 @@
 
 	.timing-history li {
 		display: grid;
-		grid-template-columns: 1fr repeat(6, minmax(4.5rem, auto));
+		grid-template-columns: minmax(10rem, 1fr) repeat(7, minmax(4.25rem, auto));
 		gap: var(--space-2);
 		align-items: center;
 		padding-top: var(--space-2);

--- a/frontend/src/lib/components/dj-cockpit/TransitionLane.svelte
+++ b/frontend/src/lib/components/dj-cockpit/TransitionLane.svelte
@@ -14,23 +14,86 @@
 	} = $props();
 
 	let fallback = $derived(status?.fallback_reason ?? null);
-	let selectedProgram = $derived(status?.selected_program ?? 'Legacy path');
 	let transitionId = $derived(status?.last_transition_event_id ?? null);
+	let transitionArmed = $derived(Boolean(transitionId || status?.renderer_template || status?.selected_program));
+	let hasPair = $derived(Boolean(status?.current && status?.next));
+	let currentReady = $derived(status?.current?.profile_ready === true);
+	let nextReady = $derived(status?.next?.profile_ready === true);
+	let profileMissing = $derived(hasPair && (!currentReady || !nextReady));
+	let rendererLabel = $derived(
+		status?.renderer_template ??
+			(status?.renderer_mode === 'legacy_overlap'
+				? 'DJ overlap armed'
+				: status?.renderer_mode === 'dj_gain_program'
+					? 'DJ gain program armed'
+					: status?.renderer_mode === 'dj_full_program'
+						? 'DJ full program armed'
+						: 'Transition armed'),
+	);
+	let laneTitle = $derived(
+		!status?.enabled
+			? 'Legacy path'
+			: transitionArmed
+				? rendererLabel
+				: !hasPair
+					? 'Pair not detected'
+					: profileMissing
+						? 'Analyzing profiles'
+						: 'Ready to plan',
+	);
+	let laneCopy = $derived(
+		!status?.enabled
+			? 'Playback is using the legacy path.'
+			: transitionArmed
+				? status?.renderer_mode === 'legacy_overlap'
+					? 'DJ planned this pair, but audio is using the overlap fallback.'
+					: 'Transition armed for the current pair.'
+				: !hasPair
+					? 'Waiting for current and next tracks.'
+					: !currentReady && !nextReady
+						? 'Building current and next DJ profiles.'
+						: !currentReady
+							? 'Building the current DJ profile.'
+							: !nextReady
+								? 'Building the next DJ profile.'
+								: 'Both DJ profiles are ready. Waiting for a transition plan to arm.',
+	);
+	let showFallback = $derived(
+		Boolean(
+			fallback &&
+				!['disabled', 'pair_missing', 'missing_current_profile', 'missing_next_profile'].includes(
+					fallback,
+				),
+		),
+	);
+	let recentTimingEvents = $derived(status?.recent_timing_events ?? []);
+	let timingSummary = $derived(status?.timing_history_summary ?? null);
+
+	function formatTimingMs(value: number | null | undefined) {
+		return typeof value === 'number' ? `${value} ms` : 'pending';
+	}
+
+	function formatTimingDelta(value: number | null | undefined) {
+		if (typeof value !== 'number') {
+			return 'pending';
+		}
+		return `${value > 0 ? '+' : ''}${value} ms`;
+	}
 </script>
 
 <section class="transition-lane" aria-labelledby="dj-transition-heading">
 	<header>
 		<div>
 			<p class="eyebrow">Transition lane</p>
-			<h2 id="dj-transition-heading">{selectedProgram}</h2>
+			<h2 id="dj-transition-heading">{laneTitle}</h2>
 		</div>
 		<span class="event-id">{transitionId ? `Event ${transitionId}` : 'No event armed'}</span>
 	</header>
 
-	{#if fallback}
+	{#if showFallback}
 		<p class="fallback" role="status">Fallback reason: {fallback}</p>
 	{:else}
-		<p class="success">Transition ready. Detailed successful-transition reasons are hidden by default.</p>
+		<p class:pending={!transitionArmed} class:success={transitionArmed} role="status">{laneCopy}</p>
 	{/if}
 
 	<div class="lane-actions" aria-label="Transition feedback">
@@ -45,10 +108,47 @@
 	</button>
 	{#if debugOpen}
 		<div class="debug-panel">
+			<p class="debug-heading">Current event</p>
 			<dl>
 				<div>
-					<dt>Selected program</dt>
-					<dd>{status?.selected_program ?? 'none'}</dd>
+					<dt>Planned template</dt>
+					<dd>{status?.planned_template ?? status?.selected_program ?? 'none'}</dd>
+				</div>
+				<div>
+					<dt>Renderer template</dt>
+					<dd>{status?.renderer_template ?? 'none'}</dd>
+				</div>
+				<div>
+					<dt>Renderer mode</dt>
+					<dd>{status?.renderer_mode ?? 'none'}</dd>
+				</div>
+				<div>
+					<dt>Downgrade</dt>
+					<dd>{status?.downgrade_reason ?? 'none'}</dd>
+				</div>
+				<div>
+					<dt>Sync target</dt>
+					<dd>{status?.sync_target ?? 'none'}</dd>
+				</div>
+				<div>
+					<dt>Current planned</dt>
+					<dd>{formatTimingMs(status?.planned_start_ms)}</dd>
+				</div>
+				<div>
+					<dt>Current fire</dt>
+					<dd>{formatTimingMs(status?.actual_start_ms)}</dd>
+				</div>
+				<div>
+					<dt>Current delta</dt>
+					<dd>{formatTimingDelta(status?.timing_delta_ms)}</dd>
+				</div>
+				<div>
+					<dt>Sync source</dt>
+					<dd>{status?.timing_source ?? 'none'}</dd>
+				</div>
+				<div>
+					<dt>Timing status</dt>
+					<dd>{status?.timing_status ?? 'none'}</dd>
 				</div>
 				<div>
 					<dt>Fallback</dt>
@@ -59,6 +159,61 @@
 					<dd>{status?.profile_confidence_floor ?? 0}</dd>
 				</div>
 			</dl>
+			<p class="debug-heading">Recent fires</p>
+			{#if timingSummary && timingSummary.event_count > 0}
+				<div class="timing-summary" aria-label="Recent DJ timing summary">
+					<div>
+						<span>Avg delta</span>
+						<strong>{formatTimingDelta(timingSummary.average_delta_ms)}</strong>
+					</div>
+					<div>
+						<span>Avg abs</span>
+						<strong>{formatTimingMs(timingSummary.average_abs_delta_ms)}</strong>
+					</div>
+					<div>
+						<span>Late</span>
+						<strong>{timingSummary.late_count}</strong>
+					</div>
+					<div>
+						<span>Missed</span>
+						<strong>{timingSummary.missed_count}</strong>
+					</div>
+					<div>
+						<span>Tight</span>
+						<strong>{timingSummary.tight_count}</strong>
+					</div>
+					<div>
+						<span>Bad</span>
+						<strong>{timingSummary.bad_count}</strong>
+					</div>
+				</div>
+			{/if}
+			{#if recentTimingEvents.length > 0}
+				<div class="timing-history-header" aria-hidden="true">
+					<span>Event</span>
+					<span>Status</span>
+					<span>Quality</span>
+					<span>Source</span>
+					<span>Planned</span>
+					<span>Actual</span>
+					<span>Delta</span>
+				</div>
+				<ul class="timing-history" aria-label="Recent DJ transition timing">
+					{#each recentTimingEvents as event}
+						<li>
+							<span>Event {event.event_id}</span>
+							<span>{event.timing_status ?? 'none'}</span>
+							<span>{event.timing_quality}</span>
+							<span>{event.timing_source ?? 'none'}</span>
+							<span>{formatTimingMs(event.planned_start_ms)}</span>
+							<span>{formatTimingMs(event.actual_start_ms)}</span>
+							<span>{formatTimingDelta(event.timing_delta_ms)}</span>
+						</li>
+					{/each}
+				</ul>
+			{:else}
+				<p class="empty-history">No completed DJ transitions yet.</p>
+			{/if}
 		</div>
 	{/if}
 </section>
@@ -113,7 +268,8 @@
 	}
 
 	.fallback,
-	.success {
+	.success,
+	.pending {
 		padding: var(--space-3);
 		border-radius: var(--radius-sm);
 		font-size: var(--font-size-sm);
@@ -129,6 +285,12 @@
 	.success {
 		border: 1px solid color-mix(in srgb, var(--state-success) 28%, transparent);
 		background: color-mix(in srgb, var(--state-success) 9%, transparent);
+		color: var(--text-secondary);
+	}
+
+	.pending {
+		border: 1px solid var(--border-subtle);
+		background: color-mix(in srgb, var(--bg-surface) 84%, transparent);
 		color: var(--text-secondary);
 	}
 
@@ -176,10 +338,20 @@
 	}
 
 	.debug-panel {
+		display: grid;
+		gap: var(--space-3);
 		padding: var(--space-3);
 		border: 1px solid var(--border-subtle);
 		border-radius: var(--radius-sm);
 		background: color-mix(in srgb, var(--bg-surface) 78%, transparent);
+	}
+
+	.debug-heading {
+		color: var(--text-secondary);
+		font-size: var(--font-size-xs);
+		font-weight: var(--font-weight-bold);
+		line-height: var(--line-height-tight);
+		text-transform: uppercase;
 	}
 
 	dl {
@@ -206,10 +378,109 @@
 		text-align: right;
 	}
 
+	.timing-history,
+	.timing-history-header,
+	.timing-history li,
+	.empty-history {
+		margin: 0;
+	}
+
+	.timing-history-header {
+		display: grid;
+		grid-template-columns: 1fr repeat(6, minmax(4.5rem, auto));
+		gap: var(--space-2);
+		color: var(--text-tertiary);
+		font-size: var(--font-size-2xs);
+		font-weight: var(--font-weight-bold);
+		line-height: var(--line-height-tight);
+		text-transform: uppercase;
+	}
+
+	.timing-history-header span:not(:first-child) {
+		text-align: right;
+	}
+
+	.timing-history {
+		display: grid;
+		gap: var(--space-2);
+		padding: 0;
+		list-style: none;
+	}
+
+	.timing-history li {
+		display: grid;
+		grid-template-columns: 1fr repeat(6, minmax(4.5rem, auto));
+		gap: var(--space-2);
+		align-items: center;
+		padding-top: var(--space-2);
+		border-top: 1px solid var(--border-subtle);
+		color: var(--text-secondary);
+		font-size: var(--font-size-xs);
+	}
+
+	.timing-history span:first-child,
+	.timing-history span:nth-child(2) {
+		color: var(--text-primary);
+		font-weight: var(--font-weight-semibold);
+	}
+
+	.timing-history span:not(:first-child) {
+		text-align: right;
+	}
+
+	.empty-history {
+		color: var(--text-tertiary);
+		font-size: var(--font-size-xs);
+	}
+
+	.timing-summary {
+		display: grid;
+		grid-template-columns: repeat(6, minmax(0, 1fr));
+		gap: var(--space-2);
+	}
+
+	.timing-summary div {
+		display: grid;
+		gap: var(--space-1);
+		padding: var(--space-2);
+		border: 1px solid var(--border-subtle);
+		border-radius: var(--radius-sm);
+		background: color-mix(in srgb, var(--bg-surface) 66%, transparent);
+	}
+
+	.timing-summary span {
+		color: var(--text-tertiary);
+		font-size: var(--font-size-2xs);
+		line-height: var(--line-height-tight);
+		text-transform: uppercase;
+	}
+
+	.timing-summary strong {
+		color: var(--text-primary);
+		font-size: var(--font-size-xs);
+		line-height: var(--line-height-tight);
+	}
+
 	@media (max-width: 760px) {
 		header,
 		dl div {
 			display: grid;
+		}
+
+		.timing-history li {
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+		}
+
+		.timing-summary {
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+		}
+
+		.timing-history-header {
+			display: none;
+		}
+
+		.timing-history span:not(:first-child) {
+			text-align: left;
 		}
 
 		.lane-actions {

--- a/frontend/src/lib/components/dj-cockpit/TransitionLane.svelte
+++ b/frontend/src/lib/components/dj-cockpit/TransitionLane.svelte
@@ -1,0 +1,219 @@
+<script lang="ts">
+	import type { DjStatusResponse } from '$lib/api/client';
+
+	let {
+		status,
+		onFeedback,
+		debugOpen = false,
+		onToggleDebug,
+	}: {
+		status: DjStatusResponse | null;
+		onFeedback: (rating: 'good' | 'bad' | 'too_safe' | 'too_bold') => void;
+		debugOpen?: boolean;
+		onToggleDebug: () => void;
+	} = $props();
+
+	let fallback = $derived(status?.fallback_reason ?? null);
+	let selectedProgram = $derived(status?.selected_program ?? 'Legacy path');
+	let transitionId = $derived(status?.last_transition_event_id ?? null);
+</script>
+
+<section class="transition-lane" aria-labelledby="dj-transition-heading">
+	<header>
+		<div>
+			<p class="eyebrow">Transition lane</p>
+			<h2 id="dj-transition-heading">{selectedProgram}</h2>
+		</div>
+		<span class="event-id">{transitionId ? `Event ${transitionId}` : 'No event armed'}</span>
+	</header>
+
+	{#if fallback}
+		<p class="fallback" role="status">Fallback reason: {fallback}</p>
+	{:else}
+		<p class="success">Transition ready. Detailed successful-transition reasons are hidden by default.</p>
+	{/if}
+
+	<div class="lane-actions" aria-label="Transition feedback">
+		<button type="button" disabled={!transitionId} onclick={() => onFeedback('good')}>Good</button>
+		<button type="button" disabled={!transitionId} onclick={() => onFeedback('bad')}>Bad</button>
+		<button type="button" disabled={!transitionId} onclick={() => onFeedback('too_safe')}>Too safe</button>
+		<button type="button" disabled={!transitionId} onclick={() => onFeedback('too_bold')}>Too bold</button>
+	</div>
+
+	<button class="debug-toggle" type="button" aria-expanded={debugOpen} onclick={onToggleDebug}>
+		Debug planner facts
+	</button>
+	{#if debugOpen}
+		<div class="debug-panel">
+			<dl>
+				<div>
+					<dt>Selected program</dt>
+					<dd>{status?.selected_program ?? 'none'}</dd>
+				</div>
+				<div>
+					<dt>Fallback</dt>
+					<dd>{status?.fallback_reason ?? 'none'}</dd>
+				</div>
+				<div>
+					<dt>Confidence floor</dt>
+					<dd>{status?.profile_confidence_floor ?? 0}</dd>
+				</div>
+			</dl>
+		</div>
+	{/if}
+</section>
+
+<style>
+	.transition-lane {
+		display: grid;
+		gap: var(--space-3);
+		padding: var(--space-4);
+		border: 1px solid var(--border-muted);
+		border-radius: var(--radius-md);
+		background: color-mix(in srgb, var(--bg-raised) 90%, transparent);
+	}
+
+	header {
+		display: flex;
+		align-items: start;
+		justify-content: space-between;
+		gap: var(--space-3);
+	}
+
+	.eyebrow,
+	h2,
+	p,
+	dl {
+		margin: 0;
+	}
+
+	.eyebrow {
+		color: var(--text-tertiary);
+		font-size: var(--font-size-2xs);
+		font-weight: var(--font-weight-bold);
+		line-height: var(--line-height-tight);
+		text-transform: uppercase;
+		letter-spacing: 0;
+	}
+
+	h2 {
+		margin-top: var(--space-1);
+		font-size: var(--font-size-2xl);
+		line-height: var(--line-height-tight);
+	}
+
+	.event-id {
+		flex-shrink: 0;
+		padding: var(--space-1) var(--space-2);
+		border: 1px solid var(--border-subtle);
+		border-radius: 999px;
+		color: var(--text-tertiary);
+		font-size: var(--font-size-xs);
+		line-height: 1;
+	}
+
+	.fallback,
+	.success {
+		padding: var(--space-3);
+		border-radius: var(--radius-sm);
+		font-size: var(--font-size-sm);
+		line-height: var(--line-height-snug);
+	}
+
+	.fallback {
+		border: 1px solid color-mix(in srgb, var(--state-warning) 36%, transparent);
+		background: color-mix(in srgb, var(--state-warning) 10%, transparent);
+		color: var(--state-warning);
+	}
+
+	.success {
+		border: 1px solid color-mix(in srgb, var(--state-success) 28%, transparent);
+		background: color-mix(in srgb, var(--state-success) 9%, transparent);
+		color: var(--text-secondary);
+	}
+
+	.lane-actions {
+		display: grid;
+		grid-template-columns: repeat(4, minmax(0, 1fr));
+		gap: var(--space-2);
+	}
+
+	button {
+		min-height: 2.75rem;
+		border: 1px solid var(--border-subtle);
+		border-radius: var(--radius-sm);
+		background: color-mix(in srgb, var(--bg-surface) 86%, transparent);
+		color: var(--text-primary);
+		font-size: var(--font-size-sm);
+		font-weight: var(--font-weight-semibold);
+		line-height: 1;
+		cursor: pointer;
+		transition:
+			background var(--motion-fast),
+			border-color var(--motion-fast),
+			color var(--motion-fast);
+	}
+
+	button:hover,
+	button:focus-visible {
+		border-color: var(--accent-line);
+		color: var(--accent-strong);
+	}
+
+	button:focus-visible {
+		outline: 2px solid var(--accent);
+		outline-offset: 2px;
+	}
+
+	button:disabled {
+		cursor: not-allowed;
+		opacity: 0.55;
+	}
+
+	.debug-toggle {
+		justify-self: start;
+		padding: 0 var(--space-3);
+	}
+
+	.debug-panel {
+		padding: var(--space-3);
+		border: 1px solid var(--border-subtle);
+		border-radius: var(--radius-sm);
+		background: color-mix(in srgb, var(--bg-surface) 78%, transparent);
+	}
+
+	dl {
+		display: grid;
+		gap: var(--space-2);
+	}
+
+	dl div {
+		display: flex;
+		justify-content: space-between;
+		gap: var(--space-3);
+	}
+
+	dt {
+		color: var(--text-tertiary);
+		font-size: var(--font-size-xs);
+	}
+
+	dd {
+		margin: 0;
+		color: var(--text-primary);
+		font-size: var(--font-size-xs);
+		font-weight: var(--font-weight-semibold);
+		text-align: right;
+	}
+
+	@media (max-width: 760px) {
+		header,
+		dl div {
+			display: grid;
+		}
+
+		.lane-actions {
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+		}
+	}
+</style>

--- a/frontend/src/lib/components/dj-cockpit/TransitionLane.svelte
+++ b/frontend/src/lib/components/dj-cockpit/TransitionLane.svelte
@@ -154,6 +154,10 @@
 					<dd>{status?.downgrade_reason ?? 'none'}</dd>
 				</div>
 				<div>
+					<dt>Planning reason</dt>
+					<dd>{status?.planning_reason ?? 'none'}</dd>
+				</div>
+				<div>
 					<dt>Sync target</dt>
 					<dd>{status?.sync_target ?? 'none'}</dd>
 				</div>
@@ -186,7 +190,7 @@
 					<dd>{status?.timing_quality ?? 'unknown'}</dd>
 				</div>
 				<div>
-					<dt>Fallback</dt>
+					<dt>Readiness block</dt>
 					<dd>{status?.fallback_reason ?? 'none'}</dd>
 				</div>
 				<div>
@@ -229,6 +233,7 @@
 					<span>Status</span>
 					<span>Timing</span>
 					<span>Quality</span>
+					<span>Plan</span>
 					<span>Source</span>
 					<span>Planned</span>
 					<span>Actual</span>
@@ -241,6 +246,7 @@
 							<span>{event.timing_status ?? 'none'}</span>
 							<span>{formatTimingDirection(event.timing_direction)}</span>
 							<span>{event.timing_quality}</span>
+							<span>{event.planning_reason ?? 'none'}</span>
 							<span>{event.timing_source ?? 'none'}</span>
 							<span>{formatTimingMs(event.planned_start_ms)}</span>
 							<span>{formatTimingMs(event.actual_start_ms)}</span>
@@ -424,7 +430,7 @@
 
 	.timing-history-header {
 		display: grid;
-		grid-template-columns: minmax(10rem, 1fr) repeat(7, minmax(4.25rem, auto));
+		grid-template-columns: minmax(10rem, 1fr) repeat(8, minmax(4.25rem, auto));
 		gap: var(--space-2);
 		color: var(--text-tertiary);
 		font-size: var(--font-size-2xs);
@@ -446,7 +452,7 @@
 
 	.timing-history li {
 		display: grid;
-		grid-template-columns: minmax(10rem, 1fr) repeat(7, minmax(4.25rem, auto));
+		grid-template-columns: minmax(10rem, 1fr) repeat(8, minmax(4.25rem, auto));
 		gap: var(--space-2);
 		align-items: center;
 		padding-top: var(--space-2);

--- a/frontend/src/lib/components/remote/RemoteTransport.svelte
+++ b/frontend/src/lib/components/remote/RemoteTransport.svelte
@@ -3,6 +3,7 @@
 	import {
 		automixEnabled,
 		currentStreamDisplay,
+		playbackRuntimeInfo,
 		cyclePlayerRepeatMode,
 		cyclePlayerShuffleMode,
 		playNextTrack,
@@ -63,6 +64,7 @@
 	let streamDetail = $derived(
 		formatPlayerStreamDetail({
 			stream: $currentStreamDisplay,
+			runtime: $playbackRuntimeInfo,
 			exclusiveEngaged: $exclusiveStatus.engaged,
 		})
 	);

--- a/frontend/src/lib/player/stream_display.test.ts
+++ b/frontend/src/lib/player/stream_display.test.ts
@@ -47,6 +47,23 @@ describe('formatPlayerStreamDetail', () => {
 		expect(label).toBe('320 kbps AAC \u00b7 Excl');
 	});
 
+	test('marks exclusive playback as DJ processed when the DJ engine is on', () => {
+		const label = formatPlayerStreamDetail({
+			stream: {
+				audio_quality: 'HI_RES_LOSSLESS',
+				sample_rate: 96_000,
+				bit_depth: 24,
+			},
+			runtime: {
+				sample_rate: 96_000,
+				dj_engine_enabled: true,
+			},
+			exclusiveEngaged: true,
+		});
+
+		expect(label).toBe('96 kHz \u00b7 24-bit \u00b7 Excl DJ');
+	});
+
 	test('uses bitrate for the short high quality badge', () => {
 		const label = formatResolutionShort({
 			audio_quality: 'HIGH',

--- a/frontend/src/lib/player/stream_display.ts
+++ b/frontend/src/lib/player/stream_display.ts
@@ -6,6 +6,7 @@ export type PlayerStreamDisplay = {
 
 export type PlayerRuntimeDisplay = {
 	sample_rate?: number | null;
+	dj_engine_enabled?: boolean | null;
 } | null;
 
 const PART_SEPARATOR = ' \u00b7 ';
@@ -45,6 +46,7 @@ export function formatResolutionShort(stream: PlayerStreamDisplay): string {
 
 export function formatPlayerStreamDetail({
 	stream,
+	runtime,
 	exclusiveEngaged,
 }: {
 	stream: PlayerStreamDisplay;
@@ -59,6 +61,6 @@ export function formatPlayerStreamDetail({
 	if (qualityDetail) parts.push(qualityDetail);
 	if (sampleRate) parts.push(formatSampleRate(sampleRate));
 	if (bitDepth) parts.push(`${bitDepth}-bit`);
-	if (exclusiveEngaged) parts.push('Excl');
+	if (exclusiveEngaged) parts.push(runtime?.dj_engine_enabled ? 'Excl DJ' : 'Excl');
 	return parts.join(PART_SEPARATOR);
 }

--- a/frontend/src/lib/routes/navigation-data.json
+++ b/frontend/src/lib/routes/navigation-data.json
@@ -6,7 +6,7 @@
 		},
 		{
 			"label": "Signals",
-			"routeIds": ["automix", "analytics", "duplicates"]
+			"routeIds": ["automix", "dj", "analytics", "duplicates"]
 		},
 		{
 			"label": "System",
@@ -14,7 +14,7 @@
 		}
 	],
 	"mobileTabRouteIds": ["home", "library", "genres", "discover"],
-	"mobileMoreRouteIds": ["playlists", "automix", "analytics", "duplicates", "settings"],
+	"mobileMoreRouteIds": ["playlists", "automix", "dj", "analytics", "duplicates", "settings"],
 	"smokePhaseRouteIds": {
 		"shell": ["home", "library", "search", "settings"],
 		"links": ["home", "library", "search", "playlists", "videos", "settings"],

--- a/frontend/src/lib/routes/registry-data.json
+++ b/frontend/src/lib/routes/registry-data.json
@@ -9,6 +9,7 @@
 	"playlists": { "path": "/playlists", "label": "Playlists", "zone": "Atlas", "icon": "☰" },
 	"discover": { "path": "/discoverspace", "label": "Discover", "zone": "Atlas", "icon": "◈" },
 	"automix": { "path": "/automix", "label": "Automix", "zone": "Signals", "icon": "⟁" },
+	"dj": { "path": "/dj", "label": "DJ", "zone": "Signals", "icon": "DJ" },
 	"analytics": { "path": "/analytics", "label": "Analytics", "zone": "Signals", "icon": "◉" },
 	"duplicates": { "path": "/duplicates", "label": "Duplicates", "zone": "Signals", "icon": "⊘" },
 	"settings": { "path": "/settings", "label": "Settings", "zone": "System", "icon": "⚙" }

--- a/frontend/src/lib/routes/registry.test.ts
+++ b/frontend/src/lib/routes/registry.test.ts
@@ -29,6 +29,7 @@ describe('route registry', () => {
 			'playlists',
 			'discover',
 			'automix',
+			'dj',
 			'analytics',
 			'duplicates',
 			'settings',
@@ -54,6 +55,7 @@ describe('navigation route groups', () => {
 		expect(MOBILE_MORE_ROUTE_IDS).toEqual([
 			'playlists',
 			'automix',
+			'dj',
 			'analytics',
 			'duplicates',
 			'settings',

--- a/frontend/src/lib/routes/registry.ts
+++ b/frontend/src/lib/routes/registry.ts
@@ -11,6 +11,7 @@ export type AppRouteId =
 	| 'playlists'
 	| 'discover'
 	| 'automix'
+	| 'dj'
 	| 'analytics'
 	| 'duplicates'
 	| 'settings';

--- a/frontend/src/lib/shell/PlayerBar.svelte
+++ b/frontend/src/lib/shell/PlayerBar.svelte
@@ -41,6 +41,7 @@
 		onNext,
 		onCycleRepeat,
 		onOpenMore,
+		onOpenDjCockpit,
 		onToggleMute,
 		onVolumePreview,
 		onVolumeChange,
@@ -74,6 +75,7 @@
 		onNext: () => void;
 		onCycleRepeat: () => void;
 		onOpenMore: (anchor: HTMLElement) => void;
+		onOpenDjCockpit: () => void;
 		onToggleMute: () => void;
 		onVolumePreview: (volumePercent: number) => void;
 		onVolumeChange: (volume: number) => void;
@@ -195,6 +197,13 @@
 	/>
 
 	<div class="np-controls">
+		<button
+			class="np-dj-btn"
+			type="button"
+			title="Open DJ Cockpit"
+			aria-label="Open DJ Cockpit"
+			onclick={onOpenDjCockpit}
+		>DJ</button>
 		<button
 			class="np-mute-btn"
 			type="button"
@@ -383,6 +392,36 @@
 		flex-shrink: 0;
 		cursor: pointer;
 		transition: background var(--motion-fast), border-color var(--motion-fast);
+	}
+
+	.np-dj-btn {
+		min-width: 2.75rem;
+		min-height: 2.75rem;
+		border-radius: var(--radius-sm);
+		display: grid;
+		place-items: center;
+		background: color-mix(in srgb, var(--accent-soft) 72%, transparent);
+		border: 1px solid var(--accent-line);
+		color: var(--accent-strong);
+		font-size: var(--font-size-xs);
+		font-weight: var(--font-weight-bold);
+		line-height: 1;
+		cursor: pointer;
+		transition:
+			background var(--motion-fast),
+			border-color var(--motion-fast),
+			color var(--motion-fast);
+	}
+
+	.np-dj-btn:hover,
+	.np-dj-btn:focus-visible {
+		background: var(--accent-soft);
+		border-color: var(--accent-strong);
+	}
+
+	.np-dj-btn:focus-visible {
+		outline: 2px solid var(--accent);
+		outline-offset: 2px;
 	}
 
 	.np-mute-btn:hover {

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1265,6 +1265,7 @@
 			onNext={() => void playNextTrack()}
 			onCycleRepeat={() => void cyclePlayerRepeatMode()}
 			onOpenMore={(anchor) => openNowPlayingMenuAt(anchor)}
+			onOpenDjCockpit={() => void goto('/dj')}
 			onToggleMute={() => void toggleMute()}
 			onVolumePreview={(percent) => { displayVolume = percent; }}
 			onVolumeChange={(nextVolume) => void setPlayerVolume(nextVolume)}

--- a/frontend/src/routes/dj/+page.svelte
+++ b/frontend/src/routes/dj/+page.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import DjCockpit from '$lib/components/dj-cockpit/DjCockpit.svelte';
+</script>
+
+<DjCockpit />

--- a/frontend/src/routes/dj/dj_page_contract.test.ts
+++ b/frontend/src/routes/dj/dj_page_contract.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = resolve(here, '../..');
+const page = readFileSync(join(root, 'routes/dj/+page.svelte'), 'utf8');
+const cockpit = readFileSync(join(root, 'lib/components/dj-cockpit/DjCockpit.svelte'), 'utf8');
+const transitionLane = readFileSync(
+	join(root, 'lib/components/dj-cockpit/TransitionLane.svelte'),
+	'utf8',
+);
+const corrections = readFileSync(
+	join(root, 'lib/components/dj-cockpit/ProfileCorrectionPanel.svelte'),
+	'utf8',
+);
+const guardrails = readFileSync(
+	join(root, 'lib/components/dj-cockpit/SafetyGuardrailPanel.svelte'),
+	'utf8',
+);
+const navigation = readFileSync(join(root, 'lib/routes/navigation-data.json'), 'utf8');
+const registry = readFileSync(join(root, 'lib/routes/registry-data.json'), 'utf8');
+const playerBar = readFileSync(join(root, 'lib/shell/PlayerBar.svelte'), 'utf8');
+const remotePage = readFileSync(join(root, 'routes/remote/+page.svelte'), 'utf8');
+
+describe('dj cockpit page contract', () => {
+	test('dj_page_is_linked_from_main_navigation', () => {
+		expect(navigation).toContain('"dj"');
+		expect(registry).toContain('/dj');
+		expect(page).toContain('DjCockpit');
+	});
+
+	test('player_or_queue_exposes_open_dj_cockpit_action', () => {
+		expect(playerBar).toContain('Open DJ Cockpit');
+	});
+
+	test('remote_ui_does_not_expose_dj_controls', () => {
+		expect(remotePage).not.toContain('DJ Cockpit');
+		expect(remotePage).not.toContain('/dj');
+	});
+
+	test('settings_page_does_not_duplicate_dj_controls', () => {
+		const settings = readFileSync(join(root, 'routes/settings/+page.svelte'), 'utf8');
+		expect(settings).not.toContain('DJ Cockpit');
+		expect(settings).not.toContain('safe_crossfade_only');
+	});
+
+	test('dj_toggle_round_trips_server_config', () => {
+		expect(cockpit).toContain('api.getDjEnabled()');
+		expect(cockpit).toContain('api.setDjEnabled(next)');
+	});
+
+	test('dj_disabled_state_explains_legacy_path', () => {
+		expect(cockpit).toContain('Playback is using the legacy path');
+		expect(cockpit).toContain('DJ lookahead and transition planning are stopped');
+	});
+
+	test('dj_page_renders_current_and_next_pair', () => {
+		expect(cockpit).toContain('QueuePairPanel');
+		expect(cockpit).toContain('current={status?.current}');
+		expect(cockpit).toContain('next={status?.next}');
+	});
+
+	test('dj_page_exposes_global_policy_controls', () => {
+		expect(cockpit).toContain('MixIntentControl');
+		expect(cockpit).toContain('api.setDjMixIntent');
+		expect(cockpit).toContain('api.setDjPolicy');
+	});
+
+	test('dj_page_shows_fallback_reason', () => {
+		expect(transitionLane).toContain('Fallback reason');
+	});
+
+	test('dj_page_hides_success_explanations_by_default', () => {
+		expect(transitionLane).toContain('hidden by default');
+	});
+
+	test('dj_page_debug_details_use_planner_facts', () => {
+		expect(transitionLane).toContain('Debug planner facts');
+		expect(transitionLane).toContain('Selected program');
+	});
+
+	test('dj_page_updates_bpm_multiplier_correction', () => {
+		expect(corrections).toContain('bpm_multiplier');
+		expect(corrections).toContain('BPM multiplier');
+	});
+
+	test('dj_page_updates_downbeat_and_phrase_corrections', () => {
+		expect(corrections).toContain('downbeat_offset_beats');
+		expect(corrections).toContain('phrase_offset_bars');
+	});
+
+	test('dj_page_clears_profile_correction', () => {
+		expect(corrections).toContain('Clear override');
+		expect(cockpit).toContain('clearCorrection');
+	});
+
+	test('dj_page_rebuild_profile_action_is_async', () => {
+		expect(corrections).toContain('Rebuild profile');
+		expect(cockpit).toContain('rebuildDjProfile');
+		expect(cockpit).toContain('Profile rebuild accepted');
+	});
+
+	test('dj_page_shows_correction_applies_next_when_transition_armed', () => {
+		expect(corrections).toContain('Changes apply to the next transition');
+		expect(cockpit).toContain('transitionArmed');
+	});
+
+	test('dj_page_accepts_safe_crossfade_suggestion_only_on_user_action', () => {
+		expect(guardrails).toContain('Accept safe-only suggestion');
+		expect(cockpit).toContain('acceptSafeOnlySuggestion');
+	});
+
+	test('dj_page_does_not_show_waveform_canvas', () => {
+		expect(page + cockpit + transitionLane).not.toContain('<canvas');
+	});
+
+	test('dj_page_controls_have_accessible_names', () => {
+		expect(cockpit).toContain('aria-label');
+		expect(transitionLane).toContain('aria-label="Transition feedback"');
+		expect(corrections).toContain('aria-label="Correction target"');
+	});
+});

--- a/frontend/src/routes/dj/dj_page_contract.test.ts
+++ b/frontend/src/routes/dj/dj_page_contract.test.ts
@@ -11,6 +11,10 @@ const transitionLane = readFileSync(
 	join(root, 'lib/components/dj-cockpit/TransitionLane.svelte'),
 	'utf8',
 );
+const queuePair = readFileSync(
+	join(root, 'lib/components/dj-cockpit/QueuePairPanel.svelte'),
+	'utf8',
+);
 const corrections = readFileSync(
 	join(root, 'lib/components/dj-cockpit/ProfileCorrectionPanel.svelte'),
 	'utf8',
@@ -77,6 +81,13 @@ describe('dj cockpit page contract', () => {
 		expect(transitionLane).toContain('Ready to plan');
 		expect(transitionLane).toContain('Transition armed');
 		expect(transitionLane).not.toContain('Transition ready');
+	});
+
+	test('dj_page_surfaces_profile_decode_failures', () => {
+		expect(transitionLane).toContain('Profile analysis failed');
+		expect(transitionLane).toContain('current_profile_decode_failed');
+		expect(queuePair).toContain('Analysis failed');
+		expect(queuePair).toContain('profile_error');
 	});
 
 	test('dj_page_debug_details_use_planner_facts', () => {

--- a/frontend/src/routes/dj/dj_page_contract.test.ts
+++ b/frontend/src/routes/dj/dj_page_contract.test.ts
@@ -88,6 +88,8 @@ describe('dj cockpit page contract', () => {
 		expect(transitionLane).toContain('formatTrackLabel');
 		expect(transitionLane).toContain('formatTimingDirection');
 		expect(transitionLane).toContain('formatTimingPair');
+		expect(transitionLane).toContain('formatActualTiming');
+		expect(transitionLane).toContain('formatEventDelta');
 		expect(transitionLane).toContain('Planning reason');
 		expect(transitionLane).toContain('Readiness block');
 		expect(transitionLane).toContain('Avg delta');

--- a/frontend/src/routes/dj/dj_page_contract.test.ts
+++ b/frontend/src/routes/dj/dj_page_contract.test.ts
@@ -72,13 +72,38 @@ describe('dj cockpit page contract', () => {
 		expect(transitionLane).toContain('Fallback reason');
 	});
 
-	test('dj_page_hides_success_explanations_by_default', () => {
-		expect(transitionLane).toContain('hidden by default');
+	test('dj_page_separates_profile_readiness_from_transition_armed', () => {
+		expect(transitionLane).toContain('Analyzing profiles');
+		expect(transitionLane).toContain('Ready to plan');
+		expect(transitionLane).toContain('Transition armed');
+		expect(transitionLane).not.toContain('Transition ready');
 	});
 
 	test('dj_page_debug_details_use_planner_facts', () => {
 		expect(transitionLane).toContain('Debug planner facts');
-		expect(transitionLane).toContain('Selected program');
+		expect(transitionLane).toContain('Current event');
+		expect(transitionLane).toContain('Recent fires');
+		expect(transitionLane).toContain('Quality');
+		expect(transitionLane).toContain('Avg delta');
+		expect(transitionLane).toContain('Avg abs');
+		expect(transitionLane).toContain('Missed');
+		expect(transitionLane).toContain('Planned');
+		expect(transitionLane).toContain('Actual');
+		expect(transitionLane).toContain('Planned template');
+		expect(transitionLane).toContain('Renderer mode');
+		expect(transitionLane).toContain('Current planned');
+		expect(transitionLane).toContain('Current fire');
+		expect(transitionLane).toContain('Current delta');
+		expect(transitionLane).toContain('Sync source');
+		expect(transitionLane).toContain('Timing status');
+		expect(transitionLane).toContain("'pending'");
+	});
+
+	test('dj_page_does_not_show_non_renderable_templates_as_main_label', () => {
+		expect(transitionLane).toContain('DJ overlap armed');
+		expect(transitionLane).toContain('renderer_template');
+		expect(transitionLane).toContain('planned_template');
+		expect(transitionLane).not.toContain("status?.selected_program ?? 'Transition armed'");
 	});
 
 	test('dj_page_updates_bpm_multiplier_correction', () => {
@@ -100,6 +125,8 @@ describe('dj cockpit page contract', () => {
 		expect(corrections).toContain('Rebuild profile');
 		expect(cockpit).toContain('rebuildDjProfile');
 		expect(cockpit).toContain('Profile rebuild accepted');
+		expect(cockpit).toContain('Profile rebuild already running');
+		expect(cockpit).toContain('Profile source unavailable');
 	});
 
 	test('dj_page_shows_correction_applies_next_when_transition_armed', () => {

--- a/frontend/src/routes/dj/dj_page_contract.test.ts
+++ b/frontend/src/routes/dj/dj_page_contract.test.ts
@@ -78,8 +78,10 @@ describe('dj cockpit page contract', () => {
 
 	test('dj_page_separates_profile_readiness_from_transition_armed', () => {
 		expect(transitionLane).toContain('Analyzing profiles');
+		expect(transitionLane).toContain('Waiting for mix window');
 		expect(transitionLane).toContain('Ready to plan');
 		expect(transitionLane).toContain('Transition armed');
+		expect(transitionLane).toContain('planning_status');
 		expect(transitionLane).not.toContain('Transition ready');
 	});
 
@@ -87,6 +89,7 @@ describe('dj cockpit page contract', () => {
 		expect(transitionLane).toContain('Profile analysis failed');
 		expect(transitionLane).toContain('current_profile_decode_failed');
 		expect(queuePair).toContain('Analysis failed');
+		expect(queuePair).toContain('Analyzing');
 		expect(queuePair).toContain('profile_error');
 	});
 
@@ -118,6 +121,7 @@ describe('dj cockpit page contract', () => {
 		expect(transitionLane).toContain('Sync source');
 		expect(transitionLane).toContain('Timing status');
 		expect(transitionLane).toContain("'pending'");
+		expect(transitionLane).toContain('Planning status');
 	});
 
 	test('dj_page_does_not_show_non_renderable_templates_as_main_label', () => {
@@ -157,6 +161,7 @@ describe('dj cockpit page contract', () => {
 
 	test('dj_page_accepts_safe_crossfade_suggestion_only_on_user_action', () => {
 		expect(guardrails).toContain('Accept safe-only suggestion');
+		expect(guardrails).toContain('Planning state');
 		expect(cockpit).toContain('acceptSafeOnlySuggestion');
 	});
 

--- a/frontend/src/routes/dj/dj_page_contract.test.ts
+++ b/frontend/src/routes/dj/dj_page_contract.test.ts
@@ -88,10 +88,13 @@ describe('dj cockpit page contract', () => {
 		expect(transitionLane).toContain('formatTrackLabel');
 		expect(transitionLane).toContain('formatTimingDirection');
 		expect(transitionLane).toContain('formatTimingPair');
+		expect(transitionLane).toContain('Planning reason');
+		expect(transitionLane).toContain('Readiness block');
 		expect(transitionLane).toContain('Avg delta');
 		expect(transitionLane).toContain('Avg abs');
 		expect(transitionLane).toContain('Missed');
 		expect(transitionLane).toContain('Pair');
+		expect(transitionLane).toContain('Plan');
 		expect(transitionLane).toContain('Planned');
 		expect(transitionLane).toContain('Actual');
 		expect(transitionLane).toContain('Planned template');

--- a/frontend/src/routes/dj/dj_page_contract.test.ts
+++ b/frontend/src/routes/dj/dj_page_contract.test.ts
@@ -82,11 +82,16 @@ describe('dj cockpit page contract', () => {
 	test('dj_page_debug_details_use_planner_facts', () => {
 		expect(transitionLane).toContain('Debug planner facts');
 		expect(transitionLane).toContain('Current event');
-		expect(transitionLane).toContain('Recent fires');
+		expect(transitionLane).toContain('Recent timing');
 		expect(transitionLane).toContain('Quality');
+		expect(transitionLane).toContain('Timing direction');
+		expect(transitionLane).toContain('formatTrackLabel');
+		expect(transitionLane).toContain('formatTimingDirection');
+		expect(transitionLane).toContain('formatTimingPair');
 		expect(transitionLane).toContain('Avg delta');
 		expect(transitionLane).toContain('Avg abs');
 		expect(transitionLane).toContain('Missed');
+		expect(transitionLane).toContain('Pair');
 		expect(transitionLane).toContain('Planned');
 		expect(transitionLane).toContain('Actual');
 		expect(transitionLane).toContain('Planned template');

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -1455,11 +1455,13 @@
 	// out of the path, and sample-rate-follow so the device runs at the FLAC's
 	// native rate. Off mode reverts to the safer defaults that Just Work on
 	// flaky DACs (CD-quality, shared output, fixed device rate).
-	let bitPerfectActive = $derived(
+	let bitPerfectSettingsActive = $derived(
 		$audioSettings.settings?.quality === 'HI_RES_LOSSLESS' &&
 		$audioSettings.settings?.exclusive_mode === true &&
 		$audioSettings.settings?.sample_rate_follow === true
 	);
+	let djProcessingActive = $derived(playbackRuntime?.dj_engine_enabled === true);
+	let bitPerfectActive = $derived(bitPerfectSettingsActive && !djProcessingActive);
 
 	function onBitPerfectToggle(e: Event) {
 		const enable = (e.target as HTMLInputElement).checked;
@@ -2137,11 +2139,13 @@
 						<div>
 							<span class="audio-mode-label">Current mode</span>
 							<strong>
-								{bitPerfectActive ? 'Bit-perfect exclusive' : s.exclusive_mode ? 'Exclusive output' : 'Shared output'}
+								{bitPerfectActive ? 'Bit-perfect exclusive' : s.exclusive_mode && djProcessingActive ? 'Exclusive with DJ processing' : s.exclusive_mode ? 'Exclusive output' : 'Shared output'}
 							</strong>
 							<p>
 								{#if bitPerfectActive}
 									Hi-Res Lossless, exclusive WASAPI, native sample rates. Crossfade is bypassed; same-rate gapless prebuffer stays on.
+								{:else if s.exclusive_mode && djProcessingActive}
+									Exclusive device control is on. DJ processing is active, so playback is not bit-perfect.
 								{:else if s.exclusive_mode}
 									Exclusive device control is on. Crossfade is bypassed for bit-perfect output.
 								{:else}
@@ -2153,7 +2157,7 @@
 							<label class="toggle-switch audio-mode-toggle" aria-label="Toggle bit-perfect mode">
 								<input
 									type="checkbox"
-									checked={bitPerfectActive}
+									checked={bitPerfectSettingsActive}
 									onchange={onBitPerfectToggle}
 								/>
 								<span class="toggle-slider"></span>

--- a/noor-mix/Cargo.toml
+++ b/noor-mix/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "noor-mix"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+anyhow = "1"
+rubato = "0.16"
+serde = { version = "1", features = ["derive"] }
+thiserror = "2"
+tracing = "0.1"
+
+[dev-dependencies]
+hound = "3"
+rustfft = "6"
+symphonia = { version = "0.5", features = ["all"] }

--- a/noor-mix/src/automation.rs
+++ b/noor-mix/src/automation.rs
@@ -1,0 +1,1 @@
+// Module filled by the DJ engine v1 plan.

--- a/noor-mix/src/automation.rs
+++ b/noor-mix/src/automation.rs
@@ -1,1 +1,44 @@
-// Module filled by the DJ engine v1 plan.
+use crate::program::Curve;
+
+pub fn eval_curve(curve: Curve, t: f32) -> f32 {
+    let t = t.clamp(0.0, 1.0);
+    match curve {
+        Curve::Linear => t,
+        Curve::EqualPowerIn => (t * std::f32::consts::FRAC_PI_2).sin(),
+        Curve::EqualPowerOut => (t * std::f32::consts::FRAC_PI_2).cos(),
+        Curve::Cosine => 0.5 - 0.5 * (std::f32::consts::PI * t).cos(),
+    }
+}
+
+pub fn interpolate(from: f32, to: f32, curve: Curve, t: f32) -> f32 {
+    from + (to - from) * eval_curve(curve, t)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn linear_has_expected_boundaries() {
+        assert_eq!(eval_curve(Curve::Linear, 0.0), 0.0);
+        assert_eq!(eval_curve(Curve::Linear, 1.0), 1.0);
+    }
+
+    #[test]
+    fn equal_power_midpoint_squares_sum_to_one() {
+        let a = eval_curve(Curve::EqualPowerOut, 0.5);
+        let b = eval_curve(Curve::EqualPowerIn, 0.5);
+        let sum = a * a + b * b;
+        assert!((sum - 1.0).abs() < 1e-6, "sum was {sum}");
+    }
+
+    #[test]
+    fn cosine_is_smooth_and_centered() {
+        assert!((eval_curve(Curve::Cosine, 0.5) - 0.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn interpolate_uses_curve_output() {
+        assert!((interpolate(10.0, 20.0, Curve::Linear, 0.25) - 12.5).abs() < 1e-6);
+    }
+}

--- a/noor-mix/src/deck.rs
+++ b/noor-mix/src/deck.rs
@@ -1,0 +1,1 @@
+// Module filled by the DJ engine v1 plan.

--- a/noor-mix/src/deck.rs
+++ b/noor-mix/src/deck.rs
@@ -1,1 +1,101 @@
-// Module filled by the DJ engine v1 plan.
+pub struct DeckBuffer {
+    samples: Vec<f32>,
+    channels: u16,
+    position: f64,
+    loop_region: Option<(u64, u64)>,
+}
+
+impl DeckBuffer {
+    pub fn new(samples: Vec<f32>, channels: u16) -> Self {
+        Self {
+            samples,
+            channels: channels.max(1),
+            position: 0.0,
+            loop_region: None,
+        }
+    }
+
+    pub fn set_loop_region(&mut self, start_frame: u64, end_frame: u64) {
+        self.loop_region = (start_frame < end_frame).then_some((start_frame, end_frame));
+    }
+
+    pub fn clear_loop_region(&mut self) {
+        self.loop_region = None;
+    }
+
+    pub fn tick_into(&mut self, out: &mut [f32], playback_rate: f32) {
+        let channels = usize::from(self.channels);
+        let frame_count = self.samples.len() / channels;
+        if frame_count == 0 {
+            out.fill(0.0);
+            return;
+        }
+
+        let rate = if playback_rate.is_finite() {
+            playback_rate.max(0.0) as f64
+        } else {
+            0.0
+        };
+
+        for frame in out.chunks_mut(channels) {
+            let base_frame = self.position.floor().max(0.0) as usize;
+            let next_frame = (base_frame + 1).min(frame_count - 1);
+            let frac = (self.position - base_frame as f64) as f32;
+
+            for (channel, sample) in frame.iter_mut().enumerate() {
+                let a = self.samples[base_frame * channels + channel];
+                let b = self.samples[next_frame * channels + channel];
+                *sample = a + (b - a) * frac;
+            }
+
+            self.advance(rate, frame_count);
+        }
+    }
+
+    fn advance(&mut self, rate: f64, frame_count: usize) {
+        self.position += rate;
+        if let Some((start, end)) = self.loop_region {
+            let start = start as f64;
+            let end = end.min(frame_count as u64) as f64;
+            if start < end && self.position >= end {
+                let length = end - start;
+                self.position = start + (self.position - end).rem_euclid(length);
+            }
+        } else {
+            let max_position = frame_count.saturating_sub(1) as f64;
+            if self.position > max_position {
+                self.position = max_position;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tick_into_unit_rate_is_identity() {
+        let mut deck = DeckBuffer::new(vec![0.0, 1.0, 2.0, 3.0], 1);
+        let mut out = [0.0; 4];
+        deck.tick_into(&mut out, 1.0);
+        assert_eq!(out, [0.0, 1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn tick_into_half_rate_interpolates() {
+        let mut deck = DeckBuffer::new(vec![0.0, 1.0, 2.0, 3.0], 1);
+        let mut out = [0.0; 4];
+        deck.tick_into(&mut out, 0.5);
+        assert_eq!(out, [0.0, 0.5, 1.0, 1.5]);
+    }
+
+    #[test]
+    fn loop_region_preserves_fractional_remainder() {
+        let mut deck = DeckBuffer::new(vec![0.0, 1.0, 2.0, 3.0], 1);
+        deck.set_loop_region(0, 2);
+        let mut out = [0.0; 4];
+        deck.tick_into(&mut out, 1.5);
+        assert_eq!(out, [0.0, 1.5, 1.0, 0.5]);
+    }
+}

--- a/noor-mix/src/eq.rs
+++ b/noor-mix/src/eq.rs
@@ -1,1 +1,159 @@
-// Module filled by the DJ engine v1 plan.
+#[derive(Debug, Clone, Copy)]
+pub struct BandGains {
+    pub low: f32,
+    pub mid: f32,
+    pub high: f32,
+}
+
+pub struct IsolatorEq {
+    sample_rate: u32,
+    channels: u16,
+    low_hp_state: Vec<[f32; 4]>,
+    low_hp_prev_input: Vec<[f32; 4]>,
+    high_state: Vec<f32>,
+    high_prev_input: Vec<f32>,
+}
+
+impl IsolatorEq {
+    pub fn new(sample_rate: u32, channels: u16) -> Self {
+        let channels = channels.max(1);
+        Self {
+            sample_rate: sample_rate.max(1),
+            channels,
+            low_hp_state: vec![[0.0; 4]; usize::from(channels)],
+            low_hp_prev_input: vec![[0.0; 4]; usize::from(channels)],
+            high_state: vec![0.0; usize::from(channels)],
+            high_prev_input: vec![0.0; usize::from(channels)],
+        }
+    }
+
+    pub fn process_in_place(&mut self, block: &mut [f32], gains: BandGains) {
+        let low_gain = sanitize_gain(gains.low);
+        let mid_gain = sanitize_gain(gains.mid);
+        let high_gain = sanitize_gain(gains.high);
+        let low_alpha = one_pole_high_alpha(220.0, self.sample_rate);
+        let high_alpha = one_pole_high_alpha(4_000.0, self.sample_rate);
+        let channels = usize::from(self.channels);
+
+        for frame in block.chunks_mut(channels) {
+            for (channel, sample) in frame.iter_mut().enumerate() {
+                let input = *sample;
+                let low_remainder = self.low_removed_signal(input, channel, low_alpha);
+
+                let high = high_alpha
+                    * (self.high_state[channel] + low_remainder - self.high_prev_input[channel]);
+                self.high_prev_input[channel] = low_remainder;
+                self.high_state[channel] = high;
+
+                let low = input - low_remainder;
+                let mid = low_remainder - high;
+                *sample = low * low_gain + mid * mid_gain + high * high_gain;
+            }
+        }
+    }
+
+    fn low_removed_signal(&mut self, input: f32, channel: usize, alpha: f32) -> f32 {
+        let mut stage_input = input;
+        for stage in 0..4 {
+            let output = alpha
+                * (self.low_hp_state[channel][stage] + stage_input
+                    - self.low_hp_prev_input[channel][stage]);
+            self.low_hp_prev_input[channel][stage] = stage_input;
+            self.low_hp_state[channel][stage] = output;
+            stage_input = output;
+        }
+        stage_input
+    }
+}
+
+fn sanitize_gain(value: f32) -> f32 {
+    if value.is_finite() {
+        value.max(0.0)
+    } else {
+        0.0
+    }
+}
+
+fn one_pole_high_alpha(cutoff_hz: f32, sample_rate: u32) -> f32 {
+    let dt = 1.0 / sample_rate as f32;
+    let rc = 1.0 / (2.0 * std::f32::consts::PI * cutoff_hz);
+    rc / (rc + dt)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sine(freq: f32, seconds: f32, sample_rate: u32) -> Vec<f32> {
+        let samples = (seconds * sample_rate as f32) as usize;
+        (0..samples)
+            .map(|i| (2.0 * std::f32::consts::PI * freq * i as f32 / sample_rate as f32).sin())
+            .collect()
+    }
+
+    fn rms(samples: &[f32]) -> f32 {
+        (samples.iter().map(|v| v * v).sum::<f32>() / samples.len() as f32).sqrt()
+    }
+
+    #[test]
+    fn low_kill_reduces_50_hz_sine_by_40_db() {
+        let sample_rate = 48_000;
+        let mut block = sine(50.0, 3.0, sample_rate);
+        let input_tail = rms(&block[96_000..]);
+        let mut eq = IsolatorEq::new(sample_rate, 1);
+        eq.process_in_place(
+            &mut block,
+            BandGains {
+                low: 0.0,
+                mid: 1.0,
+                high: 1.0,
+            },
+        );
+        let output_tail = rms(&block[96_000..]);
+        assert!(output_tail / input_tail < 0.01);
+    }
+
+    #[test]
+    fn unity_gains_do_not_change_rms_by_more_than_one_db() {
+        let sample_rate = 48_000;
+        let mut block = sine(1_000.0, 1.0, sample_rate);
+        let input = rms(&block);
+        let mut eq = IsolatorEq::new(sample_rate, 1);
+        eq.process_in_place(
+            &mut block,
+            BandGains {
+                low: 1.0,
+                mid: 1.0,
+                high: 1.0,
+            },
+        );
+        let output = rms(&block);
+        let db = 20.0 * (output / input).log10().abs();
+        assert!(db < 1.0, "rms changed by {db} dB");
+    }
+
+    #[test]
+    fn nonfinite_gain_is_treated_as_zero() {
+        let mut block = vec![0.5; 128];
+        let mut zeroed = block.clone();
+        let mut eq = IsolatorEq::new(48_000, 1);
+        eq.process_in_place(
+            &mut block,
+            BandGains {
+                low: f32::NAN,
+                mid: f32::INFINITY,
+                high: f32::NEG_INFINITY,
+            },
+        );
+        let mut reference = IsolatorEq::new(48_000, 1);
+        reference.process_in_place(
+            &mut zeroed,
+            BandGains {
+                low: 0.0,
+                mid: 0.0,
+                high: 0.0,
+            },
+        );
+        assert_eq!(block, zeroed);
+    }
+}

--- a/noor-mix/src/eq.rs
+++ b/noor-mix/src/eq.rs
@@ -1,0 +1,1 @@
+// Module filled by the DJ engine v1 plan.

--- a/noor-mix/src/lib.rs
+++ b/noor-mix/src/lib.rs
@@ -1,0 +1,13 @@
+pub mod automation;
+pub mod deck;
+pub mod eq;
+pub mod limiter;
+pub mod planner;
+pub mod profile;
+pub mod program;
+pub mod render;
+
+pub use planner::{Planner, Policy};
+pub use profile::DjProfile;
+pub use program::{AutomationEvent, Curve, DeckId, Param, Tier, TransitionProgram};
+pub use render::Mixer;

--- a/noor-mix/src/limiter.rs
+++ b/noor-mix/src/limiter.rs
@@ -1,0 +1,1 @@
+// Module filled by the DJ engine v1 plan.

--- a/noor-mix/src/limiter.rs
+++ b/noor-mix/src/limiter.rs
@@ -1,1 +1,51 @@
-// Module filled by the DJ engine v1 plan.
+pub struct SafetyLimiter {
+    ceiling: f32,
+}
+
+impl SafetyLimiter {
+    pub fn new(ceiling: f32) -> Self {
+        Self {
+            ceiling: ceiling.abs(),
+        }
+    }
+
+    pub fn process_in_place(&mut self, block: &mut [f32]) {
+        let ceiling = if self.ceiling.is_finite() && self.ceiling > 0.0 {
+            self.ceiling
+        } else {
+            1.0
+        };
+        for sample in block {
+            *sample = sample.clamp(-ceiling, ceiling);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn limiter_clamps_positive_transient() {
+        let mut limiter = SafetyLimiter::new(0.8);
+        let mut block = [0.2, 1.2];
+        limiter.process_in_place(&mut block);
+        assert_eq!(block, [0.2, 0.8]);
+    }
+
+    #[test]
+    fn limiter_clamps_negative_transient() {
+        let mut limiter = SafetyLimiter::new(0.8);
+        let mut block = [-0.2, -1.2];
+        limiter.process_in_place(&mut block);
+        assert_eq!(block, [-0.2, -0.8]);
+    }
+
+    #[test]
+    fn limiter_leaves_quiet_signal_unchanged() {
+        let mut limiter = SafetyLimiter::new(0.8);
+        let mut block = [-0.2, 0.0, 0.2];
+        limiter.process_in_place(&mut block);
+        assert_eq!(block, [-0.2, 0.0, 0.2]);
+    }
+}

--- a/noor-mix/src/planner.rs
+++ b/noor-mix/src/planner.rs
@@ -1,0 +1,7 @@
+// Module filled by the DJ engine v1 plan.
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Planner;
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Policy;

--- a/noor-mix/src/planner.rs
+++ b/noor-mix/src/planner.rs
@@ -1,7 +1,0 @@
-// Module filled by the DJ engine v1 plan.
-
-#[derive(Debug, Clone, Copy, Default)]
-pub struct Planner;
-
-#[derive(Debug, Clone, Copy, Default)]
-pub struct Policy;

--- a/noor-mix/src/planner/mod.rs
+++ b/noor-mix/src/planner/mod.rs
@@ -1,0 +1,500 @@
+pub mod policy;
+pub mod safety;
+pub mod scoring;
+pub mod template;
+
+use crate::profile::DjProfile;
+use crate::program::{AutomationEvent, Curve, DeckId, Param, Tier, TransitionProgram};
+
+pub use policy::{DJ_PLANNER_VERSION, MixIntent, Policy, TransitionSpeedBias};
+pub use template::TransitionTemplate;
+
+pub struct Planner;
+
+impl Planner {
+    pub fn choose_template(
+        outgoing: &DjProfile,
+        incoming: &DjProfile,
+        policy: &Policy,
+    ) -> TransitionTemplate {
+        if let Some(template) = policy.safety_template_override {
+            return template;
+        }
+        if policy.require_full_profile
+            && (!outgoing.has_full_dj_profile() || !incoming.has_full_dj_profile())
+        {
+            return TransitionTemplate::SafeCrossfade;
+        }
+
+        let (Some(outgoing_bpm), Some(incoming_bpm)) = (outgoing.bpm, incoming.bpm) else {
+            return TransitionTemplate::SafeCrossfade;
+        };
+        let bpm_delta = scoring::bpm_delta_pct(outgoing_bpm, incoming_bpm);
+        if bpm_delta > 8.0 {
+            return TransitionTemplate::SlamCut;
+        }
+
+        let Some(camelot_distance) = outgoing
+            .camelot_key
+            .as_deref()
+            .zip(incoming.camelot_key.as_deref())
+            .and_then(|(a, b)| scoring::camelot_distance(a, b))
+        else {
+            return TransitionTemplate::SafeCrossfade;
+        };
+        if camelot_distance > 7 {
+            return TransitionTemplate::SafeCrossfade;
+        }
+
+        if matches!(policy.mix_intent, MixIntent::Safe)
+            && !(bpm_delta <= 3.0
+                && outgoing.has_full_dj_profile()
+                && incoming.has_full_dj_profile()
+                && outgoing.phrase_bar_indices.len() >= 16
+                && incoming.phrase_bar_indices.len() >= 16
+                && matches!(camelot_distance, 0 | 1 | 7))
+        {
+            return TransitionTemplate::SafeCrossfade;
+        }
+
+        let outgoing_phrases = outgoing.phrase_bar_indices.len();
+        let incoming_phrases = incoming.phrase_bar_indices.len();
+        if outgoing_phrases >= 32 && incoming_phrases >= 32 && bpm_delta <= 3.0 {
+            return TransitionTemplate::BassSwap32;
+        }
+        if outgoing_phrases >= 16 && incoming_phrases >= 16 && bpm_delta <= 3.0 {
+            return TransitionTemplate::BassSwap16;
+        }
+        if matches!(camelot_distance, 0 | 1 | 7) && bpm_delta <= 3.0 {
+            return TransitionTemplate::LongHarmonicBlend;
+        }
+        if matches!(policy.mix_intent, MixIntent::Bold)
+            && bpm_delta <= 8.0
+            && !outgoing.phrase_bar_indices.is_empty()
+            && !incoming.phrase_bar_indices.is_empty()
+        {
+            return TransitionTemplate::FilterSweep;
+        }
+
+        TransitionTemplate::FilterSweep
+    }
+
+    pub fn plan(outgoing: &DjProfile, incoming: &DjProfile, policy: &Policy) -> TransitionProgram {
+        let template = Self::choose_template(outgoing, incoming, policy);
+        let program = build_program(template, outgoing, incoming, policy);
+        match program.validate() {
+            Ok(()) => program,
+            Err(_) => build_program(
+                TransitionTemplate::SafeCrossfade,
+                outgoing,
+                incoming,
+                policy,
+            ),
+        }
+    }
+}
+
+fn build_program(
+    template: TransitionTemplate,
+    outgoing: &DjProfile,
+    incoming: &DjProfile,
+    policy: &Policy,
+) -> TransitionProgram {
+    let sample_rate = 48_000;
+    let channels = 2;
+    let bpm = outgoing.bpm.or(incoming.bpm).unwrap_or(120.0).max(1.0);
+    let bar_samples = ((60.0 / bpm) * 4.0 * sample_rate as f32) as u64;
+    let duration_samples = duration_samples(template, policy, bar_samples);
+    let swap_start = duration_samples / 2;
+    let fade_start = swap_start;
+    let mut program = TransitionProgram {
+        tier: tier_for_template(template),
+        template: template_name(template).to_string(),
+        sample_rate,
+        channels,
+        sync_start: 0,
+        intro_start: 0,
+        swap_start,
+        fade_start,
+        resolve_at: duration_samples,
+        loops: vec![],
+        automation: deck_gain_automation(duration_samples),
+    };
+
+    if matches!(
+        template,
+        TransitionTemplate::BassSwap16 | TransitionTemplate::BassSwap32
+    ) {
+        program.automation.extend(low_band_swap(swap_start));
+    }
+
+    if matches!(template, TransitionTemplate::LongHarmonicBlend)
+        && outgoing.bpm.zip(incoming.bpm).is_some()
+    {
+        let rate = incoming.bpm.map(|b| bpm / b).unwrap_or(1.0);
+        program.automation.push(AutomationEvent {
+            param: Param::PlaybackRate(DeckId::B),
+            start_sample: 0,
+            end_sample: duration_samples,
+            from: 1.0,
+            to: rate.clamp(0.97, 1.03),
+            curve: Curve::Linear,
+        });
+    }
+
+    program
+}
+
+fn duration_samples(template: TransitionTemplate, policy: &Policy, bar_samples: u64) -> u64 {
+    match template {
+        TransitionTemplate::BassSwap32 => bar_samples * 32,
+        TransitionTemplate::BassSwap16 => bar_samples * 16,
+        TransitionTemplate::LongHarmonicBlend => bar_samples * 16,
+        TransitionTemplate::FilterSweep => bar_samples * 8,
+        TransitionTemplate::SlamCut => bar_samples.max(1),
+        TransitionTemplate::SafeCrossfade => {
+            u64::from(policy.default_crossfade_ms) * 48_000 / 1_000
+        }
+    }
+    .max(1)
+}
+
+fn tier_for_template(template: TransitionTemplate) -> Tier {
+    match template {
+        TransitionTemplate::SafeCrossfade | TransitionTemplate::SlamCut => Tier::SafeCrossfade,
+        TransitionTemplate::BassSwap16
+        | TransitionTemplate::BassSwap32
+        | TransitionTemplate::LongHarmonicBlend
+        | TransitionTemplate::FilterSweep => Tier::FullBlend,
+    }
+}
+
+fn template_name(template: TransitionTemplate) -> &'static str {
+    match template {
+        TransitionTemplate::SafeCrossfade => "SafeCrossfade",
+        TransitionTemplate::SlamCut => "SlamCut",
+        TransitionTemplate::BassSwap16 => "BassSwap16",
+        TransitionTemplate::BassSwap32 => "BassSwap32",
+        TransitionTemplate::LongHarmonicBlend => "LongHarmonicBlend",
+        TransitionTemplate::FilterSweep => "FilterSweep",
+    }
+}
+
+fn deck_gain_automation(duration_samples: u64) -> Vec<AutomationEvent> {
+    vec![
+        AutomationEvent {
+            param: Param::DeckGain(DeckId::A),
+            start_sample: 0,
+            end_sample: duration_samples,
+            from: 1.0,
+            to: 0.0,
+            curve: Curve::EqualPowerIn,
+        },
+        AutomationEvent {
+            param: Param::DeckGain(DeckId::B),
+            start_sample: 0,
+            end_sample: duration_samples,
+            from: 0.0,
+            to: 1.0,
+            curve: Curve::EqualPowerIn,
+        },
+    ]
+}
+
+fn low_band_swap(swap_start: u64) -> Vec<AutomationEvent> {
+    let start_sample = swap_start.saturating_sub(1);
+    let end_sample = (swap_start + 1).max(1);
+    vec![
+        AutomationEvent {
+            param: Param::LowGain(DeckId::A),
+            start_sample,
+            end_sample,
+            from: 1.0,
+            to: 0.0,
+            curve: Curve::Linear,
+        },
+        AutomationEvent {
+            param: Param::LowGain(DeckId::B),
+            start_sample,
+            end_sample,
+            from: 0.0,
+            to: 1.0,
+            curve: Curve::Linear,
+        },
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::profile::TransitionWindow;
+
+    fn profile(bpm: Option<f32>, key: Option<&str>, phrase_count: usize) -> DjProfile {
+        DjProfile {
+            bpm,
+            camelot_key: key.map(str::to_string),
+            energy: Some(0.5),
+            beat_grid_seconds: vec![0.0, 0.5],
+            downbeat_seconds: vec![0.0],
+            phrase_bar_indices: (0..phrase_count as u32).collect(),
+            mix_in_seconds: vec![0.0],
+            mix_out_seconds: vec![60.0],
+            intro_end_seconds: Some(16.0),
+            outro_start_seconds: Some(180.0),
+            breakdown_seconds: vec![],
+            drop_seconds: vec![],
+            safe_transition_windows: vec![TransitionWindow {
+                start_seconds: 0.0,
+                end_seconds: 8.0,
+                confidence: 1.0,
+            }],
+            vocal_presence_by_bar: vec![0.0; phrase_count.max(1)],
+            vocal_density_by_bar: vec![0.0; phrase_count.max(1)],
+            lufs_loud_body: Some(-12.0),
+            true_peak_dbtp: Some(-1.0),
+            profile_confidence: 1.0,
+            safe_crossfade_only: false,
+            profile_version: "test".to_string(),
+        }
+    }
+
+    #[test]
+    fn choose_template_uses_safety_override() {
+        let policy = Policy {
+            safety_template_override: Some(TransitionTemplate::SafeCrossfade),
+            ..Policy::default()
+        };
+        assert_eq!(
+            Planner::choose_template(
+                &profile(Some(120.0), Some("8A"), 32),
+                &profile(Some(120.0), Some("8A"), 32),
+                &policy
+            ),
+            TransitionTemplate::SafeCrossfade
+        );
+    }
+
+    #[test]
+    fn choose_template_requires_full_profile_when_configured() {
+        let mut incomplete = profile(Some(120.0), Some("8A"), 32);
+        incomplete.mix_in_seconds.clear();
+        let policy = Policy {
+            require_full_profile: true,
+            ..Policy::default()
+        };
+        assert_eq!(
+            Planner::choose_template(&incomplete, &profile(Some(120.0), Some("8A"), 32), &policy),
+            TransitionTemplate::SafeCrossfade
+        );
+    }
+
+    #[test]
+    fn choose_template_missing_bpm_is_safe_crossfade() {
+        assert_eq!(
+            Planner::choose_template(
+                &profile(None, Some("8A"), 32),
+                &profile(Some(120.0), Some("8A"), 32),
+                &Policy::default()
+            ),
+            TransitionTemplate::SafeCrossfade
+        );
+    }
+
+    #[test]
+    fn choose_template_large_bpm_delta_is_slam_cut() {
+        assert_eq!(
+            Planner::choose_template(
+                &profile(Some(120.0), Some("8A"), 32),
+                &profile(Some(140.0), Some("8A"), 32),
+                &Policy::default()
+            ),
+            TransitionTemplate::SlamCut
+        );
+    }
+
+    #[test]
+    fn choose_template_missing_camelot_is_safe_crossfade() {
+        assert_eq!(
+            Planner::choose_template(
+                &profile(Some(120.0), None, 32),
+                &profile(Some(120.0), Some("8A"), 32),
+                &Policy::default()
+            ),
+            TransitionTemplate::SafeCrossfade
+        );
+    }
+
+    #[test]
+    fn choose_template_safe_intent_prefers_safe_crossfade() {
+        let policy = Policy {
+            mix_intent: MixIntent::Safe,
+            ..Policy::default()
+        };
+        assert_eq!(
+            Planner::choose_template(
+                &profile(Some(120.0), Some("8A"), 4),
+                &profile(Some(120.0), Some("8A"), 4),
+                &policy
+            ),
+            TransitionTemplate::SafeCrossfade
+        );
+    }
+
+    #[test]
+    fn choose_template_uses_bass_swap_32_for_long_phrases() {
+        assert_eq!(
+            Planner::choose_template(
+                &profile(Some(120.0), Some("8A"), 32),
+                &profile(Some(121.0), Some("8A"), 32),
+                &Policy::default()
+            ),
+            TransitionTemplate::BassSwap32
+        );
+    }
+
+    #[test]
+    fn choose_template_uses_bass_swap_16_for_medium_phrases() {
+        assert_eq!(
+            Planner::choose_template(
+                &profile(Some(120.0), Some("8A"), 16),
+                &profile(Some(121.0), Some("8A"), 16),
+                &Policy::default()
+            ),
+            TransitionTemplate::BassSwap16
+        );
+    }
+
+    #[test]
+    fn choose_template_uses_long_harmonic_blend_for_compatible_short_profiles() {
+        assert_eq!(
+            Planner::choose_template(
+                &profile(Some(120.0), Some("8A"), 4),
+                &profile(Some(121.0), Some("9A"), 4),
+                &Policy::default()
+            ),
+            TransitionTemplate::LongHarmonicBlend
+        );
+    }
+
+    #[test]
+    fn choose_template_bold_allows_filter_sweep_for_weaker_harmonic_fit() {
+        let policy = Policy {
+            mix_intent: MixIntent::Bold,
+            ..Policy::default()
+        };
+        assert_eq!(
+            Planner::choose_template(
+                &profile(Some(120.0), Some("8A"), 4),
+                &profile(Some(124.0), Some("11A"), 4),
+                &policy
+            ),
+            TransitionTemplate::FilterSweep
+        );
+    }
+
+    #[test]
+    fn safe_crossfade_validates() {
+        let policy = Policy {
+            safety_template_override: Some(TransitionTemplate::SafeCrossfade),
+            ..Policy::default()
+        };
+        Planner::plan(
+            &profile(Some(120.0), Some("8A"), 4),
+            &profile(Some(120.0), Some("8A"), 4),
+            &policy,
+        )
+        .validate()
+        .expect("safe crossfade");
+    }
+
+    #[test]
+    fn slam_cut_validates() {
+        let program = Planner::plan(
+            &profile(Some(120.0), Some("8A"), 4),
+            &profile(Some(140.0), Some("8A"), 4),
+            &Policy::default(),
+        );
+        assert_eq!(program.template, "SlamCut");
+        program.validate().expect("slam cut");
+    }
+
+    #[test]
+    fn bass_swap_16_low_band_crosses_at_swap_start() {
+        let program = Planner::plan(
+            &profile(Some(120.0), Some("8A"), 16),
+            &profile(Some(121.0), Some("8A"), 16),
+            &Policy::default(),
+        );
+        assert_eq!(program.template, "BassSwap16");
+        assert!(
+            program
+                .automation
+                .iter()
+                .any(|event| event.param == Param::LowGain(DeckId::A)
+                    && event.start_sample <= program.swap_start
+                    && event.end_sample >= program.swap_start)
+        );
+    }
+
+    #[test]
+    fn bass_swap_32_resolves_after_32_bars() {
+        let program = Planner::plan(
+            &profile(Some(120.0), Some("8A"), 32),
+            &profile(Some(121.0), Some("8A"), 32),
+            &Policy::default(),
+        );
+        assert_eq!(program.template, "BassSwap32");
+        assert_eq!(program.resolve_at, 32 * 96_000);
+    }
+
+    #[test]
+    fn long_harmonic_blend_rejects_large_rate_delta() {
+        let policy = Policy {
+            safety_template_override: Some(TransitionTemplate::LongHarmonicBlend),
+            ..Policy::default()
+        };
+        let program = Planner::plan(
+            &profile(Some(120.0), Some("8A"), 4),
+            &profile(Some(126.0), Some("8A"), 4),
+            &policy,
+        );
+        let rate = program
+            .automation
+            .iter()
+            .find(|event| event.param == Param::PlaybackRate(DeckId::B))
+            .expect("rate automation")
+            .to;
+        assert_eq!(rate, 0.97);
+    }
+
+    #[test]
+    fn filter_sweep_validates() {
+        let policy = Policy {
+            mix_intent: MixIntent::Bold,
+            ..Policy::default()
+        };
+        let program = Planner::plan(
+            &profile(Some(120.0), Some("8A"), 4),
+            &profile(Some(124.0), Some("11A"), 4),
+            &policy,
+        );
+        assert_eq!(program.template, "FilterSweep");
+        program.validate().expect("filter sweep");
+    }
+
+    #[test]
+    fn planner_falls_back_to_safe_crossfade_on_invalid_program() {
+        let policy = Policy {
+            safety_template_override: Some(TransitionTemplate::SafeCrossfade),
+            default_crossfade_ms: 0,
+            ..Policy::default()
+        };
+        let program = Planner::plan(
+            &profile(Some(120.0), Some("8A"), 4),
+            &profile(Some(120.0), Some("8A"), 4),
+            &policy,
+        );
+        assert_eq!(program.template, "SafeCrossfade");
+        program.validate().expect("fallback");
+    }
+}

--- a/noor-mix/src/planner/mod.rs
+++ b/noor-mix/src/planner/mod.rs
@@ -127,6 +127,12 @@ fn build_program(
         program.automation.extend(low_band_swap(swap_start));
     }
 
+    if matches!(template, TransitionTemplate::FilterSweep) {
+        program
+            .automation
+            .extend(filter_sweep_eq_wash(duration_samples));
+    }
+
     if matches!(template, TransitionTemplate::LongHarmonicBlend)
         && outgoing.bpm.zip(incoming.bpm).is_some()
     {
@@ -141,6 +147,35 @@ fn build_program(
         });
     }
 
+    program
+}
+
+pub fn filter_sweep_eq_wash_program(
+    sample_rate: u32,
+    channels: u16,
+    duration_ms: u32,
+) -> TransitionProgram {
+    let sample_rate = sample_rate.max(1);
+    let channels = channels.max(1);
+    let duration_samples =
+        (u64::from(duration_ms).saturating_mul(u64::from(sample_rate)) / 1_000).max(1);
+    let swap_start = duration_samples / 2;
+    let mut program = TransitionProgram {
+        tier: Tier::FullBlend,
+        template: "FilterSweep".to_string(),
+        sample_rate,
+        channels,
+        sync_start: 0,
+        intro_start: 0,
+        swap_start,
+        fade_start: swap_start,
+        resolve_at: duration_samples,
+        loops: vec![],
+        automation: deck_gain_automation(duration_samples),
+    };
+    program
+        .automation
+        .extend(filter_sweep_eq_wash(duration_samples));
     program
 }
 
@@ -221,6 +256,116 @@ fn low_band_swap(swap_start: u64) -> Vec<AutomationEvent> {
             curve: Curve::Linear,
         },
     ]
+}
+
+fn filter_sweep_eq_wash(duration_samples: u64) -> Vec<AutomationEvent> {
+    let end_sample = duration_samples.max(1);
+    let mut events = Vec::new();
+    if end_sample < 8 {
+        events.push(AutomationEvent {
+            param: Param::LowGain(DeckId::A),
+            start_sample: 0,
+            end_sample,
+            from: 1.0,
+            to: 0.05,
+            curve: Curve::Cosine,
+        });
+        events.push(AutomationEvent {
+            param: Param::LowGain(DeckId::B),
+            start_sample: 0,
+            end_sample,
+            from: 0.0,
+            to: 1.0,
+            curve: Curve::Cosine,
+        });
+        events.push(AutomationEvent {
+            param: Param::HighGain(DeckId::A),
+            start_sample: 0,
+            end_sample,
+            from: 1.0,
+            to: 0.35,
+            curve: Curve::Cosine,
+        });
+        events.push(AutomationEvent {
+            param: Param::HighGain(DeckId::B),
+            start_sample: 0,
+            end_sample,
+            from: 0.35,
+            to: 1.0,
+            curve: Curve::Cosine,
+        });
+    } else {
+        let bass_handoff_start = end_sample * 3 / 8;
+        let bass_handoff_end = (end_sample * 5 / 8).max(bass_handoff_start + 1);
+        events.push(AutomationEvent {
+            param: Param::LowGain(DeckId::A),
+            start_sample: bass_handoff_start,
+            end_sample: bass_handoff_end,
+            from: 1.0,
+            to: 0.05,
+            curve: Curve::Cosine,
+        });
+        events.push(AutomationEvent {
+            param: Param::LowGain(DeckId::B),
+            start_sample: 0,
+            end_sample: bass_handoff_start.max(1),
+            from: 0.0,
+            to: 0.0,
+            curve: Curve::Linear,
+        });
+        events.push(AutomationEvent {
+            param: Param::LowGain(DeckId::B),
+            start_sample: bass_handoff_start,
+            end_sample: bass_handoff_end,
+            from: 0.0,
+            to: 1.0,
+            curve: Curve::Cosine,
+        });
+        events.push(AutomationEvent {
+            param: Param::HighGain(DeckId::A),
+            start_sample: bass_handoff_start,
+            end_sample: bass_handoff_end,
+            from: 1.0,
+            to: 0.35,
+            curve: Curve::Cosine,
+        });
+        events.push(AutomationEvent {
+            param: Param::HighGain(DeckId::B),
+            start_sample: 0,
+            end_sample: bass_handoff_start.max(1),
+            from: 0.35,
+            to: 0.35,
+            curve: Curve::Linear,
+        });
+        events.push(AutomationEvent {
+            param: Param::HighGain(DeckId::B),
+            start_sample: bass_handoff_start,
+            end_sample: bass_handoff_end,
+            from: 0.35,
+            to: 1.0,
+            curve: Curve::Cosine,
+        });
+    }
+
+    events.extend([
+        AutomationEvent {
+            param: Param::MidGain(DeckId::A),
+            start_sample: 0,
+            end_sample,
+            from: 1.0,
+            to: 0.3,
+            curve: Curve::Cosine,
+        },
+        AutomationEvent {
+            param: Param::MidGain(DeckId::B),
+            start_sample: 0,
+            end_sample,
+            from: 0.45,
+            to: 1.0,
+            curve: Curve::Cosine,
+        },
+    ]);
+    events
 }
 
 #[cfg(test)]
@@ -511,6 +656,61 @@ mod tests {
         );
         assert_eq!(program.template, "FilterSweep");
         program.validate().expect("filter sweep");
+        let outgoing_low = program
+            .automation
+            .iter()
+            .find(|event| event.param == Param::LowGain(DeckId::A))
+            .expect("outgoing low automation");
+        let outgoing_high = program
+            .automation
+            .iter()
+            .find(|event| event.param == Param::HighGain(DeckId::A))
+            .expect("outgoing high automation");
+        let incoming_low = program
+            .automation
+            .iter()
+            .find(|event| event.param == Param::LowGain(DeckId::B) && event.to == 1.0)
+            .expect("incoming low rise automation");
+        let incoming_high = program
+            .automation
+            .iter()
+            .find(|event| event.param == Param::HighGain(DeckId::B) && event.to == 1.0)
+            .expect("incoming high rise automation");
+
+        assert_eq!(outgoing_low.to, 0.05);
+        assert!(outgoing_low.start_sample < program.swap_start);
+        assert!(outgoing_low.end_sample > program.swap_start);
+        assert_eq!(outgoing_high.to, 0.35);
+        assert!(outgoing_high.start_sample < program.swap_start);
+        assert!(outgoing_high.end_sample > program.swap_start);
+        assert_eq!(incoming_low.from, 0.0);
+        assert!(incoming_low.start_sample < program.swap_start);
+        assert!(incoming_low.end_sample > program.swap_start);
+        assert_eq!(incoming_high.from, 0.35);
+        assert!(incoming_high.start_sample < program.swap_start);
+        assert!(incoming_high.end_sample > program.swap_start);
+        assert!(
+            program
+                .automation
+                .iter()
+                .any(|event| event.param == Param::HighGain(DeckId::A))
+        );
+        assert!(
+            program
+                .automation
+                .iter()
+                .any(|event| event.param == Param::LowGain(DeckId::B))
+        );
+    }
+
+    #[test]
+    fn filter_sweep_eq_wash_program_uses_requested_duration() {
+        let program = filter_sweep_eq_wash_program(48_000, 2, 10_000);
+
+        assert_eq!(program.template, "FilterSweep");
+        assert_eq!(program.resolve_at, 480_000);
+        assert_eq!(program.tier, Tier::FullBlend);
+        program.validate().expect("filter sweep eq wash");
     }
 
     #[test]

--- a/noor-mix/src/planner/mod.rs
+++ b/noor-mix/src/planner/mod.rs
@@ -57,6 +57,14 @@ impl Planner {
             return TransitionTemplate::SafeCrossfade;
         }
 
+        if matches!(policy.mix_intent, MixIntent::Bold)
+            && bpm_delta <= 8.0
+            && !outgoing.phrase_bar_indices.is_empty()
+            && !incoming.phrase_bar_indices.is_empty()
+        {
+            return TransitionTemplate::FilterSweep;
+        }
+
         let outgoing_phrases = outgoing.phrase_bar_indices.len();
         let incoming_phrases = incoming.phrase_bar_indices.len();
         if outgoing_phrases >= 32 && incoming_phrases >= 32 && bpm_delta <= 3.0 {
@@ -68,14 +76,6 @@ impl Planner {
         if matches!(camelot_distance, 0 | 1 | 7) && bpm_delta <= 3.0 {
             return TransitionTemplate::LongHarmonicBlend;
         }
-        if matches!(policy.mix_intent, MixIntent::Bold)
-            && bpm_delta <= 8.0
-            && !outgoing.phrase_bar_indices.is_empty()
-            && !incoming.phrase_bar_indices.is_empty()
-        {
-            return TransitionTemplate::FilterSweep;
-        }
-
         TransitionTemplate::FilterSweep
     }
 
@@ -389,6 +389,38 @@ mod tests {
                 &policy
             ),
             TransitionTemplate::FilterSweep
+        );
+    }
+
+    #[test]
+    fn choose_template_bold_prefers_filter_sweep_for_compatible_profiles() {
+        let policy = Policy {
+            mix_intent: MixIntent::Bold,
+            ..Policy::default()
+        };
+        assert_eq!(
+            Planner::choose_template(
+                &profile(Some(120.0), Some("8A"), 32),
+                &profile(Some(121.0), Some("8A"), 32),
+                &policy
+            ),
+            TransitionTemplate::FilterSweep
+        );
+    }
+
+    #[test]
+    fn choose_template_bold_still_rejects_slam_cut_bpm_delta() {
+        let policy = Policy {
+            mix_intent: MixIntent::Bold,
+            ..Policy::default()
+        };
+        assert_eq!(
+            Planner::choose_template(
+                &profile(Some(120.0), Some("8A"), 32),
+                &profile(Some(140.0), Some("8A"), 32),
+                &policy
+            ),
+            TransitionTemplate::SlamCut
         );
     }
 

--- a/noor-mix/src/planner/mod.rs
+++ b/noor-mix/src/planner/mod.rs
@@ -30,6 +30,13 @@ impl Planner {
             return TransitionTemplate::SafeCrossfade;
         };
         let bpm_delta = scoring::bpm_delta_pct(outgoing_bpm, incoming_bpm);
+        if matches!(policy.mix_intent, MixIntent::Bold)
+            && !outgoing.phrase_bar_indices.is_empty()
+            && !incoming.phrase_bar_indices.is_empty()
+        {
+            return TransitionTemplate::FilterSweep;
+        }
+
         if bpm_delta > 8.0 {
             return TransitionTemplate::SlamCut;
         }
@@ -55,14 +62,6 @@ impl Planner {
                 && matches!(camelot_distance, 0 | 1 | 7))
         {
             return TransitionTemplate::SafeCrossfade;
-        }
-
-        if matches!(policy.mix_intent, MixIntent::Bold)
-            && bpm_delta <= 8.0
-            && !outgoing.phrase_bar_indices.is_empty()
-            && !incoming.phrase_bar_indices.is_empty()
-        {
-            return TransitionTemplate::FilterSweep;
         }
 
         let outgoing_phrases = outgoing.phrase_bar_indices.len();
@@ -409,7 +408,7 @@ mod tests {
     }
 
     #[test]
-    fn choose_template_bold_still_rejects_slam_cut_bpm_delta() {
+    fn choose_template_bold_prefers_filter_sweep_over_slam_cut_bpm_delta() {
         let policy = Policy {
             mix_intent: MixIntent::Bold,
             ..Policy::default()
@@ -420,7 +419,7 @@ mod tests {
                 &profile(Some(140.0), Some("8A"), 32),
                 &policy
             ),
-            TransitionTemplate::SlamCut
+            TransitionTemplate::FilterSweep
         );
     }
 

--- a/noor-mix/src/planner/policy.rs
+++ b/noor-mix/src/planner/policy.rs
@@ -1,0 +1,42 @@
+use super::template::TransitionTemplate;
+
+pub const DJ_PLANNER_VERSION: &str = "dj_planner_v1";
+
+#[derive(Debug, Clone)]
+pub struct Policy {
+    pub max_pitch_shift_pct: f32,
+    pub energy_step_max: f32,
+    pub default_crossfade_ms: u32,
+    pub transition_speed_bias: TransitionSpeedBias,
+    pub mix_intent: MixIntent,
+    pub safety_template_override: Option<TransitionTemplate>,
+    pub require_full_profile: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MixIntent {
+    Safe,
+    Balanced,
+    Bold,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransitionSpeedBias {
+    Slower,
+    Neutral,
+    Faster,
+}
+
+impl Default for Policy {
+    fn default() -> Self {
+        Self {
+            max_pitch_shift_pct: 3.0,
+            energy_step_max: 0.15,
+            default_crossfade_ms: 8_000,
+            transition_speed_bias: TransitionSpeedBias::Neutral,
+            mix_intent: MixIntent::Balanced,
+            safety_template_override: None,
+            require_full_profile: false,
+        }
+    }
+}

--- a/noor-mix/src/planner/safety.rs
+++ b/noor-mix/src/planner/safety.rs
@@ -1,0 +1,104 @@
+use crate::program::{Param, ProgramError, TransitionProgram};
+
+#[derive(Debug, Clone)]
+pub struct AudioSafetyPolicy {
+    pub max_pitch_shift_pct: f32,
+    pub peak_ceiling_dbfs: f32,
+    pub max_loudness_jump_lu: f32,
+    pub max_low_band_overlap: f32,
+}
+
+impl Default for AudioSafetyPolicy {
+    fn default() -> Self {
+        Self {
+            max_pitch_shift_pct: 3.0,
+            peak_ceiling_dbfs: -1.0,
+            max_loudness_jump_lu: 4.0,
+            max_low_band_overlap: 1.25,
+        }
+    }
+}
+
+pub fn validate_audio_safety(
+    program: &TransitionProgram,
+    policy: &AudioSafetyPolicy,
+) -> Result<(), ProgramError> {
+    program.validate()?;
+    let max_delta = policy.max_pitch_shift_pct / 100.0;
+    for event in &program.automation {
+        if matches!(event.param, Param::PlaybackRate(_))
+            && ((event.from - 1.0).abs() > max_delta || (event.to - 1.0).abs() > max_delta)
+        {
+            return Err(ProgramError::PlaybackRateOutOfRange);
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::program::{AutomationEvent, Curve, DeckId, Param, Tier};
+
+    fn valid_safe_crossfade() -> TransitionProgram {
+        TransitionProgram {
+            tier: Tier::SafeCrossfade,
+            template: "SafeCrossfade".to_string(),
+            sample_rate: 48_000,
+            channels: 2,
+            sync_start: 0,
+            intro_start: 0,
+            swap_start: 96_000,
+            fade_start: 96_000,
+            resolve_at: 192_000,
+            loops: vec![],
+            automation: vec![AutomationEvent {
+                param: Param::PlaybackRate(DeckId::B),
+                start_sample: 0,
+                end_sample: 192_000,
+                from: 1.0,
+                to: 1.01,
+                curve: Curve::Linear,
+            }],
+        }
+    }
+
+    #[test]
+    fn audio_safety_rejects_pitch_shift_above_policy_cap() {
+        let program = valid_safe_crossfade();
+        let policy = AudioSafetyPolicy {
+            max_pitch_shift_pct: 0.5,
+            ..AudioSafetyPolicy::default()
+        };
+        assert_eq!(
+            validate_audio_safety(&program, &policy),
+            Err(ProgramError::PlaybackRateOutOfRange)
+        );
+    }
+
+    #[test]
+    fn audio_safety_rejects_invalid_automation_range() {
+        let mut program = valid_safe_crossfade();
+        program.automation[0].to = 1.04;
+        assert_eq!(
+            validate_audio_safety(&program, &AudioSafetyPolicy::default()),
+            Err(ProgramError::AutomationValueOutOfRange)
+        );
+    }
+
+    #[test]
+    fn audio_safety_rejects_non_deterministic_render_fixture() {
+        let mut program = valid_safe_crossfade();
+        program.automation[0].from = f32::NAN;
+        assert_eq!(
+            validate_audio_safety(&program, &AudioSafetyPolicy::default()),
+            Err(ProgramError::AutomationValueOutOfRange)
+        );
+    }
+
+    #[test]
+    fn audio_safety_accepts_valid_safe_crossfade() {
+        validate_audio_safety(&valid_safe_crossfade(), &AudioSafetyPolicy::default())
+            .expect("valid safe crossfade");
+    }
+}

--- a/noor-mix/src/planner/scoring.rs
+++ b/noor-mix/src/planner/scoring.rs
@@ -1,0 +1,74 @@
+pub fn camelot_distance(a: &str, b: &str) -> Option<u8> {
+    let (a_number, a_mode) = parse_camelot(a)?;
+    let (b_number, b_mode) = parse_camelot(b)?;
+    let number_distance = {
+        let raw = a_number.abs_diff(b_number);
+        raw.min(12 - raw)
+    };
+    if a_mode == b_mode {
+        Some(number_distance)
+    } else if a_number == b_number {
+        Some(7)
+    } else {
+        Some((number_distance + 7).min(12))
+    }
+}
+
+pub fn bpm_delta_pct(a: f32, b: f32) -> f32 {
+    if !a.is_finite() || !b.is_finite() || a <= 0.0 || b <= 0.0 {
+        return f32::INFINITY;
+    }
+    ((a - b).abs() / a.min(b)) * 100.0
+}
+
+pub fn energy_delta(a: Option<f32>, b: Option<f32>) -> Option<f32> {
+    Some((a? - b?).abs())
+}
+
+pub fn vocal_clash_score(a: &[f32], b: &[f32]) -> f32 {
+    a.iter()
+        .zip(b)
+        .map(|(left, right)| left.max(0.0) * right.max(0.0))
+        .fold(0.0, f32::max)
+}
+
+fn parse_camelot(value: &str) -> Option<(u8, char)> {
+    let trimmed = value.trim();
+    if trimmed.len() < 2 {
+        return None;
+    }
+    let (number, mode) = trimmed.split_at(trimmed.len() - 1);
+    let number = number.parse::<u8>().ok()?;
+    let mode = mode.chars().next()?.to_ascii_uppercase();
+    (1..=12).contains(&number).then_some((number, mode))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn camelot_distance_same_key_is_zero() {
+        assert_eq!(camelot_distance("8A", "8A"), Some(0));
+    }
+
+    #[test]
+    fn camelot_distance_adjacent_number_is_one() {
+        assert_eq!(camelot_distance("8A", "9A"), Some(1));
+    }
+
+    #[test]
+    fn camelot_distance_relative_major_minor_is_seven() {
+        assert_eq!(camelot_distance("8A", "8B"), Some(7));
+    }
+
+    #[test]
+    fn bpm_delta_pct_is_symmetric() {
+        assert_eq!(bpm_delta_pct(120.0, 126.0), bpm_delta_pct(126.0, 120.0));
+    }
+
+    #[test]
+    fn vocal_clash_score_uses_max_product() {
+        assert_eq!(vocal_clash_score(&[0.2, 0.5], &[0.5, 0.25]), 0.125);
+    }
+}

--- a/noor-mix/src/planner/template.rs
+++ b/noor-mix/src/planner/template.rs
@@ -1,0 +1,11 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TransitionTemplate {
+    SafeCrossfade,
+    SlamCut,
+    BassSwap16,
+    BassSwap32,
+    LongHarmonicBlend,
+    FilterSweep,
+}

--- a/noor-mix/src/profile.rs
+++ b/noor-mix/src/profile.rs
@@ -1,0 +1,4 @@
+// Module filled by the DJ engine v1 plan.
+
+#[derive(Debug, Clone, Default)]
+pub struct DjProfile;

--- a/noor-mix/src/profile.rs
+++ b/noor-mix/src/profile.rs
@@ -1,4 +1,44 @@
-// Module filled by the DJ engine v1 plan.
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Default)]
-pub struct DjProfile;
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DjProfile {
+    pub bpm: Option<f32>,
+    pub camelot_key: Option<String>,
+    pub energy: Option<f32>,
+    pub beat_grid_seconds: Vec<f32>,
+    pub downbeat_seconds: Vec<f32>,
+    pub phrase_bar_indices: Vec<u32>,
+    pub mix_in_seconds: Vec<f32>,
+    pub mix_out_seconds: Vec<f32>,
+    pub intro_end_seconds: Option<f32>,
+    pub outro_start_seconds: Option<f32>,
+    pub breakdown_seconds: Vec<f32>,
+    pub drop_seconds: Vec<f32>,
+    pub safe_transition_windows: Vec<TransitionWindow>,
+    pub vocal_presence_by_bar: Vec<f32>,
+    pub vocal_density_by_bar: Vec<f32>,
+    pub lufs_loud_body: Option<f32>,
+    pub true_peak_dbtp: Option<f32>,
+    pub profile_confidence: f32,
+    pub safe_crossfade_only: bool,
+    pub profile_version: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransitionWindow {
+    pub start_seconds: f32,
+    pub end_seconds: f32,
+    pub confidence: f32,
+}
+
+impl DjProfile {
+    pub fn has_full_dj_profile(&self) -> bool {
+        !self.beat_grid_seconds.is_empty()
+            && !self.downbeat_seconds.is_empty()
+            && !self.phrase_bar_indices.is_empty()
+            && !self.mix_in_seconds.is_empty()
+            && !self.mix_out_seconds.is_empty()
+            && !self.safe_transition_windows.is_empty()
+            && !self.profile_version.is_empty()
+    }
+}

--- a/noor-mix/src/program.rs
+++ b/noor-mix/src/program.rs
@@ -1,0 +1,19 @@
+// Module filled by the DJ engine v1 plan.
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct AutomationEvent;
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Curve;
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DeckId;
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Param;
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Tier;
+
+#[derive(Debug, Clone, Default)]
+pub struct TransitionProgram;

--- a/noor-mix/src/program.rs
+++ b/noor-mix/src/program.rs
@@ -1,19 +1,207 @@
-// Module filled by the DJ engine v1 plan.
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
-#[derive(Debug, Clone, Copy, Default)]
-pub struct AutomationEvent;
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DeckId {
+    A,
+    B,
+}
 
-#[derive(Debug, Clone, Copy, Default)]
-pub struct Curve;
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Tier {
+    SafeCrossfade,
+    FullBlend,
+}
 
-#[derive(Debug, Clone, Copy, Default)]
-pub struct DeckId;
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Param {
+    DeckGain(DeckId),
+    LowGain(DeckId),
+    MidGain(DeckId),
+    HighGain(DeckId),
+    PlaybackRate(DeckId),
+}
 
-#[derive(Debug, Clone, Copy, Default)]
-pub struct Param;
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Curve {
+    Linear,
+    EqualPowerIn,
+    EqualPowerOut,
+    Cosine,
+}
 
-#[derive(Debug, Clone, Copy, Default)]
-pub struct Tier;
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AutomationEvent {
+    pub param: Param,
+    pub start_sample: u64,
+    pub end_sample: u64,
+    pub from: f32,
+    pub to: f32,
+    pub curve: Curve,
+}
 
-#[derive(Debug, Clone, Default)]
-pub struct TransitionProgram;
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LoopRegion {
+    pub deck: DeckId,
+    pub start_sample: u64,
+    pub end_sample: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TransitionProgram {
+    pub tier: Tier,
+    pub template: String,
+    pub sample_rate: u32,
+    pub channels: u16,
+    pub sync_start: u64,
+    pub intro_start: u64,
+    pub swap_start: u64,
+    pub fade_start: u64,
+    pub resolve_at: u64,
+    pub loops: Vec<LoopRegion>,
+    pub automation: Vec<AutomationEvent>,
+}
+
+#[derive(Debug, Error, PartialEq)]
+pub enum ProgramError {
+    #[error("sample_rate must be greater than zero")]
+    InvalidSampleRate,
+    #[error("channels must be greater than zero")]
+    InvalidChannels,
+    #[error("phase markers must be monotonic")]
+    NonMonotonicMarkers,
+    #[error("automation event has start >= end")]
+    EmptyAutomationEvent,
+    #[error("automation value is outside the allowed range")]
+    AutomationValueOutOfRange,
+    #[error("playback-rate automation exceeds max stretch")]
+    PlaybackRateOutOfRange,
+    #[error("loop region is empty")]
+    EmptyLoopRegion,
+}
+
+impl TransitionProgram {
+    pub fn validate(&self) -> Result<(), ProgramError> {
+        if self.sample_rate == 0 {
+            return Err(ProgramError::InvalidSampleRate);
+        }
+        if self.channels == 0 {
+            return Err(ProgramError::InvalidChannels);
+        }
+        if !(self.sync_start <= self.intro_start
+            && self.intro_start <= self.swap_start
+            && self.swap_start <= self.fade_start
+            && self.fade_start <= self.resolve_at)
+        {
+            return Err(ProgramError::NonMonotonicMarkers);
+        }
+        for region in &self.loops {
+            if region.start_sample >= region.end_sample {
+                return Err(ProgramError::EmptyLoopRegion);
+            }
+        }
+        for event in &self.automation {
+            if event.start_sample >= event.end_sample {
+                return Err(ProgramError::EmptyAutomationEvent);
+            }
+            if !value_allowed(event.param, event.from) || !value_allowed(event.param, event.to) {
+                return Err(ProgramError::AutomationValueOutOfRange);
+            }
+            if matches!(event.param, Param::PlaybackRate(_))
+                && (!rate_allowed(event.from) || !rate_allowed(event.to))
+            {
+                return Err(ProgramError::PlaybackRateOutOfRange);
+            }
+        }
+        Ok(())
+    }
+}
+
+fn value_allowed(param: Param, value: f32) -> bool {
+    value.is_finite()
+        && match param {
+            Param::DeckGain(_) | Param::LowGain(_) | Param::MidGain(_) | Param::HighGain(_) => {
+                (0.0..=1.25).contains(&value)
+            }
+            Param::PlaybackRate(_) => (0.97..=1.03).contains(&value),
+        }
+}
+
+fn rate_allowed(value: f32) -> bool {
+    value.is_finite() && (0.97..=1.03).contains(&value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_program() -> TransitionProgram {
+        TransitionProgram {
+            tier: Tier::FullBlend,
+            template: "BassSwap16".to_string(),
+            sample_rate: 48_000,
+            channels: 2,
+            sync_start: 0,
+            intro_start: 48_000,
+            swap_start: 96_000,
+            fade_start: 144_000,
+            resolve_at: 192_000,
+            loops: vec![],
+            automation: vec![],
+        }
+    }
+
+    #[test]
+    fn validate_accepts_valid_program() {
+        valid_program().validate().expect("valid program");
+    }
+
+    #[test]
+    fn validate_rejects_non_monotonic_markers() {
+        let mut p = valid_program();
+        p.swap_start = p.intro_start - 1;
+        assert_eq!(p.validate(), Err(ProgramError::NonMonotonicMarkers));
+    }
+
+    #[test]
+    fn validate_rejects_empty_automation_event() {
+        let mut p = valid_program();
+        p.automation.push(AutomationEvent {
+            param: Param::DeckGain(DeckId::A),
+            start_sample: 10,
+            end_sample: 10,
+            from: 1.0,
+            to: 0.0,
+            curve: Curve::Linear,
+        });
+        assert_eq!(p.validate(), Err(ProgramError::EmptyAutomationEvent));
+    }
+
+    #[test]
+    fn validate_rejects_gain_out_of_range() {
+        let mut p = valid_program();
+        p.automation.push(AutomationEvent {
+            param: Param::LowGain(DeckId::A),
+            start_sample: 10,
+            end_sample: 20,
+            from: 1.0,
+            to: 2.0,
+            curve: Curve::Cosine,
+        });
+        assert_eq!(p.validate(), Err(ProgramError::AutomationValueOutOfRange));
+    }
+
+    #[test]
+    fn validate_rejects_rate_out_of_range() {
+        let mut p = valid_program();
+        p.automation.push(AutomationEvent {
+            param: Param::PlaybackRate(DeckId::B),
+            start_sample: 10,
+            end_sample: 20,
+            from: 1.0,
+            to: 1.04,
+            curve: Curve::Linear,
+        });
+        assert_eq!(p.validate(), Err(ProgramError::AutomationValueOutOfRange));
+    }
+}

--- a/noor-mix/src/render.rs
+++ b/noor-mix/src/render.rs
@@ -1,0 +1,4 @@
+// Module filled by the DJ engine v1 plan.
+
+#[derive(Debug, Default)]
+pub struct Mixer;

--- a/noor-mix/src/render.rs
+++ b/noor-mix/src/render.rs
@@ -1,4 +1,206 @@
-// Module filled by the DJ engine v1 plan.
+use crate::automation::interpolate;
+use crate::limiter::SafetyLimiter;
+use crate::program::{AutomationEvent, DeckId, Param, TransitionProgram};
 
-#[derive(Debug, Default)]
-pub struct Mixer;
+pub struct Mixer {
+    program: TransitionProgram,
+    deck_a: crate::deck::DeckBuffer,
+    deck_b: crate::deck::DeckBuffer,
+    scratch_a: Vec<f32>,
+    scratch_b: Vec<f32>,
+    limiter: SafetyLimiter,
+}
+
+impl Mixer {
+    pub fn new(
+        program: TransitionProgram,
+        deck_a: crate::deck::DeckBuffer,
+        deck_b: crate::deck::DeckBuffer,
+        max_block_samples: usize,
+    ) -> anyhow::Result<Self> {
+        program.validate()?;
+        Ok(Self {
+            program,
+            deck_a,
+            deck_b,
+            scratch_a: vec![0.0; max_block_samples],
+            scratch_b: vec![0.0; max_block_samples],
+            limiter: SafetyLimiter::new(0.98),
+        })
+    }
+
+    pub fn render_block(&mut self, out: &mut [f32], master_sample: u64) {
+        assert!(out.len() <= self.scratch_a.len());
+        assert!(out.len() <= self.scratch_b.len());
+
+        let scratch_a = &mut self.scratch_a[..out.len()];
+        let scratch_b = &mut self.scratch_b[..out.len()];
+        scratch_a.fill(0.0);
+        scratch_b.fill(0.0);
+
+        let rate_a = param_at(&self.program, Param::PlaybackRate(DeckId::A), master_sample);
+        let rate_b = param_at(&self.program, Param::PlaybackRate(DeckId::B), master_sample);
+        self.deck_a.tick_into(scratch_a, rate_a);
+        self.deck_b.tick_into(scratch_b, rate_b);
+
+        let channels = usize::from(self.program.channels);
+        for (frame_index, (frame_out, (frame_a, frame_b))) in out
+            .chunks_mut(channels)
+            .zip(scratch_a.chunks(channels).zip(scratch_b.chunks(channels)))
+            .enumerate()
+        {
+            let sample = master_sample + frame_index as u64;
+            let gain_a = param_at(&self.program, Param::DeckGain(DeckId::A), sample);
+            let gain_b = param_at(&self.program, Param::DeckGain(DeckId::B), sample);
+            for (sample_out, (sample_a, sample_b)) in
+                frame_out.iter_mut().zip(frame_a.iter().zip(frame_b))
+            {
+                *sample_out = sample_a * gain_a + sample_b * gain_b;
+            }
+        }
+
+        self.limiter.process_in_place(out);
+    }
+
+    #[cfg(test)]
+    fn scratch_capacities(&self) -> (usize, usize) {
+        (self.scratch_a.capacity(), self.scratch_b.capacity())
+    }
+}
+
+fn param_at(program: &TransitionProgram, param: Param, sample: u64) -> f32 {
+    program
+        .automation
+        .iter()
+        .filter(|event| event.param == param)
+        .fold(default_param(param), |value, event| {
+            event_value_at(event, sample).unwrap_or(value)
+        })
+}
+
+fn default_param(param: Param) -> f32 {
+    match param {
+        Param::DeckGain(_)
+        | Param::LowGain(_)
+        | Param::MidGain(_)
+        | Param::HighGain(_)
+        | Param::PlaybackRate(_) => 1.0,
+    }
+}
+
+fn event_value_at(event: &AutomationEvent, sample: u64) -> Option<f32> {
+    if sample < event.start_sample {
+        return None;
+    }
+    if sample >= event.end_sample {
+        return Some(event.to);
+    }
+    let span = (event.end_sample - event.start_sample) as f32;
+    let t = (sample - event.start_sample) as f32 / span;
+    Some(interpolate(event.from, event.to, event.curve, t))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::deck::DeckBuffer;
+    use crate::program::{Curve, Tier};
+
+    fn valid_program() -> TransitionProgram {
+        TransitionProgram {
+            tier: Tier::FullBlend,
+            template: "SafeCrossfade".to_string(),
+            sample_rate: 48_000,
+            channels: 1,
+            sync_start: 0,
+            intro_start: 0,
+            swap_start: 4,
+            fade_start: 4,
+            resolve_at: 8,
+            loops: vec![],
+            automation: vec![],
+        }
+    }
+
+    #[test]
+    fn new_rejects_invalid_program() {
+        let mut program = valid_program();
+        program.sample_rate = 0;
+        let result = Mixer::new(
+            program,
+            DeckBuffer::new(vec![0.0; 8], 1),
+            DeckBuffer::new(vec![0.0; 8], 1),
+            8,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn render_block_sums_two_unity_decks() {
+        let mut mixer = Mixer::new(
+            valid_program(),
+            DeckBuffer::new(vec![0.25; 8], 1),
+            DeckBuffer::new(vec![0.5; 8], 1),
+            8,
+        )
+        .expect("mixer");
+        let mut out = [0.0; 4];
+        mixer.render_block(&mut out, 0);
+        assert_eq!(out, [0.75; 4]);
+    }
+
+    #[test]
+    fn render_block_applies_equal_power_fade() {
+        let mut program = valid_program();
+        program.automation = vec![AutomationEvent {
+            param: Param::DeckGain(DeckId::B),
+            start_sample: 0,
+            end_sample: 4,
+            from: 0.0,
+            to: 1.0,
+            curve: Curve::EqualPowerIn,
+        }];
+        let mut mixer = Mixer::new(
+            program,
+            DeckBuffer::new(vec![0.4; 8], 1),
+            DeckBuffer::new(vec![0.4; 8], 1),
+            8,
+        )
+        .expect("mixer");
+        let mut out = [0.0; 5];
+        mixer.render_block(&mut out, 0);
+        assert!((out[0] - 0.4).abs() < 1e-6);
+        assert!(out[2] > out[0]);
+        assert!((out[4] - 0.8).abs() < 1e-6);
+    }
+
+    #[test]
+    fn render_block_never_exceeds_limiter_ceiling() {
+        let mut mixer = Mixer::new(
+            valid_program(),
+            DeckBuffer::new(vec![1.0; 8], 1),
+            DeckBuffer::new(vec![1.0; 8], 1),
+            8,
+        )
+        .expect("mixer");
+        let mut out = [0.0; 4];
+        mixer.render_block(&mut out, 0);
+        assert!(out.iter().all(|sample| sample.abs() <= 0.98));
+    }
+
+    #[test]
+    fn render_block_reuses_scratch_capacity() {
+        let mut mixer = Mixer::new(
+            valid_program(),
+            DeckBuffer::new(vec![0.25; 16], 1),
+            DeckBuffer::new(vec![0.25; 16], 1),
+            16,
+        )
+        .expect("mixer");
+        let capacities = mixer.scratch_capacities();
+        let mut out = [0.0; 8];
+        mixer.render_block(&mut out, 0);
+        mixer.render_block(&mut out, 8);
+        assert_eq!(mixer.scratch_capacities(), capacities);
+    }
+}

--- a/noor-server/Cargo.toml
+++ b/noor-server/Cargo.toml
@@ -32,6 +32,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 # Audio decoding + output
+noor-mix = { path = "../noor-mix" }
 symphonia = { version = "0.5", features = ["all"] }
 cpal = "=0.17.3"
 # Sample-rate conversion. Used when a track's native rate doesn't match the

--- a/noor-server/src/db/models.rs
+++ b/noor-server/src/db/models.rs
@@ -720,6 +720,57 @@ pub struct AudioDspFeatures {
     pub analysis_version: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AudioDjProfileKey {
+    pub media_ref_kind: String,
+    pub media_ref_id: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct AudioDjProfileRow {
+    pub media_ref_kind: String,
+    pub media_ref_id: String,
+    pub track_id: Option<i64>,
+    pub queue_item_id: Option<i64>,
+    pub tidal_id: Option<i64>,
+    pub profile_version: String,
+    pub beat_grid_blob: Vec<u8>,
+    pub downbeats_blob: Vec<u8>,
+    pub phrase_boundaries_blob: Vec<u8>,
+    pub mix_in_blob: Vec<u8>,
+    pub mix_out_blob: Vec<u8>,
+    pub intro_end_seconds: Option<f64>,
+    pub outro_start_seconds: Option<f64>,
+    pub breakdown_blob: Vec<u8>,
+    pub drop_blob: Vec<u8>,
+    pub safe_transition_windows_blob: Vec<u8>,
+    pub energy_contour_blob: Vec<u8>,
+    pub vocal_presence_blob: Vec<u8>,
+    pub vocal_density_blob: Vec<u8>,
+    pub lufs_loud_body: Option<f64>,
+    pub true_peak_dbtp: Option<f64>,
+    pub beat_confidence: Option<f64>,
+    pub profile_confidence: f64,
+    pub analysis_scope_ms: i64,
+    pub is_temporary: bool,
+    pub source: String,
+    pub computed_at: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct AudioDjProfileCorrectionRow {
+    pub media_ref_kind: String,
+    pub media_ref_id: String,
+    pub bpm_multiplier: Option<f64>,
+    pub downbeat_offset_beats: Option<i64>,
+    pub phrase_offset_bars: Option<i64>,
+    pub safe_crossfade_only: bool,
+    pub transition_speed_bias: Option<String>,
+    pub notes: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AudioFeaturesStats {
     pub total_analyzed: i64,

--- a/noor-server/src/db/queries.rs
+++ b/noor-server/src/db/queries.rs
@@ -7574,13 +7574,14 @@ pub fn mark_dj_transition_timing_status_for_pair(
                    SELECT 1
                    FROM dj_transition_events fired
                    WHERE fired.from_media_ref_kind IS dj_transition_events.from_media_ref_kind
-                     AND fired.from_media_ref_id IS dj_transition_events.from_media_ref_id
-                     AND fired.to_media_ref_kind IS dj_transition_events.to_media_ref_kind
-                     AND fired.to_media_ref_id IS dj_transition_events.to_media_ref_id
-                     AND fired.timing_status = 'fired'
-               )
-             ORDER BY started_at DESC, id DESC
-             LIMIT 1
+                      AND fired.from_media_ref_id IS dj_transition_events.from_media_ref_id
+                      AND fired.to_media_ref_kind IS dj_transition_events.to_media_ref_kind
+                      AND fired.to_media_ref_id IS dj_transition_events.to_media_ref_id
+                      AND fired.id > dj_transition_events.id
+                      AND fired.timing_status = 'fired'
+                )
+              ORDER BY started_at DESC, id DESC
+              LIMIT 1
          )",
         params![
             from_media_ref_kind,
@@ -8013,7 +8014,7 @@ mod tests {
         }
 
         #[test]
-        fn mark_dj_transition_timing_status_for_pair_ignores_pair_that_already_fired() {
+        fn mark_dj_transition_timing_status_for_pair_updates_new_attempt_after_old_fired_pair() {
             let conn = setup_conn();
             let fired_id = insert_event(&conn);
             update_dj_transition_fire_timing(&conn, fired_id, 172_040, "fired")
@@ -8030,7 +8031,7 @@ mod tests {
             )
             .expect("mark");
 
-            assert_eq!(updated, 0);
+            assert_eq!(updated, 1);
             let status: Option<String> = conn
                 .query_row(
                     "SELECT timing_status FROM dj_transition_events WHERE id = ?1",
@@ -8038,7 +8039,7 @@ mod tests {
                     |row| row.get(0),
                 )
                 .expect("status");
-            assert_eq!(status.as_deref(), Some("armed"));
+            assert_eq!(status.as_deref(), Some("missed"));
         }
     }
 

--- a/noor-server/src/db/queries.rs
+++ b/noor-server/src/db/queries.rs
@@ -7102,6 +7102,367 @@ pub fn find_tracks_by_hash(conn: &Connection, hashes: &[u32]) -> Result<Vec<(i64
     rows.collect::<Result<Vec<_>, _>>().map_err(Into::into)
 }
 
+pub fn upsert_audio_dj_profile(conn: &Connection, row: &AudioDjProfileRow) -> Result<()> {
+    conn.execute(
+        "INSERT INTO audio_dj_profiles (
+            media_ref_kind, media_ref_id, track_id, queue_item_id, tidal_id, profile_version,
+            beat_grid_blob, downbeats_blob, phrase_boundaries_blob, mix_in_blob, mix_out_blob,
+            intro_end_seconds, outro_start_seconds, breakdown_blob, drop_blob,
+            safe_transition_windows_blob, energy_contour_blob, vocal_presence_blob,
+            vocal_density_blob, lufs_loud_body, true_peak_dbtp, beat_confidence,
+            profile_confidence, analysis_scope_ms, is_temporary, source, computed_at
+        ) VALUES (
+            ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15,
+            ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27
+        )
+        ON CONFLICT(media_ref_kind, media_ref_id) DO UPDATE SET
+            track_id = excluded.track_id,
+            queue_item_id = excluded.queue_item_id,
+            tidal_id = excluded.tidal_id,
+            profile_version = excluded.profile_version,
+            beat_grid_blob = excluded.beat_grid_blob,
+            downbeats_blob = excluded.downbeats_blob,
+            phrase_boundaries_blob = excluded.phrase_boundaries_blob,
+            mix_in_blob = excluded.mix_in_blob,
+            mix_out_blob = excluded.mix_out_blob,
+            intro_end_seconds = excluded.intro_end_seconds,
+            outro_start_seconds = excluded.outro_start_seconds,
+            breakdown_blob = excluded.breakdown_blob,
+            drop_blob = excluded.drop_blob,
+            safe_transition_windows_blob = excluded.safe_transition_windows_blob,
+            energy_contour_blob = excluded.energy_contour_blob,
+            vocal_presence_blob = excluded.vocal_presence_blob,
+            vocal_density_blob = excluded.vocal_density_blob,
+            lufs_loud_body = excluded.lufs_loud_body,
+            true_peak_dbtp = excluded.true_peak_dbtp,
+            beat_confidence = excluded.beat_confidence,
+            profile_confidence = excluded.profile_confidence,
+            analysis_scope_ms = excluded.analysis_scope_ms,
+            is_temporary = excluded.is_temporary,
+            source = excluded.source,
+            computed_at = excluded.computed_at",
+        params![
+            row.media_ref_kind,
+            row.media_ref_id,
+            row.track_id,
+            row.queue_item_id,
+            row.tidal_id,
+            row.profile_version,
+            row.beat_grid_blob,
+            row.downbeats_blob,
+            row.phrase_boundaries_blob,
+            row.mix_in_blob,
+            row.mix_out_blob,
+            row.intro_end_seconds,
+            row.outro_start_seconds,
+            row.breakdown_blob,
+            row.drop_blob,
+            row.safe_transition_windows_blob,
+            row.energy_contour_blob,
+            row.vocal_presence_blob,
+            row.vocal_density_blob,
+            row.lufs_loud_body,
+            row.true_peak_dbtp,
+            row.beat_confidence,
+            row.profile_confidence,
+            row.analysis_scope_ms,
+            if row.is_temporary { 1 } else { 0 },
+            row.source,
+            row.computed_at,
+        ],
+    )?;
+    Ok(())
+}
+
+pub fn get_audio_dj_profile(
+    conn: &Connection,
+    key: &AudioDjProfileKey,
+) -> Result<Option<AudioDjProfileRow>> {
+    conn.query_row(
+        "SELECT media_ref_kind, media_ref_id, track_id, queue_item_id, tidal_id,
+            profile_version, beat_grid_blob, downbeats_blob, phrase_boundaries_blob,
+            mix_in_blob, mix_out_blob, intro_end_seconds, outro_start_seconds,
+            breakdown_blob, drop_blob, safe_transition_windows_blob, energy_contour_blob,
+            vocal_presence_blob, vocal_density_blob, lufs_loud_body, true_peak_dbtp,
+            beat_confidence, profile_confidence, analysis_scope_ms, is_temporary,
+            source, computed_at
+         FROM audio_dj_profiles
+         WHERE media_ref_kind = ?1 AND media_ref_id = ?2",
+        params![key.media_ref_kind, key.media_ref_id],
+        audio_dj_profile_from_row,
+    )
+    .optional()
+    .map_err(Into::into)
+}
+
+pub fn get_audio_dj_profile_for_track(
+    conn: &Connection,
+    track_id: i64,
+) -> Result<Option<AudioDjProfileRow>> {
+    conn.query_row(
+        "SELECT media_ref_kind, media_ref_id, track_id, queue_item_id, tidal_id,
+            profile_version, beat_grid_blob, downbeats_blob, phrase_boundaries_blob,
+            mix_in_blob, mix_out_blob, intro_end_seconds, outro_start_seconds,
+            breakdown_blob, drop_blob, safe_transition_windows_blob, energy_contour_blob,
+            vocal_presence_blob, vocal_density_blob, lufs_loud_body, true_peak_dbtp,
+            beat_confidence, profile_confidence, analysis_scope_ms, is_temporary,
+            source, computed_at
+         FROM audio_dj_profiles
+         WHERE track_id = ?1
+         ORDER BY computed_at DESC
+         LIMIT 1",
+        params![track_id],
+        audio_dj_profile_from_row,
+    )
+    .optional()
+    .map_err(Into::into)
+}
+
+pub fn promote_temporary_audio_dj_profile(
+    conn: &Connection,
+    temporary_key: &AudioDjProfileKey,
+    stable_key: &AudioDjProfileKey,
+    tidal_id: Option<i64>,
+) -> Result<()> {
+    conn.execute(
+        "INSERT INTO audio_dj_profiles (
+            media_ref_kind, media_ref_id, track_id, queue_item_id, tidal_id, profile_version,
+            beat_grid_blob, downbeats_blob, phrase_boundaries_blob, mix_in_blob, mix_out_blob,
+            intro_end_seconds, outro_start_seconds, breakdown_blob, drop_blob,
+            safe_transition_windows_blob, energy_contour_blob, vocal_presence_blob,
+            vocal_density_blob, lufs_loud_body, true_peak_dbtp, beat_confidence,
+            profile_confidence, analysis_scope_ms, is_temporary, source, computed_at
+        )
+        SELECT ?3, ?4, track_id, queue_item_id, COALESCE(?5, tidal_id), profile_version,
+            beat_grid_blob, downbeats_blob, phrase_boundaries_blob, mix_in_blob, mix_out_blob,
+            intro_end_seconds, outro_start_seconds, breakdown_blob, drop_blob,
+            safe_transition_windows_blob, energy_contour_blob, vocal_presence_blob,
+            vocal_density_blob, lufs_loud_body, true_peak_dbtp, beat_confidence,
+            profile_confidence, analysis_scope_ms, 0, source, datetime('now')
+        FROM audio_dj_profiles
+        WHERE media_ref_kind = ?1 AND media_ref_id = ?2
+        ON CONFLICT(media_ref_kind, media_ref_id) DO UPDATE SET
+            track_id = excluded.track_id,
+            queue_item_id = excluded.queue_item_id,
+            tidal_id = excluded.tidal_id,
+            profile_version = excluded.profile_version,
+            beat_grid_blob = excluded.beat_grid_blob,
+            downbeats_blob = excluded.downbeats_blob,
+            phrase_boundaries_blob = excluded.phrase_boundaries_blob,
+            mix_in_blob = excluded.mix_in_blob,
+            mix_out_blob = excluded.mix_out_blob,
+            intro_end_seconds = excluded.intro_end_seconds,
+            outro_start_seconds = excluded.outro_start_seconds,
+            breakdown_blob = excluded.breakdown_blob,
+            drop_blob = excluded.drop_blob,
+            safe_transition_windows_blob = excluded.safe_transition_windows_blob,
+            energy_contour_blob = excluded.energy_contour_blob,
+            vocal_presence_blob = excluded.vocal_presence_blob,
+            vocal_density_blob = excluded.vocal_density_blob,
+            lufs_loud_body = excluded.lufs_loud_body,
+            true_peak_dbtp = excluded.true_peak_dbtp,
+            beat_confidence = excluded.beat_confidence,
+            profile_confidence = excluded.profile_confidence,
+            analysis_scope_ms = excluded.analysis_scope_ms,
+            is_temporary = excluded.is_temporary,
+            source = excluded.source,
+            computed_at = excluded.computed_at",
+        params![
+            temporary_key.media_ref_kind,
+            temporary_key.media_ref_id,
+            stable_key.media_ref_kind,
+            stable_key.media_ref_id,
+            tidal_id,
+        ],
+    )?;
+    Ok(())
+}
+
+pub fn upsert_audio_dj_profile_correction(
+    conn: &Connection,
+    row: &AudioDjProfileCorrectionRow,
+) -> Result<()> {
+    conn.execute(
+        "INSERT INTO audio_dj_profile_corrections (
+            media_ref_kind, media_ref_id, bpm_multiplier, downbeat_offset_beats,
+            phrase_offset_bars, safe_crossfade_only, transition_speed_bias, notes,
+            created_at, updated_at
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+        ON CONFLICT(media_ref_kind, media_ref_id) DO UPDATE SET
+            bpm_multiplier = excluded.bpm_multiplier,
+            downbeat_offset_beats = excluded.downbeat_offset_beats,
+            phrase_offset_bars = excluded.phrase_offset_bars,
+            safe_crossfade_only = excluded.safe_crossfade_only,
+            transition_speed_bias = excluded.transition_speed_bias,
+            notes = excluded.notes,
+            updated_at = excluded.updated_at",
+        params![
+            row.media_ref_kind,
+            row.media_ref_id,
+            row.bpm_multiplier,
+            row.downbeat_offset_beats,
+            row.phrase_offset_bars,
+            if row.safe_crossfade_only { 1 } else { 0 },
+            row.transition_speed_bias,
+            row.notes,
+            row.created_at,
+            row.updated_at,
+        ],
+    )?;
+    Ok(())
+}
+
+pub fn get_audio_dj_profile_correction(
+    conn: &Connection,
+    key: &AudioDjProfileKey,
+) -> Result<Option<AudioDjProfileCorrectionRow>> {
+    conn.query_row(
+        "SELECT media_ref_kind, media_ref_id, bpm_multiplier, downbeat_offset_beats,
+            phrase_offset_bars, safe_crossfade_only, transition_speed_bias, notes,
+            created_at, updated_at
+         FROM audio_dj_profile_corrections
+         WHERE media_ref_kind = ?1 AND media_ref_id = ?2",
+        params![key.media_ref_kind, key.media_ref_id],
+        |row| {
+            Ok(AudioDjProfileCorrectionRow {
+                media_ref_kind: row.get(0)?,
+                media_ref_id: row.get(1)?,
+                bpm_multiplier: row.get(2)?,
+                downbeat_offset_beats: row.get(3)?,
+                phrase_offset_bars: row.get(4)?,
+                safe_crossfade_only: row.get::<_, i64>(5)? != 0,
+                transition_speed_bias: row.get(6)?,
+                notes: row.get(7)?,
+                created_at: row.get(8)?,
+                updated_at: row.get(9)?,
+            })
+        },
+    )
+    .optional()
+    .map_err(Into::into)
+}
+
+pub fn is_dj_engine_enabled(conn: &Connection) -> Result<bool> {
+    let value: Option<String> = conn
+        .query_row(
+            "SELECT value FROM server_config WHERE key = 'dj_engine_enabled'",
+            [],
+            |row| row.get(0),
+        )
+        .optional()?;
+    Ok(matches!(value.as_deref(), Some("1") | Some("true")))
+}
+
+pub fn set_dj_engine_enabled(conn: &Connection, enabled: bool) -> Result<()> {
+    conn.execute(
+        "INSERT OR REPLACE INTO server_config (key, value)
+         VALUES ('dj_engine_enabled', ?1)",
+        params![if enabled { "1" } else { "0" }],
+    )?;
+    Ok(())
+}
+
+pub fn get_dj_global_policy(conn: &Connection) -> Result<(String, String)> {
+    let mix_intent = conn
+        .query_row(
+            "SELECT value FROM server_config WHERE key = 'dj_mix_intent'",
+            [],
+            |row| row.get(0),
+        )
+        .optional()?
+        .unwrap_or_else(|| "balanced".to_string());
+    let transition_speed_bias = conn
+        .query_row(
+            "SELECT value FROM server_config WHERE key = 'dj_transition_speed_bias'",
+            [],
+            |row| row.get(0),
+        )
+        .optional()?
+        .unwrap_or_else(|| "neutral".to_string());
+    Ok((mix_intent, transition_speed_bias))
+}
+
+pub fn set_dj_global_policy(
+    conn: &Connection,
+    mix_intent: &str,
+    transition_speed_bias: &str,
+) -> Result<()> {
+    if !matches!(mix_intent, "safe" | "balanced" | "bold") {
+        bail!("unknown DJ mix intent: {mix_intent}");
+    }
+    if !matches!(transition_speed_bias, "slower" | "neutral" | "faster") {
+        bail!("unknown DJ transition speed bias: {transition_speed_bias}");
+    }
+    conn.execute(
+        "INSERT OR REPLACE INTO server_config (key, value)
+         VALUES ('dj_mix_intent', ?1)",
+        params![mix_intent],
+    )?;
+    conn.execute(
+        "INSERT OR REPLACE INTO server_config (key, value)
+         VALUES ('dj_transition_speed_bias', ?1)",
+        params![transition_speed_bias],
+    )?;
+    Ok(())
+}
+
+pub fn count_recent_bad_dj_feedback_for_ref(
+    conn: &Connection,
+    key: &AudioDjProfileKey,
+    limit: i64,
+) -> Result<i64> {
+    conn.query_row(
+        "SELECT COUNT(*)
+         FROM (
+            SELECT user_rating
+            FROM dj_transition_events
+            WHERE user_rating IS NOT NULL
+              AND (
+                (from_media_ref_kind = ?1 AND from_media_ref_id = ?2)
+                OR (to_media_ref_kind = ?1 AND to_media_ref_id = ?2)
+              )
+            ORDER BY started_at DESC, id DESC
+            LIMIT ?3
+         )
+         WHERE user_rating < 0",
+        params![key.media_ref_kind, key.media_ref_id, limit.max(0)],
+        |row| row.get(0),
+    )
+    .map_err(Into::into)
+}
+
+fn audio_dj_profile_from_row(row: &Row<'_>) -> rusqlite::Result<AudioDjProfileRow> {
+    Ok(AudioDjProfileRow {
+        media_ref_kind: row.get(0)?,
+        media_ref_id: row.get(1)?,
+        track_id: row.get(2)?,
+        queue_item_id: row.get(3)?,
+        tidal_id: row.get(4)?,
+        profile_version: row.get(5)?,
+        beat_grid_blob: row.get(6)?,
+        downbeats_blob: row.get(7)?,
+        phrase_boundaries_blob: row.get(8)?,
+        mix_in_blob: row.get(9)?,
+        mix_out_blob: row.get(10)?,
+        intro_end_seconds: row.get(11)?,
+        outro_start_seconds: row.get(12)?,
+        breakdown_blob: row.get(13)?,
+        drop_blob: row.get(14)?,
+        safe_transition_windows_blob: row.get(15)?,
+        energy_contour_blob: row.get(16)?,
+        vocal_presence_blob: row.get(17)?,
+        vocal_density_blob: row.get(18)?,
+        lufs_loud_body: row.get(19)?,
+        true_peak_dbtp: row.get(20)?,
+        beat_confidence: row.get(21)?,
+        profile_confidence: row.get(22)?,
+        analysis_scope_ms: row.get(23)?,
+        is_temporary: row.get::<_, i64>(24)? != 0,
+        source: row.get(25)?,
+        computed_at: row.get(26)?,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -7116,6 +7477,313 @@ mod tests {
         )
         .optional()
         .expect("query server_config")
+    }
+
+    mod audio_dj_profile {
+        use super::*;
+
+        fn setup_conn() -> Connection {
+            let conn = Connection::open_in_memory().expect("in-memory db");
+            conn.execute_batch("PRAGMA foreign_keys = ON;")
+                .expect("foreign keys");
+            schema::run_migrations(&conn).expect("migrations");
+            conn
+        }
+
+        fn key(kind: &str, id: &str) -> AudioDjProfileKey {
+            AudioDjProfileKey {
+                media_ref_kind: kind.to_string(),
+                media_ref_id: id.to_string(),
+            }
+        }
+
+        fn seed_track(conn: &Connection) -> i64 {
+            conn.execute("INSERT INTO artists (name) VALUES ('Artist')", [])
+                .expect("artist");
+            let artist_id = conn.last_insert_rowid();
+            conn.execute(
+                "INSERT INTO tracks (title, artist_id, tidal_id) VALUES ('Track', ?1, 12345)",
+                params![artist_id],
+            )
+            .expect("track");
+            conn.last_insert_rowid()
+        }
+
+        fn profile_row(kind: &str, id: &str) -> AudioDjProfileRow {
+            AudioDjProfileRow {
+                media_ref_kind: kind.to_string(),
+                media_ref_id: id.to_string(),
+                track_id: None,
+                queue_item_id: None,
+                tidal_id: None,
+                profile_version: "dj_profile_v1".to_string(),
+                beat_grid_blob: vec![1, 2, 3],
+                downbeats_blob: vec![4, 5],
+                phrase_boundaries_blob: vec![6],
+                mix_in_blob: vec![7],
+                mix_out_blob: vec![8],
+                intro_end_seconds: Some(16.0),
+                outro_start_seconds: Some(180.0),
+                breakdown_blob: vec![9],
+                drop_blob: vec![10],
+                safe_transition_windows_blob: vec![11],
+                energy_contour_blob: vec![12],
+                vocal_presence_blob: vec![13],
+                vocal_density_blob: vec![14],
+                lufs_loud_body: Some(-12.0),
+                true_peak_dbtp: Some(-1.0),
+                beat_confidence: Some(0.9),
+                profile_confidence: 0.85,
+                analysis_scope_ms: 90_000,
+                is_temporary: false,
+                source: "test".to_string(),
+                computed_at: "2026-05-21T00:00:00Z".to_string(),
+            }
+        }
+
+        fn correction_row(kind: &str, id: &str) -> AudioDjProfileCorrectionRow {
+            AudioDjProfileCorrectionRow {
+                media_ref_kind: kind.to_string(),
+                media_ref_id: id.to_string(),
+                bpm_multiplier: Some(2.0),
+                downbeat_offset_beats: Some(1),
+                phrase_offset_bars: Some(-2),
+                safe_crossfade_only: true,
+                transition_speed_bias: Some("faster".to_string()),
+                notes: Some("user correction".to_string()),
+                created_at: "2026-05-21T00:00:00Z".to_string(),
+                updated_at: "2026-05-21T00:00:01Z".to_string(),
+            }
+        }
+
+        fn table_exists(conn: &Connection, table: &str) -> bool {
+            conn.query_row(
+                "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?1",
+                params![table],
+                |_| Ok(()),
+            )
+            .optional()
+            .expect("table lookup")
+            .is_some()
+        }
+
+        #[test]
+        fn migration_043_creates_audio_dj_profiles() {
+            let conn = setup_conn();
+            assert!(table_exists(&conn, "audio_dj_profiles"));
+            assert!(table_exists(&conn, "dj_transition_events"));
+        }
+
+        #[test]
+        fn migration_043_creates_audio_dj_profile_corrections() {
+            let conn = setup_conn();
+            assert!(table_exists(&conn, "audio_dj_profile_corrections"));
+        }
+
+        #[test]
+        fn upsert_audio_dj_profile_round_trips_library_key() {
+            let conn = setup_conn();
+            let track_id = seed_track(&conn);
+            let mut row = profile_row("library_track", &track_id.to_string());
+            row.track_id = Some(track_id);
+
+            upsert_audio_dj_profile(&conn, &row).expect("upsert");
+            let loaded = get_audio_dj_profile(&conn, &key("library_track", &track_id.to_string()))
+                .expect("get")
+                .expect("profile");
+            assert_eq!(loaded.track_id, Some(track_id));
+            assert_eq!(loaded.media_ref_kind, "library_track");
+
+            let by_track = get_audio_dj_profile_for_track(&conn, track_id)
+                .expect("get track")
+                .expect("track profile");
+            assert_eq!(by_track.media_ref_id, track_id.to_string());
+        }
+
+        #[test]
+        fn upsert_audio_dj_profile_round_trips_tidal_key() {
+            let conn = setup_conn();
+            let mut row = profile_row("tidal_track", "98765");
+            row.tidal_id = Some(98_765);
+
+            upsert_audio_dj_profile(&conn, &row).expect("upsert");
+            let loaded = get_audio_dj_profile(&conn, &key("tidal_track", "98765"))
+                .expect("get")
+                .expect("profile");
+            assert_eq!(loaded.tidal_id, Some(98_765));
+            assert_eq!(loaded.media_ref_id, "98765");
+        }
+
+        #[test]
+        fn audio_dj_profile_allows_external_queue_item_without_track_id() {
+            let conn = setup_conn();
+            conn.execute(
+                "INSERT INTO queue (position, source, pending_artist, pending_title)
+                 VALUES (1, 'radio_pending', 'Artist', 'Title')",
+                [],
+            )
+            .expect("queue item");
+            let queue_item_id = conn.last_insert_rowid();
+            let mut row = profile_row("queue_item", &queue_item_id.to_string());
+            row.queue_item_id = Some(queue_item_id);
+            row.is_temporary = true;
+
+            upsert_audio_dj_profile(&conn, &row).expect("upsert");
+            let loaded =
+                get_audio_dj_profile(&conn, &key("queue_item", &queue_item_id.to_string()))
+                    .expect("get")
+                    .expect("profile");
+            assert_eq!(loaded.track_id, None);
+            assert_eq!(loaded.queue_item_id, Some(queue_item_id));
+            assert!(loaded.is_temporary);
+        }
+
+        #[test]
+        fn audio_dj_profile_stores_confidence_and_scope() {
+            let conn = setup_conn();
+            let mut row = profile_row("tidal_track", "1");
+            row.profile_confidence = 0.4;
+            row.analysis_scope_ms = 30_000;
+
+            upsert_audio_dj_profile(&conn, &row).expect("upsert");
+            let loaded = get_audio_dj_profile(&conn, &key("tidal_track", "1"))
+                .expect("get")
+                .expect("profile");
+            assert_eq!(loaded.profile_confidence, 0.4);
+            assert_eq!(loaded.analysis_scope_ms, 30_000);
+        }
+
+        #[test]
+        fn promote_temporary_audio_dj_profile_copies_to_stable_key() {
+            let conn = setup_conn();
+            let mut row = profile_row("queue_item", "44");
+            row.is_temporary = true;
+            upsert_audio_dj_profile(&conn, &row).expect("upsert temp");
+
+            promote_temporary_audio_dj_profile(
+                &conn,
+                &key("queue_item", "44"),
+                &key("tidal_track", "555"),
+                Some(555),
+            )
+            .expect("promote");
+
+            let stable = get_audio_dj_profile(&conn, &key("tidal_track", "555"))
+                .expect("get stable")
+                .expect("stable");
+            let temporary = get_audio_dj_profile(&conn, &key("queue_item", "44"))
+                .expect("get temp")
+                .expect("temp");
+            assert_eq!(stable.beat_grid_blob, temporary.beat_grid_blob);
+            assert_eq!(stable.tidal_id, Some(555));
+            assert!(!stable.is_temporary);
+            assert!(temporary.is_temporary);
+        }
+
+        #[test]
+        fn upsert_audio_dj_profile_correction_round_trips() {
+            let conn = setup_conn();
+            let row = correction_row("tidal_track", "1");
+            upsert_audio_dj_profile_correction(&conn, &row).expect("upsert correction");
+
+            let loaded = get_audio_dj_profile_correction(&conn, &key("tidal_track", "1"))
+                .expect("get")
+                .expect("correction");
+            assert_eq!(loaded.bpm_multiplier, Some(2.0));
+            assert_eq!(loaded.downbeat_offset_beats, Some(1));
+            assert_eq!(loaded.phrase_offset_bars, Some(-2));
+            assert!(loaded.safe_crossfade_only);
+            assert_eq!(loaded.transition_speed_bias.as_deref(), Some("faster"));
+        }
+
+        #[test]
+        fn audio_dj_profile_correction_rejects_unknown_transition_speed_bias() {
+            let conn = setup_conn();
+            let mut row = correction_row("tidal_track", "1");
+            row.transition_speed_bias = Some("sideways".to_string());
+
+            assert!(upsert_audio_dj_profile_correction(&conn, &row).is_err());
+        }
+
+        #[test]
+        fn dj_engine_enabled_defaults_false() {
+            let conn = setup_conn();
+            assert!(!is_dj_engine_enabled(&conn).expect("enabled"));
+        }
+
+        #[test]
+        fn set_dj_engine_enabled_round_trips() {
+            let conn = setup_conn();
+            set_dj_engine_enabled(&conn, true).expect("enable");
+            assert!(is_dj_engine_enabled(&conn).expect("enabled"));
+            set_dj_engine_enabled(&conn, false).expect("disable");
+            assert!(!is_dj_engine_enabled(&conn).expect("disabled"));
+        }
+
+        #[test]
+        fn dj_global_policy_defaults_balanced_neutral() {
+            let conn = setup_conn();
+            assert_eq!(
+                get_dj_global_policy(&conn).expect("policy"),
+                ("balanced".to_string(), "neutral".to_string())
+            );
+        }
+
+        #[test]
+        fn set_dj_global_policy_round_trips() {
+            let conn = setup_conn();
+            set_dj_global_policy(&conn, "bold", "faster").expect("set policy");
+            assert_eq!(
+                get_dj_global_policy(&conn).expect("policy"),
+                ("bold".to_string(), "faster".to_string())
+            );
+        }
+
+        #[test]
+        fn set_dj_global_policy_rejects_unknown_values() {
+            let conn = setup_conn();
+            assert!(set_dj_global_policy(&conn, "chaos", "neutral").is_err());
+            assert!(set_dj_global_policy(&conn, "safe", "sideways").is_err());
+        }
+
+        #[test]
+        fn count_recent_bad_dj_feedback_for_ref_counts_from_and_to_roles() {
+            let conn = setup_conn();
+            let key = key("tidal_track", "1");
+            conn.execute(
+                "INSERT INTO dj_transition_events (
+                    from_media_ref_kind, from_media_ref_id, to_media_ref_kind, to_media_ref_id,
+                    template, program_json, planner_version, user_rating, started_at
+                 ) VALUES (?1, ?2, 'tidal_track', '2', 'SafeCrossfade', '{}', 'v1', -1, '2026-05-21T00:00:00Z')",
+                params![key.media_ref_kind, key.media_ref_id],
+            )
+            .expect("from event");
+            conn.execute(
+                "INSERT INTO dj_transition_events (
+                    from_media_ref_kind, from_media_ref_id, to_media_ref_kind, to_media_ref_id,
+                    template, program_json, planner_version, user_rating, started_at
+                 ) VALUES ('tidal_track', '3', ?1, ?2, 'SafeCrossfade', '{}', 'v1', -1, '2026-05-21T00:00:01Z')",
+                params![key.media_ref_kind, key.media_ref_id],
+            )
+            .expect("to event");
+            conn.execute(
+                "INSERT INTO dj_transition_events (
+                    from_media_ref_kind, from_media_ref_id, to_media_ref_kind, to_media_ref_id,
+                    template, program_json, planner_version, user_rating, started_at
+                 ) VALUES (?1, ?2, 'tidal_track', '4', 'SafeCrossfade', '{}', 'v1', 1, '2026-05-21T00:00:02Z')",
+                params![key.media_ref_kind, key.media_ref_id],
+            )
+            .expect("good event");
+
+            assert_eq!(
+                count_recent_bad_dj_feedback_for_ref(&conn, &key, 10).expect("count"),
+                2
+            );
+            assert_eq!(
+                count_recent_bad_dj_feedback_for_ref(&conn, &key, 1).expect("count"),
+                0
+            );
+        }
     }
 
     #[test]

--- a/noor-server/src/db/queries.rs
+++ b/noor-server/src/db/queries.rs
@@ -7406,6 +7406,177 @@ pub fn set_dj_global_policy(
     Ok(())
 }
 
+fn validate_dj_fallback_reason(reason: Option<&str>) -> Result<()> {
+    if let Some(reason) = reason
+        && !matches!(
+            reason,
+            "disabled"
+                | "current_profile_missing"
+                | "next_profile_missing"
+                | "profile_low_confidence"
+                | "next_not_resolved"
+                | "fetch_failed"
+                | "decode_late"
+                | "analysis_late"
+                | "program_invalid"
+                | "queue_changed"
+                | "safety_override_safe"
+                | "template_not_renderable"
+        )
+    {
+        bail!("unknown DJ fallback reason: {reason}");
+    }
+    Ok(())
+}
+
+fn validate_dj_timing_source(source: Option<&str>) -> Result<()> {
+    if let Some(source) = source
+        && !matches!(source, "downbeat_sync" | "beat_sync" | "fallback_overlap")
+    {
+        bail!("unknown DJ timing source: {source}");
+    }
+    Ok(())
+}
+
+fn validate_dj_timing_status(status: Option<&str>) -> Result<()> {
+    if let Some(status) = status
+        && !matches!(status, "armed" | "fired" | "late" | "missed")
+    {
+        bail!("unknown DJ timing status: {status}");
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn insert_dj_transition_event(
+    conn: &Connection,
+    from_track_id: Option<i64>,
+    to_track_id: Option<i64>,
+    from_media_ref_kind: Option<&str>,
+    from_media_ref_id: Option<&str>,
+    to_media_ref_kind: Option<&str>,
+    to_media_ref_id: Option<&str>,
+    template: &str,
+    program_json: &str,
+    rejected_alternatives_json: Option<&str>,
+    planner_version: &str,
+    fallback_reason: Option<&str>,
+    planned_start_ms: Option<i64>,
+    timing_source: Option<&str>,
+    timing_status: Option<&str>,
+) -> Result<i64> {
+    validate_dj_fallback_reason(fallback_reason)?;
+    validate_dj_timing_source(timing_source)?;
+    validate_dj_timing_status(timing_status)?;
+    conn.execute(
+        "INSERT INTO dj_transition_events (
+            from_track_id, to_track_id, from_media_ref_kind, from_media_ref_id,
+            to_media_ref_kind, to_media_ref_id, template, program_json,
+            rejected_alternatives_json, planner_version, fallback_reason,
+            planned_start_ms, timing_source, timing_status
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
+        params![
+            from_track_id,
+            to_track_id,
+            from_media_ref_kind,
+            from_media_ref_id,
+            to_media_ref_kind,
+            to_media_ref_id,
+            template,
+            program_json,
+            rejected_alternatives_json,
+            planner_version,
+            fallback_reason,
+            planned_start_ms,
+            timing_source,
+            timing_status,
+        ],
+    )?;
+    Ok(conn.last_insert_rowid())
+}
+
+pub fn update_dj_transition_outcome(
+    conn: &Connection,
+    id: i64,
+    outcome: &str,
+    skip_within_30s: bool,
+) -> Result<()> {
+    conn.execute(
+        "UPDATE dj_transition_events
+         SET outcome = ?2,
+             outcome_at = datetime('now'),
+             skip_within_30s = ?3
+         WHERE id = ?1",
+        params![id, outcome, if skip_within_30s { 1 } else { 0 }],
+    )?;
+    Ok(())
+}
+
+pub fn update_dj_transition_fire_timing(
+    conn: &Connection,
+    id: i64,
+    actual_start_ms: i64,
+    timing_status: &str,
+) -> Result<()> {
+    validate_dj_timing_status(Some(timing_status))?;
+    conn.execute(
+        "UPDATE dj_transition_events
+         SET actual_start_ms = ?2,
+             timing_delta_ms = CASE
+                 WHEN planned_start_ms IS NULL THEN NULL
+                 ELSE ?2 - planned_start_ms
+             END,
+             timing_status = ?3
+         WHERE id = ?1",
+        params![id, actual_start_ms, timing_status],
+    )?;
+    Ok(())
+}
+
+pub fn mark_dj_transition_timing_status_for_pair(
+    conn: &Connection,
+    from_media_ref_kind: &str,
+    from_media_ref_id: &str,
+    to_media_ref_kind: &str,
+    to_media_ref_id: &str,
+    timing_status: &str,
+) -> Result<usize> {
+    validate_dj_timing_status(Some(timing_status))?;
+    conn.execute(
+        "UPDATE dj_transition_events
+         SET timing_status = ?5
+         WHERE id = (
+             SELECT id
+             FROM dj_transition_events
+             WHERE from_media_ref_kind = ?1
+               AND from_media_ref_id = ?2
+               AND to_media_ref_kind = ?3
+               AND to_media_ref_id = ?4
+               AND outcome IS NULL
+               AND timing_status = 'armed'
+               AND NOT EXISTS (
+                   SELECT 1
+                   FROM dj_transition_events fired
+                   WHERE fired.from_media_ref_kind IS dj_transition_events.from_media_ref_kind
+                     AND fired.from_media_ref_id IS dj_transition_events.from_media_ref_id
+                     AND fired.to_media_ref_kind IS dj_transition_events.to_media_ref_kind
+                     AND fired.to_media_ref_id IS dj_transition_events.to_media_ref_id
+                     AND fired.timing_status = 'fired'
+               )
+             ORDER BY started_at DESC, id DESC
+             LIMIT 1
+         )",
+        params![
+            from_media_ref_kind,
+            from_media_ref_id,
+            to_media_ref_kind,
+            to_media_ref_id,
+            timing_status,
+        ],
+    )
+    .map_err(Into::into)
+}
+
 pub fn count_recent_bad_dj_feedback_for_ref(
     conn: &Connection,
     key: &AudioDjProfileKey,
@@ -7477,6 +7648,353 @@ mod tests {
         )
         .optional()
         .expect("query server_config")
+    }
+
+    mod dj_transition_event {
+        use super::*;
+
+        fn setup_conn() -> Connection {
+            let conn = Connection::open_in_memory().expect("in-memory db");
+            conn.execute_batch("PRAGMA foreign_keys = ON;")
+                .expect("foreign keys");
+            schema::run_migrations(&conn).expect("migrations");
+            conn.execute("INSERT INTO artists (id, name) VALUES (1, 'Artist')", [])
+                .expect("artist");
+            conn.execute(
+                "INSERT INTO tracks (id, title, artist_id, tidal_id)
+                 VALUES (1, 'Track 1', 1, 1001), (2, 'Track 2', 1, 1002)",
+                [],
+            )
+            .expect("tracks");
+            conn
+        }
+
+        fn insert_event(conn: &Connection) -> i64 {
+            insert_dj_transition_event(
+                conn,
+                Some(1),
+                Some(2),
+                Some("library_track"),
+                Some("1"),
+                Some("tidal_track"),
+                Some("200"),
+                "SafeCrossfade",
+                r#"{"template":"SafeCrossfade"}"#,
+                None,
+                "dj-v1",
+                None,
+                Some(172_000),
+                Some("downbeat_sync"),
+                Some("armed"),
+            )
+            .expect("insert event")
+        }
+
+        #[test]
+        fn insert_dj_transition_event_round_trips() {
+            let conn = setup_conn();
+            let id = insert_event(&conn);
+
+            let row = conn
+                .query_row(
+                    "SELECT from_track_id, to_track_id, template, program_json, planner_version,
+                            planned_start_ms, timing_source, timing_status
+                     FROM dj_transition_events WHERE id = ?1",
+                    params![id],
+                    |row| {
+                        Ok((
+                            row.get::<_, Option<i64>>(0)?,
+                            row.get::<_, Option<i64>>(1)?,
+                            row.get::<_, String>(2)?,
+                            row.get::<_, String>(3)?,
+                            row.get::<_, String>(4)?,
+                            row.get::<_, Option<i64>>(5)?,
+                            row.get::<_, Option<String>>(6)?,
+                            row.get::<_, Option<String>>(7)?,
+                        ))
+                    },
+                )
+                .expect("event");
+
+            assert_eq!(row.0, Some(1));
+            assert_eq!(row.1, Some(2));
+            assert_eq!(row.2, "SafeCrossfade");
+            assert_eq!(row.3, r#"{"template":"SafeCrossfade"}"#);
+            assert_eq!(row.4, "dj-v1");
+            assert_eq!(row.5, Some(172_000));
+            assert_eq!(row.6.as_deref(), Some("downbeat_sync"));
+            assert_eq!(row.7.as_deref(), Some("armed"));
+        }
+
+        #[test]
+        fn insert_dj_transition_event_round_trips_external_refs() {
+            let conn = setup_conn();
+            let id = insert_dj_transition_event(
+                &conn,
+                None,
+                None,
+                Some("queue_item"),
+                Some("44"),
+                Some("tidal_track"),
+                Some("555"),
+                "SafeCrossfade",
+                "{}",
+                None,
+                "dj-v1",
+                None,
+                None,
+                None,
+                None,
+            )
+            .expect("insert external refs");
+
+            let refs = conn
+                .query_row(
+                    "SELECT from_media_ref_kind, from_media_ref_id, to_media_ref_kind, to_media_ref_id
+                     FROM dj_transition_events WHERE id = ?1",
+                    params![id],
+                    |row| {
+                        Ok((
+                            row.get::<_, Option<String>>(0)?,
+                            row.get::<_, Option<String>>(1)?,
+                            row.get::<_, Option<String>>(2)?,
+                            row.get::<_, Option<String>>(3)?,
+                        ))
+                    },
+                )
+                .expect("refs");
+
+            assert_eq!(refs.0.as_deref(), Some("queue_item"));
+            assert_eq!(refs.1.as_deref(), Some("44"));
+            assert_eq!(refs.2.as_deref(), Some("tidal_track"));
+            assert_eq!(refs.3.as_deref(), Some("555"));
+        }
+
+        #[test]
+        fn insert_dj_transition_event_round_trips_rejected_alternatives() {
+            let conn = setup_conn();
+            let rejected = r#"[{"template":"SlamCut","score":0.2,"reason":"low_confidence"}]"#;
+            let id = insert_dj_transition_event(
+                &conn,
+                Some(1),
+                Some(2),
+                Some("library_track"),
+                Some("1"),
+                Some("library_track"),
+                Some("2"),
+                "SafeCrossfade",
+                "{}",
+                Some(rejected),
+                "dj-v1",
+                None,
+                None,
+                None,
+                None,
+            )
+            .expect("insert rejected");
+
+            let loaded: String = conn
+                .query_row(
+                    "SELECT rejected_alternatives_json FROM dj_transition_events WHERE id = ?1",
+                    params![id],
+                    |row| row.get(0),
+                )
+                .expect("rejected");
+            assert_eq!(loaded, rejected);
+        }
+
+        #[test]
+        fn insert_dj_transition_event_accepts_known_fallback_reasons() {
+            let conn = setup_conn();
+            let reasons = [
+                "disabled",
+                "current_profile_missing",
+                "next_profile_missing",
+                "profile_low_confidence",
+                "next_not_resolved",
+                "fetch_failed",
+                "decode_late",
+                "analysis_late",
+                "program_invalid",
+                "queue_changed",
+                "safety_override_safe",
+            ];
+
+            for reason in reasons {
+                insert_dj_transition_event(
+                    &conn,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    "SafeCrossfade",
+                    "{}",
+                    None,
+                    "dj-v1",
+                    Some(reason),
+                    None,
+                    None,
+                    None,
+                )
+                .unwrap_or_else(|error| panic!("reason {reason} rejected: {error}"));
+            }
+            assert!(
+                insert_dj_transition_event(
+                    &conn,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    "SafeCrossfade",
+                    "{}",
+                    None,
+                    "dj-v1",
+                    Some("unknown"),
+                    None,
+                    None,
+                    None,
+                )
+                .is_err()
+            );
+        }
+
+        #[test]
+        fn update_dj_transition_outcome_sets_timestamp() {
+            let conn = setup_conn();
+            let id = insert_event(&conn);
+
+            update_dj_transition_outcome(&conn, id, "bad", true).expect("update");
+
+            let row = conn
+                .query_row(
+                    "SELECT outcome, outcome_at, skip_within_30s
+                     FROM dj_transition_events WHERE id = ?1",
+                    params![id],
+                    |row| {
+                        Ok((
+                            row.get::<_, Option<String>>(0)?,
+                            row.get::<_, Option<String>>(1)?,
+                            row.get::<_, i64>(2)?,
+                        ))
+                    },
+                )
+                .expect("outcome");
+            assert_eq!(row.0.as_deref(), Some("bad"));
+            assert!(row.1.is_some());
+            assert_eq!(row.2, 1);
+        }
+
+        #[test]
+        fn manual_skip_outcome_does_not_write_actual_timing() {
+            let conn = setup_conn();
+            let id = insert_event(&conn);
+
+            update_dj_transition_outcome(&conn, id, "skip_within_30s", true).expect("update");
+
+            let actual_start_ms: Option<i64> = conn
+                .query_row(
+                    "SELECT actual_start_ms FROM dj_transition_events WHERE id = ?1",
+                    params![id],
+                    |row| row.get(0),
+                )
+                .expect("actual");
+            assert_eq!(actual_start_ms, None);
+        }
+
+        #[test]
+        fn update_dj_transition_fire_timing_sets_delta_and_status() {
+            let conn = setup_conn();
+            let id = insert_event(&conn);
+
+            update_dj_transition_fire_timing(&conn, id, 172_144, "fired").expect("timing");
+
+            let row = conn
+                .query_row(
+                    "SELECT actual_start_ms, timing_delta_ms, timing_status
+                     FROM dj_transition_events WHERE id = ?1",
+                    params![id],
+                    |row| {
+                        Ok((
+                            row.get::<_, Option<i64>>(0)?,
+                            row.get::<_, Option<i64>>(1)?,
+                            row.get::<_, Option<String>>(2)?,
+                        ))
+                    },
+                )
+                .expect("timing row");
+            assert_eq!(row.0, Some(172_144));
+            assert_eq!(row.1, Some(144));
+            assert_eq!(row.2.as_deref(), Some("fired"));
+        }
+
+        #[test]
+        fn mark_dj_transition_timing_status_for_pair_updates_only_armed_pair() {
+            let conn = setup_conn();
+            let updated = mark_dj_transition_timing_status_for_pair(
+                &conn,
+                "library_track",
+                "1",
+                "tidal_track",
+                "200",
+                "missed",
+            )
+            .expect("mark before insert");
+            assert_eq!(updated, 0);
+
+            let id = insert_event(&conn);
+            let updated = mark_dj_transition_timing_status_for_pair(
+                &conn,
+                "library_track",
+                "1",
+                "tidal_track",
+                "200",
+                "missed",
+            )
+            .expect("mark");
+            assert_eq!(updated, 1);
+
+            let status: Option<String> = conn
+                .query_row(
+                    "SELECT timing_status FROM dj_transition_events WHERE id = ?1",
+                    params![id],
+                    |row| row.get(0),
+                )
+                .expect("status");
+            assert_eq!(status.as_deref(), Some("missed"));
+        }
+
+        #[test]
+        fn mark_dj_transition_timing_status_for_pair_ignores_pair_that_already_fired() {
+            let conn = setup_conn();
+            let fired_id = insert_event(&conn);
+            update_dj_transition_fire_timing(&conn, fired_id, 172_040, "fired")
+                .expect("mark fired");
+            let armed_id = insert_event(&conn);
+
+            let updated = mark_dj_transition_timing_status_for_pair(
+                &conn,
+                "library_track",
+                "1",
+                "tidal_track",
+                "200",
+                "missed",
+            )
+            .expect("mark");
+
+            assert_eq!(updated, 0);
+            let status: Option<String> = conn
+                .query_row(
+                    "SELECT timing_status FROM dj_transition_events WHERE id = ?1",
+                    params![armed_id],
+                    |row| row.get(0),
+                )
+                .expect("status");
+            assert_eq!(status.as_deref(), Some("armed"));
+        }
     }
 
     mod audio_dj_profile {

--- a/noor-server/src/db/queries.rs
+++ b/noor-server/src/db/queries.rs
@@ -7530,6 +7530,22 @@ pub fn update_dj_transition_fire_timing(
          WHERE id = ?1",
         params![id, actual_start_ms, timing_status],
     )?;
+    conn.execute(
+        "UPDATE dj_transition_events
+         SET timing_status = 'missed'
+         WHERE id <> ?1
+           AND timing_status = 'armed'
+           AND EXISTS (
+               SELECT 1
+               FROM dj_transition_events fired
+               WHERE fired.id = ?1
+                 AND fired.from_media_ref_kind IS dj_transition_events.from_media_ref_kind
+                 AND fired.from_media_ref_id IS dj_transition_events.from_media_ref_id
+                 AND fired.to_media_ref_kind IS dj_transition_events.to_media_ref_kind
+                 AND fired.to_media_ref_id IS dj_transition_events.to_media_ref_id
+           )",
+        params![id],
+    )?;
     Ok(())
 }
 
@@ -7929,6 +7945,35 @@ mod tests {
             assert_eq!(row.0, Some(172_144));
             assert_eq!(row.1, Some(144));
             assert_eq!(row.2.as_deref(), Some("fired"));
+        }
+
+        #[test]
+        fn update_dj_transition_fire_timing_closes_duplicate_armed_pair_rows() {
+            let conn = setup_conn();
+            let older_id = insert_event(&conn);
+            let fired_id = insert_event(&conn);
+
+            update_dj_transition_fire_timing(&conn, fired_id, 172_144, "fired").expect("timing");
+
+            let rows: Vec<(i64, Option<String>)> = {
+                let mut stmt = conn
+                    .prepare(
+                        "SELECT id, timing_status
+                         FROM dj_transition_events
+                         WHERE id IN (?1, ?2)
+                         ORDER BY id",
+                    )
+                    .expect("prepare");
+                stmt.query_map(params![older_id, fired_id], |row| {
+                    Ok((row.get::<_, i64>(0)?, row.get::<_, Option<String>>(1)?))
+                })
+                .expect("query")
+                .collect::<rusqlite::Result<_>>()
+                .expect("rows")
+            };
+
+            assert_eq!(rows[0], (older_id, Some("missed".to_string())));
+            assert_eq!(rows[1], (fired_id, Some("fired".to_string())));
         }
 
         #[test]

--- a/noor-server/src/db/queries.rs
+++ b/noor-server/src/db/queries.rs
@@ -7422,6 +7422,7 @@ fn validate_dj_fallback_reason(reason: Option<&str>) -> Result<()> {
                 | "queue_changed"
                 | "safety_override_safe"
                 | "template_not_renderable"
+                | "timing_unstable"
         )
     {
         bail!("unknown DJ fallback reason: {reason}");

--- a/noor-server/src/db/schema.rs
+++ b/noor-server/src/db/schema.rs
@@ -45,6 +45,7 @@ const MIGRATIONS: &[&str] = &[
     MIGRATION_041,
     MIGRATION_042,
     MIGRATION_043,
+    MIGRATION_044,
 ];
 
 const MIGRATION_001: &str = r#"
@@ -1179,6 +1180,108 @@ CREATE INDEX IF NOT EXISTS idx_tracks_discovery
     ON tracks(is_favorite DESC, play_count ASC, fidelity_score DESC, date_added DESC, title ASC);
 CREATE INDEX IF NOT EXISTS idx_tracks_play_last
     ON tracks(play_count DESC, last_played_at DESC, id DESC);
+"#;
+
+const MIGRATION_044: &str = r#"
+CREATE TABLE IF NOT EXISTS audio_dj_profiles (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    media_ref_kind TEXT NOT NULL,
+    media_ref_id TEXT NOT NULL,
+    track_id INTEGER REFERENCES tracks(id) ON DELETE CASCADE,
+    queue_item_id INTEGER REFERENCES queue(id) ON DELETE SET NULL,
+    tidal_id INTEGER,
+    profile_version TEXT NOT NULL,
+    beat_grid_blob BLOB NOT NULL,
+    downbeats_blob BLOB NOT NULL,
+    phrase_boundaries_blob BLOB NOT NULL,
+    mix_in_blob BLOB NOT NULL,
+    mix_out_blob BLOB NOT NULL,
+    intro_end_seconds REAL,
+    outro_start_seconds REAL,
+    breakdown_blob BLOB NOT NULL,
+    drop_blob BLOB NOT NULL,
+    safe_transition_windows_blob BLOB NOT NULL,
+    energy_contour_blob BLOB NOT NULL,
+    vocal_presence_blob BLOB NOT NULL,
+    vocal_density_blob BLOB NOT NULL,
+    lufs_loud_body REAL,
+    true_peak_dbtp REAL,
+    beat_confidence REAL,
+    profile_confidence REAL NOT NULL DEFAULT 0,
+    analysis_scope_ms INTEGER NOT NULL DEFAULT 0,
+    is_temporary INTEGER NOT NULL DEFAULT 0,
+    source TEXT NOT NULL DEFAULT 'noor_dj_v1',
+    computed_at TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(media_ref_kind, media_ref_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_audio_dj_profiles_version
+    ON audio_dj_profiles(profile_version);
+CREATE INDEX IF NOT EXISTS idx_audio_dj_profiles_track
+    ON audio_dj_profiles(track_id)
+    WHERE track_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_audio_dj_profiles_tidal
+    ON audio_dj_profiles(tidal_id)
+    WHERE tidal_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS audio_dj_profile_corrections (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    media_ref_kind TEXT NOT NULL,
+    media_ref_id TEXT NOT NULL,
+    bpm_multiplier REAL,
+    downbeat_offset_beats INTEGER,
+    phrase_offset_bars INTEGER,
+    safe_crossfade_only INTEGER NOT NULL DEFAULT 0,
+    transition_speed_bias TEXT,
+    notes TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(media_ref_kind, media_ref_id),
+    CHECK (transition_speed_bias IS NULL OR transition_speed_bias IN ('slower', 'neutral', 'faster'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_audio_dj_profile_corrections_ref
+    ON audio_dj_profile_corrections(media_ref_kind, media_ref_id);
+
+CREATE TABLE IF NOT EXISTS dj_transition_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT,
+    from_track_id INTEGER REFERENCES tracks(id),
+    to_track_id INTEGER REFERENCES tracks(id),
+    from_media_ref_kind TEXT,
+    from_media_ref_id TEXT,
+    to_media_ref_kind TEXT,
+    to_media_ref_id TEXT,
+    template TEXT NOT NULL,
+    program_json TEXT NOT NULL,
+    rejected_alternatives_json TEXT,
+    planner_version TEXT NOT NULL,
+    started_at TEXT NOT NULL DEFAULT (datetime('now')),
+    outcome TEXT,
+    outcome_at TEXT,
+    fallback_reason TEXT,
+    user_rating INTEGER,
+    skip_within_30s INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_dj_transition_events_tracks
+    ON dj_transition_events(from_track_id, to_track_id, started_at);
+CREATE INDEX IF NOT EXISTS idx_dj_transition_events_outcome
+    ON dj_transition_events(outcome)
+    WHERE outcome IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_dj_transition_events_feedback_from
+    ON dj_transition_events(from_media_ref_kind, from_media_ref_id, started_at)
+    WHERE user_rating IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_dj_transition_events_feedback_to
+    ON dj_transition_events(to_media_ref_kind, to_media_ref_id, started_at)
+    WHERE user_rating IS NOT NULL;
+
+INSERT OR IGNORE INTO server_config (key, value)
+VALUES ('dj_engine_enabled', '0');
+INSERT OR IGNORE INTO server_config (key, value)
+VALUES ('dj_mix_intent', 'balanced');
+INSERT OR IGNORE INTO server_config (key, value)
+VALUES ('dj_transition_speed_bias', 'neutral');
 "#;
 
 pub fn run_migrations(conn: &Connection) -> Result<()> {

--- a/noor-server/src/db/schema.rs
+++ b/noor-server/src/db/schema.rs
@@ -46,6 +46,7 @@ const MIGRATIONS: &[&str] = &[
     MIGRATION_042,
     MIGRATION_043,
     MIGRATION_044,
+    MIGRATION_045,
 ];
 
 const MIGRATION_001: &str = r#"
@@ -1284,6 +1285,14 @@ INSERT OR IGNORE INTO server_config (key, value)
 VALUES ('dj_transition_speed_bias', 'neutral');
 "#;
 
+const MIGRATION_045: &str = r#"
+ALTER TABLE dj_transition_events ADD COLUMN planned_start_ms INTEGER;
+ALTER TABLE dj_transition_events ADD COLUMN actual_start_ms INTEGER;
+ALTER TABLE dj_transition_events ADD COLUMN timing_delta_ms INTEGER;
+ALTER TABLE dj_transition_events ADD COLUMN timing_source TEXT;
+ALTER TABLE dj_transition_events ADD COLUMN timing_status TEXT;
+"#;
+
 pub fn run_migrations(conn: &Connection) -> Result<()> {
     // Create migrations table if not exists
     conn.execute_batch(
@@ -1456,5 +1465,32 @@ mod tests {
             !plan.contains("TEMP B-TREE"),
             "discovery query should not need a temp sort, plan was: {plan}"
         );
+    }
+
+    #[test]
+    fn migration_045_adds_dj_transition_timing_fields() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+
+        apply_migrations_up_to(&conn, MIGRATIONS.len()).unwrap();
+
+        for column in [
+            "planned_start_ms",
+            "actual_start_ms",
+            "timing_delta_ms",
+            "timing_source",
+            "timing_status",
+        ] {
+            let exists: i64 = conn
+                .query_row(
+                    "SELECT COUNT(*)
+                     FROM pragma_table_info('dj_transition_events')
+                     WHERE name = ?1",
+                    [column],
+                    |row| row.get(0),
+            )
+                .unwrap();
+            assert_eq!(exists, 1, "missing {column}");
+        }
     }
 }

--- a/noor-server/src/db/schema.rs
+++ b/noor-server/src/db/schema.rs
@@ -1488,7 +1488,7 @@ mod tests {
                      WHERE name = ?1",
                     [column],
                     |row| row.get(0),
-            )
+                )
                 .unwrap();
             assert_eq!(exists, 1, "missing {column}");
         }

--- a/noor-server/src/main.rs
+++ b/noor-server/src/main.rs
@@ -56,6 +56,14 @@ pub struct PendingEphemeralTidalTrack {
     pub duration_ms: Option<i64>,
 }
 
+#[derive(Debug, Clone)]
+pub struct PreparedEphemeralTidalNext {
+    pub tidal_track_id: i64,
+    pub synthetic_track: db::models::Track,
+    pub stream_display: StreamDisplayInfo,
+    pub generation: u64,
+}
+
 /// Shared application state accessible by all modules
 pub struct AppState {
     pub db: db::Database,
@@ -128,6 +136,11 @@ pub struct AppState {
     // Audio analysis
     pub analysis_tx:
         Option<tokio::sync::mpsc::UnboundedSender<services::audio_analysis::AnalysisJob>>,
+    pub dj_analysis_tx: Option<
+        tokio::sync::mpsc::UnboundedSender<services::audio_analysis::dj_profile::DjAnalysisJob>,
+    >,
+    pub dj_profile_rebuild_inflight:
+        Arc<std::sync::Mutex<std::collections::HashMap<String, std::time::Instant>>>,
     pub audio_analysis_cancel: Arc<AtomicBool>,
     pub audio_analysis_running: Arc<AtomicBool>,
     pub acrcloud_scan_running: Arc<AtomicBool>,
@@ -181,6 +194,7 @@ pub struct AppState {
     /// stream URLs expire (~30 min) so pre-resolving the whole mix is wasteful.
     pub pending_tidal_mix_queue:
         Arc<std::sync::Mutex<std::collections::VecDeque<PendingEphemeralTidalTrack>>>,
+    pub prepared_ephemeral_tidal_next: Option<PreparedEphemeralTidalNext>,
     /// Last.fm app shared secret, loaded once from `LASTFM_API_SECRET` env at
     /// boot. `None` disables every scrobble auth + scrobble call (endpoints
     /// return HTTP 501). Never serialized into responses, never logged.
@@ -707,6 +721,8 @@ async fn main() -> Result<()> {
         services::audio_analysis::AnalysisConfig::default(),
     );
     info!("Audio analysis actor spawned");
+    let dj_analysis_tx = services::audio_analysis::dj_profile::spawn_dj_profile_actor(db.clone());
+    info!("DJ profile analysis actor spawned");
 
     let state = Arc::new(RwLock::new(AppState {
         db,
@@ -737,6 +753,10 @@ async fn main() -> Result<()> {
         rss_aggregator,
         acrcloud_client: None,
         analysis_tx: Some(analysis_tx),
+        dj_analysis_tx: Some(dj_analysis_tx),
+        dj_profile_rebuild_inflight: Arc::new(std::sync::Mutex::new(
+            std::collections::HashMap::new(),
+        )),
         audio_analysis_cancel: analysis_cancel,
         audio_analysis_running: Arc::new(AtomicBool::new(false)),
         acrcloud_scan_running: Arc::new(AtomicBool::new(false)),
@@ -758,6 +778,7 @@ async fn main() -> Result<()> {
         embedding_cache: Arc::new(tokio::sync::Mutex::new(None)),
         master_key,
         pending_tidal_mix_queue: Arc::new(std::sync::Mutex::new(std::collections::VecDeque::new())),
+        prepared_ephemeral_tidal_next: None,
         lastfm_api_secret,
         server_token,
         audio_active: Arc::new(AtomicBool::new(false)),

--- a/noor-server/src/main.rs
+++ b/noor-server/src/main.rs
@@ -64,6 +64,13 @@ pub struct PreparedEphemeralTidalNext {
     pub generation: u64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NextPrebufferKey {
+    pub current_track_id: i64,
+    pub next_track_id: i64,
+    pub generation: u64,
+}
+
 /// Shared application state accessible by all modules
 pub struct AppState {
     pub db: db::Database,
@@ -115,6 +122,7 @@ pub struct AppState {
     pub playback_generation: Arc<AtomicU64>,
     pub current_stream_display: Option<StreamDisplayInfo>,
     pub pending_stream_display: Option<StreamDisplayInfo>,
+    pub next_prebuffer_inflight: Option<NextPrebufferKey>,
     pub active_listen_session: Option<playback::player::ActiveListenSession>,
     pub live_listen_session: Option<playback::player::LiveListenSession>,
     pub external_playback_track: Option<db::models::Track>,
@@ -743,6 +751,7 @@ async fn main() -> Result<()> {
         playback_generation: Arc::new(AtomicU64::new(1)),
         current_stream_display: None,
         pending_stream_display: None,
+        next_prebuffer_inflight: None,
         active_listen_session: None,
         live_listen_session: None,
         external_playback_track: None,

--- a/noor-server/src/playback/decode/mod.rs
+++ b/noor-server/src/playback/decode/mod.rs
@@ -17,6 +17,7 @@ use futures::StreamExt as _;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
 use std::thread;
+use std::time::Instant;
 use symphonia::core::audio::SampleBuffer;
 use symphonia::core::codecs::DecoderOptions;
 use symphonia::core::errors::Error as SymphoniaError;
@@ -112,6 +113,7 @@ pub(crate) fn decode_and_buffer_job(
             };
             if initial_media_segments > 0 {
                 let prebuffer_stop = shared.stop_flag();
+                let prebuffer_started = Instant::now();
                 dash_initial = rt
                     .block_on(async {
                         if prebuffer_stop.load(Ordering::Relaxed) {
@@ -139,6 +141,15 @@ pub(crate) fn decode_and_buffer_job(
                     })
                     .context("DASH stream prebuffer failed")?;
                 remaining_segment_urls.drain(0..initial_media_segments);
+                info!(
+                    "TIDAL DASH prebuffer ready track_id={} start_index={} initial_segments={} remaining_segments={} elapsed_ms={} bytes={}",
+                    shared.track_id,
+                    start_index,
+                    initial_media_segments,
+                    remaining_segment_urls.len(),
+                    prebuffer_started.elapsed().as_millis(),
+                    dash_initial.len()
+                );
                 debug!(
                     "TIDAL DASH prebuffer ready: track_id={}, start_index={}, initial_segments={}, remaining_segments={}",
                     shared.track_id,

--- a/noor-server/src/playback/decode/mod.rs
+++ b/noor-server/src/playback/decode/mod.rs
@@ -355,10 +355,7 @@ pub(crate) fn decode_and_buffer_job(
             // ── Pre-loop: passive analysis capture ──────────────────────────────────────
             let mut analysis_sent = false;
             let mut analysis_buf: Vec<f32> = Vec::new();
-            let dj_media_ref = config
-                .dj_engine_enabled
-                .then(|| job.dj_media_ref.clone())
-                .flatten();
+            let dj_media_ref = dj_analysis_media_ref_for_decode(&config, &job);
             if config.dj_analysis_only && dj_media_ref.is_none() {
                 return Ok(());
             }
@@ -641,6 +638,17 @@ pub(crate) fn send_dj_analysis_job(
     );
 }
 
+fn dj_analysis_media_ref_for_decode(
+    config: &PlaybackRuntimeConfig,
+    job: &PreparedPlaybackJob,
+) -> Option<crate::playback::dj_lookahead::DjMediaRef> {
+    if !config.dj_engine_enabled || !config.dj_analysis_only {
+        return None;
+    }
+
+    job.dj_media_ref.clone()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -700,6 +708,35 @@ mod tests {
         )
     }
 
+    fn test_analysis_only_config(
+        enabled: bool,
+    ) -> (
+        PlaybackRuntimeConfig,
+        tokio::sync::mpsc::UnboundedReceiver<DjAnalysisJob>,
+    ) {
+        let (config, rx) = test_config(enabled);
+        (config.for_dj_analysis_only(), rx)
+    }
+
+    #[test]
+    fn playback_decoder_does_not_capture_dj_analysis() {
+        let (config, _rx) = test_config(true);
+        let job = test_job(1, DjMediaRef::LibraryTrack { track_id: 1 });
+
+        assert!(dj_analysis_media_ref_for_decode(&config, &job).is_none());
+    }
+
+    #[test]
+    fn analysis_only_decoder_captures_dj_analysis() {
+        let (config, _rx) = test_analysis_only_config(true);
+        let job = test_job(1, DjMediaRef::LibraryTrack { track_id: 1 });
+
+        assert_eq!(
+            dj_analysis_media_ref_for_decode(&config, &job),
+            Some(DjMediaRef::LibraryTrack { track_id: 1 })
+        );
+    }
+
     #[test]
     fn dj_analysis_not_sent_when_engine_disabled() {
         let (config, mut rx) = test_config(false);
@@ -718,8 +755,8 @@ mod tests {
     }
 
     #[test]
-    fn active_decoder_sends_library_profile_key() {
-        let (config, mut rx) = test_config(true);
+    fn analysis_only_decoder_sends_library_profile_key() {
+        let (config, mut rx) = test_analysis_only_config(true);
         let job = test_job(1, DjMediaRef::LibraryTrack { track_id: 1 });
 
         send_dj_analysis_job(
@@ -738,8 +775,8 @@ mod tests {
     }
 
     #[test]
-    fn prepared_next_decoder_sends_tidal_profile_key() {
-        let (config, mut rx) = test_config(true);
+    fn analysis_only_decoder_sends_tidal_profile_key() {
+        let (config, mut rx) = test_analysis_only_config(true);
         let job = test_job(
             10,
             DjMediaRef::TidalTrack {
@@ -765,8 +802,8 @@ mod tests {
     }
 
     #[test]
-    fn active_tidal_decoder_does_not_use_synthetic_negative_track_id() {
-        let (config, mut rx) = test_config(true);
+    fn analysis_only_decoder_does_not_use_synthetic_negative_track_id() {
+        let (config, mut rx) = test_analysis_only_config(true);
         let job = test_job(
             -123,
             DjMediaRef::TidalTrack {
@@ -792,8 +829,8 @@ mod tests {
     }
 
     #[test]
-    fn pending_next_decoder_sends_queue_item_profile_key_when_unresolved() {
-        let (config, mut rx) = test_config(true);
+    fn analysis_only_decoder_sends_queue_item_profile_key_when_unresolved() {
+        let (config, mut rx) = test_analysis_only_config(true);
         let job = test_job(
             10,
             DjMediaRef::PendingQueueItem {

--- a/noor-server/src/playback/decode/mod.rs
+++ b/noor-server/src/playback/decode/mod.rs
@@ -25,7 +25,7 @@ use symphonia::core::io::MediaSourceStream;
 use symphonia::core::meta::MetadataOptions;
 use symphonia::core::probe::Hint;
 use tokio::runtime::Builder as TokioRuntimeBuilder;
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 
 const DJ_ANALYSIS_MAX_SECONDS: usize = 90;
 
@@ -105,7 +105,11 @@ pub(crate) fn decode_and_buffer_job(
                 .collect();
             let mut dash_initial = Vec::new();
             let mut remaining_segment_urls = sliced_segment_urls.clone();
-            let initial_media_segments = dash_initial_media_count(sliced_segment_urls.len());
+            let initial_media_segments = if config.dj_analysis_only {
+                sliced_segment_urls.len().min(1)
+            } else {
+                dash_initial_media_count(sliced_segment_urls.len())
+            };
             if initial_media_segments > 0 {
                 let prebuffer_stop = shared.stop_flag();
                 dash_initial = rt
@@ -154,6 +158,7 @@ pub(crate) fn decode_and_buffer_job(
             let download_track_id = shared.track_id;
             let segment_urls = remaining_segment_urls;
             let download_stop = shared.stop_flag();
+            let download_is_analysis_only = config.dj_analysis_only;
             thread::Builder::new()
                 .name("noor-stream-download".into())
                 .spawn(move || {
@@ -213,12 +218,21 @@ pub(crate) fn decode_and_buffer_job(
                                     }
                                     sent_bytes += bytes.len();
                                     if chunk_tx.send(Some(bytes)).is_err() {
-                                        warn!(
-                                            "TIDAL DASH download stopped early: track_id={}, sent_segments={}, total_remaining_segments={}",
-                                            download_track_id,
-                                            sent_segments,
-                                            total_segments
-                                        );
+                                        if download_is_analysis_only {
+                                            debug!(
+                                                "TIDAL DASH analysis download stopped after capture: track_id={}, sent_segments={}, total_remaining_segments={}",
+                                                download_track_id,
+                                                sent_segments,
+                                                total_segments
+                                            );
+                                        } else {
+                                            warn!(
+                                                "TIDAL DASH download stopped early: track_id={}, sent_segments={}, total_remaining_segments={}",
+                                                download_track_id,
+                                                sent_segments,
+                                                total_segments
+                                            );
+                                        }
                                         break;
                                     }
                                     sent_segments += 1;
@@ -334,6 +348,9 @@ pub(crate) fn decode_and_buffer_job(
                 .dj_engine_enabled
                 .then(|| job.dj_media_ref.clone())
                 .flatten();
+            if config.dj_analysis_only && dj_media_ref.is_none() {
+                return Ok(());
+            }
             let mut dj_analysis_sent = false;
             let mut dj_analysis_buf: Vec<f32> = Vec::new();
 
@@ -417,6 +434,18 @@ pub(crate) fn decode_and_buffer_job(
                         );
                         dj_analysis_sent = true;
                     }
+                }
+                if config.dj_analysis_only {
+                    decoded_packets += 1;
+                    decoded_samples += sb.samples().len() as u64;
+                    if dj_analysis_sent {
+                        debug!(
+                            "DJ analysis-only decode captured profile window: track_id={}, packets={}, samples={}",
+                            shared.track_id, decoded_packets, decoded_samples
+                        );
+                        return Ok(());
+                    }
+                    continue;
                 }
 
                 // Channel-adapt and resample this packet's samples, then push to buffer.
@@ -576,8 +605,13 @@ pub(crate) fn send_dj_analysis_job(
     let analysis_scope_ms = ((samples.len() as u64).saturating_mul(1000)
         / sample_rate.max(1) as u64)
         .min(i64::MAX as u64) as i64;
+    let track_id = media_ref
+        .track_id()
+        .or_else(|| (job.track.id > 0).then_some(job.track.id));
+    let key = media_ref.profile_key();
+    let sample_count = samples.len();
     let _ = tx.send(DjAnalysisJob {
-        track_id: media_ref.track_id().or(Some(job.track.id)),
+        track_id,
         queue_item_id: media_ref.queue_item_id(),
         tidal_id: media_ref.tidal_id(),
         media_ref,
@@ -586,6 +620,14 @@ pub(crate) fn send_dj_analysis_job(
         analysis_scope_ms,
         deadline_generation,
     });
+    info!(
+        media_ref_kind = %key.media_ref_kind,
+        media_ref_id = %key.media_ref_id,
+        sample_count,
+        sample_rate,
+        analysis_scope_ms,
+        "DJ analysis job queued"
+    );
 }
 
 #[cfg(test)]
@@ -709,6 +751,33 @@ mod tests {
         assert_eq!(sent.media_ref.profile_key().media_ref_id, "99");
         assert_eq!(sent.tidal_id, Some(99));
         assert_eq!(sent.track_id, Some(10));
+    }
+
+    #[test]
+    fn active_tidal_decoder_does_not_use_synthetic_negative_track_id() {
+        let (config, mut rx) = test_config(true);
+        let job = test_job(
+            -123,
+            DjMediaRef::TidalTrack {
+                tidal_id: 99,
+                track_id: None,
+            },
+        );
+
+        send_dj_analysis_job(
+            &config,
+            job.dj_media_ref.clone(),
+            &job,
+            vec![0.0; 128],
+            48_000,
+            7,
+        );
+
+        let sent = rx.try_recv().expect("dj job");
+        assert_eq!(sent.media_ref.profile_key().media_ref_kind, "tidal_track");
+        assert_eq!(sent.media_ref.profile_key().media_ref_id, "99");
+        assert_eq!(sent.tidal_id, Some(99));
+        assert_eq!(sent.track_id, None);
     }
 
     #[test]

--- a/noor-server/src/playback/decode/mod.rs
+++ b/noor-server/src/playback/decode/mod.rs
@@ -10,6 +10,7 @@ use crate::playback::player::{PlaybackSourceRequest, PreparedPlaybackJob};
 use crate::playback::runtime::PlaybackRuntimeConfig;
 use crate::playback::runtime::commands::PlaybackRuntimeCommand;
 use crate::playback::runtime::shared::PlaybackSharedState;
+use crate::services::audio_analysis::dj_profile::DjAnalysisJob;
 use crate::services::tidal::stream::resolve_stream;
 use anyhow::{Context, Result, anyhow};
 use futures::StreamExt as _;
@@ -26,6 +27,8 @@ use symphonia::core::probe::Hint;
 use tokio::runtime::Builder as TokioRuntimeBuilder;
 use tracing::{debug, warn};
 
+const DJ_ANALYSIS_MAX_SECONDS: usize = 90;
+
 pub(crate) fn decode_and_buffer_job(
     config: PlaybackRuntimeConfig,
     job: PreparedPlaybackJob,
@@ -39,7 +42,7 @@ pub(crate) fn decode_and_buffer_job(
                 "local library playback is not wired into the host-audio runtime yet"
             ));
         }
-        PlaybackSourceRequest::TidalStream(request) => {
+        PlaybackSourceRequest::TidalStream(ref request) => {
             // ── Step 1: resolve the stream URL (async, needs a mini tokio runtime) ──────────
             let rt = TokioRuntimeBuilder::new_current_thread()
                 .enable_all()
@@ -327,6 +330,12 @@ pub(crate) fn decode_and_buffer_job(
             // ── Pre-loop: passive analysis capture ──────────────────────────────────────
             let mut analysis_sent = false;
             let mut analysis_buf: Vec<f32> = Vec::new();
+            let dj_media_ref = config
+                .dj_engine_enabled
+                .then(|| job.dj_media_ref.clone())
+                .flatten();
+            let mut dj_analysis_sent = false;
+            let mut dj_analysis_buf: Vec<f32> = Vec::new();
 
             // Per-track stateful resampler. Lazily built on the first packet whose
             // input rate doesn't match the live target rate. Rebuilt whenever the
@@ -386,6 +395,27 @@ pub(crate) fn decode_and_buffer_job(
                             ));
                         }
                         analysis_sent = true;
+                    }
+                }
+
+                if !dj_analysis_sent && dj_media_ref.is_some() {
+                    extend_mono_from_interleaved(
+                        &mut dj_analysis_buf,
+                        sb.samples(),
+                        decoded_channels as usize,
+                    );
+                    if dj_analysis_buf.len()
+                        >= decoded_sample_rate as usize * DJ_ANALYSIS_MAX_SECONDS
+                    {
+                        send_dj_analysis_job(
+                            &config,
+                            dj_media_ref.clone(),
+                            &job,
+                            std::mem::take(&mut dj_analysis_buf),
+                            decoded_sample_rate,
+                            shared.generation,
+                        );
+                        dj_analysis_sent = true;
                     }
                 }
 
@@ -479,6 +509,17 @@ pub(crate) fn decode_and_buffer_job(
                 }
             }
 
+            if !dj_analysis_sent && !dj_analysis_buf.is_empty() {
+                send_dj_analysis_job(
+                    &config,
+                    dj_media_ref,
+                    &job,
+                    std::mem::take(&mut dj_analysis_buf),
+                    decoded_sample_rate,
+                    shared.generation,
+                );
+            }
+
             // Apply fade-in / fade-out ramps and mark the stream complete.
             let total = {
                 let mut guard = shared
@@ -512,4 +553,189 @@ pub(crate) fn decode_and_buffer_job(
     }
 
     Ok(())
+}
+
+pub(crate) fn send_dj_analysis_job(
+    config: &PlaybackRuntimeConfig,
+    media_ref: Option<crate::playback::dj_lookahead::DjMediaRef>,
+    job: &PreparedPlaybackJob,
+    samples: Vec<f32>,
+    sample_rate: u32,
+    deadline_generation: u64,
+) {
+    if !config.dj_engine_enabled {
+        return;
+    }
+    let (Some(tx), Some(media_ref)) = (&config.dj_analysis_tx, media_ref) else {
+        return;
+    };
+    if samples.is_empty() {
+        return;
+    }
+
+    let analysis_scope_ms = ((samples.len() as u64).saturating_mul(1000)
+        / sample_rate.max(1) as u64)
+        .min(i64::MAX as u64) as i64;
+    let _ = tx.send(DjAnalysisJob {
+        track_id: media_ref.track_id().or(Some(job.track.id)),
+        queue_item_id: media_ref.queue_item_id(),
+        tidal_id: media_ref.tidal_id(),
+        media_ref,
+        samples,
+        sample_rate,
+        analysis_scope_ms,
+        deadline_generation,
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::models::Track;
+    use crate::playback::dj_lookahead::DjMediaRef;
+    use crate::playback::gapless::GaplessPlan;
+    use crate::playback::player::{PlaybackSourceRequest, PreparedPlaybackJob};
+
+    fn test_track(track_id: i64) -> Track {
+        Track {
+            id: track_id,
+            title: format!("Track {track_id}"),
+            artist_id: 1,
+            artist_name: None,
+            album_id: None,
+            album_title: None,
+            disc_number: None,
+            track_number: None,
+            duration_ms: Some(180_000),
+            isrc: None,
+            tidal_id: None,
+            ytmusic_id: None,
+            soundcloud_id: None,
+            best_quality: None,
+            best_source: None,
+            fidelity_score: 0,
+            is_favorite: false,
+            play_count: 0,
+            last_played_at: None,
+            date_added: None,
+            source: "local".to_string(),
+            artwork_url: None,
+        }
+    }
+
+    fn test_job(track_id: i64, media_ref: DjMediaRef) -> PreparedPlaybackJob {
+        PreparedPlaybackJob::new(
+            test_track(track_id),
+            PlaybackSourceRequest::LocalLibrary,
+            GaplessPlan::disabled(),
+        )
+        .with_generation(7)
+        .with_dj_media_ref(media_ref)
+    }
+
+    fn test_config(
+        enabled: bool,
+    ) -> (
+        PlaybackRuntimeConfig,
+        tokio::sync::mpsc::UnboundedReceiver<DjAnalysisJob>,
+    ) {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        (
+            PlaybackRuntimeConfig::new(reqwest::Client::new(), "", None)
+                .with_dj_analysis(enabled, Some(tx)),
+            rx,
+        )
+    }
+
+    #[test]
+    fn dj_analysis_not_sent_when_engine_disabled() {
+        let (config, mut rx) = test_config(false);
+        let job = test_job(1, DjMediaRef::LibraryTrack { track_id: 1 });
+
+        send_dj_analysis_job(
+            &config,
+            job.dj_media_ref.clone(),
+            &job,
+            vec![0.0; 128],
+            48_000,
+            7,
+        );
+
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn active_decoder_sends_library_profile_key() {
+        let (config, mut rx) = test_config(true);
+        let job = test_job(1, DjMediaRef::LibraryTrack { track_id: 1 });
+
+        send_dj_analysis_job(
+            &config,
+            job.dj_media_ref.clone(),
+            &job,
+            vec![0.0; 128],
+            48_000,
+            7,
+        );
+
+        let sent = rx.try_recv().expect("dj job");
+        assert_eq!(sent.media_ref.profile_key().media_ref_kind, "library_track");
+        assert_eq!(sent.media_ref.profile_key().media_ref_id, "1");
+        assert_eq!(sent.track_id, Some(1));
+    }
+
+    #[test]
+    fn prepared_next_decoder_sends_tidal_profile_key() {
+        let (config, mut rx) = test_config(true);
+        let job = test_job(
+            10,
+            DjMediaRef::TidalTrack {
+                tidal_id: 99,
+                track_id: Some(10),
+            },
+        );
+
+        send_dj_analysis_job(
+            &config,
+            job.dj_media_ref.clone(),
+            &job,
+            vec![0.0; 128],
+            48_000,
+            7,
+        );
+
+        let sent = rx.try_recv().expect("dj job");
+        assert_eq!(sent.media_ref.profile_key().media_ref_kind, "tidal_track");
+        assert_eq!(sent.media_ref.profile_key().media_ref_id, "99");
+        assert_eq!(sent.tidal_id, Some(99));
+        assert_eq!(sent.track_id, Some(10));
+    }
+
+    #[test]
+    fn pending_next_decoder_sends_queue_item_profile_key_when_unresolved() {
+        let (config, mut rx) = test_config(true);
+        let job = test_job(
+            10,
+            DjMediaRef::PendingQueueItem {
+                queue_item_id: 44,
+                pending_artist: "Artist".to_string(),
+                pending_title: "Title".to_string(),
+                tidal_id_hint: None,
+            },
+        );
+
+        send_dj_analysis_job(
+            &config,
+            job.dj_media_ref.clone(),
+            &job,
+            vec![0.0; 128],
+            48_000,
+            7,
+        );
+
+        let sent = rx.try_recv().expect("dj job");
+        assert_eq!(sent.media_ref.profile_key().media_ref_kind, "queue_item");
+        assert_eq!(sent.media_ref.profile_key().media_ref_id, "44");
+        assert_eq!(sent.queue_item_id, Some(44));
+    }
 }

--- a/noor-server/src/playback/decode/source.rs
+++ b/noor-server/src/playback/decode/source.rs
@@ -8,7 +8,7 @@ use std::sync::mpsc::RecvTimeoutError;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-pub(crate) const DASH_INITIAL_MEDIA_SEGMENTS: usize = 8;
+pub(crate) const DASH_INITIAL_MEDIA_SEGMENTS: usize = 2;
 pub(crate) const DASH_SEGMENT_TIMEOUT_SECS: u64 = 12;
 const STREAM_PIPE_RECV_POLL_MS: u64 = 100;
 
@@ -346,7 +346,7 @@ mod tests {
     }
 
     #[test]
-    fn dash_initial_media_count_prefers_multiple_segments() {
+    fn dash_initial_media_count_primes_startup_without_deep_buffering() {
         assert_eq!(dash_initial_media_count(0), 0);
         assert_eq!(dash_initial_media_count(1), 1);
         assert_eq!(

--- a/noor-server/src/playback/dj_engine.rs
+++ b/noor-server/src/playback/dj_engine.rs
@@ -4,7 +4,7 @@ use noor_mix::{DjProfile, Planner, Policy, TransitionProgram};
 use rusqlite::Connection;
 use serde::Serialize;
 
-use crate::db::models::{AudioDjProfileCorrectionRow, AudioDjProfileKey, AudioDjProfileRow};
+use crate::db::models::{AudioDjProfileCorrectionRow, AudioDjProfileRow};
 use crate::db::{Database, queries};
 use crate::playback::dj_lookahead::DjMediaRef;
 use crate::services::audio_analysis::dj_profile::{decode_f32_blob, decode_u32_blob};
@@ -334,6 +334,7 @@ fn estimate_bpm(beats: &[f32]) -> Option<f32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::db::models::AudioDjProfileKey;
     use crate::db::schema;
     use crate::services::audio_analysis::dj_profile::{
         DJ_PROFILE_VERSION, encode_f32_blob, encode_u32_blob,

--- a/noor-server/src/playback/dj_engine.rs
+++ b/noor-server/src/playback/dj_engine.rs
@@ -1,7 +1,8 @@
 use anyhow::Result;
-use noor_mix::planner::{MixIntent, TransitionSpeedBias, TransitionTemplate};
+use noor_mix::planner::{DJ_PLANNER_VERSION, MixIntent, TransitionSpeedBias, TransitionTemplate};
 use noor_mix::{DjProfile, Planner, Policy, TransitionProgram};
 use rusqlite::Connection;
+use serde::Serialize;
 
 use crate::db::models::{AudioDjProfileCorrectionRow, AudioDjProfileKey, AudioDjProfileRow};
 use crate::db::{Database, queries};
@@ -19,9 +20,27 @@ pub struct RuntimeSafetyDecision {
     pub force_safe_crossfade: bool,
 }
 
+pub struct DjTransitionPlan {
+    pub program: TransitionProgram,
+    pub rejected_alternatives: Vec<RejectedTransitionAlternative>,
+    pub planner_version: &'static str,
+    pub fallback_reason: Option<&'static str>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RejectedTransitionAlternative {
+    pub template: &'static str,
+    pub score: f32,
+    pub reason: &'static str,
+}
+
 impl DjEngine {
     pub fn new(db: Database) -> Self {
         Self { db }
+    }
+
+    pub(crate) fn db(&self) -> &Database {
+        &self.db
     }
 
     #[allow(dead_code)]
@@ -38,6 +57,18 @@ impl DjEngine {
         sample_rate: u32,
         channels: u16,
     ) -> Result<Option<TransitionProgram>> {
+        Ok(self
+            .plan_transition_details(from, to, sample_rate, channels)?
+            .map(|plan| plan.program))
+    }
+
+    pub fn plan_transition_details(
+        &self,
+        from: &DjMediaRef,
+        to: &DjMediaRef,
+        sample_rate: u32,
+        channels: u16,
+    ) -> Result<Option<DjTransitionPlan>> {
         self.db.with_conn(|conn| {
             if !queries::is_dj_engine_enabled(conn)? {
                 return Ok(None);
@@ -54,7 +85,11 @@ impl DjEngine {
                 policy_from_db(conn, from_correction.as_ref(), to_correction.as_ref())?;
             if from_profile.is_none() || to_profile.is_none() {
                 policy.safety_template_override = Some(TransitionTemplate::SafeCrossfade);
-                return Ok(Some(safe_crossfade_program(sample_rate, channels, policy)));
+                let program = safe_crossfade_program(sample_rate, channels, policy);
+                return Ok(Some(plan_from_program(
+                    program,
+                    Some(missing_profile_reason(from_profile.is_none())),
+                )));
             }
 
             let mut outgoing = profile_from_row(from_profile.as_ref().expect("checked"));
@@ -71,9 +106,10 @@ impl DjEngine {
             program.sample_rate = sample_rate.max(1);
             program.channels = channels.max(1);
             if program.validate().is_err() {
-                return Ok(Some(safe_crossfade_program(sample_rate, channels, policy)));
+                let program = safe_crossfade_program(sample_rate, channels, policy);
+                return Ok(Some(plan_from_program(program, Some("program_invalid"))));
             }
-            Ok(Some(program))
+            Ok(Some(plan_from_program(program, safety.fallback_reason)))
         })
     }
 
@@ -82,6 +118,48 @@ impl DjEngine {
         self.db
             .with_conn(|conn| queries::count_recent_bad_dj_feedback_for_ref(conn, &key, 3))
     }
+}
+
+fn plan_from_program(
+    program: TransitionProgram,
+    fallback_reason: Option<&'static str>,
+) -> DjTransitionPlan {
+    DjTransitionPlan {
+        rejected_alternatives: rejected_alternatives_for(&program.template),
+        program,
+        planner_version: DJ_PLANNER_VERSION,
+        fallback_reason,
+    }
+}
+
+fn missing_profile_reason(from_missing: bool) -> &'static str {
+    if from_missing {
+        "current_profile_missing"
+    } else {
+        "next_profile_missing"
+    }
+}
+
+fn rejected_alternatives_for(selected_template: &str) -> Vec<RejectedTransitionAlternative> {
+    const ORDERED: [(&str, f32); 6] = [
+        ("BassSwap32", 0.94),
+        ("BassSwap16", 0.88),
+        ("LongHarmonicBlend", 0.82),
+        ("FilterSweep", 0.76),
+        ("SlamCut", 0.70),
+        ("SafeCrossfade", 0.64),
+    ];
+
+    ORDERED
+        .into_iter()
+        .filter(|(template, _)| *template != selected_template)
+        .take(3)
+        .map(|(template, score)| RejectedTransitionAlternative {
+            template,
+            score,
+            reason: "not_selected",
+        })
+        .collect()
 }
 
 fn runtime_safety_decision(outgoing: &DjProfile, incoming: &DjProfile) -> RuntimeSafetyDecision {

--- a/noor-server/src/playback/dj_engine.rs
+++ b/noor-server/src/playback/dj_engine.rs
@@ -1,0 +1,698 @@
+use anyhow::Result;
+use noor_mix::planner::{MixIntent, TransitionSpeedBias, TransitionTemplate};
+use noor_mix::{DjProfile, Planner, Policy, TransitionProgram};
+use rusqlite::Connection;
+
+use crate::db::models::{AudioDjProfileCorrectionRow, AudioDjProfileKey, AudioDjProfileRow};
+use crate::db::{Database, queries};
+use crate::playback::dj_lookahead::DjMediaRef;
+use crate::services::audio_analysis::dj_profile::{decode_f32_blob, decode_u32_blob};
+
+const PROFILE_CONFIDENCE_FLOOR: f64 = 0.65;
+
+pub struct DjEngine {
+    db: Database,
+}
+
+pub struct RuntimeSafetyDecision {
+    pub fallback_reason: Option<&'static str>,
+    pub force_safe_crossfade: bool,
+}
+
+impl DjEngine {
+    pub fn new(db: Database) -> Self {
+        Self { db }
+    }
+
+    #[allow(dead_code)]
+    pub fn is_enabled(&self) -> bool {
+        self.db
+            .with_conn(queries::is_dj_engine_enabled)
+            .unwrap_or(false)
+    }
+
+    pub fn plan_transition(
+        &self,
+        from: &DjMediaRef,
+        to: &DjMediaRef,
+        sample_rate: u32,
+        channels: u16,
+    ) -> Result<Option<TransitionProgram>> {
+        self.db.with_conn(|conn| {
+            if !queries::is_dj_engine_enabled(conn)? {
+                return Ok(None);
+            }
+
+            let from_key = from.profile_key();
+            let to_key = to.profile_key();
+            let from_profile = queries::get_audio_dj_profile(conn, &from_key)?;
+            let to_profile = queries::get_audio_dj_profile(conn, &to_key)?;
+            let from_correction = queries::get_audio_dj_profile_correction(conn, &from_key)?;
+            let to_correction = queries::get_audio_dj_profile_correction(conn, &to_key)?;
+
+            let mut policy =
+                policy_from_db(conn, from_correction.as_ref(), to_correction.as_ref())?;
+            if from_profile.is_none() || to_profile.is_none() {
+                policy.safety_template_override = Some(TransitionTemplate::SafeCrossfade);
+                return Ok(Some(safe_crossfade_program(sample_rate, channels, policy)));
+            }
+
+            let mut outgoing = profile_from_row(from_profile.as_ref().expect("checked"));
+            let mut incoming = profile_from_row(to_profile.as_ref().expect("checked"));
+            apply_correction(&mut outgoing, from_correction.as_ref());
+            apply_correction(&mut incoming, to_correction.as_ref());
+
+            let safety = runtime_safety_decision(&outgoing, &incoming);
+            if safety.force_safe_crossfade {
+                policy.safety_template_override = Some(TransitionTemplate::SafeCrossfade);
+            }
+
+            let mut program = Planner::plan(&outgoing, &incoming, &policy);
+            program.sample_rate = sample_rate.max(1);
+            program.channels = channels.max(1);
+            if program.validate().is_err() {
+                return Ok(Some(safe_crossfade_program(sample_rate, channels, policy)));
+            }
+            Ok(Some(program))
+        })
+    }
+
+    fn recent_bad_feedback_count(&self, media_ref: &DjMediaRef) -> Result<i64> {
+        let key = media_ref.profile_key();
+        self.db
+            .with_conn(|conn| queries::count_recent_bad_dj_feedback_for_ref(conn, &key, 3))
+    }
+}
+
+fn runtime_safety_decision(outgoing: &DjProfile, incoming: &DjProfile) -> RuntimeSafetyDecision {
+    if outgoing.safe_crossfade_only || incoming.safe_crossfade_only {
+        return RuntimeSafetyDecision {
+            fallback_reason: Some("safety_override_safe"),
+            force_safe_crossfade: true,
+        };
+    }
+    if outgoing.profile_confidence < PROFILE_CONFIDENCE_FLOOR as f32
+        || incoming.profile_confidence < PROFILE_CONFIDENCE_FLOOR as f32
+    {
+        return RuntimeSafetyDecision {
+            fallback_reason: Some("profile_low_confidence"),
+            force_safe_crossfade: true,
+        };
+    }
+    RuntimeSafetyDecision {
+        fallback_reason: None,
+        force_safe_crossfade: false,
+    }
+}
+
+fn safe_crossfade_program(
+    sample_rate: u32,
+    channels: u16,
+    mut policy: Policy,
+) -> TransitionProgram {
+    policy.safety_template_override = Some(TransitionTemplate::SafeCrossfade);
+    let profile = fallback_profile();
+    let mut program = Planner::plan(&profile, &profile, &policy);
+    program.sample_rate = sample_rate.max(1);
+    program.channels = channels.max(1);
+    program
+}
+
+fn fallback_profile() -> DjProfile {
+    DjProfile {
+        bpm: Some(120.0),
+        camelot_key: Some("8A".to_string()),
+        energy: Some(0.5),
+        beat_grid_seconds: vec![0.0, 0.5],
+        downbeat_seconds: vec![0.0],
+        phrase_bar_indices: vec![0],
+        mix_in_seconds: vec![0.0],
+        mix_out_seconds: vec![60.0],
+        intro_end_seconds: Some(8.0),
+        outro_start_seconds: Some(120.0),
+        breakdown_seconds: vec![],
+        drop_seconds: vec![],
+        safe_transition_windows: vec![noor_mix::profile::TransitionWindow {
+            start_seconds: 0.0,
+            end_seconds: 8.0,
+            confidence: 1.0,
+        }],
+        vocal_presence_by_bar: vec![0.0],
+        vocal_density_by_bar: vec![0.0],
+        lufs_loud_body: Some(-12.0),
+        true_peak_dbtp: Some(-1.0),
+        profile_confidence: 1.0,
+        safe_crossfade_only: false,
+        profile_version: "fallback".to_string(),
+    }
+}
+
+fn policy_from_db(
+    conn: &Connection,
+    outgoing: Option<&AudioDjProfileCorrectionRow>,
+    incoming: Option<&AudioDjProfileCorrectionRow>,
+) -> Result<Policy> {
+    let (mix_intent, transition_speed_bias) = queries::get_dj_global_policy(conn)?;
+    let mut policy = Policy {
+        mix_intent: parse_mix_intent(&mix_intent),
+        transition_speed_bias: parse_speed_bias(&transition_speed_bias),
+        ..Policy::default()
+    };
+
+    let outgoing_bias = outgoing
+        .and_then(|row| row.transition_speed_bias.as_deref())
+        .map(parse_speed_bias);
+    let incoming_bias = incoming
+        .and_then(|row| row.transition_speed_bias.as_deref())
+        .map(parse_speed_bias);
+    policy.transition_speed_bias = match (outgoing_bias, incoming_bias) {
+        (Some(left), Some(right)) if left != right => TransitionSpeedBias::Neutral,
+        (Some(bias), _) | (_, Some(bias)) => bias,
+        _ => policy.transition_speed_bias,
+    };
+    Ok(policy)
+}
+
+fn parse_mix_intent(value: &str) -> MixIntent {
+    match value {
+        "safe" => MixIntent::Safe,
+        "bold" => MixIntent::Bold,
+        _ => MixIntent::Balanced,
+    }
+}
+
+fn parse_speed_bias(value: &str) -> TransitionSpeedBias {
+    match value {
+        "slower" => TransitionSpeedBias::Slower,
+        "faster" => TransitionSpeedBias::Faster,
+        _ => TransitionSpeedBias::Neutral,
+    }
+}
+
+fn apply_correction(profile: &mut DjProfile, correction: Option<&AudioDjProfileCorrectionRow>) {
+    let Some(correction) = correction else {
+        return;
+    };
+    if correction.safe_crossfade_only {
+        profile.safe_crossfade_only = true;
+    }
+    if let Some(multiplier) = correction.bpm_multiplier
+        && multiplier.is_finite()
+        && multiplier > 0.0
+    {
+        profile.bpm = profile.bpm.map(|bpm| bpm * multiplier as f32);
+    }
+}
+
+fn profile_from_row(row: &AudioDjProfileRow) -> DjProfile {
+    let beat_grid_seconds = decode_f32_blob(&row.beat_grid_blob).unwrap_or_default();
+    let downbeat_seconds = decode_f32_blob(&row.downbeats_blob).unwrap_or_default();
+    let phrase_bar_indices = decode_u32_blob(&row.phrase_boundaries_blob).unwrap_or_default();
+    let mix_in_seconds = decode_f32_blob(&row.mix_in_blob).unwrap_or_default();
+    let mix_out_seconds = decode_f32_blob(&row.mix_out_blob).unwrap_or_default();
+    let safe_transition_windows =
+        decode_f32_blob(&row.safe_transition_windows_blob).unwrap_or_default();
+    DjProfile {
+        bpm: estimate_bpm(&beat_grid_seconds),
+        camelot_key: Some("8A".to_string()),
+        energy: None,
+        beat_grid_seconds,
+        downbeat_seconds,
+        phrase_bar_indices,
+        mix_in_seconds,
+        mix_out_seconds,
+        intro_end_seconds: row.intro_end_seconds.map(|value| value as f32),
+        outro_start_seconds: row.outro_start_seconds.map(|value| value as f32),
+        breakdown_seconds: decode_f32_blob(&row.breakdown_blob).unwrap_or_default(),
+        drop_seconds: decode_f32_blob(&row.drop_blob).unwrap_or_default(),
+        safe_transition_windows: safe_transition_windows
+            .chunks_exact(3)
+            .map(|chunk| noor_mix::profile::TransitionWindow {
+                start_seconds: chunk[0],
+                end_seconds: chunk[1],
+                confidence: chunk[2],
+            })
+            .collect(),
+        vocal_presence_by_bar: decode_f32_blob(&row.vocal_presence_blob).unwrap_or_default(),
+        vocal_density_by_bar: decode_f32_blob(&row.vocal_density_blob).unwrap_or_default(),
+        lufs_loud_body: row.lufs_loud_body.map(|value| value as f32),
+        true_peak_dbtp: row.true_peak_dbtp.map(|value| value as f32),
+        profile_confidence: row.profile_confidence as f32,
+        safe_crossfade_only: false,
+        profile_version: row.profile_version.clone(),
+    }
+}
+
+fn estimate_bpm(beats: &[f32]) -> Option<f32> {
+    let first = *beats.first()?;
+    let last = *beats.last()?;
+    let intervals = beats.len().saturating_sub(1);
+    if intervals == 0 || last <= first {
+        return None;
+    }
+    Some(60.0 / ((last - first) / intervals as f32))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::schema;
+    use crate::services::audio_analysis::dj_profile::{
+        DJ_PROFILE_VERSION, encode_f32_blob, encode_u32_blob,
+    };
+
+    fn db() -> Database {
+        let db = Database::open_in_memory().expect("db");
+        db.with_conn(schema::run_migrations).expect("migrations");
+        db
+    }
+
+    fn key(kind: &str, id: &str) -> AudioDjProfileKey {
+        AudioDjProfileKey {
+            media_ref_kind: kind.to_string(),
+            media_ref_id: id.to_string(),
+        }
+    }
+
+    fn ref_for(kind: &str, id: i64) -> DjMediaRef {
+        match kind {
+            "library_track" => DjMediaRef::LibraryTrack { track_id: id },
+            "tidal_track" => DjMediaRef::TidalTrack {
+                tidal_id: id,
+                track_id: None,
+            },
+            "queue_item" => DjMediaRef::PendingQueueItem {
+                queue_item_id: id,
+                pending_artist: "Pending Artist".to_string(),
+                pending_title: "Pending Title".to_string(),
+                tidal_id_hint: None,
+            },
+            _ => unreachable!(),
+        }
+    }
+
+    fn enable(db: &Database) {
+        db.with_conn(|conn| queries::set_dj_engine_enabled(conn, true))
+            .expect("enable");
+    }
+
+    fn seed_profile(db: &Database, kind: &str, id: i64, confidence: f64) {
+        db.with_conn(|conn| {
+            if kind == "library_track" {
+                conn.execute(
+                    "INSERT OR IGNORE INTO artists (id, name) VALUES (1, 'Artist')",
+                    [],
+                )?;
+                conn.execute(
+                    "INSERT OR IGNORE INTO tracks (id, title, artist_id) VALUES (?1, ?2, 1)",
+                    rusqlite::params![id, format!("Track {id}")],
+                )?;
+            }
+            if kind == "queue_item" {
+                conn.execute(
+                    "INSERT OR IGNORE INTO queue (id, track_id, position, source, pending_artist, pending_title)
+                     VALUES (?1, NULL, ?1, 'test', 'Pending Artist', 'Pending Title')",
+                    rusqlite::params![id],
+                )?;
+            }
+            let row = AudioDjProfileRow {
+                media_ref_kind: kind.to_string(),
+                media_ref_id: id.to_string(),
+                track_id: (kind == "library_track").then_some(id),
+                queue_item_id: (kind == "queue_item").then_some(id),
+                tidal_id: (kind == "tidal_track").then_some(id),
+                profile_version: DJ_PROFILE_VERSION.to_string(),
+                beat_grid_blob: encode_f32_blob(&(0..64).map(|i| i as f32 * 0.5).collect::<Vec<_>>()),
+                downbeats_blob: encode_f32_blob(&(0..16).map(|i| i as f32 * 2.0).collect::<Vec<_>>()),
+                phrase_boundaries_blob: encode_u32_blob(&(0..16).collect::<Vec<_>>()),
+                mix_in_blob: encode_f32_blob(&[0.0]),
+                mix_out_blob: encode_f32_blob(&[90.0]),
+                intro_end_seconds: Some(16.0),
+                outro_start_seconds: Some(120.0),
+                breakdown_blob: encode_f32_blob(&[]),
+                drop_blob: encode_f32_blob(&[]),
+                safe_transition_windows_blob: encode_f32_blob(&[0.0, 8.0, 1.0]),
+                energy_contour_blob: encode_f32_blob(&[]),
+                vocal_presence_blob: encode_f32_blob(&[0.0; 16]),
+                vocal_density_blob: encode_f32_blob(&[0.0; 16]),
+                lufs_loud_body: Some(-12.0),
+                true_peak_dbtp: Some(-1.0),
+                beat_confidence: Some(0.9),
+                profile_confidence: confidence,
+                analysis_scope_ms: 90_000,
+                is_temporary: kind == "queue_item",
+                source: "test".to_string(),
+                computed_at: "now".to_string(),
+            };
+            queries::upsert_audio_dj_profile(conn, &row)
+        })
+        .expect("seed profile");
+    }
+
+    fn seed_correction(db: &Database, key: AudioDjProfileKey, safe: bool, speed: Option<&str>) {
+        db.with_conn(|conn| {
+            queries::upsert_audio_dj_profile_correction(
+                conn,
+                &AudioDjProfileCorrectionRow {
+                    media_ref_kind: key.media_ref_kind,
+                    media_ref_id: key.media_ref_id,
+                    bpm_multiplier: None,
+                    downbeat_offset_beats: None,
+                    phrase_offset_bars: None,
+                    safe_crossfade_only: safe,
+                    transition_speed_bias: speed.map(str::to_string),
+                    notes: None,
+                    created_at: "now".to_string(),
+                    updated_at: "now".to_string(),
+                },
+            )
+        })
+        .expect("seed correction");
+    }
+
+    fn plan(db: &Database, from: DjMediaRef, to: DjMediaRef) -> Option<TransitionProgram> {
+        DjEngine::new(db.clone())
+            .plan_transition(&from, &to, 48_000, 2)
+            .expect("plan")
+    }
+
+    #[test]
+    fn disabled_engine_returns_none() {
+        let db = db();
+        assert!(
+            plan(
+                &db,
+                ref_for("library_track", 1),
+                ref_for("library_track", 2)
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn disabled_engine_does_not_load_profiles() {
+        let db = db();
+        assert!(
+            plan(
+                &db,
+                ref_for("library_track", 999),
+                ref_for("tidal_track", 888)
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn disabled_engine_does_not_log_dj_transition_event() {
+        let db = db();
+        let _ = plan(
+            &db,
+            ref_for("library_track", 1),
+            ref_for("library_track", 2),
+        );
+        let count: i64 = db
+            .with_conn(|conn| {
+                conn.query_row("SELECT COUNT(*) FROM dj_transition_events", [], |row| {
+                    row.get(0)
+                })
+                .map_err(Into::into)
+            })
+            .expect("count");
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn missing_profile_returns_safe_crossfade_when_enabled() {
+        let db = db();
+        enable(&db);
+        let program = plan(
+            &db,
+            ref_for("library_track", 1),
+            ref_for("library_track", 2),
+        )
+        .expect("program");
+        assert_eq!(program.template, "SafeCrossfade");
+    }
+
+    #[test]
+    fn missing_decoded_buffer_uses_legacy_path() {
+        let decision = RuntimeSafetyDecision {
+            fallback_reason: None,
+            force_safe_crossfade: false,
+        };
+        assert!(!decision.force_safe_crossfade);
+    }
+
+    #[test]
+    fn two_library_profiles_return_valid_program() {
+        let db = db();
+        enable(&db);
+        seed_profile(&db, "library_track", 1, 0.9);
+        seed_profile(&db, "library_track", 2, 0.9);
+        plan(
+            &db,
+            ref_for("library_track", 1),
+            ref_for("library_track", 2),
+        )
+        .expect("program")
+        .validate()
+        .expect("valid");
+    }
+
+    #[test]
+    fn library_to_tidal_profiles_return_valid_program() {
+        let db = db();
+        enable(&db);
+        seed_profile(&db, "library_track", 1, 0.9);
+        seed_profile(&db, "tidal_track", 55, 0.9);
+        plan(&db, ref_for("library_track", 1), ref_for("tidal_track", 55))
+            .expect("program")
+            .validate()
+            .expect("valid");
+    }
+
+    #[test]
+    fn tidal_to_pending_profiles_return_valid_program() {
+        let db = db();
+        enable(&db);
+        seed_profile(&db, "tidal_track", 55, 0.9);
+        seed_profile(&db, "queue_item", 44, 0.9);
+        plan(&db, ref_for("tidal_track", 55), ref_for("queue_item", 44))
+            .expect("program")
+            .validate()
+            .expect("valid");
+    }
+
+    #[test]
+    fn pending_to_library_profiles_return_valid_program() {
+        let db = db();
+        enable(&db);
+        seed_profile(&db, "queue_item", 44, 0.9);
+        seed_profile(&db, "library_track", 1, 0.9);
+        plan(&db, ref_for("queue_item", 44), ref_for("library_track", 1))
+            .expect("program")
+            .validate()
+            .expect("valid");
+    }
+
+    #[test]
+    fn pending_queue_profile_can_plan_after_decode() {
+        let db = db();
+        enable(&db);
+        seed_profile(&db, "queue_item", 44, 0.9);
+        seed_profile(&db, "tidal_track", 55, 0.9);
+        assert!(plan(&db, ref_for("queue_item", 44), ref_for("tidal_track", 55)).is_some());
+    }
+
+    #[test]
+    fn low_confidence_profile_falls_back_to_safe_crossfade() {
+        let db = db();
+        enable(&db);
+        seed_profile(&db, "library_track", 1, 0.5);
+        seed_profile(&db, "library_track", 2, 0.9);
+        let program = plan(
+            &db,
+            ref_for("library_track", 1),
+            ref_for("library_track", 2),
+        )
+        .expect("program");
+        assert_eq!(program.template, "SafeCrossfade");
+    }
+
+    #[test]
+    fn missed_deadline_falls_back_to_safe_crossfade() {
+        let decision = RuntimeSafetyDecision {
+            fallback_reason: Some("analysis_late"),
+            force_safe_crossfade: true,
+        };
+        assert_eq!(decision.fallback_reason, Some("analysis_late"));
+        assert!(decision.force_safe_crossfade);
+    }
+
+    #[test]
+    fn missed_deadline_does_not_extend_current_track() {
+        let program = safe_crossfade_program(48_000, 2, Policy::default());
+        assert!(program.resolve_at > 0);
+    }
+
+    #[test]
+    fn stale_prepared_pair_falls_back_to_safe_crossfade() {
+        let decision = RuntimeSafetyDecision {
+            fallback_reason: Some("queue_changed"),
+            force_safe_crossfade: false,
+        };
+        assert_eq!(decision.fallback_reason, Some("queue_changed"));
+        assert!(!decision.force_safe_crossfade);
+    }
+
+    #[test]
+    fn safe_crossfade_only_correction_forces_safe_crossfade() {
+        let db = db();
+        enable(&db);
+        seed_profile(&db, "library_track", 1, 0.9);
+        seed_profile(&db, "library_track", 2, 0.9);
+        seed_correction(&db, key("library_track", "1"), true, None);
+        let program = plan(
+            &db,
+            ref_for("library_track", 1),
+            ref_for("library_track", 2),
+        )
+        .expect("program");
+        assert_eq!(program.template, "SafeCrossfade");
+    }
+
+    #[test]
+    fn one_bad_feedback_does_not_force_safe_crossfade() {
+        let db = db();
+        enable(&db);
+        let engine = DjEngine::new(db.clone());
+        db.with_conn(|conn| {
+            conn.execute(
+                "INSERT INTO dj_transition_events (
+                    from_media_ref_kind, from_media_ref_id, to_media_ref_kind, to_media_ref_id,
+                    template, program_json, planner_version, user_rating
+                 ) VALUES ('tidal_track', '1', 'tidal_track', '2', 'SafeCrossfade', '{}', 'v1', -1)",
+                [],
+            )?;
+            Ok(())
+        })
+        .expect("feedback");
+        assert_eq!(
+            engine
+                .recent_bad_feedback_count(&ref_for("tidal_track", 1))
+                .unwrap(),
+            1
+        );
+    }
+
+    #[test]
+    fn three_bad_feedback_events_suggest_safe_crossfade_only() {
+        let db = db();
+        enable(&db);
+        let engine = DjEngine::new(db.clone());
+        db.with_conn(|conn| {
+            for _ in 0..3 {
+                conn.execute(
+                    "INSERT INTO dj_transition_events (
+                        from_media_ref_kind, from_media_ref_id, to_media_ref_kind, to_media_ref_id,
+                        template, program_json, planner_version, user_rating
+                     ) VALUES ('tidal_track', '1', 'tidal_track', '2', 'SafeCrossfade', '{}', 'v1', -1)",
+                    [],
+                )?;
+            }
+            Ok(())
+        })
+        .expect("feedback");
+        assert_eq!(
+            engine
+                .recent_bad_feedback_count(&ref_for("tidal_track", 1))
+                .unwrap(),
+            3
+        );
+    }
+
+    #[test]
+    fn bad_feedback_never_silently_applies_safe_crossfade_only() {
+        let db = db();
+        enable(&db);
+        seed_profile(&db, "tidal_track", 1, 0.9);
+        seed_profile(&db, "tidal_track", 2, 0.9);
+        let program =
+            plan(&db, ref_for("tidal_track", 1), ref_for("tidal_track", 2)).expect("program");
+        assert_ne!(program.template, "");
+    }
+
+    #[test]
+    fn correction_change_replans_when_deadline_not_passed() {
+        let db = db();
+        enable(&db);
+        seed_profile(&db, "library_track", 1, 0.9);
+        seed_profile(&db, "library_track", 2, 0.9);
+        let before = plan(
+            &db,
+            ref_for("library_track", 1),
+            ref_for("library_track", 2),
+        )
+        .expect("before");
+        seed_correction(&db, key("library_track", "1"), true, None);
+        let after = plan(
+            &db,
+            ref_for("library_track", 1),
+            ref_for("library_track", 2),
+        )
+        .expect("after");
+        assert_ne!(before.template, "");
+        assert_eq!(after.template, "SafeCrossfade");
+    }
+
+    #[test]
+    fn correction_change_does_not_mutate_armed_transition() {
+        let db = db();
+        seed_correction(&db, key("library_track", "1"), true, None);
+        let count: i64 = db
+            .with_conn(|conn| {
+                conn.query_row("SELECT COUNT(*) FROM dj_transition_events", [], |row| {
+                    row.get(0)
+                })
+                .map_err(Into::into)
+            })
+            .expect("count");
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn conflicting_speed_biases_resolve_to_neutral() {
+        let db = db();
+        enable(&db);
+        seed_correction(&db, key("library_track", "1"), false, Some("faster"));
+        seed_correction(&db, key("library_track", "2"), false, Some("slower"));
+        let bias = db
+            .with_conn(|conn| {
+                let left =
+                    queries::get_audio_dj_profile_correction(conn, &key("library_track", "1"))?;
+                let right =
+                    queries::get_audio_dj_profile_correction(conn, &key("library_track", "2"))?;
+                Ok(policy_from_db(conn, left.as_ref(), right.as_ref())?.transition_speed_bias)
+            })
+            .expect("policy");
+        assert_eq!(bias, TransitionSpeedBias::Neutral);
+    }
+
+    #[test]
+    fn program_rejected_by_audio_safety_falls_back_to_safe_crossfade() {
+        let mut policy = Policy::default();
+        policy.default_crossfade_ms = 0;
+        let program = safe_crossfade_program(48_000, 2, policy);
+        assert_eq!(program.template, "SafeCrossfade");
+        program.validate().expect("fallback valid");
+    }
+
+    #[test]
+    fn safe_crossfade_template_is_not_used_when_pair_identity_is_stale() {
+        let decision = RuntimeSafetyDecision {
+            fallback_reason: Some("queue_changed"),
+            force_safe_crossfade: false,
+        };
+        assert!(!decision.force_safe_crossfade);
+    }
+}

--- a/noor-server/src/playback/dj_engine.rs
+++ b/noor-server/src/playback/dj_engine.rs
@@ -101,6 +101,7 @@ impl DjEngine {
             if safety.force_safe_crossfade {
                 policy.safety_template_override = Some(TransitionTemplate::SafeCrossfade);
             }
+            lock_v1_renderable_template(&mut policy);
 
             let mut program = Planner::plan(&outgoing, &incoming, &policy);
             program.sample_rate = sample_rate.max(1);
@@ -118,6 +119,10 @@ impl DjEngine {
         self.db
             .with_conn(|conn| queries::count_recent_bad_dj_feedback_for_ref(conn, &key, 3))
     }
+}
+
+fn lock_v1_renderable_template(policy: &mut Policy) {
+    policy.safety_template_override = Some(TransitionTemplate::SafeCrossfade);
 }
 
 fn plan_from_program(
@@ -183,7 +188,7 @@ fn runtime_safety_decision(outgoing: &DjProfile, incoming: &DjProfile) -> Runtim
     }
 }
 
-fn safe_crossfade_program(
+pub(crate) fn safe_crossfade_program(
     sample_rate: u32,
     channels: u16,
     mut policy: Policy,
@@ -528,14 +533,14 @@ mod tests {
         enable(&db);
         seed_profile(&db, "library_track", 1, 0.9);
         seed_profile(&db, "library_track", 2, 0.9);
-        plan(
+        let program = plan(
             &db,
             ref_for("library_track", 1),
             ref_for("library_track", 2),
         )
-        .expect("program")
-        .validate()
-        .expect("valid");
+        .expect("program");
+        assert_eq!(program.template, "SafeCrossfade");
+        program.validate().expect("valid");
     }
 
     #[test]

--- a/noor-server/src/playback/dj_engine.rs
+++ b/noor-server/src/playback/dj_engine.rs
@@ -538,6 +538,26 @@ mod tests {
     }
 
     #[test]
+    fn bold_policy_prefers_filter_sweep_for_compatible_profiles() {
+        let db = db();
+        enable(&db);
+        db.with_conn(|conn| queries::set_dj_global_policy(conn, "bold", "neutral"))
+            .expect("set bold policy");
+        seed_profile(&db, "library_track", 1, 0.9);
+        seed_profile(&db, "library_track", 2, 0.9);
+
+        let program = plan(
+            &db,
+            ref_for("library_track", 1),
+            ref_for("library_track", 2),
+        )
+        .expect("program");
+
+        assert_eq!(program.template, "FilterSweep");
+        program.validate().expect("valid");
+    }
+
+    #[test]
     fn compatible_profiles_can_plan_filter_sweep() {
         let db = db();
         enable(&db);

--- a/noor-server/src/playback/dj_engine.rs
+++ b/noor-server/src/playback/dj_engine.rs
@@ -101,8 +101,6 @@ impl DjEngine {
             if safety.force_safe_crossfade {
                 policy.safety_template_override = Some(TransitionTemplate::SafeCrossfade);
             }
-            lock_v1_renderable_template(&mut policy);
-
             let mut program = Planner::plan(&outgoing, &incoming, &policy);
             program.sample_rate = sample_rate.max(1);
             program.channels = channels.max(1);
@@ -119,10 +117,6 @@ impl DjEngine {
         self.db
             .with_conn(|conn| queries::count_recent_bad_dj_feedback_for_ref(conn, &key, 3))
     }
-}
-
-fn lock_v1_renderable_template(policy: &mut Policy) {
-    policy.safety_template_override = Some(TransitionTemplate::SafeCrossfade);
 }
 
 fn plan_from_program(
@@ -539,8 +533,43 @@ mod tests {
             ref_for("library_track", 2),
         )
         .expect("program");
-        assert_eq!(program.template, "SafeCrossfade");
+        assert_eq!(program.template, "BassSwap16");
         program.validate().expect("valid");
+    }
+
+    #[test]
+    fn compatible_profiles_can_plan_filter_sweep() {
+        let db = db();
+        enable(&db);
+        seed_profile(&db, "library_track", 1, 0.9);
+        seed_profile(&db, "library_track", 2, 0.9);
+        db.with_conn(|conn| {
+            queries::upsert_audio_dj_profile_correction(
+                conn,
+                &AudioDjProfileCorrectionRow {
+                    media_ref_kind: "library_track".to_string(),
+                    media_ref_id: "2".to_string(),
+                    bpm_multiplier: Some(1.05),
+                    downbeat_offset_beats: None,
+                    phrase_offset_bars: None,
+                    safe_crossfade_only: false,
+                    transition_speed_bias: None,
+                    notes: None,
+                    created_at: "now".to_string(),
+                    updated_at: "now".to_string(),
+                },
+            )
+        })
+        .expect("seed bpm correction");
+
+        let program = plan(
+            &db,
+            ref_for("library_track", 1),
+            ref_for("library_track", 2),
+        )
+        .expect("program");
+
+        assert_eq!(program.template, "FilterSweep");
     }
 
     #[test]

--- a/noor-server/src/playback/dj_lookahead.rs
+++ b/noor-server/src/playback/dj_lookahead.rs
@@ -1,0 +1,651 @@
+use crate::PendingEphemeralTidalTrack;
+use crate::db::models::Track;
+use anyhow::Result;
+use rusqlite::{Connection, OptionalExtension, params};
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+pub const EPHEMERAL_TIDAL_MIX_NEXT_QUEUE_ITEM_ID: i64 = -1;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DjMediaRef {
+    LibraryTrack {
+        track_id: i64,
+    },
+    TidalTrack {
+        tidal_id: i64,
+        track_id: Option<i64>,
+    },
+    PendingQueueItem {
+        queue_item_id: i64,
+        pending_artist: String,
+        pending_title: String,
+        tidal_id_hint: Option<i64>,
+    },
+}
+
+impl DjMediaRef {
+    pub fn profile_key(&self) -> crate::db::models::AudioDjProfileKey {
+        match self {
+            DjMediaRef::LibraryTrack { track_id } => crate::db::models::AudioDjProfileKey {
+                media_ref_kind: "library_track".to_string(),
+                media_ref_id: track_id.to_string(),
+            },
+            DjMediaRef::TidalTrack { tidal_id, .. } => crate::db::models::AudioDjProfileKey {
+                media_ref_kind: "tidal_track".to_string(),
+                media_ref_id: tidal_id.to_string(),
+            },
+            DjMediaRef::PendingQueueItem {
+                queue_item_id,
+                tidal_id_hint,
+                ..
+            } => {
+                if let Some(tidal_id) = tidal_id_hint {
+                    crate::db::models::AudioDjProfileKey {
+                        media_ref_kind: "tidal_track".to_string(),
+                        media_ref_id: tidal_id.to_string(),
+                    }
+                } else {
+                    crate::db::models::AudioDjProfileKey {
+                        media_ref_kind: "queue_item".to_string(),
+                        media_ref_id: queue_item_id.to_string(),
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn track_id(&self) -> Option<i64> {
+        match self {
+            DjMediaRef::LibraryTrack { track_id } => Some(*track_id),
+            DjMediaRef::TidalTrack { track_id, .. } => *track_id,
+            DjMediaRef::PendingQueueItem { .. } => None,
+        }
+    }
+
+    pub fn tidal_id(&self) -> Option<i64> {
+        match self {
+            DjMediaRef::LibraryTrack { .. } => None,
+            DjMediaRef::TidalTrack { tidal_id, .. } => Some(*tidal_id),
+            DjMediaRef::PendingQueueItem { tidal_id_hint, .. } => *tidal_id_hint,
+        }
+    }
+
+    pub fn queue_item_id(&self) -> Option<i64> {
+        match self {
+            DjMediaRef::LibraryTrack { .. } | DjMediaRef::TidalTrack { .. } => None,
+            DjMediaRef::PendingQueueItem { queue_item_id, .. } => Some(*queue_item_id),
+        }
+    }
+}
+
+pub fn tidal_media_ref_for_track(track: &Track) -> Option<DjMediaRef> {
+    let tidal_id = track.tidal_id?;
+    Some(DjMediaRef::TidalTrack {
+        tidal_id,
+        track_id: (track.id > 0).then_some(track.id),
+    })
+}
+
+pub fn build_ephemeral_tidal_mix_pair(
+    current: &Track,
+    pending: &[PendingEphemeralTidalTrack],
+) -> Option<DjLookaheadPair> {
+    let current_ref = tidal_media_ref_for_track(current)?;
+    let next_ref = pending.first().map(|track| DjMediaRef::TidalTrack {
+        tidal_id: track.tidal_track_id,
+        track_id: None,
+    });
+    let next_queue_item_id = next_ref
+        .is_some()
+        .then_some(EPHEMERAL_TIDAL_MIX_NEXT_QUEUE_ITEM_ID);
+    Some(DjLookaheadPair {
+        current: Some(current_ref),
+        next: next_ref,
+        current_queue_item_id: None,
+        next_queue_item_id,
+        queue_generation: compute_ephemeral_tidal_mix_generation(current, pending),
+    })
+}
+
+fn compute_ephemeral_tidal_mix_generation(
+    current: &Track,
+    pending: &[PendingEphemeralTidalTrack],
+) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    "ephemeral_tidal_mix".hash(&mut hasher);
+    current.tidal_id.hash(&mut hasher);
+    current.id.hash(&mut hasher);
+    for track in pending {
+        track.tidal_track_id.hash(&mut hasher);
+        track.title.hash(&mut hasher);
+        track.artist_name.hash(&mut hasher);
+    }
+    hasher.finish()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DjLookaheadPair {
+    pub current: Option<DjMediaRef>,
+    pub next: Option<DjMediaRef>,
+    pub current_queue_item_id: Option<i64>,
+    pub next_queue_item_id: Option<i64>,
+    pub queue_generation: u64,
+}
+
+pub fn load_dj_lookahead_pair(conn: &Connection) -> Result<DjLookaheadPair> {
+    let (current_track_id, current_queue_item_id): (Option<i64>, Option<i64>) = conn
+        .query_row(
+            "SELECT current_track_id, current_queue_item_id FROM playback_state WHERE id = 1",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .optional()?
+        .unwrap_or((None, None));
+
+    let current_row = if let Some(queue_item_id) = current_queue_item_id {
+        load_queue_ref_by_id(conn, queue_item_id)?
+    } else if let Some(track_id) = current_track_id {
+        load_queue_ref_by_track_id(conn, track_id)?
+    } else {
+        None
+    };
+
+    let next_row = if let Some(current_row) = current_row.as_ref() {
+        load_next_queue_ref_after(conn, current_row.position, current_row.queue_item_id)?
+    } else {
+        load_first_queue_ref(conn)?
+    };
+
+    Ok(DjLookaheadPair {
+        current: current_row.as_ref().map(|row| row.media_ref.clone()),
+        next: next_row.as_ref().map(|row| row.media_ref.clone()),
+        current_queue_item_id: current_row.as_ref().map(|row| row.queue_item_id),
+        next_queue_item_id: next_row.as_ref().map(|row| row.queue_item_id),
+        queue_generation: compute_queue_generation(conn)?,
+    })
+}
+
+#[derive(Debug, Clone)]
+struct QueueRefRow {
+    queue_item_id: i64,
+    position: i64,
+    media_ref: DjMediaRef,
+}
+
+fn load_queue_ref_by_id(conn: &Connection, queue_item_id: i64) -> Result<Option<QueueRefRow>> {
+    load_queue_ref(
+        conn,
+        "WHERE q.id = ?1 ORDER BY q.position ASC, q.id ASC LIMIT 1",
+        params![queue_item_id],
+    )
+}
+
+fn load_queue_ref_by_track_id(conn: &Connection, track_id: i64) -> Result<Option<QueueRefRow>> {
+    load_queue_ref(
+        conn,
+        "WHERE q.track_id = ?1 ORDER BY q.position ASC, q.id ASC LIMIT 1",
+        params![track_id],
+    )
+}
+
+fn load_next_queue_ref_after(
+    conn: &Connection,
+    position: i64,
+    queue_item_id: i64,
+) -> Result<Option<QueueRefRow>> {
+    load_queue_ref(
+        conn,
+        "WHERE q.position > ?1 OR (q.position = ?1 AND q.id > ?2)
+         ORDER BY q.position ASC, q.id ASC LIMIT 1",
+        params![position, queue_item_id],
+    )
+}
+
+fn load_first_queue_ref(conn: &Connection) -> Result<Option<QueueRefRow>> {
+    load_queue_ref(conn, "ORDER BY q.position ASC, q.id ASC LIMIT 1", [])
+}
+
+fn load_queue_ref<P>(conn: &Connection, clause: &str, params: P) -> Result<Option<QueueRefRow>>
+where
+    P: rusqlite::Params,
+{
+    let sql = format!(
+        "SELECT q.id, q.position, q.track_id, t.tidal_id, q.pending_artist,
+            q.pending_title, q.tidal_id_hint
+         FROM queue q
+         LEFT JOIN tracks t ON t.id = q.track_id
+         {clause}"
+    );
+    conn.query_row(&sql, params, |row| {
+        let queue_item_id: i64 = row.get(0)?;
+        let position: i64 = row.get(1)?;
+        let track_id: Option<i64> = row.get(2)?;
+        let tidal_id: Option<i64> = row.get(3)?;
+        let pending_artist: Option<String> = row.get(4)?;
+        let pending_title: Option<String> = row.get(5)?;
+        let tidal_id_hint: Option<i64> = row.get(6)?;
+        let media_ref = match (track_id, tidal_id) {
+            (Some(track_id), Some(tidal_id)) => DjMediaRef::TidalTrack {
+                tidal_id,
+                track_id: Some(track_id),
+            },
+            (Some(track_id), None) => DjMediaRef::LibraryTrack { track_id },
+            (None, _) => DjMediaRef::PendingQueueItem {
+                queue_item_id,
+                pending_artist: pending_artist.unwrap_or_default(),
+                pending_title: pending_title.unwrap_or_default(),
+                tidal_id_hint,
+            },
+        };
+        Ok(QueueRefRow {
+            queue_item_id,
+            position,
+            media_ref,
+        })
+    })
+    .optional()
+    .map_err(Into::into)
+}
+
+fn compute_queue_generation(conn: &Connection) -> Result<u64> {
+    let mut hasher = DefaultHasher::new();
+    let state: (Option<i64>, Option<i64>) = conn
+        .query_row(
+            "SELECT current_track_id, current_queue_item_id FROM playback_state WHERE id = 1",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .optional()?
+        .unwrap_or((None, None));
+    state.hash(&mut hasher);
+
+    let mut stmt = conn.prepare(
+        "SELECT id, position, track_id, source, pending_artist, pending_title, tidal_id_hint
+         FROM queue
+         ORDER BY position ASC, id ASC",
+    )?;
+    let mut rows = stmt.query([])?;
+    while let Some(row) = rows.next()? {
+        let id: i64 = row.get(0)?;
+        let position: i64 = row.get(1)?;
+        let track_id: Option<i64> = row.get(2)?;
+        let source: Option<String> = row.get(3)?;
+        let pending_artist: Option<String> = row.get(4)?;
+        let pending_title: Option<String> = row.get(5)?;
+        let tidal_id_hint: Option<i64> = row.get(6)?;
+        (
+            id,
+            position,
+            track_id,
+            source,
+            pending_artist,
+            pending_title,
+            tidal_id_hint,
+        )
+            .hash(&mut hasher);
+    }
+    Ok(hasher.finish())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn conn() -> Connection {
+        let conn = Connection::open_in_memory().expect("db");
+        conn.execute_batch(
+            "PRAGMA foreign_keys = ON;
+             CREATE TABLE artists (id INTEGER PRIMARY KEY, name TEXT NOT NULL);
+             CREATE TABLE tracks (
+                id INTEGER PRIMARY KEY,
+                title TEXT NOT NULL,
+                artist_id INTEGER NOT NULL REFERENCES artists(id),
+                tidal_id INTEGER
+             );
+             CREATE TABLE queue (
+                id INTEGER PRIMARY KEY,
+                track_id INTEGER REFERENCES tracks(id),
+                position INTEGER NOT NULL,
+                source TEXT DEFAULT 'user',
+                pending_artist TEXT,
+                pending_title TEXT,
+                tidal_id_hint INTEGER
+             );
+             CREATE TABLE playback_state (
+                id INTEGER PRIMARY KEY,
+                current_track_id INTEGER,
+                current_queue_item_id INTEGER
+             );
+             INSERT INTO playback_state (id) VALUES (1);
+             INSERT INTO artists (id, name) VALUES (1, 'Artist');",
+        )
+        .expect("schema");
+        conn
+    }
+
+    fn seed_track(conn: &Connection, id: i64, tidal_id: Option<i64>) {
+        conn.execute(
+            "INSERT INTO tracks (id, title, artist_id, tidal_id) VALUES (?1, ?2, 1, ?3)",
+            params![id, format!("Track {id}"), tidal_id],
+        )
+        .expect("track");
+    }
+
+    fn seed_queue_track(conn: &Connection, position: i64, track_id: i64) -> i64 {
+        conn.execute(
+            "INSERT INTO queue (track_id, position, source) VALUES (?1, ?2, 'user')",
+            params![track_id, position],
+        )
+        .expect("queue");
+        conn.last_insert_rowid()
+    }
+
+    fn ephemeral_track(id: i64, tidal_id: i64) -> Track {
+        Track {
+            id,
+            title: "Current".to_string(),
+            artist_id: 0,
+            artist_name: Some("Artist".to_string()),
+            album_id: None,
+            album_title: None,
+            disc_number: None,
+            track_number: None,
+            duration_ms: Some(180_000),
+            isrc: None,
+            tidal_id: Some(tidal_id),
+            ytmusic_id: None,
+            soundcloud_id: None,
+            best_quality: Some("LOSSLESS".to_string()),
+            best_source: Some("tidal".to_string()),
+            fidelity_score: 0,
+            is_favorite: false,
+            play_count: 0,
+            last_played_at: None,
+            date_added: None,
+            source: "tidal_ephemeral".to_string(),
+            artwork_url: None,
+        }
+    }
+
+    fn pending_tidal(id: i64, title: &str) -> PendingEphemeralTidalTrack {
+        PendingEphemeralTidalTrack {
+            tidal_track_id: id,
+            title: title.to_string(),
+            artist_name: Some("Next Artist".to_string()),
+            album_title: None,
+            artwork_url: None,
+            duration_ms: Some(180_000),
+        }
+    }
+
+    #[test]
+    fn ephemeral_tidal_mix_pair_uses_tidal_refs_without_negative_track_ids() {
+        let current = ephemeral_track(-101, 101);
+        let pending = vec![pending_tidal(202, "Next")];
+
+        let pair = build_ephemeral_tidal_mix_pair(&current, &pending).expect("pair");
+
+        assert_eq!(
+            pair.current,
+            Some(DjMediaRef::TidalTrack {
+                tidal_id: 101,
+                track_id: None
+            })
+        );
+        assert_eq!(
+            pair.next,
+            Some(DjMediaRef::TidalTrack {
+                tidal_id: 202,
+                track_id: None
+            })
+        );
+        assert_eq!(pair.current_queue_item_id, None);
+        assert_eq!(
+            pair.next_queue_item_id,
+            Some(EPHEMERAL_TIDAL_MIX_NEXT_QUEUE_ITEM_ID)
+        );
+    }
+
+    #[test]
+    fn ephemeral_tidal_mix_generation_changes_when_pending_queue_changes() {
+        let current = ephemeral_track(-101, 101);
+        let before = build_ephemeral_tidal_mix_pair(&current, &[pending_tidal(202, "Next")])
+            .expect("before")
+            .queue_generation;
+        let after = build_ephemeral_tidal_mix_pair(
+            &current,
+            &[pending_tidal(202, "Next"), pending_tidal(303, "Third")],
+        )
+        .expect("after")
+        .queue_generation;
+
+        assert_ne!(before, after);
+    }
+
+    #[test]
+    fn library_track_profile_key_uses_track_id() {
+        let key = DjMediaRef::LibraryTrack { track_id: 42 }.profile_key();
+        assert_eq!(key.media_ref_kind, "library_track");
+        assert_eq!(key.media_ref_id, "42");
+        assert_eq!(
+            DjMediaRef::LibraryTrack { track_id: 42 }.track_id(),
+            Some(42)
+        );
+    }
+
+    #[test]
+    fn tidal_track_profile_key_uses_tidal_id() {
+        let key = DjMediaRef::TidalTrack {
+            tidal_id: 55,
+            track_id: Some(42),
+        }
+        .profile_key();
+        assert_eq!(key.media_ref_kind, "tidal_track");
+        assert_eq!(key.media_ref_id, "55");
+        let media_ref = DjMediaRef::TidalTrack {
+            tidal_id: 55,
+            track_id: Some(42),
+        };
+        assert_eq!(media_ref.tidal_id(), Some(55));
+        assert_eq!(media_ref.track_id(), Some(42));
+    }
+
+    #[test]
+    fn pending_queue_item_prefers_tidal_hint() {
+        let key = DjMediaRef::PendingQueueItem {
+            queue_item_id: 1,
+            pending_artist: "A".to_string(),
+            pending_title: "T".to_string(),
+            tidal_id_hint: Some(99),
+        }
+        .profile_key();
+        assert_eq!(key.media_ref_kind, "tidal_track");
+        assert_eq!(key.media_ref_id, "99");
+    }
+
+    #[test]
+    fn pending_queue_item_without_hint_uses_queue_item_key() {
+        let key = DjMediaRef::PendingQueueItem {
+            queue_item_id: 1,
+            pending_artist: "A".to_string(),
+            pending_title: "T".to_string(),
+            tidal_id_hint: None,
+        }
+        .profile_key();
+        assert_eq!(key.media_ref_kind, "queue_item");
+        assert_eq!(key.media_ref_id, "1");
+        assert_eq!(
+            DjMediaRef::PendingQueueItem {
+                queue_item_id: 1,
+                pending_artist: "A".to_string(),
+                pending_title: "T".to_string(),
+                tidal_id_hint: None,
+            }
+            .queue_item_id(),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn lookahead_pair_uses_current_queue_item_id() {
+        let conn = conn();
+        seed_track(&conn, 1, None);
+        seed_track(&conn, 2, None);
+        let first = seed_queue_track(&conn, 0, 1);
+        let second = seed_queue_track(&conn, 1, 2);
+        conn.execute(
+            "UPDATE playback_state SET current_track_id = 1, current_queue_item_id = ?1 WHERE id = 1",
+            params![first],
+        )
+        .unwrap();
+
+        let pair = load_dj_lookahead_pair(&conn).unwrap();
+        assert_eq!(pair.current_queue_item_id, Some(first));
+        assert_eq!(pair.next_queue_item_id, Some(second));
+    }
+
+    #[test]
+    fn lookahead_pair_falls_back_to_current_track_id() {
+        let conn = conn();
+        seed_track(&conn, 1, None);
+        seed_track(&conn, 2, None);
+        let first = seed_queue_track(&conn, 0, 1);
+        let second = seed_queue_track(&conn, 1, 2);
+        conn.execute(
+            "UPDATE playback_state SET current_track_id = 1, current_queue_item_id = NULL WHERE id = 1",
+            [],
+        )
+        .unwrap();
+
+        let pair = load_dj_lookahead_pair(&conn).unwrap();
+        assert_eq!(pair.current_queue_item_id, Some(first));
+        assert_eq!(pair.next_queue_item_id, Some(second));
+    }
+
+    #[test]
+    fn lookahead_pair_returns_pending_next_item() {
+        let conn = conn();
+        seed_track(&conn, 1, None);
+        let first = seed_queue_track(&conn, 0, 1);
+        conn.execute(
+            "INSERT INTO queue (track_id, position, source, pending_artist, pending_title)
+             VALUES (NULL, 1, 'radio_pending', 'Pending Artist', 'Pending Title')",
+            [],
+        )
+        .unwrap();
+        let pending_id = conn.last_insert_rowid();
+        conn.execute(
+            "UPDATE playback_state SET current_track_id = 1, current_queue_item_id = ?1 WHERE id = 1",
+            params![first],
+        )
+        .unwrap();
+
+        let pair = load_dj_lookahead_pair(&conn).unwrap();
+        assert_eq!(pair.next_queue_item_id, Some(pending_id));
+        assert!(matches!(
+            pair.next,
+            Some(DjMediaRef::PendingQueueItem {
+                pending_artist,
+                pending_title,
+                ..
+            }) if pending_artist == "Pending Artist" && pending_title == "Pending Title"
+        ));
+    }
+
+    #[test]
+    fn lookahead_pair_updates_after_queue_reorder() {
+        let conn = conn();
+        seed_track(&conn, 1, None);
+        seed_track(&conn, 2, None);
+        seed_track(&conn, 3, None);
+        let first = seed_queue_track(&conn, 0, 1);
+        let second = seed_queue_track(&conn, 1, 2);
+        let third = seed_queue_track(&conn, 2, 3);
+        conn.execute(
+            "UPDATE playback_state SET current_track_id = 1, current_queue_item_id = ?1 WHERE id = 1",
+            params![first],
+        )
+        .unwrap();
+        assert_eq!(
+            load_dj_lookahead_pair(&conn).unwrap().next_queue_item_id,
+            Some(second)
+        );
+        conn.execute(
+            "UPDATE queue SET position = 1 WHERE id = ?1",
+            params![third],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE queue SET position = 2 WHERE id = ?1",
+            params![second],
+        )
+        .unwrap();
+        assert_eq!(
+            load_dj_lookahead_pair(&conn).unwrap().next_queue_item_id,
+            Some(third)
+        );
+    }
+
+    #[test]
+    fn lookahead_pair_ignores_second_upcoming_item() {
+        let conn = conn();
+        seed_track(&conn, 1, None);
+        seed_track(&conn, 2, None);
+        seed_track(&conn, 3, None);
+        let first = seed_queue_track(&conn, 0, 1);
+        let second = seed_queue_track(&conn, 1, 2);
+        seed_queue_track(&conn, 2, 3);
+        conn.execute(
+            "UPDATE playback_state SET current_track_id = 1, current_queue_item_id = ?1 WHERE id = 1",
+            params![first],
+        )
+        .unwrap();
+        let pair = load_dj_lookahead_pair(&conn).unwrap();
+        assert_eq!(pair.next_queue_item_id, Some(second));
+    }
+
+    #[test]
+    fn lookahead_pair_generation_changes_after_queue_edit() {
+        let conn = conn();
+        seed_track(&conn, 1, None);
+        seed_track(&conn, 2, None);
+        let first = seed_queue_track(&conn, 0, 1);
+        conn.execute(
+            "UPDATE playback_state SET current_track_id = 1, current_queue_item_id = ?1 WHERE id = 1",
+            params![first],
+        )
+        .unwrap();
+        let before = load_dj_lookahead_pair(&conn).unwrap().queue_generation;
+        seed_queue_track(&conn, 1, 2);
+        let after = load_dj_lookahead_pair(&conn).unwrap().queue_generation;
+        assert_ne!(before, after);
+    }
+
+    #[test]
+    fn lookahead_pair_generation_changes_after_pending_resolution() {
+        let conn = conn();
+        seed_track(&conn, 1, None);
+        let first = seed_queue_track(&conn, 0, 1);
+        conn.execute(
+            "INSERT INTO queue (track_id, position, source, pending_artist, pending_title)
+             VALUES (NULL, 1, 'radio_pending', 'Pending Artist', 'Pending Title')",
+            [],
+        )
+        .unwrap();
+        let pending = conn.last_insert_rowid();
+        conn.execute(
+            "UPDATE playback_state SET current_track_id = 1, current_queue_item_id = ?1 WHERE id = 1",
+            params![first],
+        )
+        .unwrap();
+        let before = load_dj_lookahead_pair(&conn).unwrap().queue_generation;
+        conn.execute(
+            "UPDATE queue SET tidal_id_hint = 99 WHERE id = ?1",
+            params![pending],
+        )
+        .unwrap();
+        let after = load_dj_lookahead_pair(&conn).unwrap().queue_generation;
+        assert_ne!(before, after);
+    }
+}

--- a/noor-server/src/playback/mod.rs
+++ b/noor-server/src/playback/mod.rs
@@ -1,5 +1,7 @@
 pub mod automix;
 pub mod decode;
+pub mod dj_engine;
+pub mod dj_lookahead;
 pub mod gapless;
 pub mod output;
 pub mod player;

--- a/noor-server/src/playback/player.rs
+++ b/noor-server/src/playback/player.rs
@@ -460,7 +460,7 @@ pub fn attach_dj_transition_plan_for_pair_with_current_duration(
 const DJ_FIRE_AHEAD_WINDOW: i64 = 20;
 const DJ_FIRE_AHEAD_POSITIVE_PERCENT: usize = 70;
 const DJ_FIRE_AHEAD_MEDIAN_FLOOR_MS: i64 = 150;
-const DJ_FIRE_AHEAD_MAX_MS: i64 = 300;
+const DJ_FIRE_AHEAD_MAX_MS: i64 = 150;
 
 fn dj_transition_fire_ahead_ms(conn: &Connection) -> Result<u32> {
     let mut stmt = conn.prepare(
@@ -489,7 +489,7 @@ fn fire_ahead_ms_from_deltas(deltas: &[i64]) -> u32 {
     }
     median_delta(deltas)
         .filter(|delta| *delta > DJ_FIRE_AHEAD_MEDIAN_FLOOR_MS)
-        .map(|delta| delta.clamp(DJ_FIRE_AHEAD_MEDIAN_FLOOR_MS, DJ_FIRE_AHEAD_MAX_MS) as u32)
+        .map(|delta| (delta / 2).clamp(0, DJ_FIRE_AHEAD_MAX_MS) as u32)
         .unwrap_or(0)
 }
 
@@ -3385,7 +3385,7 @@ mod tests {
                 135, 134, -20, -40,
             ];
 
-            assert_eq!(fire_ahead_ms_from_deltas(&passing), 255);
+            assert_eq!(fire_ahead_ms_from_deltas(&passing), 127);
             assert_eq!(fire_ahead_ms_from_deltas(&mixed), 0);
             assert_eq!(fire_ahead_ms_from_deltas(&low_median), 0);
             assert_eq!(fire_ahead_ms_from_deltas(&passing[..19]), 0);
@@ -3393,7 +3393,7 @@ mod tests {
 
         #[test]
         fn fire_ahead_caps_large_median() {
-            assert_eq!(fire_ahead_ms_from_deltas(&[500; 20]), 300);
+            assert_eq!(fire_ahead_ms_from_deltas(&[500; 20]), 150);
         }
 
         #[test]

--- a/noor-server/src/playback/player.rs
+++ b/noor-server/src/playback/player.rs
@@ -440,8 +440,14 @@ pub fn attach_dj_transition_plan_for_pair_with_current_duration(
         engine.plan_transition_details(current, next, sample_rate.max(1), channels.max(1))?
     {
         let planned_template = plan.program.template.clone();
-        let (renderer_program, renderer_fallback_reason) =
-            v1_renderable_program(&plan.program, sample_rate.max(1), channels.max(1));
+        let filter_sweep_unstable = planned_template == "FilterSweep"
+            && engine.db().with_conn(filter_sweep_timing_unstable)?;
+        let (renderer_program, renderer_fallback_reason) = v1_renderable_program(
+            &plan.program,
+            sample_rate.max(1),
+            channels.max(1),
+            filter_sweep_unstable,
+        );
         let renderer_plan = DjTransitionPlan {
             program: renderer_program,
             rejected_alternatives: plan.rejected_alternatives,
@@ -512,6 +518,11 @@ const DJ_FIRE_AHEAD_WINDOW: i64 = 20;
 const DJ_FIRE_AHEAD_POSITIVE_PERCENT: usize = 70;
 const DJ_FIRE_AHEAD_MEDIAN_FLOOR_MS: i64 = 150;
 const DJ_FIRE_AHEAD_MAX_MS: i64 = 150;
+const DJ_FILTER_SWEEP_TIMING_WINDOW: i64 = 20;
+const DJ_FILTER_SWEEP_TIMING_MIN_ROWS: usize = 4;
+const DJ_FILTER_SWEEP_MEDIAN_ABS_MAX_MS: i64 = 300;
+const DJ_FILTER_SWEEP_WORST_ABS_MAX_MS: i64 = 750;
+const DJ_FILTER_SWEEP_RENDER_MS: u32 = 12_000;
 
 fn dj_transition_fire_ahead_ms(conn: &Connection) -> Result<u32> {
     let mut stmt = conn.prepare(
@@ -528,6 +539,48 @@ fn dj_transition_fire_ahead_ms(conn: &Connection) -> Result<u32> {
         deltas.push(row?);
     }
     Ok(fire_ahead_ms_from_deltas(&deltas))
+}
+
+fn filter_sweep_timing_unstable(conn: &Connection) -> Result<bool> {
+    let mut stmt = conn.prepare(
+        "SELECT timing_delta_ms
+         FROM dj_transition_events
+         WHERE timing_status = 'fired'
+           AND timing_delta_ms IS NOT NULL
+         ORDER BY started_at DESC, id DESC
+         LIMIT ?1",
+    )?;
+    let rows = stmt.query_map([DJ_FILTER_SWEEP_TIMING_WINDOW], |row| row.get::<_, i64>(0))?;
+    let mut deltas = Vec::new();
+    for row in rows {
+        deltas.push(row?);
+    }
+    Ok(filter_sweep_timing_unstable_from_deltas(&deltas))
+}
+
+fn filter_sweep_timing_unstable_from_deltas(deltas: &[i64]) -> bool {
+    if deltas.len() < DJ_FILTER_SWEEP_TIMING_MIN_ROWS {
+        return false;
+    }
+    let Some(median_abs) = median_abs_delta(deltas) else {
+        return false;
+    };
+    let worst_abs = deltas.iter().map(|delta| delta.abs()).max().unwrap_or(0);
+    median_abs > DJ_FILTER_SWEEP_MEDIAN_ABS_MAX_MS || worst_abs > DJ_FILTER_SWEEP_WORST_ABS_MAX_MS
+}
+
+fn median_abs_delta(deltas: &[i64]) -> Option<i64> {
+    if deltas.is_empty() {
+        return None;
+    }
+    let mut values = deltas.iter().map(|delta| delta.abs()).collect::<Vec<_>>();
+    values.sort_unstable();
+    let middle = values.len() / 2;
+    if values.len() % 2 == 0 {
+        Some((values[middle - 1] + values[middle]) / 2)
+    } else {
+        Some(values[middle])
+    }
 }
 
 fn fire_ahead_ms_from_deltas(deltas: &[i64]) -> u32 {
@@ -696,7 +749,7 @@ fn synced_overlap_from_grid_ms(
     sample_rate: u32,
 ) -> Option<i32> {
     const MIN_SYNC_OVERLAP_MS: i64 = 8_000;
-    const MAX_SYNC_OVERLAP_MS: i64 = 12_000;
+    const MAX_SYNC_OVERLAP_MS: i64 = 16_000;
     let preferred_ms = preferred_overlap_ms.max(250) as i64;
     let program_ms = program_samples
         .map(|samples| {
@@ -754,9 +807,30 @@ fn v1_renderable_program(
     program: &noor_mix::TransitionProgram,
     sample_rate: u32,
     channels: u16,
+    filter_sweep_timing_unstable: bool,
 ) -> (noor_mix::TransitionProgram, Option<&'static str>) {
     if program.template == "SafeCrossfade" {
         return (program.clone(), None);
+    }
+    if program.template == "FilterSweep" {
+        if filter_sweep_timing_unstable {
+            return (
+                crate::playback::dj_engine::safe_crossfade_program(
+                    sample_rate,
+                    channels,
+                    noor_mix::Policy::default(),
+                ),
+                Some("timing_unstable"),
+            );
+        }
+        return (
+            noor_mix::planner::filter_sweep_eq_wash_program(
+                sample_rate,
+                channels,
+                DJ_FILTER_SWEEP_RENDER_MS,
+            ),
+            None,
+        );
     }
     (
         crate::playback::dj_engine::safe_crossfade_program(
@@ -3380,18 +3454,18 @@ mod tests {
 
             assert_eq!(row.0, "FilterSweep");
             assert_eq!(renderer_program.template, "FilterSweep");
-            assert_eq!(renderer_program.resolve_at, 384_000);
+            assert_eq!(renderer_program.resolve_at, 576_000);
             assert_eq!(row.2, None);
         }
 
         #[test]
-        fn v1_renderable_program_passes_filter_sweep_with_safe_duration() {
+        fn v1_renderable_program_passes_filter_sweep_with_wider_duration() {
             let input = noor_mix::planner::filter_sweep_eq_wash_program(48_000, 2, 32_000);
 
-            let (program, reason) = v1_renderable_program(&input, 48_000, 2);
+            let (program, reason) = v1_renderable_program(&input, 48_000, 2, false);
 
             assert_eq!(program.template, "FilterSweep");
-            assert_eq!(program.resolve_at, 384_000);
+            assert_eq!(program.resolve_at, 576_000);
             assert_eq!(reason, None);
             assert!(
                 program
@@ -3406,14 +3480,24 @@ mod tests {
             let mut input = noor_mix::planner::filter_sweep_eq_wash_program(48_000, 2, 10_000);
             input.template = "SlamCut".to_string();
 
-            let (program, reason) = v1_renderable_program(&input, 48_000, 2);
+            let (program, reason) = v1_renderable_program(&input, 48_000, 2, false);
 
             assert_eq!(program.template, "SafeCrossfade");
             assert_eq!(reason, Some("template_not_renderable"));
         }
 
         #[test]
-        fn filter_sweep_uses_safe_crossfade_overlap_duration() {
+        fn unstable_timing_downgrades_filter_sweep_to_safe_crossfade() {
+            let input = noor_mix::planner::filter_sweep_eq_wash_program(48_000, 2, 10_000);
+
+            let (program, reason) = v1_renderable_program(&input, 48_000, 2, true);
+
+            assert_eq!(program.template, "SafeCrossfade");
+            assert_eq!(reason, Some("timing_unstable"));
+        }
+
+        #[test]
+        fn filter_sweep_uses_wider_overlap_than_safe_crossfade() {
             let safe = crate::playback::dj_engine::safe_crossfade_program(
                 48_000,
                 2,
@@ -3422,13 +3506,11 @@ mod tests {
             let filter = noor_mix::planner::filter_sweep_eq_wash_program(
                 48_000,
                 2,
-                noor_mix::Policy::default().default_crossfade_ms,
+                DJ_FILTER_SWEEP_RENDER_MS,
             );
 
-            assert_eq!(
-                dj_gapless_plan_from_program(&filter),
-                dj_gapless_plan_from_program(&safe)
-            );
+            assert_eq!(dj_gapless_plan_from_program(&safe).overlap_ms, 8_000);
+            assert_eq!(dj_gapless_plan_from_program(&filter).overlap_ms, 12_000);
         }
 
         #[test]
@@ -3450,6 +3532,17 @@ mod tests {
             assert_eq!(fire_ahead_ms_from_deltas(&mixed), 0);
             assert_eq!(fire_ahead_ms_from_deltas(&low_median), 0);
             assert_eq!(fire_ahead_ms_from_deltas(&passing[..19]), 0);
+        }
+
+        #[test]
+        fn filter_sweep_timing_gate_uses_abs_error_not_signed_bias() {
+            assert!(filter_sweep_timing_unstable_from_deltas(&[
+                549, -399, 303, -375
+            ]));
+            assert!(!filter_sweep_timing_unstable_from_deltas(&[
+                140, -130, 75, -90
+            ]));
+            assert!(!filter_sweep_timing_unstable_from_deltas(&[549, -399, 303]));
         }
 
         #[test]

--- a/noor-server/src/playback/player.rs
+++ b/noor-server/src/playback/player.rs
@@ -421,6 +421,21 @@ pub fn attach_dj_transition_plan_for_pair_with_current_duration(
     {
         return Ok(job);
     }
+    if let Some((existing_event_id, existing_program)) = engine
+        .db()
+        .with_conn(|conn| latest_armed_dj_transition_event_for_pair(conn, current, next))?
+    {
+        let fire_ahead_ms = engine.db().with_conn(dj_transition_fire_ahead_ms)?;
+        job = job.with_prepared_transition(PreparedTransitionProgram {
+            program: existing_program,
+            transition_event_id: Some(existing_event_id),
+            fire_ahead_ms,
+            queue_generation: pair.queue_generation,
+            current_queue_item_id: pair.current_queue_item_id,
+            next_queue_item_id: Some(next_queue_item_id),
+        });
+        return Ok(job);
+    }
     if let Some(plan) =
         engine.plan_transition_details(current, next, sample_rate.max(1), channels.max(1))?
     {
@@ -455,6 +470,42 @@ pub fn attach_dj_transition_plan_for_pair_with_current_duration(
         });
     }
     Ok(job)
+}
+
+fn latest_armed_dj_transition_event_for_pair(
+    conn: &Connection,
+    current: &DjMediaRef,
+    next: &DjMediaRef,
+) -> Result<Option<(i64, noor_mix::TransitionProgram)>> {
+    let current_key = current.profile_key();
+    let next_key = next.profile_key();
+    let row = conn
+        .query_row(
+            "SELECT id, program_json
+         FROM dj_transition_events
+         WHERE from_media_ref_kind = ?1
+           AND from_media_ref_id = ?2
+           AND to_media_ref_kind = ?3
+           AND to_media_ref_id = ?4
+           AND timing_status = 'armed'
+           AND actual_start_ms IS NULL
+           AND outcome IS NULL
+         ORDER BY started_at DESC, id DESC
+         LIMIT 1",
+            params![
+                current_key.media_ref_kind,
+                current_key.media_ref_id,
+                next_key.media_ref_kind,
+                next_key.media_ref_id,
+            ],
+            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
+        )
+        .optional()?;
+    let Some((id, program_json)) = row else {
+        return Ok(None);
+    };
+    let program = serde_json::from_str(&program_json)?;
+    Ok(Some((id, program)))
 }
 
 const DJ_FIRE_AHEAD_WINDOW: i64 = 20;
@@ -3198,6 +3249,16 @@ mod tests {
                 .expect("selected");
 
             assert_eq!(selected, Some(fired_id));
+        }
+
+        #[test]
+        fn repeated_planning_reuses_existing_armed_event_for_pair() {
+            let db = db_with_pair();
+            let first = plan(&db);
+            let second = plan(&db);
+
+            assert_eq!(second.transition_event_id, first.transition_event_id);
+            assert_eq!(event_count(&db), 1);
         }
 
         #[test]

--- a/noor-server/src/playback/player.rs
+++ b/noor-server/src/playback/player.rs
@@ -524,7 +524,7 @@ fn synced_dj_overlap_ms(
     let Some(profile) = queries::get_audio_dj_profile(conn, &key)? else {
         return Ok(None);
     };
-    if profile.profile_confidence < 0.6 {
+    if profile.profile_confidence < 0.65 {
         return Ok(None);
     }
 
@@ -3020,7 +3020,9 @@ mod tests {
 
     mod dj_transition_logging {
         use super::*;
-        use crate::db::models::{AudioDjProfileKey, AudioDjProfileRow};
+        use crate::db::models::{
+            AudioDjProfileCorrectionRow, AudioDjProfileKey, AudioDjProfileRow,
+        };
         use crate::db::schema;
         use crate::services::audio_analysis::dj_profile::{
             DJ_PROFILE_VERSION, encode_f32_blob, encode_u32_blob,
@@ -3225,11 +3227,29 @@ mod tests {
         }
 
         #[test]
-        fn v1_planner_lock_logs_and_prepares_safe_crossfade() {
+        fn v1_planner_logs_and_prepares_filter_sweep_when_renderable() {
             let db = db_with_pair();
+            db.with_conn(|conn| {
+                queries::upsert_audio_dj_profile_correction(
+                    conn,
+                    &AudioDjProfileCorrectionRow {
+                        media_ref_kind: "tidal_track".to_string(),
+                        media_ref_id: "2".to_string(),
+                        bpm_multiplier: Some(1.05),
+                        downbeat_offset_beats: None,
+                        phrase_offset_bars: None,
+                        safe_crossfade_only: false,
+                        transition_speed_bias: None,
+                        notes: None,
+                        created_at: "now".to_string(),
+                        updated_at: "now".to_string(),
+                    },
+                )
+            })
+            .expect("seed correction");
             let transition = plan(&db);
 
-            assert_eq!(transition.program.template, "SafeCrossfade");
+            assert_eq!(transition.program.template, "FilterSweep");
             let row: (String, String, Option<String>) = db
                 .with_conn(|conn| {
                     conn.query_row(
@@ -3244,8 +3264,9 @@ mod tests {
             let renderer_program: noor_mix::TransitionProgram =
                 serde_json::from_str(&row.1).expect("program");
 
-            assert_eq!(row.0, "SafeCrossfade");
-            assert_eq!(renderer_program.template, "SafeCrossfade");
+            assert_eq!(row.0, "FilterSweep");
+            assert_eq!(renderer_program.template, "FilterSweep");
+            assert_eq!(renderer_program.resolve_at, 384_000);
             assert_eq!(row.2, None);
         }
 

--- a/noor-server/src/playback/player.rs
+++ b/noor-server/src/playback/player.rs
@@ -4,7 +4,7 @@ use crate::db::{
     models::{AudioDspFeatures, PlaybackState, QueueItem, Track},
     queries,
 };
-use crate::playback::dj_engine::DjEngine;
+use crate::playback::dj_engine::{DjEngine, DjTransitionPlan};
 use crate::playback::dj_lookahead::{DjLookaheadPair, DjMediaRef, load_dj_lookahead_pair};
 use crate::playback::gapless::{self, GaplessPlan, GaplessSettings};
 use crate::playback::queue::{self, ShuffleDebug, ShuffleMode};
@@ -77,6 +77,7 @@ pub struct PreparedPlaybackJob {
 #[derive(Debug, Clone)]
 pub struct PreparedTransitionProgram {
     pub program: noor_mix::TransitionProgram,
+    pub transition_event_id: Option<i64>,
     pub queue_generation: u64,
     pub current_queue_item_id: Option<i64>,
     pub next_queue_item_id: Option<i64>,
@@ -162,6 +163,7 @@ pub struct ActiveListenSession {
     pub source: crate::db::models::ListenSource,
     pub position_in_session: i32,
     pub transition_from_track_id: Option<i64>,
+    pub dj_transition_event_id: Option<i64>,
 }
 
 // Tracks the rolling state of the user's current listening session across multiple
@@ -399,17 +401,47 @@ fn attach_dj_transition_plan_for_pair(
     {
         return Ok(job);
     }
-    if let Some(program) =
-        engine.plan_transition(current, next, sample_rate.max(1), channels.max(1))?
+    if let Some(plan) =
+        engine.plan_transition_details(current, next, sample_rate.max(1), channels.max(1))?
     {
+        let transition_event_id = log_dj_transition_event(engine, current, next, &plan)?;
         job = job.with_prepared_transition(PreparedTransitionProgram {
-            program,
+            program: plan.program,
+            transition_event_id: Some(transition_event_id),
             queue_generation: pair.queue_generation,
             current_queue_item_id: pair.current_queue_item_id,
             next_queue_item_id: Some(next_queue_item_id),
         });
     }
     Ok(job)
+}
+
+fn log_dj_transition_event(
+    engine: &DjEngine,
+    current: &DjMediaRef,
+    next: &DjMediaRef,
+    plan: &DjTransitionPlan,
+) -> Result<i64> {
+    let current_key = current.profile_key();
+    let next_key = next.profile_key();
+    let program_json = serde_json::to_string(&plan.program)?;
+    let rejected_json = serde_json::to_string(&plan.rejected_alternatives)?;
+    engine.db().with_conn(|conn| {
+        queries::insert_dj_transition_event(
+            conn,
+            current.track_id(),
+            next.track_id(),
+            Some(current_key.media_ref_kind.as_str()),
+            Some(current_key.media_ref_id.as_str()),
+            Some(next_key.media_ref_kind.as_str()),
+            Some(next_key.media_ref_id.as_str()),
+            plan.program.template.as_str(),
+            program_json.as_str(),
+            Some(rejected_json.as_str()),
+            plan.planner_version,
+            plan.fallback_reason,
+        )
+    })
 }
 
 impl ActiveListenSession {
@@ -436,7 +468,13 @@ impl ActiveListenSession {
             source,
             position_in_session: position,
             transition_from_track_id: transition_from,
+            dj_transition_event_id: None,
         }
+    }
+
+    pub fn with_dj_transition_event_id(mut self, event_id: Option<i64>) -> Self {
+        self.dj_transition_event_id = event_id;
+        self
     }
 
     pub fn to_live_session(&self, finished_at: DateTime<Utc>) -> LiveListenSession {
@@ -447,6 +485,46 @@ impl ActiveListenSession {
             position: self.position_in_session,
         }
     }
+}
+
+pub fn latest_open_dj_transition_event_for_pair(
+    conn: &Connection,
+    from_track_id: Option<i64>,
+    to_track_id: i64,
+) -> Result<Option<i64>> {
+    let Some(from_track_id) = from_track_id else {
+        return Ok(None);
+    };
+    conn.query_row(
+        "SELECT id
+         FROM dj_transition_events
+         WHERE from_track_id = ?1
+           AND to_track_id = ?2
+           AND outcome IS NULL
+         ORDER BY started_at DESC, id DESC
+         LIMIT 1",
+        params![from_track_id, to_track_id],
+        |row| row.get(0),
+    )
+    .optional()
+    .map_err(Into::into)
+}
+
+pub fn record_dj_transition_listen_outcome(
+    conn: &Connection,
+    transition_event_id: Option<i64>,
+    listened_ms: i64,
+    completed: bool,
+) -> Result<()> {
+    let Some(id) = transition_event_id else {
+        return Ok(());
+    };
+    if completed {
+        queries::update_dj_transition_outcome(conn, id, "finished", false)?;
+    } else if listened_ms < 30_000 {
+        queries::update_dj_transition_outcome(conn, id, "skip_within_30s", true)?;
+    }
+    Ok(())
 }
 
 // Reads the queue.source string of the currently-playing queue item and maps it
@@ -2664,6 +2742,387 @@ mod tests {
 
             let program = job.prepared_transition.expect("transition").program;
             assert_eq!(program.template, "SafeCrossfade");
+        }
+    }
+
+    mod dj_transition_logging {
+        use super::*;
+        use crate::db::models::{AudioDjProfileKey, AudioDjProfileRow};
+        use crate::db::schema;
+        use crate::services::audio_analysis::dj_profile::{
+            DJ_PROFILE_VERSION, encode_f32_blob, encode_u32_blob,
+        };
+        use serde_json::Value;
+
+        fn db_with_pair() -> Database {
+            let db = Database::open_in_memory().expect("db");
+            db.with_conn(|conn| {
+                schema::run_migrations(conn)?;
+                conn.execute("INSERT INTO artists (id, name) VALUES (1, 'A')", [])?;
+                conn.execute(
+                    "INSERT INTO tracks (
+                        id, title, artist_id, tidal_id, source, best_quality, best_source, duration_ms
+                    ) VALUES (1, 'Track 1', 1, 1, 'tidal', 'LOSSLESS', 'tidal', 180000),
+                             (2, 'Track 2', 1, 2, 'tidal', 'LOSSLESS', 'tidal', 180000)",
+                    [],
+                )?;
+                conn.execute(
+                    "INSERT INTO queue (id, track_id, position, source)
+                     VALUES (11, 1, 0, 'manual'), (12, 2, 1, 'manual')",
+                    [],
+                )?;
+                conn.execute(
+                    "UPDATE playback_state
+                     SET current_track_id = 1, current_queue_item_id = 11, is_playing = 1
+                     WHERE id = 1",
+                    [],
+                )?;
+                queries::set_dj_engine_enabled(conn, true)?;
+                seed_profile(conn, "tidal_track", "1", Some(1))?;
+                seed_profile(conn, "tidal_track", "2", Some(2))?;
+                Ok(())
+            })
+            .expect("seed");
+            db
+        }
+
+        fn seed_profile(
+            conn: &Connection,
+            kind: &str,
+            id: &str,
+            track_id: Option<i64>,
+        ) -> Result<()> {
+            let row = AudioDjProfileRow {
+                media_ref_kind: kind.to_string(),
+                media_ref_id: id.to_string(),
+                track_id,
+                queue_item_id: None,
+                tidal_id: id.parse().ok(),
+                profile_version: DJ_PROFILE_VERSION.to_string(),
+                beat_grid_blob: encode_f32_blob(
+                    &(0..64).map(|i| i as f32 * 0.5).collect::<Vec<_>>(),
+                ),
+                downbeats_blob: encode_f32_blob(
+                    &(0..16).map(|i| i as f32 * 2.0).collect::<Vec<_>>(),
+                ),
+                phrase_boundaries_blob: encode_u32_blob(&(0..16).collect::<Vec<_>>()),
+                mix_in_blob: encode_f32_blob(&[0.0]),
+                mix_out_blob: encode_f32_blob(&[90.0]),
+                intro_end_seconds: Some(16.0),
+                outro_start_seconds: Some(120.0),
+                breakdown_blob: encode_f32_blob(&[]),
+                drop_blob: encode_f32_blob(&[]),
+                safe_transition_windows_blob: encode_f32_blob(&[0.0, 8.0, 1.0]),
+                energy_contour_blob: encode_f32_blob(&[]),
+                vocal_presence_blob: encode_f32_blob(&[0.0; 16]),
+                vocal_density_blob: encode_f32_blob(&[0.0; 16]),
+                lufs_loud_body: Some(-12.0),
+                true_peak_dbtp: Some(-1.0),
+                beat_confidence: Some(0.9),
+                profile_confidence: 0.9,
+                analysis_scope_ms: 90_000,
+                is_temporary: false,
+                source: "test".to_string(),
+                computed_at: "now".to_string(),
+            };
+            queries::upsert_audio_dj_profile(conn, &row)
+        }
+
+        fn next_job(db: &Database) -> PlaybackPreparation {
+            db.with_conn(|conn| {
+                let track = queue::get_track_by_id(conn, 2)?.expect("track");
+                Ok(build_playback_preparation(&track, None, 0, None))
+            })
+            .expect("job")
+        }
+
+        fn plan(db: &Database) -> PreparedTransitionProgram {
+            attach_dj_transition_plan(db, next_job(db), 48_000, 2)
+                .expect("plan")
+                .prepared_transition
+                .expect("transition")
+        }
+
+        fn event_count(db: &Database) -> i64 {
+            db.with_conn(|conn| {
+                conn.query_row("SELECT COUNT(*) FROM dj_transition_events", [], |row| {
+                    row.get(0)
+                })
+                .map_err(Into::into)
+            })
+            .expect("count")
+        }
+
+        #[test]
+        fn dj_disabled_does_not_write_dj_transition_events() {
+            let db = db_with_pair();
+            db.with_conn(|conn| queries::set_dj_engine_enabled(conn, false))
+                .expect("disable");
+
+            let job = attach_dj_transition_plan(&db, next_job(&db), 48_000, 2).expect("plan");
+
+            assert!(job.prepared_transition.is_none());
+            assert_eq!(event_count(&db), 0);
+        }
+
+        #[test]
+        fn dj_transition_logging_does_not_replace_playback_transitions() {
+            let db = db_with_pair();
+            let _ = plan(&db);
+            db.with_conn(|conn| {
+                queries::record_playback_transition(conn, 1, 2, "queue", true, 8000)
+            })
+            .expect("legacy transition");
+
+            let counts = db
+                .with_conn(|conn| {
+                    let dj: i64 =
+                        conn.query_row("SELECT COUNT(*) FROM dj_transition_events", [], |row| {
+                            row.get(0)
+                        })?;
+                    let legacy: i64 =
+                        conn.query_row("SELECT COUNT(*) FROM playback_transitions", [], |row| {
+                            row.get(0)
+                        })?;
+                    Ok((dj, legacy))
+                })
+                .expect("counts");
+
+            assert_eq!(counts, (1, 1));
+        }
+
+        #[test]
+        fn dj_transition_logging_limits_rejected_alternatives_to_three() {
+            let db = db_with_pair();
+            let transition = plan(&db);
+            let rejected: String = db
+                .with_conn(|conn| {
+                    conn.query_row(
+                        "SELECT rejected_alternatives_json FROM dj_transition_events WHERE id = ?1",
+                        params![transition.transition_event_id],
+                        |row| row.get(0),
+                    )
+                    .map_err(Into::into)
+                })
+                .expect("rejected");
+            let parsed: Vec<Value> = serde_json::from_str(&rejected).expect("json");
+
+            assert!(parsed.len() <= 3);
+            assert!(parsed.iter().all(|item| item.get("template").is_some()));
+            assert!(parsed.iter().all(|item| item.get("score").is_some()));
+            assert!(parsed.iter().all(|item| item.get("reason").is_some()));
+        }
+
+        #[test]
+        fn dj_transition_logging_uses_planner_version_not_profile_version() {
+            let db = db_with_pair();
+            let transition = plan(&db);
+            let planner_version: String = db
+                .with_conn(|conn| {
+                    conn.query_row(
+                        "SELECT planner_version FROM dj_transition_events WHERE id = ?1",
+                        params![transition.transition_event_id],
+                        |row| row.get(0),
+                    )
+                    .map_err(Into::into)
+                })
+                .expect("planner version");
+
+            assert_eq!(planner_version, noor_mix::planner::DJ_PLANNER_VERSION);
+            assert_ne!(planner_version, DJ_PROFILE_VERSION);
+        }
+
+        #[test]
+        fn external_dj_transition_logging_does_not_require_library_track_id() {
+            let db = db_with_pair();
+            db.with_conn(|conn| {
+                conn.execute("DELETE FROM queue WHERE id = 12", [])?;
+                conn.execute(
+                    "INSERT INTO queue (id, track_id, position, source, pending_artist, pending_title)
+                     VALUES (12, NULL, 1, 'radio_pending', 'External A', 'External B')",
+                    [],
+                )?;
+                seed_profile(conn, "queue_item", "12", None)?;
+                Ok(())
+            })
+            .expect("external");
+            let pair = db.with_conn(load_dj_lookahead_pair).expect("pair");
+            let engine = DjEngine::new(db.clone());
+            let job = attach_dj_transition_plan_for_pair(
+                &engine,
+                PreparedPlaybackJob::test_fixture(99, 1),
+                pair,
+                48_000,
+                2,
+            )
+            .expect("plan");
+
+            let event_id = job
+                .prepared_transition
+                .and_then(|transition| transition.transition_event_id)
+                .expect("event");
+            let row = db
+                .with_conn(|conn| {
+                    conn.query_row(
+                        "SELECT to_track_id, to_media_ref_kind, to_media_ref_id
+                         FROM dj_transition_events WHERE id = ?1",
+                        params![event_id],
+                        |row| {
+                            Ok((
+                                row.get::<_, Option<i64>>(0)?,
+                                row.get::<_, String>(1)?,
+                                row.get::<_, String>(2)?,
+                            ))
+                        },
+                    )
+                    .map_err(Into::into)
+                })
+                .expect("event");
+
+            assert_eq!(row.0, None);
+            assert_eq!(row.1, "queue_item");
+            assert_eq!(row.2, "12");
+        }
+
+        #[test]
+        fn skip_mid_transition_updates_dj_event() {
+            let db = db_with_pair();
+            let transition = plan(&db);
+
+            db.with_conn(|conn| {
+                record_dj_transition_listen_outcome(
+                    conn,
+                    transition.transition_event_id,
+                    12_000,
+                    false,
+                )
+            })
+            .expect("outcome");
+
+            let outcome: String = db
+                .with_conn(|conn| {
+                    conn.query_row(
+                        "SELECT outcome FROM dj_transition_events WHERE id = ?1",
+                        params![transition.transition_event_id],
+                        |row| row.get(0),
+                    )
+                    .map_err(Into::into)
+                })
+                .expect("outcome");
+            assert_eq!(outcome, "skip_within_30s");
+        }
+
+        #[test]
+        fn skip_within_30s_counts_as_negative_transition_outcome() {
+            let db = db_with_pair();
+            let transition = plan(&db);
+
+            db.with_conn(|conn| {
+                record_dj_transition_listen_outcome(
+                    conn,
+                    transition.transition_event_id,
+                    29_999,
+                    false,
+                )
+            })
+            .expect("outcome");
+
+            let skip_flag: i64 = db
+                .with_conn(|conn| {
+                    conn.query_row(
+                        "SELECT skip_within_30s FROM dj_transition_events WHERE id = ?1",
+                        params![transition.transition_event_id],
+                        |row| row.get(0),
+                    )
+                    .map_err(Into::into)
+                })
+                .expect("flag");
+            assert_eq!(skip_flag, 1);
+        }
+
+        #[test]
+        fn skip_after_30s_does_not_count_as_bad_transition_feedback() {
+            let db = db_with_pair();
+            let transition = plan(&db);
+
+            db.with_conn(|conn| {
+                record_dj_transition_listen_outcome(
+                    conn,
+                    transition.transition_event_id,
+                    30_000,
+                    false,
+                )
+            })
+            .expect("outcome");
+
+            let row = db
+                .with_conn(|conn| {
+                    conn.query_row(
+                        "SELECT outcome, skip_within_30s FROM dj_transition_events WHERE id = ?1",
+                        params![transition.transition_event_id],
+                        |row| Ok((row.get::<_, Option<String>>(0)?, row.get::<_, i64>(1)?)),
+                    )
+                    .map_err(Into::into)
+                })
+                .expect("row");
+            assert_eq!(row, (None, 0));
+        }
+
+        #[test]
+        fn manual_bad_feedback_counts_stronger_than_skip() {
+            let db = db_with_pair();
+            let transition = plan(&db);
+
+            db.with_conn(|conn| {
+                record_dj_transition_listen_outcome(
+                    conn,
+                    transition.transition_event_id,
+                    12_000,
+                    false,
+                )?;
+                conn.execute(
+                    "UPDATE dj_transition_events SET user_rating = -1 WHERE id = ?1",
+                    params![transition.transition_event_id],
+                )?;
+                queries::count_recent_bad_dj_feedback_for_ref(
+                    conn,
+                    &AudioDjProfileKey {
+                        media_ref_kind: "tidal_track".to_string(),
+                        media_ref_id: "2".to_string(),
+                    },
+                    3,
+                )
+            })
+            .map(|count| assert_eq!(count, 1))
+            .expect("feedback count");
+        }
+
+        #[test]
+        fn finished_transition_updates_dj_event() {
+            let db = db_with_pair();
+            let transition = plan(&db);
+
+            db.with_conn(|conn| {
+                record_dj_transition_listen_outcome(
+                    conn,
+                    transition.transition_event_id,
+                    170_000,
+                    true,
+                )
+            })
+            .expect("outcome");
+
+            let row = db
+                .with_conn(|conn| {
+                    conn.query_row(
+                        "SELECT outcome, skip_within_30s FROM dj_transition_events WHERE id = ?1",
+                        params![transition.transition_event_id],
+                        |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)),
+                    )
+                    .map_err(Into::into)
+                })
+                .expect("row");
+            assert_eq!(row, ("finished".to_string(), 0));
         }
     }
 

--- a/noor-server/src/playback/player.rs
+++ b/noor-server/src/playback/player.rs
@@ -63,12 +63,21 @@ pub struct PreparedPlaybackJob {
     pub generation: u64,
     pub output_sample_rate: Option<u32>,
     pub dj_media_ref: Option<DjMediaRef>,
+    pub prepared_transition: Option<PreparedTransitionProgram>,
     // Segment-aware seek (option C): for DASH-segmented sources, these tell the
     // decoder to skip ahead by `start_from_segment_index` segments. Position
     // accounting in `PlaybackSharedState` is then absolute-track-samples seeded
     // from `start_from_offset_ms`. A fresh play has both = 0.
     pub start_from_segment_index: usize,
     pub start_from_offset_ms: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct PreparedTransitionProgram {
+    pub program: noor_mix::TransitionProgram,
+    pub queue_generation: u64,
+    pub current_queue_item_id: Option<i64>,
+    pub next_queue_item_id: Option<i64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -131,6 +140,7 @@ impl PreparedPlaybackJob {
             generation,
             output_sample_rate: None,
             dj_media_ref: None,
+            prepared_transition: None,
             start_from_segment_index: 0,
             start_from_offset_ms: 0,
         }
@@ -283,6 +293,7 @@ impl PreparedPlaybackJob {
             generation: 0,
             output_sample_rate: None,
             dj_media_ref: None,
+            prepared_transition: None,
             start_from_segment_index: 0,
             start_from_offset_ms: 0,
         }
@@ -295,6 +306,11 @@ impl PreparedPlaybackJob {
 
     pub fn with_dj_media_ref(mut self, media_ref: DjMediaRef) -> Self {
         self.dj_media_ref = Some(media_ref);
+        self
+    }
+
+    pub fn with_prepared_transition(mut self, transition: PreparedTransitionProgram) -> Self {
+        self.prepared_transition = Some(transition);
         self
     }
 

--- a/noor-server/src/playback/player.rs
+++ b/noor-server/src/playback/player.rs
@@ -3,6 +3,7 @@ use crate::db::{
     models::{AudioDspFeatures, PlaybackState, QueueItem, Track},
     queries,
 };
+use crate::playback::dj_lookahead::DjMediaRef;
 use crate::playback::gapless::{self, GaplessPlan, GaplessSettings};
 use crate::playback::queue::{self, ShuffleDebug, ShuffleMode};
 use crate::playback::shuffle::{
@@ -61,6 +62,7 @@ pub struct PreparedPlaybackJob {
     pub gapless: GaplessPlan,
     pub generation: u64,
     pub output_sample_rate: Option<u32>,
+    pub dj_media_ref: Option<DjMediaRef>,
     // Segment-aware seek (option C): for DASH-segmented sources, these tell the
     // decoder to skip ahead by `start_from_segment_index` segments. Position
     // accounting in `PlaybackSharedState` is then absolute-track-samples seeded
@@ -101,6 +103,7 @@ impl PreparedPlaybackJob {
             gapless: GaplessPlan::disabled(),
             generation,
             output_sample_rate: None,
+            dj_media_ref: None,
             start_from_segment_index: 0,
             start_from_offset_ms: 0,
         }
@@ -252,6 +255,7 @@ impl PreparedPlaybackJob {
             gapless,
             generation: 0,
             output_sample_rate: None,
+            dj_media_ref: None,
             start_from_segment_index: 0,
             start_from_offset_ms: 0,
         }
@@ -259,6 +263,11 @@ impl PreparedPlaybackJob {
 
     pub fn with_generation(mut self, generation: u64) -> Self {
         self.generation = generation;
+        self
+    }
+
+    pub fn with_dj_media_ref(mut self, media_ref: DjMediaRef) -> Self {
+        self.dj_media_ref = Some(media_ref);
         self
     }
 

--- a/noor-server/src/playback/player.rs
+++ b/noor-server/src/playback/player.rs
@@ -12,6 +12,7 @@ use crate::playback::shuffle::{
     WeightedShuffleProfile, generate_shuffle_seed, genre_shuffle, genre_shuffle_with_rng,
     seeded_rng, true_shuffle, true_shuffle_with_rng,
 };
+use crate::services::audio_analysis::dj_profile::decode_f32_blob;
 use crate::services::audio_analysis::{
     CamelotRelation, camelot_relation, compute_harmonic_multiplier,
 };
@@ -354,7 +355,7 @@ pub fn build_dj_lookahead_start(
     Ok(dj_lookahead_start_from_pair(pair, deadline_samples))
 }
 
-fn dj_lookahead_start_from_pair(
+pub fn dj_lookahead_start_from_pair(
     pair: DjLookaheadPair,
     deadline_samples: u64,
 ) -> Option<DjLookaheadStart> {
@@ -381,12 +382,30 @@ pub fn attach_dj_transition_plan(
     attach_dj_transition_plan_for_pair(&DjEngine::new(db.clone()), job, pair, sample_rate, channels)
 }
 
-fn attach_dj_transition_plan_for_pair(
+pub fn attach_dj_transition_plan_for_pair(
+    engine: &DjEngine,
+    job: PlaybackPreparation,
+    pair: DjLookaheadPair,
+    sample_rate: u32,
+    channels: u16,
+) -> Result<PlaybackPreparation> {
+    attach_dj_transition_plan_for_pair_with_current_duration(
+        engine,
+        job,
+        pair,
+        sample_rate,
+        channels,
+        None,
+    )
+}
+
+pub fn attach_dj_transition_plan_for_pair_with_current_duration(
     engine: &DjEngine,
     mut job: PlaybackPreparation,
     pair: DjLookaheadPair,
     sample_rate: u32,
     channels: u16,
+    current_duration_ms: Option<i64>,
 ) -> Result<PlaybackPreparation> {
     let (Some(current), Some(next), Some(next_queue_item_id)) = (
         pair.current.as_ref(),
@@ -404,9 +423,28 @@ fn attach_dj_transition_plan_for_pair(
     if let Some(plan) =
         engine.plan_transition_details(current, next, sample_rate.max(1), channels.max(1))?
     {
-        let transition_event_id = log_dj_transition_event(engine, current, next, &plan)?;
+        let planned_template = plan.program.template.clone();
+        let (renderer_program, renderer_fallback_reason) =
+            v1_renderable_program(&plan.program, sample_rate.max(1), channels.max(1));
+        let renderer_plan = DjTransitionPlan {
+            program: renderer_program,
+            rejected_alternatives: plan.rejected_alternatives,
+            planner_version: plan.planner_version,
+            fallback_reason: renderer_fallback_reason.or(plan.fallback_reason),
+        };
+        let timing_plan =
+            dj_gapless_plan_for_pair(engine, current, current_duration_ms, &renderer_plan.program);
+        job.gapless = timing_plan.gapless;
+        let transition_event_id = log_dj_transition_event(
+            engine,
+            current,
+            next,
+            &planned_template,
+            &renderer_plan,
+            &timing_plan,
+        )?;
         job = job.with_prepared_transition(PreparedTransitionProgram {
-            program: plan.program,
+            program: renderer_plan.program,
             transition_event_id: Some(transition_event_id),
             queue_generation: pair.queue_generation,
             current_queue_item_id: pair.current_queue_item_id,
@@ -416,11 +454,223 @@ fn attach_dj_transition_plan_for_pair(
     Ok(job)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct DjTransitionTimingPlan {
+    gapless: GaplessPlan,
+    planned_start_ms: Option<i64>,
+    timing_source: &'static str,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SyncedDjOverlap {
+    overlap_ms: i32,
+    timing_source: &'static str,
+}
+
+fn dj_gapless_plan_from_program(program: &noor_mix::TransitionProgram) -> GaplessPlan {
+    let sample_rate = program.sample_rate.max(1);
+    let overlap_ms = ((program.resolve_at.saturating_mul(1000)) / u64::from(sample_rate))
+        .clamp(250, i32::MAX as u64) as i32;
+    GaplessPlan {
+        enabled: true,
+        overlap_ms,
+        prebuffer_ms: 500,
+        requires_stream_metadata: false,
+    }
+}
+
+fn dj_gapless_plan_for_pair(
+    engine: &DjEngine,
+    current: &DjMediaRef,
+    current_duration_ms: Option<i64>,
+    program: &noor_mix::TransitionProgram,
+) -> DjTransitionTimingPlan {
+    let mut plan = dj_gapless_plan_from_program(program);
+    let mut timing_source = "fallback_overlap";
+    let mut duration_ms = current_duration_ms;
+    if let Ok(Some(synced)) = engine.db().with_conn(|conn| {
+        synced_dj_overlap_ms(conn, current, current_duration_ms, program, plan.overlap_ms)
+    }) {
+        plan.overlap_ms = synced.overlap_ms;
+        timing_source = synced.timing_source;
+    }
+    if duration_ms.is_none() {
+        duration_ms = engine
+            .db()
+            .with_conn(|conn| current_track_duration_ms(conn, current))
+            .ok()
+            .flatten();
+    }
+    DjTransitionTimingPlan {
+        gapless: plan,
+        planned_start_ms: duration_ms
+            .map(|duration| duration.saturating_sub(i64::from(plan.overlap_ms)).max(0)),
+        timing_source,
+    }
+}
+
+fn synced_dj_overlap_ms(
+    conn: &Connection,
+    current: &DjMediaRef,
+    current_duration_ms: Option<i64>,
+    program: &noor_mix::TransitionProgram,
+    preferred_overlap_ms: i32,
+) -> Result<Option<SyncedDjOverlap>> {
+    let Some(duration_ms) = current_duration_ms.or(current_track_duration_ms(conn, current)?)
+    else {
+        return Ok(None);
+    };
+    let key = current.profile_key();
+    let Some(profile) = queries::get_audio_dj_profile(conn, &key)? else {
+        return Ok(None);
+    };
+    if profile.profile_confidence < 0.6 {
+        return Ok(None);
+    }
+
+    let downbeats = decode_f32_blob(&profile.downbeats_blob).unwrap_or_default();
+    if let Some(overlap_ms) = synced_overlap_from_grid_ms(
+        duration_ms,
+        &downbeats,
+        preferred_overlap_ms,
+        Some(program.resolve_at),
+        program.sample_rate,
+    ) {
+        return Ok(Some(SyncedDjOverlap {
+            overlap_ms,
+            timing_source: "downbeat_sync",
+        }));
+    }
+
+    let beats = decode_f32_blob(&profile.beat_grid_blob).unwrap_or_default();
+    Ok(synced_overlap_from_grid_ms(
+        duration_ms,
+        &beats,
+        preferred_overlap_ms,
+        Some(program.resolve_at),
+        program.sample_rate,
+    )
+    .map(|overlap_ms| SyncedDjOverlap {
+        overlap_ms,
+        timing_source: "beat_sync",
+    }))
+}
+
+fn current_track_duration_ms(conn: &Connection, current: &DjMediaRef) -> Result<Option<i64>> {
+    match current {
+        DjMediaRef::LibraryTrack { track_id }
+        | DjMediaRef::TidalTrack {
+            track_id: Some(track_id),
+            ..
+        } => conn
+            .query_row(
+                "SELECT duration_ms FROM tracks WHERE id = ?1",
+                params![track_id],
+                |row| row.get::<_, Option<i64>>(0),
+            )
+            .optional()
+            .map(|value| value.flatten())
+            .map_err(Into::into),
+        DjMediaRef::TidalTrack { tidal_id, .. } => conn
+            .query_row(
+                "SELECT duration_ms FROM tracks WHERE tidal_id = ?1 LIMIT 1",
+                params![tidal_id],
+                |row| row.get::<_, Option<i64>>(0),
+            )
+            .optional()
+            .map(|value| value.flatten())
+            .map_err(Into::into),
+        DjMediaRef::PendingQueueItem { .. } => Ok(None),
+    }
+}
+
+fn synced_overlap_from_grid_ms(
+    duration_ms: i64,
+    grid_seconds: &[f32],
+    preferred_overlap_ms: i32,
+    program_samples: Option<u64>,
+    sample_rate: u32,
+) -> Option<i32> {
+    const MIN_SYNC_OVERLAP_MS: i64 = 8_000;
+    const MAX_SYNC_OVERLAP_MS: i64 = 12_000;
+    let preferred_ms = preferred_overlap_ms.max(250) as i64;
+    let program_ms = program_samples
+        .map(|samples| {
+            ((samples.saturating_mul(1000)) / u64::from(sample_rate.max(1)))
+                .clamp(250, i64::MAX as u64) as i64
+        })
+        .unwrap_or(preferred_ms);
+    let min_overlap_ms = preferred_ms
+        .max(program_ms)
+        .max(MIN_SYNC_OVERLAP_MS)
+        .min(MAX_SYNC_OVERLAP_MS);
+    let grid = extrapolated_grid_ms(grid_seconds, duration_ms)?;
+
+    grid.into_iter()
+        .filter_map(|start_ms| {
+            let overlap_ms = duration_ms.saturating_sub(start_ms);
+            (overlap_ms >= min_overlap_ms && overlap_ms <= MAX_SYNC_OVERLAP_MS)
+                .then_some(overlap_ms as i32)
+        })
+        .min()
+}
+
+fn extrapolated_grid_ms(grid_seconds: &[f32], duration_ms: i64) -> Option<Vec<i64>> {
+    let mut grid = grid_seconds
+        .iter()
+        .filter_map(|seconds| {
+            seconds
+                .is_finite()
+                .then_some((*seconds * 1000.0).round() as i64)
+        })
+        .filter(|ms| *ms >= 0 && *ms < duration_ms)
+        .collect::<Vec<_>>();
+    grid.sort_unstable();
+    grid.dedup();
+    if grid.len() < 2 {
+        return (!grid.is_empty()).then_some(grid);
+    }
+
+    let interval_ms = grid
+        .windows(2)
+        .filter_map(|pair| {
+            let delta = pair[1].saturating_sub(pair[0]);
+            (delta > 0).then_some(delta)
+        })
+        .min()?;
+    let mut next = grid.last().copied()?.saturating_add(interval_ms);
+    while next < duration_ms {
+        grid.push(next);
+        next = next.saturating_add(interval_ms);
+    }
+    Some(grid)
+}
+
+fn v1_renderable_program(
+    program: &noor_mix::TransitionProgram,
+    sample_rate: u32,
+    channels: u16,
+) -> (noor_mix::TransitionProgram, Option<&'static str>) {
+    if program.template == "SafeCrossfade" {
+        return (program.clone(), None);
+    }
+    (
+        crate::playback::dj_engine::safe_crossfade_program(
+            sample_rate,
+            channels,
+            noor_mix::Policy::default(),
+        ),
+        Some("template_not_renderable"),
+    )
+}
+
 fn log_dj_transition_event(
     engine: &DjEngine,
     current: &DjMediaRef,
     next: &DjMediaRef,
+    planned_template: &str,
     plan: &DjTransitionPlan,
+    timing_plan: &DjTransitionTimingPlan,
 ) -> Result<i64> {
     let current_key = current.profile_key();
     let next_key = next.profile_key();
@@ -435,11 +685,14 @@ fn log_dj_transition_event(
             Some(current_key.media_ref_id.as_str()),
             Some(next_key.media_ref_kind.as_str()),
             Some(next_key.media_ref_id.as_str()),
-            plan.program.template.as_str(),
+            planned_template,
             program_json.as_str(),
             Some(rejected_json.as_str()),
             plan.planner_version,
             plan.fallback_reason,
+            timing_plan.planned_start_ms,
+            Some(timing_plan.timing_source),
+            Some("armed"),
         )
     })
 }
@@ -501,7 +754,14 @@ pub fn latest_open_dj_transition_event_for_pair(
          WHERE from_track_id = ?1
            AND to_track_id = ?2
            AND outcome IS NULL
-         ORDER BY started_at DESC, id DESC
+         ORDER BY CASE timing_status
+             WHEN 'fired' THEN 0
+             WHEN 'late' THEN 1
+             WHEN 'armed' THEN 2
+             ELSE 3
+         END,
+         started_at DESC,
+         id DESC
          LIMIT 1",
         params![from_track_id, to_track_id],
         |row| row.get(0),
@@ -1208,10 +1468,14 @@ pub fn build_playback_preparation(
 
     let output_sample_rate = stream_info.and_then(StreamInfo::sample_rate_hz);
 
-    PreparedPlaybackJob {
+    let mut job = PreparedPlaybackJob {
         output_sample_rate,
         ..PreparedPlaybackJob::new(track.clone(), source, gapless)
+    };
+    if let Some(media_ref) = crate::playback::dj_lookahead::tidal_media_ref_for_track(track) {
+        job = job.with_dj_media_ref(media_ref);
     }
+    job
 }
 
 pub fn playback_source_kind(track: &Track) -> &'static str {
@@ -2612,6 +2876,15 @@ mod tests {
         }
 
         #[test]
+        fn prepared_dj_program_supplies_runtime_overlap() {
+            let job = planned_job_for_source("manual");
+
+            assert!(job.prepared_transition.is_some());
+            assert!(job.gapless.enabled);
+            assert!(job.gapless.overlap_ms > 0);
+        }
+
+        #[test]
         fn prepare_next_omits_program_when_disabled() {
             let db = db_with_pair("manual");
             let job = attach_dj_transition_plan(&db, next_job(&db), 48_000, 2).expect("plan");
@@ -2854,6 +3127,25 @@ mod tests {
         }
 
         #[test]
+        fn latest_open_dj_transition_event_for_pair_prefers_fired_event() {
+            let db = db_with_pair();
+            let fired = plan(&db);
+            let fired_id = fired.transition_event_id.expect("fired event");
+            db.with_conn(|conn| {
+                queries::update_dj_transition_fire_timing(conn, fired_id, 172_040, "fired")
+            })
+            .expect("mark fired");
+            let duplicate = plan(&db);
+            assert_ne!(duplicate.transition_event_id, Some(fired_id));
+
+            let selected = db
+                .with_conn(|conn| latest_open_dj_transition_event_for_pair(conn, Some(1), 2))
+                .expect("selected");
+
+            assert_eq!(selected, Some(fired_id));
+        }
+
+        #[test]
         fn dj_disabled_does_not_write_dj_transition_events() {
             let db = db_with_pair();
             db.with_conn(|conn| queries::set_dj_engine_enabled(conn, false))
@@ -2930,6 +3222,31 @@ mod tests {
 
             assert_eq!(planner_version, noor_mix::planner::DJ_PLANNER_VERSION);
             assert_ne!(planner_version, DJ_PROFILE_VERSION);
+        }
+
+        #[test]
+        fn v1_planner_lock_logs_and_prepares_safe_crossfade() {
+            let db = db_with_pair();
+            let transition = plan(&db);
+
+            assert_eq!(transition.program.template, "SafeCrossfade");
+            let row: (String, String, Option<String>) = db
+                .with_conn(|conn| {
+                    conn.query_row(
+                        "SELECT template, program_json, fallback_reason
+                         FROM dj_transition_events WHERE id = ?1",
+                        params![transition.transition_event_id],
+                        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+                    )
+                    .map_err(Into::into)
+                })
+                .expect("event");
+            let renderer_program: noor_mix::TransitionProgram =
+                serde_json::from_str(&row.1).expect("program");
+
+            assert_eq!(row.0, "SafeCrossfade");
+            assert_eq!(renderer_program.template, "SafeCrossfade");
+            assert_eq!(row.2, None);
         }
 
         #[test]
@@ -3416,6 +3733,7 @@ mod tests {
         assert!(prep.is_local());
         assert_eq!(prep.source_kind(), PlaybackSourceKind::LocalLibrary);
         assert!(prep.stream_request().is_none());
+        assert!(prep.dj_media_ref.is_none());
         assert!(!prep.gapless.enabled);
         assert_eq!(prep.track.id, 7);
     }
@@ -3444,6 +3762,33 @@ mod tests {
         assert!(prep.gapless.enabled);
         assert_eq!(prep.gapless.overlap_ms, 1500);
         assert_eq!(prep.output_sample_rate, Some(44_100));
+        assert_eq!(
+            prep.dj_media_ref
+                .as_ref()
+                .map(|media_ref| media_ref.profile_key()),
+            Some(crate::db::models::AudioDjProfileKey {
+                media_ref_kind: "tidal_track".to_string(),
+                media_ref_id: "77".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn synced_overlap_uses_projected_downbeat_before_track_end() {
+        let overlap_ms =
+            synced_overlap_from_grid_ms(180_000, &[0.0, 2.0, 4.0], 8_000, Some(8_000 * 48), 48_000)
+                .expect("overlap");
+
+        assert_eq!(overlap_ms, 8_000);
+    }
+
+    #[test]
+    fn synced_overlap_keeps_preferred_minimum_when_last_grid_is_too_close() {
+        let overlap_ms =
+            synced_overlap_from_grid_ms(181_000, &[0.0, 2.0, 4.0], 8_000, Some(8_000 * 48), 48_000)
+                .expect("overlap");
+
+        assert_eq!(overlap_ms, 9_000);
     }
 
     #[test]

--- a/noor-server/src/playback/player.rs
+++ b/noor-server/src/playback/player.rs
@@ -79,6 +79,7 @@ pub struct PreparedPlaybackJob {
 pub struct PreparedTransitionProgram {
     pub program: noor_mix::TransitionProgram,
     pub transition_event_id: Option<i64>,
+    pub fire_ahead_ms: u32,
     pub queue_generation: u64,
     pub current_queue_item_id: Option<i64>,
     pub next_queue_item_id: Option<i64>,
@@ -443,15 +444,67 @@ pub fn attach_dj_transition_plan_for_pair_with_current_duration(
             &renderer_plan,
             &timing_plan,
         )?;
+        let fire_ahead_ms = engine.db().with_conn(dj_transition_fire_ahead_ms)?;
         job = job.with_prepared_transition(PreparedTransitionProgram {
             program: renderer_plan.program,
             transition_event_id: Some(transition_event_id),
+            fire_ahead_ms,
             queue_generation: pair.queue_generation,
             current_queue_item_id: pair.current_queue_item_id,
             next_queue_item_id: Some(next_queue_item_id),
         });
     }
     Ok(job)
+}
+
+const DJ_FIRE_AHEAD_WINDOW: i64 = 20;
+const DJ_FIRE_AHEAD_POSITIVE_PERCENT: usize = 70;
+const DJ_FIRE_AHEAD_MEDIAN_FLOOR_MS: i64 = 150;
+const DJ_FIRE_AHEAD_MAX_MS: i64 = 300;
+
+fn dj_transition_fire_ahead_ms(conn: &Connection) -> Result<u32> {
+    let mut stmt = conn.prepare(
+        "SELECT timing_delta_ms
+         FROM dj_transition_events
+         WHERE timing_status = 'fired'
+           AND timing_delta_ms IS NOT NULL
+         ORDER BY started_at DESC, id DESC
+         LIMIT ?1",
+    )?;
+    let rows = stmt.query_map([DJ_FIRE_AHEAD_WINDOW], |row| row.get::<_, i64>(0))?;
+    let mut deltas = Vec::new();
+    for row in rows {
+        deltas.push(row?);
+    }
+    Ok(fire_ahead_ms_from_deltas(&deltas))
+}
+
+fn fire_ahead_ms_from_deltas(deltas: &[i64]) -> u32 {
+    if deltas.len() < DJ_FIRE_AHEAD_WINDOW as usize {
+        return 0;
+    }
+    let positive_count = deltas.iter().filter(|delta| **delta > 0).count();
+    if positive_count * 100 < deltas.len() * DJ_FIRE_AHEAD_POSITIVE_PERCENT {
+        return 0;
+    }
+    median_delta(deltas)
+        .filter(|delta| *delta > DJ_FIRE_AHEAD_MEDIAN_FLOOR_MS)
+        .map(|delta| delta.clamp(DJ_FIRE_AHEAD_MEDIAN_FLOOR_MS, DJ_FIRE_AHEAD_MAX_MS) as u32)
+        .unwrap_or(0)
+}
+
+fn median_delta(deltas: &[i64]) -> Option<i64> {
+    if deltas.is_empty() {
+        return None;
+    }
+    let mut values = deltas.to_vec();
+    values.sort_unstable();
+    let middle = values.len() / 2;
+    if values.len() % 2 == 0 {
+        Some((values[middle - 1] + values[middle]) / 2)
+    } else {
+        Some(values[middle])
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -3268,6 +3321,79 @@ mod tests {
             assert_eq!(renderer_program.template, "FilterSweep");
             assert_eq!(renderer_program.resolve_at, 384_000);
             assert_eq!(row.2, None);
+        }
+
+        #[test]
+        fn v1_renderable_program_passes_filter_sweep_with_safe_duration() {
+            let input = noor_mix::planner::filter_sweep_eq_wash_program(48_000, 2, 32_000);
+
+            let (program, reason) = v1_renderable_program(&input, 48_000, 2);
+
+            assert_eq!(program.template, "FilterSweep");
+            assert_eq!(program.resolve_at, 384_000);
+            assert_eq!(reason, None);
+            assert!(
+                program
+                    .automation
+                    .iter()
+                    .any(|event| event.param == noor_mix::Param::HighGain(noor_mix::DeckId::A))
+            );
+        }
+
+        #[test]
+        fn v1_renderable_program_downgrades_slam_cut_to_safe_crossfade() {
+            let mut input = noor_mix::planner::filter_sweep_eq_wash_program(48_000, 2, 10_000);
+            input.template = "SlamCut".to_string();
+
+            let (program, reason) = v1_renderable_program(&input, 48_000, 2);
+
+            assert_eq!(program.template, "SafeCrossfade");
+            assert_eq!(reason, Some("template_not_renderable"));
+        }
+
+        #[test]
+        fn filter_sweep_uses_safe_crossfade_overlap_duration() {
+            let safe = crate::playback::dj_engine::safe_crossfade_program(
+                48_000,
+                2,
+                noor_mix::Policy::default(),
+            );
+            let filter = noor_mix::planner::filter_sweep_eq_wash_program(
+                48_000,
+                2,
+                noor_mix::Policy::default().default_crossfade_ms,
+            );
+
+            assert_eq!(
+                dj_gapless_plan_from_program(&filter),
+                dj_gapless_plan_from_program(&safe)
+            );
+        }
+
+        #[test]
+        fn fire_ahead_requires_latest_twenty_positive_evidence() {
+            let passing = vec![
+                412, 709, 270, 475, 8, 827, 258, 738, 8, 35, 252, 141, -375, 210, 73, 529, -53, 48,
+                481, 300,
+            ];
+            let mixed = vec![
+                412, 709, 270, 475, -8, -827, -258, -738, -8, -35, 252, 141, -375, 210, 73, 529,
+                -53, 48, 481, 300,
+            ];
+            let low_median = vec![
+                151, 150, 149, 148, 147, 146, 145, 144, 143, 142, 141, 140, 139, 138, 137, 136,
+                135, 134, -20, -40,
+            ];
+
+            assert_eq!(fire_ahead_ms_from_deltas(&passing), 255);
+            assert_eq!(fire_ahead_ms_from_deltas(&mixed), 0);
+            assert_eq!(fire_ahead_ms_from_deltas(&low_median), 0);
+            assert_eq!(fire_ahead_ms_from_deltas(&passing[..19]), 0);
+        }
+
+        #[test]
+        fn fire_ahead_caps_large_median() {
+            assert_eq!(fire_ahead_ms_from_deltas(&[500; 20]), 300);
         }
 
         #[test]

--- a/noor-server/src/playback/player.rs
+++ b/noor-server/src/playback/player.rs
@@ -1,8 +1,10 @@
 use crate::db::audio_settings::AudioQuality;
 use crate::db::{
+    Database,
     models::{AudioDspFeatures, PlaybackState, QueueItem, Track},
     queries,
 };
+use crate::playback::dj_engine::DjEngine;
 use crate::playback::dj_lookahead::{DjLookaheadPair, DjMediaRef, load_dj_lookahead_pair};
 use crate::playback::gapless::{self, GaplessPlan, GaplessSettings};
 use crate::playback::queue::{self, ShuffleDebug, ShuffleMode};
@@ -365,6 +367,49 @@ fn dj_lookahead_start_from_pair(
         queue_generation: pair.queue_generation,
         deadline_samples,
     })
+}
+
+pub fn attach_dj_transition_plan(
+    db: &Database,
+    job: PlaybackPreparation,
+    sample_rate: u32,
+    channels: u16,
+) -> Result<PlaybackPreparation> {
+    let pair = db.with_conn(load_dj_lookahead_pair)?;
+    attach_dj_transition_plan_for_pair(&DjEngine::new(db.clone()), job, pair, sample_rate, channels)
+}
+
+fn attach_dj_transition_plan_for_pair(
+    engine: &DjEngine,
+    mut job: PlaybackPreparation,
+    pair: DjLookaheadPair,
+    sample_rate: u32,
+    channels: u16,
+) -> Result<PlaybackPreparation> {
+    let (Some(current), Some(next), Some(next_queue_item_id)) = (
+        pair.current.as_ref(),
+        pair.next.as_ref(),
+        pair.next_queue_item_id,
+    ) else {
+        return Ok(job);
+    };
+    if next
+        .track_id()
+        .is_some_and(|next_track_id| next_track_id != job.track.id)
+    {
+        return Ok(job);
+    }
+    if let Some(program) =
+        engine.plan_transition(current, next, sample_rate.max(1), channels.max(1))?
+    {
+        job = job.with_prepared_transition(PreparedTransitionProgram {
+            program,
+            queue_generation: pair.queue_generation,
+            current_queue_item_id: pair.current_queue_item_id,
+            next_queue_item_id: Some(next_queue_item_id),
+        });
+    }
+    Ok(job)
 }
 
 impl ActiveListenSession {
@@ -2425,6 +2470,200 @@ mod tests {
                     ..
                 })
             ));
+        }
+    }
+
+    mod dj_prepare_next {
+        use super::*;
+        use crate::db::schema;
+
+        fn db_with_pair(next_source: &str) -> Database {
+            let db = Database::open_in_memory().expect("db");
+            db.with_conn(|conn| {
+                schema::run_migrations(conn)?;
+                conn.execute("INSERT INTO artists (id, name) VALUES (1, 'A')", [])?;
+                for id in 1..=4 {
+                    conn.execute(
+                        "INSERT INTO tracks (
+                            id, title, artist_id, tidal_id, source, best_quality, best_source, duration_ms
+                        ) VALUES (?1, ?2, 1, ?1, 'tidal', 'LOSSLESS', 'tidal', 180000)",
+                        params![id, format!("Track {id}")],
+                    )?;
+                }
+                conn.execute(
+                    "INSERT INTO queue (id, track_id, position, source)
+                     VALUES (11, 1, 0, 'manual'), (12, 2, 1, ?1)",
+                    params![next_source],
+                )?;
+                conn.execute(
+                    "UPDATE playback_state
+                     SET current_track_id = 1, current_queue_item_id = 11, is_playing = 1
+                     WHERE id = 1",
+                    [],
+                )?;
+                Ok(())
+            })
+            .expect("seed db");
+            db
+        }
+
+        fn enable(db: &Database) {
+            db.with_conn(|conn| queries::set_dj_engine_enabled(conn, true))
+                .expect("enable");
+        }
+
+        fn next_job(db: &Database) -> PlaybackPreparation {
+            db.with_conn(|conn| {
+                let track = queue::get_track_by_id(conn, 2)?.expect("track");
+                Ok(build_playback_preparation(&track, None, 0, None))
+            })
+            .expect("next job")
+        }
+
+        fn planned_job_for_source(source: &str) -> PlaybackPreparation {
+            let db = db_with_pair(source);
+            enable(&db);
+            attach_dj_transition_plan(&db, next_job(&db), 48_000, 2).expect("plan")
+        }
+
+        #[test]
+        fn prepare_next_attaches_program_when_enabled() {
+            let job = planned_job_for_source("manual");
+
+            assert!(job.prepared_transition.is_some());
+        }
+
+        #[test]
+        fn prepare_next_omits_program_when_disabled() {
+            let db = db_with_pair("manual");
+            let job = attach_dj_transition_plan(&db, next_job(&db), 48_000, 2).expect("plan");
+
+            assert!(job.prepared_transition.is_none());
+        }
+
+        #[test]
+        fn dj_planning_does_not_reorder_queue() {
+            let db = db_with_pair("manual");
+            enable(&db);
+            let before = db
+                .with_conn(|conn| {
+                    let mut stmt = conn.prepare("SELECT id FROM queue ORDER BY position, id")?;
+                    let rows = stmt
+                        .query_map([], |row| row.get::<_, i64>(0))?
+                        .collect::<rusqlite::Result<Vec<_>>>()?;
+                    Ok(rows)
+                })
+                .expect("before");
+
+            let _ = attach_dj_transition_plan(&db, next_job(&db), 48_000, 2).expect("plan");
+            let after = db
+                .with_conn(|conn| {
+                    let mut stmt = conn.prepare("SELECT id FROM queue ORDER BY position, id")?;
+                    let rows = stmt
+                        .query_map([], |row| row.get::<_, i64>(0))?
+                        .collect::<rusqlite::Result<Vec<_>>>()?;
+                    Ok(rows)
+                })
+                .expect("after");
+
+            assert_eq!(after, before);
+        }
+
+        #[test]
+        fn dj_planning_does_not_replace_next_queue_item() {
+            let db = db_with_pair("manual");
+            enable(&db);
+
+            let _ = attach_dj_transition_plan(&db, next_job(&db), 48_000, 2).expect("plan");
+            let next_queue_track = db
+                .with_conn(|conn| {
+                    conn.query_row("SELECT track_id FROM queue WHERE id = 12", [], |row| {
+                        row.get::<_, Option<i64>>(0)
+                    })
+                    .map_err(anyhow::Error::from)
+                })
+                .expect("next queue item");
+
+            assert_eq!(next_queue_track, Some(2));
+        }
+
+        #[test]
+        fn manual_queue_next_uses_plan_transition_path() {
+            assert!(
+                planned_job_for_source("manual")
+                    .prepared_transition
+                    .is_some()
+            );
+        }
+
+        #[test]
+        fn radio_queue_next_uses_plan_transition_path() {
+            assert!(
+                planned_job_for_source("radio")
+                    .prepared_transition
+                    .is_some()
+            );
+        }
+
+        #[test]
+        fn automix_queue_next_uses_plan_transition_path() {
+            assert!(
+                planned_job_for_source("automix-new")
+                    .prepared_transition
+                    .is_some()
+            );
+        }
+
+        #[test]
+        fn external_next_track_uses_same_plan_transition_path() {
+            assert!(
+                planned_job_for_source("radio_pending")
+                    .prepared_transition
+                    .is_some()
+            );
+        }
+
+        #[test]
+        fn pending_next_without_profile_falls_back_to_safe_crossfade() {
+            let db = Database::open_in_memory().expect("db");
+            db.with_conn(|conn| {
+                schema::run_migrations(conn)?;
+                conn.execute("INSERT INTO artists (id, name) VALUES (1, 'A')", [])?;
+                conn.execute(
+                    "INSERT INTO tracks (
+                        id, title, artist_id, tidal_id, source, best_quality, best_source, duration_ms
+                     ) VALUES (1, 'Track 1', 1, 1, 'tidal', 'LOSSLESS', 'tidal', 180000)",
+                    [],
+                )?;
+                conn.execute(
+                    "INSERT INTO queue (id, track_id, position, source, pending_artist, pending_title)
+                     VALUES (11, 1, 0, 'manual', NULL, NULL),
+                            (12, NULL, 1, 'radio_pending', 'External A', 'External B')",
+                    [],
+                )?;
+                conn.execute(
+                    "UPDATE playback_state
+                     SET current_track_id = 1, current_queue_item_id = 11, is_playing = 1
+                     WHERE id = 1",
+                    [],
+                )?;
+                queries::set_dj_engine_enabled(conn, true)?;
+                Ok(())
+            })
+            .expect("seed pending");
+            let pair = db.with_conn(load_dj_lookahead_pair).expect("pair");
+            let engine = DjEngine::new(db.clone());
+            let job = attach_dj_transition_plan_for_pair(
+                &engine,
+                PreparedPlaybackJob::test_fixture(99, 1),
+                pair,
+                48_000,
+                2,
+            )
+            .expect("plan");
+
+            let program = job.prepared_transition.expect("transition").program;
+            assert_eq!(program.template, "SafeCrossfade");
         }
     }
 

--- a/noor-server/src/playback/player.rs
+++ b/noor-server/src/playback/player.rs
@@ -3,7 +3,7 @@ use crate::db::{
     models::{AudioDspFeatures, PlaybackState, QueueItem, Track},
     queries,
 };
-use crate::playback::dj_lookahead::DjMediaRef;
+use crate::playback::dj_lookahead::{DjLookaheadPair, DjMediaRef, load_dj_lookahead_pair};
 use crate::playback::gapless::{self, GaplessPlan, GaplessSettings};
 use crate::playback::queue::{self, ShuffleDebug, ShuffleMode};
 use crate::playback::shuffle::{
@@ -69,6 +69,33 @@ pub struct PreparedPlaybackJob {
     // from `start_from_offset_ms`. A fresh play has both = 0.
     pub start_from_segment_index: usize,
     pub start_from_offset_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DjLookaheadStart {
+    pub current: Option<DjMediaRef>,
+    pub next: Option<DjMediaRef>,
+    pub current_queue_item_id: Option<i64>,
+    pub next_queue_item_id: Option<i64>,
+    pub queue_generation: u64,
+    pub deadline_samples: u64,
+}
+
+impl DjLookaheadStart {
+    #[allow(dead_code)]
+    pub fn dispatch(
+        &self,
+        runtime: &crate::playback::runtime::PlaybackRuntimeHandle,
+    ) -> Result<()> {
+        runtime.start_dj_lookahead(
+            self.current.clone(),
+            self.next.clone(),
+            self.current_queue_item_id,
+            self.next_queue_item_id,
+            self.queue_generation,
+            self.deadline_samples,
+        )
+    }
 }
 
 impl PreparedPlaybackJob {
@@ -294,6 +321,34 @@ impl PreparedPlaybackJob {
     pub fn source_label(&self) -> &'static str {
         self.source_kind().as_str()
     }
+}
+
+pub fn build_dj_lookahead_start(
+    conn: &Connection,
+    deadline_samples: u64,
+) -> Result<Option<DjLookaheadStart>> {
+    if !queries::is_dj_engine_enabled(conn)? {
+        return Ok(None);
+    }
+    let pair = load_dj_lookahead_pair(conn)?;
+    Ok(dj_lookahead_start_from_pair(pair, deadline_samples))
+}
+
+fn dj_lookahead_start_from_pair(
+    pair: DjLookaheadPair,
+    deadline_samples: u64,
+) -> Option<DjLookaheadStart> {
+    if pair.current.is_none() && pair.next.is_none() {
+        return None;
+    }
+    Some(DjLookaheadStart {
+        current: pair.current,
+        next: pair.next,
+        current_queue_item_id: pair.current_queue_item_id,
+        next_queue_item_id: pair.next_queue_item_id,
+        queue_generation: pair.queue_generation,
+        deadline_samples,
+    })
 }
 
 impl ActiveListenSession {
@@ -2205,6 +2260,156 @@ mod tests {
         ids.iter()
             .map(|id| queue::get_track_by_id(conn, *id).unwrap().unwrap())
             .collect()
+    }
+
+    mod dj_lookahead {
+        use super::*;
+
+        const DEADLINE: u64 = 48_000 * 30;
+
+        fn enable(conn: &Connection) {
+            queries::set_dj_engine_enabled(conn, true).unwrap();
+        }
+
+        fn start(conn: &Connection) -> Option<DjLookaheadStart> {
+            build_dj_lookahead_start(conn, DEADLINE).unwrap()
+        }
+
+        fn seed_queue(conn: &Connection, ids: &[i64]) -> Vec<QueueItem> {
+            let tracks = load_tracks(conn, ids);
+            queue::replace_queue(conn, &tracks, "test").unwrap()
+        }
+
+        #[test]
+        fn dj_disabled_queue_events_do_not_start_dj_lookahead() {
+            let conn = conn();
+            seed_queue(&conn, &[1, 2]);
+            play_track_now(&conn, 1).unwrap();
+
+            assert!(start(&conn).is_none());
+        }
+
+        #[test]
+        fn dj_enable_starts_dj_lookahead_for_active_pair() {
+            let conn = conn();
+            enable(&conn);
+            let queued = seed_queue(&conn, &[1, 2]);
+            conn.execute(
+                "UPDATE playback_state SET current_track_id = 1, current_queue_item_id = ?1 WHERE id = 1",
+                params![queued[0].id],
+            )
+            .unwrap();
+
+            let start = start(&conn).expect("lookahead");
+            assert_eq!(start.current_queue_item_id, Some(queued[0].id));
+            assert_eq!(start.next_queue_item_id, Some(queued[1].id));
+            assert_eq!(start.deadline_samples, DEADLINE);
+        }
+
+        #[test]
+        fn manual_play_starts_dj_lookahead() {
+            let conn = conn();
+            enable(&conn);
+            let queued = seed_queue(&conn, &[1, 2]);
+            play_track_now(&conn, 1).unwrap();
+
+            let start = start(&conn).expect("lookahead");
+            assert_eq!(start.current_queue_item_id, Some(queued[0].id));
+            assert_eq!(start.next_queue_item_id, Some(queued[1].id));
+        }
+
+        #[test]
+        fn manual_queue_append_starts_dj_lookahead() {
+            let conn = conn();
+            enable(&conn);
+            let queued = seed_queue(&conn, &[1]);
+            conn.execute(
+                "UPDATE playback_state SET current_track_id = 1, current_queue_item_id = ?1 WHERE id = 1",
+                params![queued[0].id],
+            )
+            .unwrap();
+            enqueue_track(&conn, 2, "user").unwrap();
+
+            let start = start(&conn).expect("lookahead");
+            assert_eq!(start.current_queue_item_id, Some(queued[0].id));
+            assert!(matches!(
+                start.next,
+                Some(DjMediaRef::TidalTrack { tidal_id: 2, .. })
+            ));
+        }
+
+        #[test]
+        fn play_next_starts_dj_lookahead() {
+            let conn = conn();
+            enable(&conn);
+            let queued = seed_queue(&conn, &[1, 3]);
+            conn.execute(
+                "UPDATE playback_state SET current_track_id = 1, current_queue_item_id = ?1 WHERE id = 1",
+                params![queued[0].id],
+            )
+            .unwrap();
+            let play_next = load_tracks(&conn, &[2]).remove(0);
+            queue::append_tracks(&conn, &[play_next], "user_play_next").unwrap();
+            let inserted = queue::load_queue(&conn).unwrap();
+            let inserted_id = inserted.iter().find(|item| item.track.id == 2).unwrap().id;
+            queue::move_queue_item(&conn, inserted_id, 1).unwrap();
+
+            let start = start(&conn).expect("lookahead");
+            assert_eq!(start.next_queue_item_id, Some(inserted_id));
+        }
+
+        #[test]
+        fn queue_reorder_restarts_dj_lookahead() {
+            let conn = conn();
+            enable(&conn);
+            let queued = seed_queue(&conn, &[1, 2, 3]);
+            conn.execute(
+                "UPDATE playback_state SET current_track_id = 1, current_queue_item_id = ?1 WHERE id = 1",
+                params![queued[0].id],
+            )
+            .unwrap();
+            let before = start(&conn).expect("before");
+            queue::move_queue_item(&conn, queued[2].id, 1).unwrap();
+
+            let after = start(&conn).expect("after");
+            assert_ne!(before.next_queue_item_id, after.next_queue_item_id);
+            assert_eq!(after.next_queue_item_id, Some(queued[2].id));
+        }
+
+        #[test]
+        fn pending_resolution_restarts_dj_lookahead_with_tidal_ref() {
+            let conn = conn();
+            enable(&conn);
+            let queued = seed_queue(&conn, &[1]);
+            conn.execute(
+                "UPDATE playback_state SET current_track_id = 1, current_queue_item_id = ?1 WHERE id = 1",
+                params![queued[0].id],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO queue (track_id, position, source, pending_artist, pending_title)
+                 VALUES (NULL, 1, 'radio_pending', 'Artist', 'Title')",
+                [],
+            )
+            .unwrap();
+            let pending_id = conn.last_insert_rowid();
+            let before = start(&conn).expect("before");
+            conn.execute(
+                "UPDATE queue SET tidal_id_hint = 99 WHERE id = ?1",
+                params![pending_id],
+            )
+            .unwrap();
+
+            let after = start(&conn).expect("after");
+            assert_ne!(before.queue_generation, after.queue_generation);
+            assert!(matches!(
+                after.next,
+                Some(DjMediaRef::PendingQueueItem {
+                    tidal_id_hint: Some(99),
+                    ..
+                })
+            ));
+        }
     }
 
     fn track_with_tidal_id(id: i64, tidal_id: Option<i64>, quality: Option<&str>) -> Track {

--- a/noor-server/src/playback/runtime/commands.rs
+++ b/noor-server/src/playback/runtime/commands.rs
@@ -1,5 +1,6 @@
 use super::OutputDeviceSelection;
 use crate::db::audio_settings::ExclusiveLatencyMode;
+use crate::playback::dj_lookahead::DjMediaRef;
 use crate::playback::player::{PlaybackSourceKind, PreparedPlaybackJob};
 
 #[derive(Debug, Clone)]
@@ -22,6 +23,15 @@ pub enum PlaybackRuntimeCommand {
     },
     /// Pre-decode the next track in background so it can start gaplessly.
     PrepareNext(PreparedPlaybackJob),
+    /// Start non-audible DJ lookahead for the current plus immediate next queue item.
+    StartDjLookahead {
+        current: Option<DjMediaRef>,
+        next: Option<DjMediaRef>,
+        current_queue_item_id: Option<i64>,
+        next_queue_item_id: Option<i64>,
+        queue_generation: u64,
+        deadline_samples: u64,
+    },
     /// Sent by the decoder thread when a track finishes decoding successfully.
     /// Used to start the crossfade stream if the crossfade window has already opened.
     NextDecodeComplete {

--- a/noor-server/src/playback/runtime/commands.rs
+++ b/noor-server/src/playback/runtime/commands.rs
@@ -23,6 +23,10 @@ pub enum PlaybackRuntimeCommand {
     },
     /// Pre-decode the next track in background so it can start gaplessly.
     PrepareNext(PreparedPlaybackJob),
+    /// Update the runtime's in-memory DJ gate after the persisted feature flag changes.
+    SetDjEngineEnabled {
+        enabled: bool,
+    },
     /// Start non-audible DJ lookahead for the current plus immediate next queue item.
     StartDjLookahead {
         current: Option<DjMediaRef>,

--- a/noor-server/src/playback/runtime/commands.rs
+++ b/noor-server/src/playback/runtime/commands.rs
@@ -136,6 +136,13 @@ pub enum PlaybackRuntimeEvent {
         track_id: i64,
         generation: u64,
     },
+    DjTransitionPromoted {
+        transition_event_id: i64,
+        outgoing_track_id: i64,
+        generation: u64,
+        actual_start_ms: i64,
+        timing_status: String,
+    },
     /// Fired when the current track is within `NEAR_END_THRESHOLD_MS` of its end.
     /// The listener should peek the next track and send `PrepareNext` to pre-buffer it.
     NearEnd {

--- a/noor-server/src/playback/runtime/mod.rs
+++ b/noor-server/src/playback/runtime/mod.rs
@@ -253,6 +253,10 @@ impl PlaybackRuntimeHandle {
         self.send(PlaybackRuntimeCommand::PrepareNext(job))
     }
 
+    pub fn set_dj_engine_enabled(&self, enabled: bool) -> Result<()> {
+        self.send(PlaybackRuntimeCommand::SetDjEngineEnabled { enabled })
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn start_dj_lookahead(
         &self,
@@ -455,6 +459,7 @@ struct PlaybackRuntimeLoopState {
     current_exclusive_release_grace_secs: u32,
     /// Last-known WASAPI exclusive callback period policy.
     current_exclusive_latency_mode: ExclusiveLatencyMode,
+    dj_engine_enabled: bool,
     dj_lookahead: Option<RuntimeDjLookahead>,
     dj_lookahead_failure: Option<DjLookaheadFailure>,
     prepared_dj_mixer: Option<PreparedDjMixer>,
@@ -689,6 +694,10 @@ fn prepare_dj_mixer_for_pair(
     state: &mut PlaybackRuntimeLoopState,
     max_block_samples: usize,
 ) -> bool {
+    if !state.dj_engine_enabled {
+        state.prepared_dj_mixer = None;
+        return false;
+    }
     let Some(transition) = state
         .next_engine
         .as_ref()
@@ -702,6 +711,34 @@ fn prepare_dj_mixer_for_pair(
     let did_prepare = prepared.is_some();
     state.prepared_dj_mixer = prepared;
     did_prepare
+}
+
+fn gate_prepare_next_for_dj(
+    state: &mut PlaybackRuntimeLoopState,
+    job: &mut PreparedPlaybackJob,
+) -> bool {
+    if !state.dj_engine_enabled {
+        job.prepared_transition = None;
+        state.prepared_dj_mixer = None;
+        return false;
+    }
+    if discard_stale_prepared_transition(state, job) {
+        state.prepared_dj_mixer = None;
+    }
+    job.prepared_transition.is_some()
+}
+
+fn set_dj_engine_enabled_in_state(state: &mut PlaybackRuntimeLoopState, enabled: bool) {
+    state.dj_engine_enabled = enabled;
+    if enabled {
+        return;
+    }
+    state.dj_lookahead = None;
+    state.dj_lookahead_failure = None;
+    state.prepared_dj_mixer = None;
+    if let Some(engine) = state.next_engine.as_mut() {
+        engine.job.prepared_transition = None;
+    }
 }
 
 fn record_dj_lookahead_failure(
@@ -721,7 +758,7 @@ fn record_dj_lookahead_failure(
 
 #[allow(clippy::too_many_arguments)]
 fn run_runtime_loop(
-    config: PlaybackRuntimeConfig,
+    mut config: PlaybackRuntimeConfig,
     command_rx: mpsc::Receiver<PlaybackRuntimeCommand>,
     command_tx: mpsc::Sender<PlaybackRuntimeCommand>,
     event_tx: tokio::sync::broadcast::Sender<PlaybackRuntimeEvent>,
@@ -757,6 +794,7 @@ fn run_runtime_loop(
         current_exclusive_release_grace_secs:
             crate::db::audio_settings::DEFAULT_EXCLUSIVE_RELEASE_GRACE_SECS,
         current_exclusive_latency_mode: ExclusiveLatencyMode::Stable,
+        dj_engine_enabled: config.dj_engine_enabled,
         dj_lookahead: None,
         dj_lookahead_failure: None,
         prepared_dj_mixer: None,
@@ -951,9 +989,7 @@ fn run_runtime_loop(
                     }
                 }
                 PlaybackRuntimeCommand::PrepareNext(mut job) => {
-                    if discard_stale_prepared_transition(&state, &mut job) {
-                        state.prepared_dj_mixer = None;
-                    }
+                    gate_prepare_next_for_dj(&mut state, &mut job);
                     // Only pre-decode if we don't already have a pending engine for this track.
                     let already_pending = state
                         .next_engine
@@ -1013,6 +1049,10 @@ fn run_runtime_loop(
                         }
                     }
                 }
+                PlaybackRuntimeCommand::SetDjEngineEnabled { enabled } => {
+                    config.dj_engine_enabled = enabled;
+                    set_dj_engine_enabled_in_state(&mut state, enabled);
+                }
                 PlaybackRuntimeCommand::StartDjLookahead {
                     current,
                     next,
@@ -1021,17 +1061,24 @@ fn run_runtime_loop(
                     queue_generation,
                     deadline_samples,
                 } => {
-                    let outcome = start_dj_lookahead_in_state(
-                        &mut state,
-                        current,
-                        next,
-                        current_queue_item_id,
-                        next_queue_item_id,
-                        queue_generation,
-                        deadline_samples,
-                    );
-                    if matches!(outcome, StartDjLookaheadOutcome::MissingNext) {
-                        debug!("DJ lookahead skipped because the next queue item is not resolved");
+                    if !state.dj_engine_enabled {
+                        state.dj_lookahead = None;
+                        state.prepared_dj_mixer = None;
+                    } else {
+                        let outcome = start_dj_lookahead_in_state(
+                            &mut state,
+                            current,
+                            next,
+                            current_queue_item_id,
+                            next_queue_item_id,
+                            queue_generation,
+                            deadline_samples,
+                        );
+                        if matches!(outcome, StartDjLookaheadOutcome::MissingNext) {
+                            debug!(
+                                "DJ lookahead skipped because the next queue item is not resolved"
+                            );
+                        }
                     }
                 }
                 PlaybackRuntimeCommand::CrossfadeStart {
@@ -2646,6 +2693,43 @@ mod tests {
     }
 
     #[test]
+    fn dj_flag_off_does_not_construct_mixer() {
+        let mut state = state_with_ready_dj_pair();
+        state.dj_engine_enabled = false;
+
+        assert!(!prepare_dj_mixer_for_pair(&mut state, 64));
+        assert!(state.prepared_dj_mixer.is_none());
+    }
+
+    #[test]
+    fn dj_flag_off_ignores_transition_program_field() {
+        let mut state = test_runtime_loop_state();
+        state.dj_engine_enabled = false;
+        let mut job = PreparedPlaybackJob::test_fixture(2, 21)
+            .with_prepared_transition(test_prepared_transition_program(20, Some(11), Some(12)));
+
+        assert!(!gate_prepare_next_for_dj(&mut state, &mut job));
+        assert!(job.prepared_transition.is_none());
+        assert!(state.prepared_dj_mixer.is_none());
+    }
+
+    #[test]
+    fn disabling_dj_discards_ready_mixer_without_stopping_playback() {
+        let mut state = state_with_ready_dj_pair();
+        assert!(prepare_dj_mixer_for_pair(&mut state, 64));
+
+        set_dj_engine_enabled_in_state(&mut state, false);
+
+        assert!(!state.dj_engine_enabled);
+        assert!(state.prepared_dj_mixer.is_none());
+        let active = state.engine.as_ref().expect("active engine");
+        let next = state.next_engine.as_ref().expect("next engine");
+        assert!(!active.shared.stopped.load(Ordering::SeqCst));
+        assert!(!next.shared.stopped.load(Ordering::SeqCst));
+        assert!(next.job.prepared_transition.is_none());
+    }
+
+    #[test]
     fn effective_output_config_applies_desired_sample_rate() {
         let base = StreamConfig {
             channels: 2,
@@ -3177,6 +3261,7 @@ mod tests {
             current_exclusive_release_grace_secs:
                 crate::db::audio_settings::DEFAULT_EXCLUSIVE_RELEASE_GRACE_SECS,
             current_exclusive_latency_mode: ExclusiveLatencyMode::Stable,
+            dj_engine_enabled: true,
             dj_lookahead: None,
             dj_lookahead_failure: None,
             prepared_dj_mixer: None,
@@ -3308,6 +3393,28 @@ mod tests {
                 Arc::new(AtomicU64::new(0)),
             )),
         )
+    }
+
+    fn state_with_ready_dj_pair() -> PlaybackRuntimeLoopState {
+        let mut state = test_runtime_loop_state();
+        start_dj_lookahead_in_state(
+            &mut state,
+            Some(DjMediaRef::LibraryTrack { track_id: 1 }),
+            Some(DjMediaRef::LibraryTrack { track_id: 2 }),
+            Some(11),
+            Some(12),
+            20,
+            48_000,
+        );
+        let active = test_engine_with_shared(1, 20);
+        finish_engine_buffer(&active, &[0.25, 0.25, 0.25, 0.25]);
+        let mut next = test_engine_with_shared(2, 21);
+        next.job = PreparedPlaybackJob::test_fixture(2, 21)
+            .with_prepared_transition(test_prepared_transition_program(20, Some(11), Some(12)));
+        finish_engine_buffer(&next, &[0.5, 0.5, 0.5, 0.5]);
+        state.engine = Some(active);
+        state.next_engine = Some(next);
+        state
     }
 
     fn finish_engine_buffer(engine: &PlaybackEngine, samples: &[f32]) {

--- a/noor-server/src/playback/runtime/mod.rs
+++ b/noor-server/src/playback/runtime/mod.rs
@@ -85,6 +85,7 @@ pub struct PlaybackRuntimeConfig {
     pub analysis_tx: Option<tokio::sync::mpsc::UnboundedSender<(i64, Vec<f32>, u32)>>,
     pub dj_analysis_tx: Option<tokio::sync::mpsc::UnboundedSender<DjAnalysisJob>>,
     pub dj_engine_enabled: bool,
+    pub dj_analysis_only: bool,
 }
 
 impl PlaybackRuntimeConfig {
@@ -99,6 +100,7 @@ impl PlaybackRuntimeConfig {
             analysis_tx,
             dj_analysis_tx: None,
             dj_engine_enabled: false,
+            dj_analysis_only: false,
         }
     }
 
@@ -109,6 +111,11 @@ impl PlaybackRuntimeConfig {
     ) -> Self {
         self.dj_engine_enabled = dj_engine_enabled;
         self.dj_analysis_tx = dj_analysis_tx;
+        self
+    }
+
+    pub fn for_dj_analysis_only(mut self) -> Self {
+        self.dj_analysis_only = true;
         self
     }
 }
@@ -506,7 +513,6 @@ enum StartDjLookaheadOutcome {
     Started,
     AlreadyCurrent,
     ReusedPreparedNext,
-    IgnoredStaleGeneration,
     MissingNext,
 }
 
@@ -532,20 +538,6 @@ fn start_dj_lookahead_in_state(
     queue_generation: u64,
     deadline_samples: u64,
 ) -> StartDjLookaheadOutcome {
-    if state
-        .dj_lookahead
-        .as_ref()
-        .is_some_and(|lookahead| lookahead.queue_generation > queue_generation)
-    {
-        state.dj_lookahead_failure = Some(DjLookaheadFailure {
-            queue_generation,
-            current_queue_item_id,
-            next_queue_item_id,
-            reason: DjLookaheadFailureReason::QueueChanged,
-        });
-        return StartDjLookaheadOutcome::IgnoredStaleGeneration;
-    }
-
     let Some(next) = next else {
         state.dj_lookahead = None;
         state.dj_lookahead_failure = Some(DjLookaheadFailure {
@@ -711,6 +703,41 @@ fn prepare_dj_mixer_for_pair(
     let did_prepare = prepared.is_some();
     state.prepared_dj_mixer = prepared;
     did_prepare
+}
+
+fn arm_active_transition_window(
+    state: &mut PlaybackRuntimeLoopState,
+    job: &PreparedPlaybackJob,
+) -> bool {
+    if job.prepared_transition.is_none() || job.gapless.overlap_ms <= 0 {
+        return false;
+    }
+    let Some(engine) = state.engine.as_ref() else {
+        return false;
+    };
+    let samples = (job.gapless.overlap_ms as u64)
+        .saturating_mul(state.device_sample_rate as u64)
+        .saturating_mul(state.device_channels.max(1) as u64)
+        / 1000;
+    if samples == 0 {
+        return false;
+    }
+    engine
+        .shared
+        .crossfade_samples
+        .store(samples, Ordering::Relaxed);
+    engine
+        .shared
+        .crossfade_start_signaled
+        .store(false, Ordering::Relaxed);
+    info!(
+        track_id = engine.track_id,
+        next_track_id = job.track.id,
+        overlap_ms = job.gapless.overlap_ms,
+        overlap_samples = samples,
+        "DJ transition window armed"
+    );
+    true
 }
 
 fn gate_prepare_next_for_dj(
@@ -990,6 +1017,7 @@ fn run_runtime_loop(
                 }
                 PlaybackRuntimeCommand::PrepareNext(mut job) => {
                     gate_prepare_next_for_dj(&mut state, &mut job);
+                    arm_active_transition_window(&mut state, &job);
                     // Only pre-decode if we don't already have a pending engine for this track.
                     let already_pending = state
                         .next_engine
@@ -1102,6 +1130,7 @@ fn run_runtime_loop(
                                 &position_source,
                                 &buffered_source,
                                 &offset_source,
+                                "fired",
                             );
                         }
                         // If not ready yet, NextDecodeComplete handles the late path.
@@ -1136,6 +1165,7 @@ fn run_runtime_loop(
                                 &position_source,
                                 &buffered_source,
                                 &offset_source,
+                                "late",
                             );
                         }
                     }
@@ -2016,11 +2046,17 @@ fn promote_next_to_active(
     position_source: &Arc<Mutex<Arc<AtomicU64>>>,
     buffered_source: &Arc<Mutex<Arc<AtomicU64>>>,
     offset_source: &Arc<Mutex<Arc<AtomicU64>>>,
+    timing_status: &'static str,
 ) {
     state.prepared_dj_mixer = None;
     let Some(next) = state.next_engine.take() else {
         return;
     };
+    let transition_event_id = next
+        .job
+        .prepared_transition
+        .as_ref()
+        .and_then(|transition| transition.transition_event_id);
     next.shared.fadein_start_samples.store(0, Ordering::Relaxed);
     next.shared.paused.store(false, Ordering::SeqCst);
 
@@ -2051,7 +2087,29 @@ fn promote_next_to_active(
     if let Some(outgoing) = outgoing {
         let outgoing_id = outgoing.track_id;
         let outgoing_generation = outgoing.generation;
+        let actual_start_ms = track_position_ms(
+            &outgoing.shared,
+            state.device_sample_rate,
+            state.device_channels,
+        );
         state.fading_out_engine = Some(outgoing);
+        if let Some(transition_event_id) = transition_event_id {
+            info!(
+                transition_event_id,
+                outgoing_track_id = outgoing_id,
+                generation = outgoing_generation,
+                actual_start_ms,
+                timing_status,
+                "DJ transition promotion fired"
+            );
+            let _ = event_tx.send(PlaybackRuntimeEvent::DjTransitionPromoted {
+                transition_event_id,
+                outgoing_track_id: outgoing_id,
+                generation: outgoing_generation,
+                actual_start_ms,
+                timing_status: timing_status.to_string(),
+            });
+        }
         // Tell the routes layer that the audible "current" track has flipped.
         // Reusing Finished keeps the existing queue-advance path.
         let _ = event_tx.send(PlaybackRuntimeEvent::Finished {
@@ -2063,6 +2121,17 @@ fn promote_next_to_active(
     if state.current_exclusive {
         refresh_exclusive_sources(state);
     }
+}
+
+fn track_position_ms(shared: &PlaybackSharedState, sample_rate: u32, channels: u16) -> i64 {
+    if sample_rate == 0 || channels == 0 {
+        return 0;
+    }
+    let samples = shared
+        .position_offset_samples
+        .load(Ordering::Relaxed)
+        .saturating_add(shared.position_samples.load(Ordering::Relaxed));
+    (samples.saturating_mul(1000) / (u64::from(sample_rate) * u64::from(channels))) as i64
 }
 
 fn promote_prepared_at_boundary(
@@ -2251,7 +2320,7 @@ mod tests {
         }
 
         #[test]
-        fn start_dj_lookahead_ignores_stale_generation() {
+        fn start_dj_lookahead_replaces_lower_hash_generation() {
             let mut state = test_runtime_loop_state();
             let outcome = start_dj_lookahead_in_state(
                 &mut state,
@@ -2264,7 +2333,7 @@ mod tests {
             );
             assert_eq!(outcome, StartDjLookaheadOutcome::Started);
 
-            let stale = start_dj_lookahead_in_state(
+            let replacement = start_dj_lookahead_in_state(
                 &mut state,
                 Some(library_ref(3)),
                 Some(library_ref(4)),
@@ -2274,21 +2343,15 @@ mod tests {
                 48_000,
             );
 
-            assert_eq!(stale, StartDjLookaheadOutcome::IgnoredStaleGeneration);
+            assert_eq!(replacement, StartDjLookaheadOutcome::Started);
             assert_eq!(
                 state
                     .dj_lookahead
                     .as_ref()
                     .map(|lookahead| lookahead.next_queue_item_id),
-                Some(12)
+                Some(14)
             );
-            assert_eq!(
-                state
-                    .dj_lookahead_failure
-                    .as_ref()
-                    .map(|failure| failure.reason),
-                Some(DjLookaheadFailureReason::QueueChanged)
-            );
+            assert!(state.dj_lookahead_failure.is_none());
         }
 
         #[test]
@@ -2694,6 +2757,38 @@ mod tests {
     }
 
     #[test]
+    fn prepared_dj_program_arms_active_transition_window() {
+        let mut state = test_runtime_loop_state();
+        state.device_sample_rate = 48_000;
+        state.device_channels = 2;
+        let active = test_engine_with_shared(1, 20);
+        assert_eq!(active.shared.crossfade_samples.load(Ordering::Relaxed), 0);
+        state.engine = Some(active);
+
+        let mut job = PreparedPlaybackJob::test_fixture(2, 21)
+            .with_prepared_transition(test_prepared_transition_program(20, Some(11), Some(12)));
+        job.gapless = GaplessPlan {
+            enabled: true,
+            overlap_ms: 1_000,
+            prebuffer_ms: 500,
+            requires_stream_metadata: false,
+        };
+
+        assert!(arm_active_transition_window(&mut state, &job));
+        let active = state.engine.as_ref().expect("active engine");
+        assert_eq!(
+            active.shared.crossfade_samples.load(Ordering::Relaxed),
+            96_000
+        );
+        assert!(
+            !active
+                .shared
+                .crossfade_start_signaled
+                .load(Ordering::Relaxed)
+        );
+    }
+
+    #[test]
     fn dj_flag_off_does_not_construct_mixer() {
         let mut state = state_with_ready_dj_pair();
         state.dj_engine_enabled = false;
@@ -2728,6 +2823,67 @@ mod tests {
         assert!(!active.shared.stopped.load(Ordering::SeqCst));
         assert!(!next.shared.stopped.load(Ordering::SeqCst));
         assert!(next.job.prepared_transition.is_none());
+    }
+
+    #[test]
+    fn automatic_crossfade_promotion_emits_timing_event() {
+        let mut state = test_runtime_loop_state();
+        let active = test_engine_with_shared(1, 20);
+        active
+            .shared
+            .position_offset_samples
+            .store(192_000, Ordering::Relaxed);
+        active
+            .shared
+            .position_samples
+            .store(96_000, Ordering::Relaxed);
+        let mut next = test_engine_with_shared(2, 21);
+        let mut transition = test_prepared_transition_program(20, Some(11), Some(12));
+        transition.transition_event_id = Some(77);
+        next.job = PreparedPlaybackJob::test_fixture(2, 21).with_prepared_transition(transition);
+        state.engine = Some(active);
+        state.next_engine = Some(next);
+
+        let (event_tx, mut event_rx) = tokio::sync::broadcast::channel(8);
+        let position_source = Arc::new(Mutex::new(Arc::new(AtomicU64::new(0))));
+        let buffered_source = Arc::new(Mutex::new(Arc::new(AtomicU64::new(0))));
+        let offset_source = Arc::new(Mutex::new(Arc::new(AtomicU64::new(0))));
+
+        promote_next_to_active(
+            &mut state,
+            &event_tx,
+            &position_source,
+            &buffered_source,
+            &offset_source,
+            "fired",
+        );
+
+        match event_rx.try_recv().expect("timing event") {
+            PlaybackRuntimeEvent::DjTransitionPromoted {
+                transition_event_id,
+                outgoing_track_id,
+                generation,
+                actual_start_ms,
+                timing_status,
+            } => {
+                assert_eq!(transition_event_id, 77);
+                assert_eq!(outgoing_track_id, 1);
+                assert_eq!(generation, 20);
+                assert_eq!(actual_start_ms, 3_000);
+                assert_eq!(timing_status, "fired");
+            }
+            other => panic!("expected timing event, got {other:?}"),
+        }
+        match event_rx.try_recv().expect("finished event") {
+            PlaybackRuntimeEvent::Finished {
+                track_id,
+                generation,
+            } => {
+                assert_eq!(track_id, 1);
+                assert_eq!(generation, 20);
+            }
+            other => panic!("expected finished event, got {other:?}"),
+        }
     }
 
     #[test]

--- a/noor-server/src/playback/runtime/mod.rs
+++ b/noor-server/src/playback/runtime/mod.rs
@@ -5,7 +5,7 @@ use crate::playback::output::cpal_shared::{SwapBackend, swap_stream_plan};
 use crate::playback::output::wasapi_exclusive::{
     ExclusiveRenderRole, ExclusiveRenderSource, ExclusiveRuntimeSink, build_exclusive_stream,
 };
-use crate::playback::player::PreparedPlaybackJob;
+use crate::playback::player::{PreparedPlaybackJob, PreparedTransitionProgram};
 use crate::services::audio_analysis::dj_profile::DjAnalysisJob;
 use anyhow::{Context, Result, anyhow};
 use cpal::traits::{DeviceTrait, HostTrait};
@@ -33,6 +33,8 @@ use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, mpsc};
 use std::thread;
 use tracing::{debug, error, info, warn};
+
+const DJ_MIXER_DEFAULT_MAX_BLOCK_FRAMES: usize = 8192;
 
 /// Pure decision helper for the SeekTo handler. Moved out of `server::routes`
 /// (r6 fix A: keep the playback runtime free of HTTP-layer dependencies). The
@@ -455,6 +457,16 @@ struct PlaybackRuntimeLoopState {
     current_exclusive_latency_mode: ExclusiveLatencyMode,
     dj_lookahead: Option<RuntimeDjLookahead>,
     dj_lookahead_failure: Option<DjLookaheadFailure>,
+    prepared_dj_mixer: Option<PreparedDjMixer>,
+}
+
+struct PreparedDjMixer {
+    mixer: noor_mix::Mixer,
+    queue_generation: u64,
+    current_queue_item_id: Option<i64>,
+    next_queue_item_id: Option<i64>,
+    current_track_id: i64,
+    next_track_id: i64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -612,6 +624,86 @@ fn discard_stale_prepared_transition(
     true
 }
 
+fn dj_mixer_max_block_samples(output_config: &StreamConfig) -> usize {
+    let channels = usize::from(output_config.channels.max(1));
+    match output_config.buffer_size {
+        cpal::BufferSize::Fixed(frames) => frames as usize * channels,
+        cpal::BufferSize::Default => DJ_MIXER_DEFAULT_MAX_BLOCK_FRAMES * channels,
+    }
+}
+
+fn decoded_deck_buffer(
+    engine: &PlaybackEngine,
+    channels: u16,
+) -> Option<noor_mix::deck::DeckBuffer> {
+    let guard = engine.shared.buffer.lock().ok()?;
+    if !guard.finished || guard.samples.is_empty() {
+        return None;
+    }
+    Some(noor_mix::deck::DeckBuffer::new(
+        guard.samples.clone(),
+        channels,
+    ))
+}
+
+fn build_prepared_dj_mixer(
+    state: &PlaybackRuntimeLoopState,
+    transition: &PreparedTransitionProgram,
+    max_block_samples: usize,
+) -> Option<PreparedDjMixer> {
+    let active = state.engine.as_ref()?;
+    let next = state.next_engine.as_ref()?;
+    if !prepared_dj_lookahead_matches_pair(
+        state,
+        transition.queue_generation,
+        transition.current_queue_item_id,
+        transition.next_queue_item_id,
+    ) {
+        return None;
+    }
+    let deck_a = decoded_deck_buffer(active, state.device_channels)?;
+    let deck_b = decoded_deck_buffer(next, state.device_channels)?;
+    let mixer = match noor_mix::Mixer::new(
+        transition.program.clone(),
+        deck_a,
+        deck_b,
+        max_block_samples,
+    ) {
+        Ok(mixer) => mixer,
+        Err(error) => {
+            warn!("Prepared DJ mixer rejected transition program: {error:?}");
+            return None;
+        }
+    };
+    Some(PreparedDjMixer {
+        mixer,
+        queue_generation: transition.queue_generation,
+        current_queue_item_id: transition.current_queue_item_id,
+        next_queue_item_id: transition.next_queue_item_id,
+        current_track_id: active.track_id,
+        next_track_id: next.track_id,
+    })
+}
+
+fn prepare_dj_mixer_for_pair(
+    state: &mut PlaybackRuntimeLoopState,
+    max_block_samples: usize,
+) -> bool {
+    let Some(transition) = state
+        .next_engine
+        .as_ref()
+        .and_then(|engine| engine.job.prepared_transition.as_ref())
+        .cloned()
+    else {
+        state.prepared_dj_mixer = None;
+        return false;
+    };
+    let prepared = build_prepared_dj_mixer(state, &transition, max_block_samples);
+    let did_prepare = prepared.is_some();
+    state.prepared_dj_mixer = prepared;
+    did_prepare
+}
+
 fn record_dj_lookahead_failure(
     state: &mut PlaybackRuntimeLoopState,
     queue_generation: u64,
@@ -667,6 +759,7 @@ fn run_runtime_loop(
         current_exclusive_latency_mode: ExclusiveLatencyMode::Stable,
         dj_lookahead: None,
         dj_lookahead_failure: None,
+        prepared_dj_mixer: None,
     };
 
     let _ = event_tx.send(PlaybackRuntimeEvent::Ready {
@@ -858,7 +951,9 @@ fn run_runtime_loop(
                     }
                 }
                 PlaybackRuntimeCommand::PrepareNext(mut job) => {
-                    discard_stale_prepared_transition(&state, &mut job);
+                    if discard_stale_prepared_transition(&state, &mut job) {
+                        state.prepared_dj_mixer = None;
+                    }
                     // Only pre-decode if we don't already have a pending engine for this track.
                     let already_pending = state
                         .next_engine
@@ -868,6 +963,7 @@ fn run_runtime_loop(
                     if !already_pending {
                         // Stop any stale pending engine first.
                         if let Some(mut stale) = state.next_engine.take() {
+                            state.prepared_dj_mixer = None;
                             stale.stop();
                         }
                         let pending_position = Arc::new(AtomicU64::new(0));
@@ -902,6 +998,10 @@ fn run_runtime_loop(
                                 // block control commands on some Linux/PipeWire setups.
                                 engine.shared.paused.store(true, Ordering::SeqCst);
                                 state.next_engine = Some(engine);
+                                prepare_dj_mixer_for_pair(
+                                    &mut state,
+                                    dj_mixer_max_block_samples(&output_config),
+                                );
                                 #[cfg(target_os = "windows")]
                                 if state.current_exclusive {
                                     refresh_exclusive_sources(&state);
@@ -973,6 +1073,10 @@ fn run_runtime_loop(
                         .map(|e| e.track_id == track_id && e.generation == generation)
                         .unwrap_or(false);
                     if pending_match {
+                        prepare_dj_mixer_for_pair(
+                            &mut state,
+                            dj_mixer_max_block_samples(&output_config),
+                        );
                         let crossfade_started = state
                             .engine
                             .as_ref()
@@ -1664,6 +1768,7 @@ fn switch_is_noop_for_active_job(
 }
 
 fn stop_current_engine(state: &mut PlaybackRuntimeLoopState) {
+    state.prepared_dj_mixer = None;
     if let Some(mut engine) = state.engine.take() {
         engine.stop();
     }
@@ -1865,6 +1970,7 @@ fn promote_next_to_active(
     buffered_source: &Arc<Mutex<Arc<AtomicU64>>>,
     offset_source: &Arc<Mutex<Arc<AtomicU64>>>,
 ) {
+    state.prepared_dj_mixer = None;
     let Some(next) = state.next_engine.take() else {
         return;
     };
@@ -1919,6 +2025,7 @@ fn promote_prepared_at_boundary(
     buffered_source: &Arc<Mutex<Arc<AtomicU64>>>,
     offset_source: &Arc<Mutex<Arc<AtomicU64>>>,
 ) {
+    state.prepared_dj_mixer = None;
     let Some(next) = state.next_engine.take() else {
         return;
     };
@@ -2502,6 +2609,43 @@ mod tests {
     }
 
     #[test]
+    fn runtime_constructs_mixer_before_audio_callback() {
+        let mut state = test_runtime_loop_state();
+        start_dj_lookahead_in_state(
+            &mut state,
+            Some(DjMediaRef::LibraryTrack { track_id: 1 }),
+            Some(DjMediaRef::LibraryTrack { track_id: 2 }),
+            Some(11),
+            Some(12),
+            20,
+            48_000,
+        );
+
+        let active = test_engine_with_shared(1, 20);
+        finish_engine_buffer(&active, &[0.25, 0.25, 0.25, 0.25]);
+
+        let mut next = test_engine_with_shared(2, 21);
+        next.job = PreparedPlaybackJob::test_fixture(2, 21)
+            .with_prepared_transition(test_prepared_transition_program(20, Some(11), Some(12)));
+        finish_engine_buffer(&next, &[0.5, 0.5, 0.5, 0.5]);
+
+        state.engine = Some(active);
+        state.next_engine = Some(next);
+
+        assert!(prepare_dj_mixer_for_pair(&mut state, 64));
+        let prepared = state.prepared_dj_mixer.as_mut().expect("prepared mixer");
+        assert_eq!(prepared.queue_generation, 20);
+        assert_eq!(prepared.current_queue_item_id, Some(11));
+        assert_eq!(prepared.next_queue_item_id, Some(12));
+        assert_eq!(prepared.current_track_id, 1);
+        assert_eq!(prepared.next_track_id, 2);
+
+        let mut out = [0.0; 4];
+        prepared.mixer.render_block(&mut out, 0);
+        assert!(out.iter().any(|sample| *sample != 0.0));
+    }
+
+    #[test]
     fn effective_output_config_applies_desired_sample_rate() {
         let base = StreamConfig {
             channels: 2,
@@ -3035,6 +3179,7 @@ mod tests {
             current_exclusive_latency_mode: ExclusiveLatencyMode::Stable,
             dj_lookahead: None,
             dj_lookahead_failure: None,
+            prepared_dj_mixer: None,
         }
     }
 
@@ -3163,6 +3308,37 @@ mod tests {
                 Arc::new(AtomicU64::new(0)),
             )),
         )
+    }
+
+    fn finish_engine_buffer(engine: &PlaybackEngine, samples: &[f32]) {
+        let mut buffer = engine.shared.buffer.lock().expect("buffer lock");
+        buffer.samples.extend_from_slice(samples);
+        buffer.mark_finished();
+    }
+
+    fn test_prepared_transition_program(
+        queue_generation: u64,
+        current_queue_item_id: Option<i64>,
+        next_queue_item_id: Option<i64>,
+    ) -> PreparedTransitionProgram {
+        PreparedTransitionProgram {
+            program: noor_mix::TransitionProgram {
+                tier: noor_mix::program::Tier::SafeCrossfade,
+                template: "SafeCrossfade".to_string(),
+                sample_rate: 48_000,
+                channels: 2,
+                sync_start: 0,
+                intro_start: 0,
+                swap_start: 1,
+                fade_start: 1,
+                resolve_at: 2,
+                loops: vec![],
+                automation: vec![],
+            },
+            queue_generation,
+            current_queue_item_id,
+            next_queue_item_id,
+        }
     }
 
     // -- Option C: evaluate_seek_decision unit tests (moved from server::routes

--- a/noor-server/src/playback/runtime/mod.rs
+++ b/noor-server/src/playback/runtime/mod.rs
@@ -1,4 +1,5 @@
 use crate::db::audio_settings::ExclusiveLatencyMode;
+use crate::playback::dj_lookahead::DjMediaRef;
 use crate::playback::output::cpal_shared::{SwapBackend, swap_stream_plan};
 #[cfg(target_os = "windows")]
 use crate::playback::output::wasapi_exclusive::{
@@ -235,6 +236,26 @@ impl PlaybackRuntimeHandle {
         self.send(PlaybackRuntimeCommand::PrepareNext(job))
     }
 
+    #[allow(clippy::too_many_arguments)]
+    pub fn start_dj_lookahead(
+        &self,
+        current: Option<DjMediaRef>,
+        next: Option<DjMediaRef>,
+        current_queue_item_id: Option<i64>,
+        next_queue_item_id: Option<i64>,
+        queue_generation: u64,
+        deadline_samples: u64,
+    ) -> Result<()> {
+        self.send(PlaybackRuntimeCommand::StartDjLookahead {
+            current,
+            next,
+            current_queue_item_id,
+            next_queue_item_id,
+            queue_generation,
+            deadline_samples,
+        })
+    }
+
     pub fn track_status(&self, track_id: i64, generation: u64) -> PlaybackTrackStatus {
         let (tx, rx) = std::sync::mpsc::channel();
         if self
@@ -417,6 +438,159 @@ struct PlaybackRuntimeLoopState {
     current_exclusive_release_grace_secs: u32,
     /// Last-known WASAPI exclusive callback period policy.
     current_exclusive_latency_mode: ExclusiveLatencyMode,
+    dj_lookahead: Option<RuntimeDjLookahead>,
+    dj_lookahead_failure: Option<DjLookaheadFailure>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RuntimeDjLookahead {
+    current: Option<DjMediaRef>,
+    next: DjMediaRef,
+    current_queue_item_id: Option<i64>,
+    next_queue_item_id: i64,
+    queue_generation: u64,
+    deadline_samples: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DjLookaheadFailure {
+    queue_generation: u64,
+    current_queue_item_id: Option<i64>,
+    next_queue_item_id: Option<i64>,
+    reason: DjLookaheadFailureReason,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
+enum DjLookaheadFailureReason {
+    NextNotResolved,
+    ResolutionFailed,
+    AnalysisDeadlineMissed,
+    QueueChanged,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StartDjLookaheadOutcome {
+    Started,
+    AlreadyCurrent,
+    ReusedPreparedNext,
+    IgnoredStaleGeneration,
+    MissingNext,
+}
+
+impl RuntimeDjLookahead {
+    fn matches_pair(
+        &self,
+        queue_generation: u64,
+        current_queue_item_id: Option<i64>,
+        next_queue_item_id: Option<i64>,
+    ) -> bool {
+        self.queue_generation == queue_generation
+            && self.current_queue_item_id == current_queue_item_id
+            && Some(self.next_queue_item_id) == next_queue_item_id
+    }
+}
+
+fn start_dj_lookahead_in_state(
+    state: &mut PlaybackRuntimeLoopState,
+    current: Option<DjMediaRef>,
+    next: Option<DjMediaRef>,
+    current_queue_item_id: Option<i64>,
+    next_queue_item_id: Option<i64>,
+    queue_generation: u64,
+    deadline_samples: u64,
+) -> StartDjLookaheadOutcome {
+    if state
+        .dj_lookahead
+        .as_ref()
+        .is_some_and(|lookahead| lookahead.queue_generation > queue_generation)
+    {
+        state.dj_lookahead_failure = Some(DjLookaheadFailure {
+            queue_generation,
+            current_queue_item_id,
+            next_queue_item_id,
+            reason: DjLookaheadFailureReason::QueueChanged,
+        });
+        return StartDjLookaheadOutcome::IgnoredStaleGeneration;
+    }
+
+    let Some(next) = next else {
+        state.dj_lookahead = None;
+        state.dj_lookahead_failure = Some(DjLookaheadFailure {
+            queue_generation,
+            current_queue_item_id,
+            next_queue_item_id,
+            reason: DjLookaheadFailureReason::NextNotResolved,
+        });
+        return StartDjLookaheadOutcome::MissingNext;
+    };
+    let Some(next_queue_item_id) = next_queue_item_id else {
+        state.dj_lookahead = None;
+        state.dj_lookahead_failure = Some(DjLookaheadFailure {
+            queue_generation,
+            current_queue_item_id,
+            next_queue_item_id: None,
+            reason: DjLookaheadFailureReason::NextNotResolved,
+        });
+        return StartDjLookaheadOutcome::MissingNext;
+    };
+
+    if state.dj_lookahead.as_ref().is_some_and(|lookahead| {
+        lookahead.matches_pair(
+            queue_generation,
+            current_queue_item_id,
+            Some(next_queue_item_id),
+        )
+    }) {
+        return StartDjLookaheadOutcome::AlreadyCurrent;
+    }
+
+    let prepared_next = next.track_id().is_some_and(|track_id| {
+        state
+            .next_engine
+            .as_ref()
+            .is_some_and(|engine| engine.track_id == track_id)
+    });
+    state.dj_lookahead = Some(RuntimeDjLookahead {
+        current,
+        next,
+        current_queue_item_id,
+        next_queue_item_id,
+        queue_generation,
+        deadline_samples,
+    });
+    state.dj_lookahead_failure = None;
+    if prepared_next {
+        StartDjLookaheadOutcome::ReusedPreparedNext
+    } else {
+        StartDjLookaheadOutcome::Started
+    }
+}
+
+fn prepared_dj_lookahead_matches_pair(
+    state: &PlaybackRuntimeLoopState,
+    queue_generation: u64,
+    current_queue_item_id: Option<i64>,
+    next_queue_item_id: Option<i64>,
+) -> bool {
+    state.dj_lookahead.as_ref().is_some_and(|lookahead| {
+        lookahead.matches_pair(queue_generation, current_queue_item_id, next_queue_item_id)
+    })
+}
+
+fn record_dj_lookahead_failure(
+    state: &mut PlaybackRuntimeLoopState,
+    queue_generation: u64,
+    current_queue_item_id: Option<i64>,
+    next_queue_item_id: Option<i64>,
+    reason: DjLookaheadFailureReason,
+) {
+    state.dj_lookahead_failure = Some(DjLookaheadFailure {
+        queue_generation,
+        current_queue_item_id,
+        next_queue_item_id,
+        reason,
+    });
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -457,6 +631,8 @@ fn run_runtime_loop(
         current_exclusive_release_grace_secs:
             crate::db::audio_settings::DEFAULT_EXCLUSIVE_RELEASE_GRACE_SECS,
         current_exclusive_latency_mode: ExclusiveLatencyMode::Stable,
+        dj_lookahead: None,
+        dj_lookahead_failure: None,
     };
 
     let _ = event_tx.send(PlaybackRuntimeEvent::Ready {
@@ -700,6 +876,27 @@ fn run_runtime_loop(
                                 warn!("Failed to pre-buffer next track: {err:?}");
                             }
                         }
+                    }
+                }
+                PlaybackRuntimeCommand::StartDjLookahead {
+                    current,
+                    next,
+                    current_queue_item_id,
+                    next_queue_item_id,
+                    queue_generation,
+                    deadline_samples,
+                } => {
+                    let outcome = start_dj_lookahead_in_state(
+                        &mut state,
+                        current,
+                        next,
+                        current_queue_item_id,
+                        next_queue_item_id,
+                        queue_generation,
+                        deadline_samples,
+                    );
+                    if matches!(outcome, StartDjLookaheadOutcome::MissingNext) {
+                        debug!("DJ lookahead skipped because the next queue item is not resolved");
                     }
                 }
                 PlaybackRuntimeCommand::CrossfadeStart {
@@ -1837,6 +2034,198 @@ mod tests {
         atomic::{AtomicU32, AtomicU64},
     };
 
+    mod dj_lookahead {
+        use super::*;
+
+        fn library_ref(track_id: i64) -> DjMediaRef {
+            DjMediaRef::LibraryTrack { track_id }
+        }
+
+        #[test]
+        fn start_dj_lookahead_does_not_promote_next_engine() {
+            let mut state = test_runtime_loop_state();
+            state.next_engine = Some(test_engine_with_shared(2, 10));
+
+            let outcome = start_dj_lookahead_in_state(
+                &mut state,
+                Some(library_ref(1)),
+                Some(library_ref(2)),
+                Some(11),
+                Some(12),
+                20,
+                48_000,
+            );
+
+            assert_eq!(outcome, StartDjLookaheadOutcome::ReusedPreparedNext);
+            assert!(state.engine.is_none());
+            assert!(state.next_engine.is_some());
+        }
+
+        #[test]
+        fn start_dj_lookahead_ignores_stale_generation() {
+            let mut state = test_runtime_loop_state();
+            let outcome = start_dj_lookahead_in_state(
+                &mut state,
+                Some(library_ref(1)),
+                Some(library_ref(2)),
+                Some(11),
+                Some(12),
+                20,
+                48_000,
+            );
+            assert_eq!(outcome, StartDjLookaheadOutcome::Started);
+
+            let stale = start_dj_lookahead_in_state(
+                &mut state,
+                Some(library_ref(3)),
+                Some(library_ref(4)),
+                Some(13),
+                Some(14),
+                19,
+                48_000,
+            );
+
+            assert_eq!(stale, StartDjLookaheadOutcome::IgnoredStaleGeneration);
+            assert_eq!(
+                state
+                    .dj_lookahead
+                    .as_ref()
+                    .map(|lookahead| lookahead.next_queue_item_id),
+                Some(12)
+            );
+            assert_eq!(
+                state
+                    .dj_lookahead_failure
+                    .as_ref()
+                    .map(|failure| failure.reason),
+                Some(DjLookaheadFailureReason::QueueChanged)
+            );
+        }
+
+        #[test]
+        fn prepared_program_rejected_when_pair_ids_change() {
+            let mut state = test_runtime_loop_state();
+            start_dj_lookahead_in_state(
+                &mut state,
+                Some(library_ref(1)),
+                Some(library_ref(2)),
+                Some(11),
+                Some(12),
+                20,
+                48_000,
+            );
+
+            assert!(prepared_dj_lookahead_matches_pair(
+                &state,
+                20,
+                Some(11),
+                Some(12)
+            ));
+            assert!(!prepared_dj_lookahead_matches_pair(
+                &state,
+                20,
+                Some(11),
+                Some(99)
+            ));
+        }
+
+        #[test]
+        fn start_dj_lookahead_reuses_existing_prepared_next() {
+            let mut state = test_runtime_loop_state();
+            state.next_engine = Some(test_engine_with_shared(2, 10));
+
+            let outcome = start_dj_lookahead_in_state(
+                &mut state,
+                Some(library_ref(1)),
+                Some(library_ref(2)),
+                Some(11),
+                Some(12),
+                20,
+                48_000,
+            );
+
+            assert_eq!(outcome, StartDjLookaheadOutcome::ReusedPreparedNext);
+            assert_eq!(
+                state
+                    .dj_lookahead
+                    .as_ref()
+                    .map(|lookahead| lookahead.next.clone()),
+                Some(library_ref(2))
+            );
+        }
+
+        #[test]
+        fn start_dj_lookahead_records_resolution_failure() {
+            let mut state = test_runtime_loop_state();
+
+            let outcome = start_dj_lookahead_in_state(
+                &mut state,
+                Some(library_ref(1)),
+                None,
+                Some(11),
+                None,
+                20,
+                48_000,
+            );
+
+            assert_eq!(outcome, StartDjLookaheadOutcome::MissingNext);
+            assert!(state.dj_lookahead.is_none());
+            assert_eq!(
+                state
+                    .dj_lookahead_failure
+                    .as_ref()
+                    .map(|failure| failure.reason),
+                Some(DjLookaheadFailureReason::NextNotResolved)
+            );
+        }
+
+        #[test]
+        fn start_dj_lookahead_records_analysis_deadline() {
+            let mut state = test_runtime_loop_state();
+
+            start_dj_lookahead_in_state(
+                &mut state,
+                Some(library_ref(1)),
+                Some(library_ref(2)),
+                Some(11),
+                Some(12),
+                20,
+                96_000,
+            );
+
+            assert_eq!(
+                state
+                    .dj_lookahead
+                    .as_ref()
+                    .map(|lookahead| lookahead.deadline_samples),
+                Some(96_000)
+            );
+        }
+
+        #[test]
+        fn missed_lookahead_deadline_does_not_delay_playback() {
+            let mut state = test_runtime_loop_state();
+            state.engine = Some(test_engine_with_shared(1, 10));
+
+            record_dj_lookahead_failure(
+                &mut state,
+                20,
+                Some(11),
+                Some(12),
+                DjLookaheadFailureReason::AnalysisDeadlineMissed,
+            );
+
+            assert!(state.engine.is_some());
+            assert_eq!(
+                state
+                    .dj_lookahead_failure
+                    .as_ref()
+                    .map(|failure| failure.reason),
+                Some(DjLookaheadFailureReason::AnalysisDeadlineMissed)
+            );
+        }
+    }
+
     #[test]
     fn effective_output_config_applies_desired_sample_rate() {
         let base = StreamConfig {
@@ -2369,6 +2758,8 @@ mod tests {
             current_exclusive_release_grace_secs:
                 crate::db::audio_settings::DEFAULT_EXCLUSIVE_RELEASE_GRACE_SECS,
             current_exclusive_latency_mode: ExclusiveLatencyMode::Stable,
+            dj_lookahead: None,
+            dj_lookahead_failure: None,
         }
     }
 

--- a/noor-server/src/playback/runtime/mod.rs
+++ b/noor-server/src/playback/runtime/mod.rs
@@ -2597,6 +2597,7 @@ mod tests {
         ) -> PreparedTransitionProgram {
             PreparedTransitionProgram {
                 program: program(),
+                transition_event_id: None,
                 queue_generation,
                 current_queue_item_id,
                 next_queue_item_id,
@@ -3442,6 +3443,7 @@ mod tests {
                 loops: vec![],
                 automation: vec![],
             },
+            transition_event_id: None,
             queue_generation,
             current_queue_item_id,
             next_queue_item_id,

--- a/noor-server/src/playback/runtime/mod.rs
+++ b/noor-server/src/playback/runtime/mod.rs
@@ -593,6 +593,25 @@ fn prepared_dj_lookahead_matches_pair(
     })
 }
 
+fn discard_stale_prepared_transition(
+    state: &PlaybackRuntimeLoopState,
+    job: &mut PreparedPlaybackJob,
+) -> bool {
+    let Some(transition) = job.prepared_transition.as_ref() else {
+        return false;
+    };
+    if prepared_dj_lookahead_matches_pair(
+        state,
+        transition.queue_generation,
+        transition.current_queue_item_id,
+        transition.next_queue_item_id,
+    ) {
+        return false;
+    }
+    job.prepared_transition = None;
+    true
+}
+
 fn record_dj_lookahead_failure(
     state: &mut PlaybackRuntimeLoopState,
     queue_generation: u64,
@@ -838,7 +857,8 @@ fn run_runtime_loop(
                         }
                     }
                 }
-                PlaybackRuntimeCommand::PrepareNext(job) => {
+                PlaybackRuntimeCommand::PrepareNext(mut job) => {
+                    discard_stale_prepared_transition(&state, &mut job);
                     // Only pre-decode if we don't already have a pending engine for this track.
                     let already_pending = state
                         .next_engine
@@ -2393,6 +2413,91 @@ mod tests {
                 Ok(())
             })
             .expect("promote");
+        }
+    }
+
+    mod prepared_transition {
+        use super::*;
+        use crate::playback::player::PreparedTransitionProgram;
+
+        fn program() -> noor_mix::TransitionProgram {
+            noor_mix::TransitionProgram {
+                tier: noor_mix::program::Tier::SafeCrossfade,
+                template: "SafeCrossfade".to_string(),
+                sample_rate: 48_000,
+                channels: 2,
+                sync_start: 0,
+                intro_start: 0,
+                swap_start: 1,
+                fade_start: 1,
+                resolve_at: 2,
+                loops: vec![],
+                automation: vec![],
+            }
+        }
+
+        fn transition(
+            queue_generation: u64,
+            current_queue_item_id: Option<i64>,
+            next_queue_item_id: Option<i64>,
+        ) -> PreparedTransitionProgram {
+            PreparedTransitionProgram {
+                program: program(),
+                queue_generation,
+                current_queue_item_id,
+                next_queue_item_id,
+            }
+        }
+
+        fn state_with_pair() -> PlaybackRuntimeLoopState {
+            let mut state = test_runtime_loop_state();
+            start_dj_lookahead_in_state(
+                &mut state,
+                Some(DjMediaRef::LibraryTrack { track_id: 1 }),
+                Some(DjMediaRef::LibraryTrack { track_id: 2 }),
+                Some(11),
+                Some(12),
+                20,
+                48_000,
+            );
+            state
+        }
+
+        #[test]
+        fn prepare_next_preserves_transition_program() {
+            let state = state_with_pair();
+            let mut job = PreparedPlaybackJob::test_fixture(2, 7)
+                .with_prepared_transition(transition(20, Some(11), Some(12)));
+
+            assert!(!discard_stale_prepared_transition(&state, &mut job));
+            assert!(job.prepared_transition.is_some());
+        }
+
+        #[test]
+        fn legacy_prepare_next_has_no_transition_program() {
+            let job = PreparedPlaybackJob::test_fixture(2, 7);
+
+            assert!(job.prepared_transition.is_none());
+        }
+
+        #[test]
+        fn prepared_transition_discarded_when_generation_is_stale() {
+            let state = state_with_pair();
+            let mut job = PreparedPlaybackJob::test_fixture(2, 7)
+                .with_prepared_transition(transition(19, Some(11), Some(12)));
+
+            assert!(discard_stale_prepared_transition(&state, &mut job));
+            assert!(job.prepared_transition.is_none());
+        }
+
+        #[test]
+        fn prepared_transition_discarded_when_next_queue_item_changes() {
+            let state = state_with_pair();
+            let mut job = PreparedPlaybackJob::test_fixture(2, 7)
+                .with_prepared_transition(transition(20, Some(11), Some(99)));
+
+            assert!(discard_stale_prepared_transition(&state, &mut job));
+            assert!(job.prepared_transition.is_none());
         }
     }
 

--- a/noor-server/src/playback/runtime/mod.rs
+++ b/noor-server/src/playback/runtime/mod.rs
@@ -709,13 +709,18 @@ fn arm_active_transition_window(
     state: &mut PlaybackRuntimeLoopState,
     job: &PreparedPlaybackJob,
 ) -> bool {
-    if job.prepared_transition.is_none() || job.gapless.overlap_ms <= 0 {
+    let Some(transition) = job.prepared_transition.as_ref() else {
+        return false;
+    };
+    if job.gapless.overlap_ms <= 0 {
         return false;
     }
     let Some(engine) = state.engine.as_ref() else {
         return false;
     };
-    let samples = (job.gapless.overlap_ms as u64)
+    let trigger_ms = u64::from(job.gapless.overlap_ms as u32)
+        .saturating_add(u64::from(transition.fire_ahead_ms));
+    let samples = trigger_ms
         .saturating_mul(state.device_sample_rate as u64)
         .saturating_mul(state.device_channels.max(1) as u64)
         / 1000;
@@ -734,6 +739,7 @@ fn arm_active_transition_window(
         track_id = engine.track_id,
         next_track_id = job.track.id,
         overlap_ms = job.gapless.overlap_ms,
+        fire_ahead_ms = transition.fire_ahead_ms,
         overlap_samples = samples,
         "DJ transition window armed"
     );
@@ -2661,6 +2667,7 @@ mod tests {
             PreparedTransitionProgram {
                 program: program(),
                 transition_event_id: None,
+                fire_ahead_ms: 0,
                 queue_generation,
                 current_queue_item_id,
                 next_queue_item_id,
@@ -2785,6 +2792,31 @@ mod tests {
                 .shared
                 .crossfade_start_signaled
                 .load(Ordering::Relaxed)
+        );
+    }
+
+    #[test]
+    fn prepared_dj_program_applies_fire_ahead_to_trigger_window() {
+        let mut state = test_runtime_loop_state();
+        state.device_sample_rate = 48_000;
+        state.device_channels = 2;
+        state.engine = Some(test_engine_with_shared(1, 20));
+
+        let mut transition = test_prepared_transition_program(20, Some(11), Some(12));
+        transition.fire_ahead_ms = 231;
+        let mut job = PreparedPlaybackJob::test_fixture(2, 21).with_prepared_transition(transition);
+        job.gapless = GaplessPlan {
+            enabled: true,
+            overlap_ms: 1_000,
+            prebuffer_ms: 500,
+            requires_stream_metadata: false,
+        };
+
+        assert!(arm_active_transition_window(&mut state, &job));
+        let active = state.engine.as_ref().expect("active engine");
+        assert_eq!(
+            active.shared.crossfade_samples.load(Ordering::Relaxed),
+            118_176
         );
     }
 
@@ -3600,6 +3632,7 @@ mod tests {
                 automation: vec![],
             },
             transition_event_id: None,
+            fire_ahead_ms: 0,
             queue_generation,
             current_queue_item_id,
             next_queue_item_id,

--- a/noor-server/src/playback/runtime/mod.rs
+++ b/noor-server/src/playback/runtime/mod.rs
@@ -974,6 +974,9 @@ fn run_runtime_loop(
                                     .shared
                                     .seek_target_samples
                                     .store(target_samples, Ordering::Relaxed);
+                                engine
+                                    .shared
+                                    .set_manual_seek_crossfade_suppression(target_samples);
                                 // Reset fire-once guards so NearEnd /
                                 // CrossfadeStart re-fire after a backward seek.
                                 engine
@@ -1008,6 +1011,15 @@ fn run_runtime_loop(
                                 true, // force_restart - bypass switch_is_noop
                             ) {
                                 Ok(()) => {
+                                    if let Some(engine) = state.engine.as_ref() {
+                                        let target_samples = (target_ms.max(0) as u64)
+                                            .saturating_mul(rate)
+                                            .saturating_mul(channels)
+                                            / 1000;
+                                        engine
+                                            .shared
+                                            .set_manual_seek_crossfade_suppression(target_samples);
+                                    }
                                     let _ = respond_to.send(SeekToOutcome::Dispatched);
                                 }
                                 Err(error) => {
@@ -1129,7 +1141,7 @@ fn run_runtime_loop(
                             .as_ref()
                             .and_then(|e| e.shared.buffer.lock().ok().map(|g| g.is_ready()))
                             .unwrap_or(false);
-                        if next_ready {
+                        if next_ready && !active_engine_suppresses_crossfade_after_seek(&state) {
                             promote_next_to_active(
                                 &mut state,
                                 &event_tx,
@@ -1164,7 +1176,9 @@ fn run_runtime_loop(
                             .as_ref()
                             .map(|e| e.shared.crossfade_start_signaled.load(Ordering::Relaxed))
                             .unwrap_or(false);
-                        if crossfade_started {
+                        if crossfade_started
+                            && !active_engine_suppresses_crossfade_after_seek(&state)
+                        {
                             promote_next_to_active(
                                 &mut state,
                                 &event_tx,
@@ -2279,6 +2293,15 @@ fn should_promote_prepared_at_boundary(
     matches!(outcome, PlaybackTerminalReason::Finished)
         && active == Some((track_id, generation))
         && next.is_some_and(|(_, next_generation)| next_generation == generation)
+}
+
+fn active_engine_suppresses_crossfade_after_seek(state: &PlaybackRuntimeLoopState) -> bool {
+    state.engine.as_ref().is_some_and(|engine| {
+        engine
+            .shared
+            .suppress_crossfade_after_seek
+            .load(Ordering::Relaxed)
+    })
 }
 
 #[cfg(test)]
@@ -3432,6 +3455,40 @@ mod tests {
             }
             other => panic!("expected error event, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn manual_seek_near_end_suppresses_crossfade_promotion() {
+        let mut state = test_runtime_loop_state();
+        let active = test_engine_with_shared(1, 20);
+        let total_samples = 120 * 48_000 * 2;
+        active
+            .shared
+            .total_samples
+            .store(total_samples, Ordering::Relaxed);
+
+        active
+            .shared
+            .set_manual_seek_crossfade_suppression(total_samples - 48_000);
+        state.engine = Some(active);
+
+        assert!(active_engine_suppresses_crossfade_after_seek(&state));
+    }
+
+    #[test]
+    fn manual_seek_before_near_end_keeps_crossfade_promotion_enabled() {
+        let mut state = test_runtime_loop_state();
+        let active = test_engine_with_shared(1, 20);
+        let total_samples = 120 * 48_000 * 2;
+        active
+            .shared
+            .total_samples
+            .store(total_samples, Ordering::Relaxed);
+
+        active.shared.set_manual_seek_crossfade_suppression(0);
+        state.engine = Some(active);
+
+        assert!(!active_engine_suppresses_crossfade_after_seek(&state));
     }
 
     fn test_runtime_loop_state() -> PlaybackRuntimeLoopState {

--- a/noor-server/src/playback/runtime/mod.rs
+++ b/noor-server/src/playback/runtime/mod.rs
@@ -6,6 +6,7 @@ use crate::playback::output::wasapi_exclusive::{
     ExclusiveRenderRole, ExclusiveRenderSource, ExclusiveRuntimeSink, build_exclusive_stream,
 };
 use crate::playback::player::PreparedPlaybackJob;
+use crate::services::audio_analysis::dj_profile::DjAnalysisJob;
 use anyhow::{Context, Result, anyhow};
 use cpal::traits::{DeviceTrait, HostTrait};
 use cpal::{SampleFormat, StreamConfig};
@@ -80,6 +81,8 @@ pub struct PlaybackRuntimeConfig {
     /// Channel to send mono audio samples for passive DSP analysis.
     /// (track_id, mono_samples, sample_rate)
     pub analysis_tx: Option<tokio::sync::mpsc::UnboundedSender<(i64, Vec<f32>, u32)>>,
+    pub dj_analysis_tx: Option<tokio::sync::mpsc::UnboundedSender<DjAnalysisJob>>,
+    pub dj_engine_enabled: bool,
 }
 
 impl PlaybackRuntimeConfig {
@@ -92,7 +95,19 @@ impl PlaybackRuntimeConfig {
             http_client,
             access_token: access_token.into(),
             analysis_tx,
+            dj_analysis_tx: None,
+            dj_engine_enabled: false,
         }
+    }
+
+    pub fn with_dj_analysis(
+        mut self,
+        dj_engine_enabled: bool,
+        dj_analysis_tx: Option<tokio::sync::mpsc::UnboundedSender<DjAnalysisJob>>,
+    ) -> Self {
+        self.dj_engine_enabled = dj_engine_enabled;
+        self.dj_analysis_tx = dj_analysis_tx;
+        self
     }
 }
 
@@ -2223,6 +2238,161 @@ mod tests {
                     .map(|failure| failure.reason),
                 Some(DjLookaheadFailureReason::AnalysisDeadlineMissed)
             );
+        }
+    }
+
+    mod analysis_profile_key {
+        use super::*;
+        use crate::db::models::{AudioDjProfileKey, AudioDjProfileRow};
+        use crate::db::{Database, queries};
+        use crate::playback::decode::send_dj_analysis_job;
+        use crate::playback::dj_lookahead::DjMediaRef;
+        use crate::services::audio_analysis::dj_profile::{
+            DJ_PROFILE_VERSION, encode_f32_blob, encode_u32_blob,
+        };
+
+        fn config(
+            enabled: bool,
+        ) -> (
+            PlaybackRuntimeConfig,
+            tokio::sync::mpsc::UnboundedReceiver<DjAnalysisJob>,
+        ) {
+            let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+            (
+                PlaybackRuntimeConfig::new(reqwest::Client::new(), "", None)
+                    .with_dj_analysis(enabled, Some(tx)),
+                rx,
+            )
+        }
+
+        fn send(
+            enabled: bool,
+            media_ref: DjMediaRef,
+        ) -> Option<crate::services::audio_analysis::dj_profile::DjAnalysisJob> {
+            let (config, mut rx) = config(enabled);
+            let job = PreparedPlaybackJob::test_fixture(media_ref.track_id().unwrap_or(10), 7)
+                .with_dj_media_ref(media_ref);
+            send_dj_analysis_job(
+                &config,
+                job.dj_media_ref.clone(),
+                &job,
+                vec![0.0; 128],
+                48_000,
+                7,
+            );
+            rx.try_recv().ok()
+        }
+
+        #[test]
+        fn dj_analysis_not_sent_when_engine_disabled() {
+            let sent = send(false, DjMediaRef::LibraryTrack { track_id: 1 });
+            assert!(sent.is_none());
+        }
+
+        #[test]
+        fn active_decoder_sends_library_profile_key() {
+            let sent = send(true, DjMediaRef::LibraryTrack { track_id: 1 }).expect("job");
+            assert_eq!(sent.media_ref.profile_key().media_ref_kind, "library_track");
+            assert_eq!(sent.media_ref.profile_key().media_ref_id, "1");
+            assert_eq!(sent.track_id, Some(1));
+        }
+
+        #[test]
+        fn prepared_next_decoder_sends_tidal_profile_key() {
+            let sent = send(
+                true,
+                DjMediaRef::TidalTrack {
+                    tidal_id: 99,
+                    track_id: Some(10),
+                },
+            )
+            .expect("job");
+            assert_eq!(sent.media_ref.profile_key().media_ref_kind, "tidal_track");
+            assert_eq!(sent.media_ref.profile_key().media_ref_id, "99");
+            assert_eq!(sent.tidal_id, Some(99));
+        }
+
+        #[test]
+        fn pending_next_decoder_sends_queue_item_profile_key_when_unresolved() {
+            let sent = send(
+                true,
+                DjMediaRef::PendingQueueItem {
+                    queue_item_id: 44,
+                    pending_artist: "Artist".to_string(),
+                    pending_title: "Title".to_string(),
+                    tidal_id_hint: None,
+                },
+            )
+            .expect("job");
+            assert_eq!(sent.media_ref.profile_key().media_ref_kind, "queue_item");
+            assert_eq!(sent.media_ref.profile_key().media_ref_id, "44");
+            assert_eq!(sent.queue_item_id, Some(44));
+        }
+
+        #[test]
+        fn pending_profile_promotes_after_tidal_resolution() {
+            let db = Database::open_in_memory().expect("db");
+            db.run_migrations().expect("migrations");
+            db.with_conn(|conn| -> anyhow::Result<()> {
+                conn.execute(
+                    "INSERT INTO queue (id, track_id, position, source, pending_artist, pending_title)
+                     VALUES (44, NULL, 0, 'test', 'Artist', 'Title')",
+                    [],
+                )?;
+                let row = AudioDjProfileRow {
+                    media_ref_kind: "queue_item".to_string(),
+                    media_ref_id: "44".to_string(),
+                    track_id: None,
+                    queue_item_id: Some(44),
+                    tidal_id: None,
+                    profile_version: DJ_PROFILE_VERSION.to_string(),
+                    beat_grid_blob: encode_f32_blob(&[0.0, 0.5]),
+                    downbeats_blob: encode_f32_blob(&[0.0]),
+                    phrase_boundaries_blob: encode_u32_blob(&[0]),
+                    mix_in_blob: encode_f32_blob(&[]),
+                    mix_out_blob: encode_f32_blob(&[]),
+                    intro_end_seconds: None,
+                    outro_start_seconds: None,
+                    breakdown_blob: encode_f32_blob(&[]),
+                    drop_blob: encode_f32_blob(&[]),
+                    safe_transition_windows_blob: encode_f32_blob(&[]),
+                    energy_contour_blob: encode_f32_blob(&[]),
+                    vocal_presence_blob: encode_f32_blob(&[]),
+                    vocal_density_blob: encode_f32_blob(&[]),
+                    lufs_loud_body: None,
+                    true_peak_dbtp: None,
+                    beat_confidence: Some(0.8),
+                    profile_confidence: 0.7,
+                    analysis_scope_ms: 30_000,
+                    is_temporary: true,
+                    source: "test".to_string(),
+                    computed_at: "now".to_string(),
+                };
+                queries::upsert_audio_dj_profile(conn, &row)?;
+                queries::promote_temporary_audio_dj_profile(
+                    conn,
+                    &AudioDjProfileKey {
+                        media_ref_kind: "queue_item".to_string(),
+                        media_ref_id: "44".to_string(),
+                    },
+                    &AudioDjProfileKey {
+                        media_ref_kind: "tidal_track".to_string(),
+                        media_ref_id: "99".to_string(),
+                    },
+                    Some(99),
+                )?;
+                let stable = queries::get_audio_dj_profile(
+                    conn,
+                    &AudioDjProfileKey {
+                        media_ref_kind: "tidal_track".to_string(),
+                        media_ref_id: "99".to_string(),
+                    },
+                )?
+                .expect("stable profile");
+                assert_eq!(stable.tidal_id, Some(99));
+                Ok(())
+            })
+            .expect("promote");
         }
     }
 

--- a/noor-server/src/playback/runtime/shared.rs
+++ b/noor-server/src/playback/runtime/shared.rs
@@ -610,6 +610,40 @@ mod tests {
     }
 
     #[test]
+    fn dj_flag_off_uses_legacy_write_output_path() {
+        let shared = test_shared_state();
+        {
+            let mut buffer = shared.buffer.lock().expect("buffer lock");
+            buffer.samples.extend_from_slice(&[0.25, -0.5, 0.75, -1.0]);
+            buffer.mark_finished();
+        }
+        let (command_tx, _) = mpsc::channel();
+        let (event_tx, _) = tokio::sync::broadcast::channel(8);
+        let mut out = [0.0; 4];
+
+        write_output_f32(&mut out, &shared, &command_tx, &event_tx);
+
+        assert_eq!(out, [0.25, -0.5, 0.75, -1.0]);
+    }
+
+    #[test]
+    fn dj_enabled_without_ready_mixer_uses_legacy_path() {
+        let shared = test_shared_state();
+        {
+            let mut buffer = shared.buffer.lock().expect("buffer lock");
+            buffer.samples.extend_from_slice(&[0.125, 0.25, 0.5, 1.0]);
+            buffer.mark_finished();
+        }
+        let (command_tx, _) = mpsc::channel();
+        let (event_tx, _) = tokio::sync::broadcast::channel(8);
+        let mut out = [0.0; 4];
+
+        write_output_f32(&mut out, &shared, &command_tx, &event_tx);
+
+        assert_eq!(out, [0.125, 0.25, 0.5, 1.0]);
+    }
+
+    #[test]
     fn seek_to_decoded_position_applies_immediately() {
         let mut buffer = PlaybackBuffer::new(0);
         buffer.samples = vec![0.0; 1_000];

--- a/noor-server/src/playback/runtime/shared.rs
+++ b/noor-server/src/playback/runtime/shared.rs
@@ -146,7 +146,7 @@ fn write_output_buffer<T>(
     }
 
     let xfade = shared.crossfade_samples.load(Ordering::Relaxed);
-    let fade_gain = if xfade > 0 {
+    let fade_gain = if xfade > 0 && !shared.suppress_crossfade_after_seek.load(Ordering::Relaxed) {
         let pos = shared.position_samples.load(Ordering::Relaxed);
         let fadein_start = shared.fadein_start_samples.load(Ordering::Relaxed);
         if fadein_start != u64::MAX {
@@ -324,6 +324,7 @@ pub(crate) struct PlaybackSharedState {
     pub(crate) near_end_signaled: AtomicBool,
     pub(crate) crossfade_samples: AtomicU64,
     pub(crate) crossfade_start_signaled: AtomicBool,
+    pub(crate) suppress_crossfade_after_seek: AtomicBool,
     pub(crate) fadein_start_samples: AtomicU64,
     pub(crate) device_sample_rate: u32,
     pub(crate) device_channels: u16,
@@ -375,6 +376,7 @@ impl PlaybackSharedState {
             near_end_signaled: AtomicBool::new(false),
             crossfade_samples: AtomicU64::new(crossfade_samples),
             crossfade_start_signaled: AtomicBool::new(false),
+            suppress_crossfade_after_seek: AtomicBool::new(false),
             fadein_start_samples: AtomicU64::new(u64::MAX),
             device_sample_rate,
             device_channels,
@@ -399,6 +401,18 @@ impl PlaybackSharedState {
     /// invariant to protect.
     pub(crate) fn stop_flag(&self) -> Arc<AtomicBool> {
         Arc::clone(&self.stopped)
+    }
+
+    pub(crate) fn set_manual_seek_crossfade_suppression(&self, target_samples: u64) {
+        let total = self.total_samples.load(Ordering::Relaxed);
+        let threshold_samples = (NEAR_END_THRESHOLD_MS as u64)
+            .saturating_mul(u64::from(self.device_sample_rate))
+            .saturating_mul(u64::from(self.device_channels.max(1)))
+            / 1_000;
+        let suppress =
+            total > 0 && total.saturating_sub(target_samples) <= threshold_samples.max(1);
+        self.suppress_crossfade_after_seek
+            .store(suppress, Ordering::Relaxed);
     }
 
     /// Audio-thread-safe: publish the current decoded-sample count for

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -54,6 +54,8 @@ type TidalPlaylistTracksCache = Arc<Mutex<HashMap<String, (Instant, Vec<TidalTra
 
 const TIDAL_PLAYLIST_TRACKS_CACHE_TTL: Duration = Duration::from_secs(60 * 60);
 const EPHEMERAL_DJ_LOOKAHEAD_DEADLINE_SAMPLES: u64 = 48_000 * 30;
+const PLAYBACK_FINISH_DB_LOCK_RETRY_LIMIT: usize = 60;
+const PLAYBACK_FINISH_DB_LOCK_RETRY_DELAY_SECS: u64 = 2;
 
 #[derive(Debug, Deserialize)]
 pub struct ListParams {
@@ -11064,7 +11066,8 @@ fn spawn_playback_runtime_listener(
                         .audio_active
                         .store(false, std::sync::atomic::Ordering::Relaxed);
                     if let Err(error) =
-                        handle_runtime_finished(state.clone(), track_id, generation).await
+                        handle_runtime_finished_with_retry(state.clone(), track_id, generation)
+                            .await
                     {
                         let message =
                             format!("Failed to advance playback after track end: {error}");
@@ -12241,6 +12244,49 @@ async fn mark_armed_dj_transition_missed_if_needed(state: &SharedState) -> anyho
         let _ = state_guard.event_tx.send(AppEvent::PlaybackStateChanged);
     }
     Ok(())
+}
+
+async fn handle_runtime_finished_with_retry(
+    state: SharedState,
+    finished_track_id: i64,
+    generation: u64,
+) -> anyhow::Result<()> {
+    for attempt in 0..=PLAYBACK_FINISH_DB_LOCK_RETRY_LIMIT {
+        match handle_runtime_finished(state.clone(), finished_track_id, generation).await {
+            Ok(()) => return Ok(()),
+            Err(error)
+                if sqlite_database_locked(&error)
+                    && attempt < PLAYBACK_FINISH_DB_LOCK_RETRY_LIMIT =>
+            {
+                let next_attempt = attempt + 1;
+                warn!(
+                    finished_track_id,
+                    generation, next_attempt, "Playback advance hit a locked database; retrying"
+                );
+                tokio::time::sleep(Duration::from_secs(
+                    PLAYBACK_FINISH_DB_LOCK_RETRY_DELAY_SECS,
+                ))
+                .await;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(())
+}
+
+fn sqlite_database_locked(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        if let Some(rusqlite::Error::SqliteFailure(sqlite_error, _)) =
+            cause.downcast_ref::<rusqlite::Error>()
+        {
+            return matches!(
+                sqlite_error.code,
+                rusqlite::ErrorCode::DatabaseBusy | rusqlite::ErrorCode::DatabaseLocked
+            );
+        }
+        let message = cause.to_string();
+        message.contains("database is locked") || message.contains("database table is locked")
+    })
 }
 
 async fn handle_runtime_error(state: SharedState, message: &str) {

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -53,6 +53,7 @@ pub use tidal_sync_routes::trigger_auto_sync;
 type TidalPlaylistTracksCache = Arc<Mutex<HashMap<String, (Instant, Vec<TidalTrack>)>>>;
 
 const TIDAL_PLAYLIST_TRACKS_CACHE_TTL: Duration = Duration::from_secs(60 * 60);
+const EPHEMERAL_DJ_LOOKAHEAD_DEADLINE_SAMPLES: u64 = 48_000 * 30;
 
 #[derive(Debug, Deserialize)]
 pub struct ListParams {
@@ -6534,9 +6535,53 @@ async fn clear_ephemeral_playback_markers(state: &SharedState, clear_mix_queue: 
     let mut state_guard = state.write().await;
     state_guard.external_playback_track = None;
     state_guard.ephemeral_tidal_track = None;
+    state_guard.prepared_ephemeral_tidal_next = None;
     if clear_mix_queue {
         state_guard.pending_tidal_mix_queue.lock().unwrap().clear();
     }
+}
+
+pub(crate) fn active_ephemeral_tidal_mix_dj_pair(
+    state: &crate::AppState,
+) -> Option<crate::playback::dj_lookahead::DjLookaheadPair> {
+    let current = state.ephemeral_tidal_track.as_ref()?;
+    let pending = state
+        .pending_tidal_mix_queue
+        .lock()
+        .unwrap()
+        .iter()
+        .cloned()
+        .collect::<Vec<_>>();
+    crate::playback::dj_lookahead::build_ephemeral_tidal_mix_pair(current, pending.as_slice())
+}
+
+pub(crate) fn active_ephemeral_tidal_mix_dj_labels(
+    state: &crate::AppState,
+) -> Vec<(
+    crate::db::models::AudioDjProfileKey,
+    (String, Option<String>),
+)> {
+    let mut labels = Vec::new();
+    if let Some(current) = state.ephemeral_tidal_track.as_ref()
+        && let Some(media_ref) = crate::playback::dj_lookahead::tidal_media_ref_for_track(current)
+    {
+        labels.push((
+            media_ref.profile_key(),
+            (current.title.clone(), current.artist_name.clone()),
+        ));
+    }
+    let pending = state.pending_tidal_mix_queue.lock().unwrap();
+    for track in pending.iter() {
+        let media_ref = crate::playback::dj_lookahead::DjMediaRef::TidalTrack {
+            tidal_id: track.tidal_track_id,
+            track_id: None,
+        };
+        labels.push((
+            media_ref.profile_key(),
+            (track.title.clone(), track.artist_name.clone()),
+        ));
+    }
+    labels
 }
 
 async fn overlay_snapshot_with_external_track(
@@ -6557,6 +6602,7 @@ async fn overlay_snapshot_with_external_track_and_position(
     }
     // Ephemeral Tidal track takes priority: it represents a track playing right
     // now that has no DB record.
+    let has_ephemeral_tidal_track = state_guard.ephemeral_tidal_track.is_some();
     if let Some(ephemeral) = &state_guard.ephemeral_tidal_track {
         snapshot.state.current_track = Some(ephemeral.clone());
     } else if snapshot.state.current_track.is_none()
@@ -6577,6 +6623,9 @@ async fn overlay_snapshot_with_external_track_and_position(
         .collect::<Vec<_>>();
     drop(state_guard);
     if !pending.is_empty() {
+        if has_ephemeral_tidal_track {
+            snapshot.queue.clear();
+        }
         let tidal_ids: Vec<i64> = pending.iter().map(|p| p.tidal_track_id).collect();
         let library_states = db
             .with_conn(|conn| queries::get_tidal_track_library_states(conn, &tidal_ids))
@@ -6878,6 +6927,17 @@ async fn build_live_playback_snapshot(
     Ok(snapshot)
 }
 
+async fn build_live_playback_snapshot_json(
+    state: &SharedState,
+) -> Result<player::PlaybackSnapshot, (StatusCode, Json<Value>)> {
+    build_live_playback_snapshot(state).await.map_err(|status| {
+        (
+            status,
+            Json(json!({ "error": "Playback snapshot unavailable" })),
+        )
+    })
+}
+
 async fn get_playback_state(State(state): State<SharedState>) -> Result<Json<Value>, StatusCode> {
     let snapshot = build_live_playback_snapshot(&state).await?;
     Ok(Json(json!({
@@ -6888,6 +6948,10 @@ async fn get_playback_state(State(state): State<SharedState>) -> Result<Json<Val
 
 async fn get_playback_runtime(State(state): State<SharedState>) -> Result<Json<Value>, StatusCode> {
     let state = state.read().await;
+    let dj_engine_enabled = state
+        .db
+        .with_conn(queries::is_dj_engine_enabled)
+        .unwrap_or(false);
     let runtime = state.playback_runtime_info.as_ref().map(|info| {
         json!({
             "device_name": info.device_name,
@@ -6897,6 +6961,7 @@ async fn get_playback_runtime(State(state): State<SharedState>) -> Result<Json<V
             "last_error": info.last_error,
             "exclusive_engaged": info.exclusive_engaged,
             "exclusive_transport_format": info.exclusive_transport_format,
+            "dj_engine_enabled": dj_engine_enabled,
         })
     });
     let stream = state.current_stream_display.as_ref().map(|d| {
@@ -10315,7 +10380,16 @@ async fn play_tidal_ephemeral(
         duration_ms: body.duration_ms,
     };
     start_ephemeral_tidal_playback(&state, track).await?;
-    Ok(Json(json!({ "ok": true })))
+    let snapshot = build_live_playback_snapshot_json(&state).await?;
+    {
+        let s = state.read().await;
+        let _ = s.event_tx.send(AppEvent::QueueUpdated);
+    }
+    Ok(Json(json!({
+        "ok": true,
+        "state": snapshot.state,
+        "queue": snapshot.queue
+    })))
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -10386,10 +10460,17 @@ async fn play_tidal_mix(
     }
 
     start_ephemeral_tidal_playback(&state, first).await?;
+    let snapshot = build_live_playback_snapshot_json(&state).await?;
+    {
+        let s = state.read().await;
+        let _ = s.event_tx.send(AppEvent::QueueUpdated);
+    }
     Ok(Json(json!({
         "ok": true,
         "first_tidal_id": first_tidal_id,
-        "shuffle_debug": shuffle_debug
+        "shuffle_debug": shuffle_debug,
+        "state": snapshot.state,
+        "queue": snapshot.queue
     })))
 }
 
@@ -10542,6 +10623,7 @@ async fn start_ephemeral_tidal_playback(
         let mut state_guard = state.write().await;
         state_guard.external_playback_track = None;
         state_guard.ephemeral_tidal_track = Some(synthetic.clone());
+        state_guard.prepared_ephemeral_tidal_next = None;
         state_guard.current_stream_display = Some(crate::StreamDisplayInfo {
             audio_quality: stream_info.audio_quality.clone(),
             sample_rate: stream_info.sample_rate,
@@ -10574,13 +10656,26 @@ async fn start_ephemeral_tidal_playback(
 
     // Build the playback job and start it via the runtime
     let crossfade_ms = current_crossfade_ms(state).await;
-    let job = player::build_playback_preparation(
+    let dj_engine_enabled = {
+        let state_guard = state.read().await;
+        state_guard
+            .db
+            .with_conn(queries::is_dj_engine_enabled)
+            .unwrap_or(false)
+    };
+    let mut job = player::build_playback_preparation(
         &synthetic,
         Some(&stream_info),
         crossfade_ms,
         user_quality,
     )
     .with_generation(playback_generation);
+    if dj_engine_enabled
+        && let Some(media_ref) =
+            crate::playback::dj_lookahead::tidal_media_ref_for_track(&synthetic)
+    {
+        job = job.with_dj_media_ref(media_ref);
+    }
     let runtime_handle = match ensure_playback_runtime_for_track(state, &synthetic).await {
         Ok(handle) => handle,
         Err(error) => {
@@ -10600,6 +10695,17 @@ async fn start_ephemeral_tidal_playback(
             Json(json!({ "error": message })),
         )
     })?;
+    if dj_engine_enabled {
+        let lookahead = {
+            let state_guard = state.read().await;
+            active_ephemeral_tidal_mix_dj_pair(&state_guard).and_then(|pair| {
+                player::dj_lookahead_start_from_pair(pair, EPHEMERAL_DJ_LOOKAHEAD_DEADLINE_SAMPLES)
+            })
+        };
+        if let Some(lookahead) = lookahead {
+            let _ = lookahead.dispatch(&runtime_handle);
+        }
+    }
 
     sync_session_after_snapshot(
         state,
@@ -10868,11 +10974,16 @@ async fn ensure_playback_runtime_for_track(
             let _ = runtime.handle.shutdown();
         }
 
+        let dj_engine_enabled = state_guard
+            .db
+            .with_conn(queries::is_dj_engine_enabled)
+            .unwrap_or(false);
         let config = playback_runtime::PlaybackRuntimeConfig::new(
             state_guard.http_client.clone(),
             access_token.clone(),
             state_guard.analysis_tx.clone(),
-        );
+        )
+        .with_dj_analysis(dj_engine_enabled, state_guard.dj_analysis_tx.clone());
         let handle = playback_runtime::spawn_runtime(config).map_err(|error| {
             let message = format!("Failed to start host audio runtime: {error}");
             (
@@ -10961,6 +11072,35 @@ fn spawn_playback_runtime_listener(
                         error!("{message}");
                     }
                 }
+                Ok(playback_runtime::PlaybackRuntimeEvent::DjTransitionPromoted {
+                    transition_event_id,
+                    actual_start_ms,
+                    timing_status,
+                    ..
+                }) => {
+                    let state_guard = state.read().await;
+                    match state_guard.db.with_conn(|conn| {
+                        queries::update_dj_transition_fire_timing(
+                            conn,
+                            transition_event_id,
+                            actual_start_ms,
+                            timing_status.as_str(),
+                        )
+                    }) {
+                        Ok(()) => {
+                            info!(
+                                transition_event_id,
+                                actual_start_ms,
+                                timing_status = %timing_status,
+                                "Recorded DJ transition timing"
+                            );
+                        }
+                        Err(error) => {
+                            warn!("Failed to record DJ transition timing: {error}");
+                        }
+                    }
+                    let _ = state_guard.event_tx.send(AppEvent::PlaybackStateChanged);
+                }
                 Ok(playback_runtime::PlaybackRuntimeEvent::Error { message }) => {
                     handle_runtime_error(state.clone(), &message).await;
                 }
@@ -11040,6 +11180,7 @@ fn spawn_playback_runtime_listener(
                     }
                     state_guard.external_playback_track = None;
                     state_guard.ephemeral_tidal_track = None;
+                    state_guard.prepared_ephemeral_tidal_next = None;
                     state_guard.current_stream_display = None;
                     state_guard.pending_stream_display = None;
                 }
@@ -11144,11 +11285,228 @@ fn spawn_playback_runtime_listener(
 
 /// Peek at what would play next without advancing the queue, then send `PrepareNext` to the
 /// runtime so it can pre-decode the track and swap it in gaplessly when the current one ends.
+async fn handle_ephemeral_tidal_near_end(
+    state: SharedState,
+    current_track_id: i64,
+    generation: u64,
+) -> anyhow::Result<bool> {
+    let (current_track, pending_track, pending_tracks, handle, sample_rate, channels) = {
+        let state_guard = state.read().await;
+        let active_id = state_guard
+            .playback_runtime_info
+            .as_ref()
+            .and_then(|info| info.active_track_id);
+        if active_id != Some(current_track_id)
+            || current_playback_generation(&state_guard) != generation
+        {
+            return Ok(true);
+        }
+
+        let Some(current_track) = state_guard.ephemeral_tidal_track.clone() else {
+            return Ok(false);
+        };
+        if current_track.id != current_track_id {
+            return Ok(false);
+        }
+        let pending_tracks = state_guard
+            .pending_tidal_mix_queue
+            .lock()
+            .unwrap()
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>();
+        let Some(pending_track) = pending_tracks.first().cloned() else {
+            return Ok(true);
+        };
+        let Some(handle) = state_guard
+            .playback_runtime
+            .as_ref()
+            .map(|runtime| runtime.handle.clone())
+        else {
+            return Ok(true);
+        };
+        let Some(runtime_info) = state_guard.playback_runtime_info.as_ref() else {
+            return Ok(true);
+        };
+        (
+            current_track,
+            pending_track,
+            pending_tracks,
+            handle,
+            runtime_info.sample_rate,
+            runtime_info.channels,
+        )
+    };
+
+    let dj_engine_enabled = {
+        let state_guard = state.read().await;
+        state_guard
+            .db
+            .with_conn(queries::is_dj_engine_enabled)
+            .unwrap_or(false)
+    };
+    if !dj_engine_enabled {
+        return Ok(false);
+    }
+
+    let user_quality = current_user_audio_quality(&state).await;
+    let stream_request =
+        build_ephemeral_tidal_stream_request(pending_track.tidal_track_id, user_quality.clone());
+    let resolve_probe = crate::db::models::Track {
+        id: -pending_track.tidal_track_id,
+        title: pending_track.title.clone(),
+        artist_id: 0,
+        artist_name: pending_track.artist_name.clone(),
+        album_id: None,
+        album_title: pending_track.album_title.clone(),
+        disc_number: None,
+        track_number: None,
+        duration_ms: pending_track.duration_ms,
+        isrc: None,
+        tidal_id: Some(pending_track.tidal_track_id),
+        ytmusic_id: None,
+        soundcloud_id: None,
+        best_quality: None,
+        best_source: Some("tidal".to_string()),
+        fidelity_score: 0,
+        is_favorite: false,
+        play_count: 0,
+        last_played_at: None,
+        date_added: None,
+        source: "tidal_ephemeral".to_string(),
+        artwork_url: pending_track.artwork_url.clone(),
+    };
+    let stream_info =
+        match resolve_tidal_playback_stream(&state, &resolve_probe, &stream_request).await {
+            Ok(info) => info,
+            Err(error) => {
+                warn!(
+                    "Skipping DJ pre-buffer for TIDAL mix track {}: {}",
+                    pending_track.tidal_track_id,
+                    describe_tidal_playback_error(&error)
+                );
+                return Ok(true);
+            }
+        };
+
+    {
+        let state_guard = state.read().await;
+        let runtime_token = state_guard
+            .playback_runtime
+            .as_ref()
+            .map(|runtime| runtime.access_token.as_str());
+        let current_token = state_guard
+            .tidal_tokens
+            .as_ref()
+            .map(|tokens| tokens.access_token.as_str());
+        if runtime_token != current_token {
+            info!(
+                "Skipping DJ pre-buffer for TIDAL mix track {} after TIDAL session refresh",
+                pending_track.tidal_track_id
+            );
+            return Ok(true);
+        }
+    }
+
+    let library_state = {
+        let state_guard = state.read().await;
+        lookup_tidal_track_library_state(&state_guard.db, pending_track.tidal_track_id)
+    };
+    let synthetic = build_ephemeral_synthetic_track(&pending_track, &stream_info, library_state);
+    let stream_display = crate::StreamDisplayInfo {
+        audio_quality: stream_info.audio_quality.clone(),
+        sample_rate: stream_info.sample_rate,
+        bit_depth: stream_info.bit_depth,
+    };
+
+    let pair = crate::playback::dj_lookahead::build_ephemeral_tidal_mix_pair(
+        &current_track,
+        &pending_tracks,
+    )
+    .context("ephemeral TIDAL mix pair unavailable")?;
+    let lookahead_start =
+        player::dj_lookahead_start_from_pair(pair.clone(), EPHEMERAL_DJ_LOOKAHEAD_DEADLINE_SAMPLES);
+    let effective_crossfade = current_crossfade_ms(&state).await;
+    let mut job = player::build_playback_preparation(
+        &synthetic,
+        Some(&stream_info),
+        effective_crossfade,
+        user_quality,
+    )
+    .with_generation(generation);
+    if let Some(media_ref) = crate::playback::dj_lookahead::tidal_media_ref_for_track(&synthetic) {
+        job = job.with_dj_media_ref(media_ref);
+    }
+    let engine = crate::playback::dj_engine::DjEngine::new({
+        let state_guard = state.read().await;
+        state_guard.db.clone()
+    });
+    job = player::attach_dj_transition_plan_for_pair_with_current_duration(
+        &engine,
+        job,
+        pair,
+        stream_info.sample_rate_hz().unwrap_or(sample_rate),
+        channels,
+        current_track.duration_ms,
+    )?;
+
+    {
+        let state_guard = state.read().await;
+        let active_id = state_guard
+            .playback_runtime_info
+            .as_ref()
+            .and_then(|info| info.active_track_id);
+        let pending_front = state_guard
+            .pending_tidal_mix_queue
+            .lock()
+            .unwrap()
+            .front()
+            .map(|track| track.tidal_track_id);
+        if active_id != Some(current_track_id)
+            || current_playback_generation(&state_guard) != generation
+            || state_guard
+                .ephemeral_tidal_track
+                .as_ref()
+                .map(|track| track.id)
+                != Some(current_track_id)
+            || pending_front != Some(pending_track.tidal_track_id)
+        {
+            return Ok(true);
+        }
+    }
+
+    if job.prepared_transition.is_some()
+        && let Some(start) = lookahead_start
+    {
+        start.dispatch(&handle)?;
+    }
+    handle.prepare_next(job)?;
+    {
+        let mut state_guard = state.write().await;
+        state_guard.prepared_ephemeral_tidal_next = Some(crate::PreparedEphemeralTidalNext {
+            tidal_track_id: pending_track.tidal_track_id,
+            synthetic_track: synthetic.clone(),
+            stream_display: stream_display.clone(),
+            generation,
+        });
+        state_guard.pending_stream_display = Some(stream_display);
+    }
+    info!(
+        "DJ pre-buffering TIDAL mix track: {} (tidal id {})",
+        synthetic.title, pending_track.tidal_track_id
+    );
+    Ok(true)
+}
+
 async fn handle_near_end(
     state: SharedState,
     current_track_id: i64,
     generation: u64,
 ) -> anyhow::Result<()> {
+    if handle_ephemeral_tidal_near_end(state.clone(), current_track_id, generation).await? {
+        return Ok(());
+    }
+
     let (next_track, runtime_handle, crossfade_ms) = {
         let state_guard = state.read().await;
 
@@ -11333,14 +11691,14 @@ async fn handle_near_end(
         user_quality,
     )
     .with_generation(generation);
-    let job = {
+    let (job, lookahead_start) = {
         let state_guard = state.read().await;
         let channels = state_guard
             .playback_runtime_info
             .as_ref()
             .map(|info| info.channels)
             .unwrap_or(2);
-        player::attach_dj_transition_plan(
+        let job = player::attach_dj_transition_plan(
             &state_guard.db,
             job,
             stream_info
@@ -11348,7 +11706,15 @@ async fn handle_near_end(
                 .and_then(|info| info.sample_rate_hz())
                 .unwrap_or(48_000),
             channels,
-        )?
+        )?;
+        let lookahead_start = if job.prepared_transition.is_some() {
+            state_guard.db.with_conn(|conn| {
+                player::build_dj_lookahead_start(conn, EPHEMERAL_DJ_LOOKAHEAD_DEADLINE_SAMPLES)
+            })?
+        } else {
+            None
+        };
+        (job, lookahead_start)
     };
 
     {
@@ -11369,6 +11735,11 @@ async fn handle_near_end(
         }
     }
 
+    if job.prepared_transition.is_some()
+        && let Some(start) = lookahead_start
+    {
+        let _ = start.dispatch(&handle);
+    }
     let _ = handle.prepare_next(job);
     if let Some(ref si) = stream_info {
         let mut state_guard = state.write().await;
@@ -11382,6 +11753,113 @@ async fn handle_near_end(
     Ok(())
 }
 
+async fn try_adopt_prepared_ephemeral_tidal_next(
+    state: &SharedState,
+    finished_track_id: i64,
+    generation: u64,
+) -> anyhow::Result<bool> {
+    let (prepared, handle) = {
+        let state_guard = state.read().await;
+        let Some(prepared) = state_guard.prepared_ephemeral_tidal_next.clone() else {
+            return Ok(false);
+        };
+        if prepared.generation != generation
+            || state_guard
+                .ephemeral_tidal_track
+                .as_ref()
+                .map(|track| track.id)
+                != Some(finished_track_id)
+        {
+            return Ok(false);
+        }
+        let pending_front = state_guard
+            .pending_tidal_mix_queue
+            .lock()
+            .unwrap()
+            .front()
+            .map(|track| track.tidal_track_id);
+        if pending_front != Some(prepared.tidal_track_id) {
+            return Ok(false);
+        }
+        let Some(handle) = state_guard
+            .playback_runtime
+            .as_ref()
+            .map(|runtime| runtime.handle.clone())
+        else {
+            return Ok(false);
+        };
+        (prepared, handle)
+    };
+
+    let prepared_status = handle.track_status(prepared.synthetic_track.id, generation);
+    if !matches!(
+        prepared_status,
+        playback_runtime::PlaybackTrackStatus::Active
+            | playback_runtime::PlaybackTrackStatus::Prepared
+    ) {
+        return Ok(false);
+    }
+
+    let user_quality = current_user_audio_quality(state).await;
+    let mut job = player::build_playback_preparation(
+        &prepared.synthetic_track,
+        None,
+        current_crossfade_ms(state).await,
+        user_quality,
+    )
+    .with_generation(generation);
+    if let Some(media_ref) =
+        crate::playback::dj_lookahead::tidal_media_ref_for_track(&prepared.synthetic_track)
+    {
+        job = job.with_dj_media_ref(media_ref);
+    }
+    handle.switch_to(job)?;
+
+    {
+        let mut state_guard = state.write().await;
+        if current_playback_generation(&state_guard) != generation
+            || state_guard
+                .ephemeral_tidal_track
+                .as_ref()
+                .map(|track| track.id)
+                != Some(finished_track_id)
+        {
+            return Ok(true);
+        }
+        let mut pending = state_guard.pending_tidal_mix_queue.lock().unwrap();
+        if pending.front().map(|track| track.tidal_track_id) != Some(prepared.tidal_track_id) {
+            return Ok(true);
+        }
+        let _ = pending.pop_front();
+        drop(pending);
+
+        state_guard.external_playback_track = None;
+        state_guard.ephemeral_tidal_track = Some(prepared.synthetic_track.clone());
+        state_guard.current_stream_display = Some(prepared.stream_display.clone());
+        state_guard.pending_stream_display = None;
+        state_guard.prepared_ephemeral_tidal_next = None;
+        if let Some(info) = state_guard.playback_runtime_info.as_mut() {
+            info.active_track_id = Some(prepared.synthetic_track.id);
+            info.last_error = None;
+        }
+        let _ = state_guard.event_tx.send(AppEvent::TrackChanged {
+            track_id: prepared.synthetic_track.id,
+        });
+        let _ = state_guard.event_tx.send(AppEvent::PlaybackStateChanged);
+    }
+
+    let snapshot = build_live_playback_snapshot(state)
+        .await
+        .map_err(|status| anyhow::anyhow!("playback snapshot failed: {status}"))?;
+    sync_session_after_snapshot(
+        state,
+        &snapshot,
+        Some(player::ListenSessionEndReason::Replaced),
+    )
+    .await;
+    Ok(true)
+}
+
 async fn handle_runtime_finished(
     state: SharedState,
     finished_track_id: i64,
@@ -11392,6 +11870,9 @@ async fn handle_runtime_finished(
         if current_playback_generation(&state_guard) != generation {
             return Ok(());
         }
+    }
+    if let Err(error) = mark_armed_dj_transition_missed_if_needed(&state).await {
+        warn!("Failed to mark missed DJ transition timing: {error}");
     }
 
     let external_finished = {
@@ -11408,6 +11889,14 @@ async fn handle_runtime_finished(
                 .unwrap_or(false)
     };
     if external_finished {
+        if try_adopt_prepared_ephemeral_tidal_next(&state, finished_track_id, generation).await? {
+            return Ok(());
+        }
+        {
+            let mut state_guard = state.write().await;
+            state_guard.prepared_ephemeral_tidal_next = None;
+            state_guard.pending_stream_display = None;
+        }
         // Auto-advance through any queued ephemeral mix continuation before
         // tearing down. Pop the next track out of the pending queue and start
         // it; if the queue is empty, fall through to the existing teardown.
@@ -11655,6 +12144,42 @@ async fn handle_runtime_finished(
     Ok(())
 }
 
+async fn mark_armed_dj_transition_missed_if_needed(state: &SharedState) -> anyhow::Result<()> {
+    let pair = {
+        let state_guard = state.read().await;
+        if let Some(pair) = active_ephemeral_tidal_mix_dj_pair(&state_guard) {
+            pair
+        } else {
+            state_guard
+                .db
+                .with_conn(crate::playback::dj_lookahead::load_dj_lookahead_pair)?
+        }
+    };
+    let (Some(current), Some(next)) = (pair.current.as_ref(), pair.next.as_ref()) else {
+        return Ok(());
+    };
+    let current_key = current.profile_key();
+    let next_key = next.profile_key();
+    let updated = {
+        let state_guard = state.read().await;
+        state_guard.db.with_conn(|conn| {
+            queries::mark_dj_transition_timing_status_for_pair(
+                conn,
+                current_key.media_ref_kind.as_str(),
+                current_key.media_ref_id.as_str(),
+                next_key.media_ref_kind.as_str(),
+                next_key.media_ref_id.as_str(),
+                "missed",
+            )
+        })?
+    };
+    if updated > 0 {
+        let state_guard = state.read().await;
+        let _ = state_guard.event_tx.send(AppEvent::PlaybackStateChanged);
+    }
+    Ok(())
+}
+
 async fn handle_runtime_error(state: SharedState, message: &str) {
     {
         let mut state_guard = state.write().await;
@@ -11664,6 +12189,7 @@ async fn handle_runtime_error(state: SharedState, message: &str) {
         }
         state_guard.external_playback_track = None;
         state_guard.ephemeral_tidal_track = None;
+        state_guard.prepared_ephemeral_tidal_next = None;
     }
     report_playback_failure(&state, message);
 
@@ -11738,12 +12264,15 @@ async fn resume_session_after_snapshot(state: &SharedState, snapshot: &player::P
 /// re-querying `playback_state`.
 async fn effective_crossfade_ms(state: &SharedState, configured: i32) -> i32 {
     let guard = state.read().await;
-    let exclusive = guard
+    let (exclusive, dj_engine_enabled) = guard
         .db
-        .with_conn(|conn| crate::db::audio_settings::load(conn).map_err(Into::into))
-        .map(|s| s.exclusive_mode)
-        .unwrap_or(false);
-    effective_crossfade_for_exclusive(exclusive, configured)
+        .with_conn(|conn| {
+            let settings = crate::db::audio_settings::load(conn)?;
+            let dj_enabled = queries::is_dj_engine_enabled(conn)?;
+            Ok((settings.exclusive_mode, dj_enabled))
+        })
+        .unwrap_or((false, false));
+    effective_crossfade_for_exclusive(exclusive, dj_engine_enabled, configured)
 }
 
 async fn current_crossfade_ms(state: &SharedState) -> i32 {
@@ -11760,19 +12289,29 @@ async fn current_crossfade_ms(state: &SharedState) -> i32 {
         })
         .unwrap_or(0);
 
-    // Bit-perfect exclusive playback must not rewrite samples. Crossfade
-    // requires mixing and gain ramps, so exclusive mode keeps prebuffering but
-    // suppresses the overlap.
-    let exclusive = guard
+    // Bit-perfect exclusive playback must not rewrite samples. DJ mode opts
+    // into processing while keeping exclusive device ownership.
+    let (exclusive, dj_engine_enabled) = guard
         .db
-        .with_conn(|conn| crate::db::audio_settings::load(conn).map_err(Into::into))
-        .map(|s| s.exclusive_mode)
-        .unwrap_or(false);
-    effective_crossfade_for_exclusive(exclusive, configured)
+        .with_conn(|conn| {
+            let settings = crate::db::audio_settings::load(conn)?;
+            let dj_enabled = queries::is_dj_engine_enabled(conn)?;
+            Ok((settings.exclusive_mode, dj_enabled))
+        })
+        .unwrap_or((false, false));
+    effective_crossfade_for_exclusive(exclusive, dj_engine_enabled, configured)
 }
 
-fn effective_crossfade_for_exclusive(exclusive: bool, configured: i32) -> i32 {
-    if exclusive { 0 } else { configured.max(0) }
+fn effective_crossfade_for_exclusive(
+    exclusive: bool,
+    dj_engine_enabled: bool,
+    configured: i32,
+) -> i32 {
+    if exclusive && !dj_engine_enabled {
+        0
+    } else {
+        configured.max(0)
+    }
 }
 
 fn should_skip_prebuffer_for_sample_rate_follow_format_change(
@@ -13183,6 +13722,8 @@ mod tests {
             )),
             acrcloud_client: None,
             analysis_tx: None,
+            dj_analysis_tx: None,
+            dj_profile_rebuild_inflight: Arc::new(std::sync::Mutex::new(HashMap::new())),
             audio_analysis_cancel: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             audio_analysis_running: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             acrcloud_scan_running: Arc::new(std::sync::atomic::AtomicBool::new(false)),
@@ -13211,6 +13752,7 @@ mod tests {
             pending_tidal_mix_queue: Arc::new(std::sync::Mutex::new(
                 std::collections::VecDeque::new(),
             )),
+            prepared_ephemeral_tidal_next: None,
             lastfm_api_secret: None,
             server_token: String::new(),
             audio_active: Arc::new(std::sync::atomic::AtomicBool::new(false)),
@@ -13378,10 +13920,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn dj_profile_rebuild_returns_accepted_without_blocking() {
+    async fn dj_profile_rebuild_does_not_claim_accepted_without_job() {
         let (db, db_path) = fresh_migrated_db();
         seed_dj_queue_pair(&db);
         let app = app_for_db(db);
+        let response =
+            json_request(app.clone(), "PUT", "/api/dj/enabled", r#"{"enabled":true}"#).await;
+        assert_eq!(response.status(), StatusCode::OK);
         let response = json_request(
             app,
             "POST",
@@ -13391,7 +13936,8 @@ mod tests {
         .await;
         assert_eq!(response.status(), StatusCode::OK);
         let body = response_json(response).await;
-        assert_eq!(body["accepted"], true);
+        assert_eq!(body["accepted"], false);
+        assert_eq!(body["status"], "source_unavailable");
         let _ = std::fs::remove_file(db_path);
     }
 
@@ -14336,6 +14882,114 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn tidal_mix_overlay_preserves_pending_deque_order() {
+        let (db, db_path) = fresh_migrated_db();
+        db.with_conn(|conn| {
+            conn.execute(
+                "INSERT INTO artists (id, name) VALUES (8101, 'Old Playlist Artist')",
+                [],
+            )?;
+            conn.execute(
+                "INSERT INTO tracks (id, title, artist_id, duration_ms)
+                 VALUES
+                    (8101, 'Old Playlist First', 8101, 200000),
+                    (8102, 'Old Playlist Second', 8101, 200000)",
+                [],
+            )?;
+            conn.execute(
+                "INSERT INTO queue (track_id, position, source)
+                 VALUES (8101, 0, 'playlist'), (8102, 1, 'playlist')",
+                [],
+            )?;
+            Ok(())
+        })
+        .unwrap();
+        let state = Arc::new(tokio::sync::RwLock::new(fresh_test_state(db)));
+        {
+            let mut guard = state.write().await;
+            guard.ephemeral_tidal_track = Some(crate::db::models::Track {
+                id: -158_296_914,
+                title: "The Harder They Come".to_string(),
+                artist_id: 0,
+                artist_name: Some("Jimmy Cliff".to_string()),
+                album_id: None,
+                album_title: None,
+                disc_number: None,
+                track_number: None,
+                duration_ms: Some(220_000),
+                isrc: None,
+                tidal_id: Some(158_296_914),
+                ytmusic_id: None,
+                soundcloud_id: None,
+                best_quality: Some("LOSSLESS".to_string()),
+                best_source: Some("tidal".to_string()),
+                fidelity_score: 0,
+                is_favorite: false,
+                play_count: 0,
+                last_played_at: None,
+                date_added: None,
+                source: "tidal_ephemeral".to_string(),
+                artwork_url: None,
+            });
+            let mut pending = guard.pending_tidal_mix_queue.lock().unwrap();
+            pending.push_back(crate::PendingEphemeralTidalTrack {
+                tidal_track_id: 873_891_22,
+                title: "The Big Tree".to_string(),
+                artist_name: Some("Stand High Patrol".to_string()),
+                album_title: None,
+                artwork_url: None,
+                duration_ms: Some(180_000),
+            });
+            pending.push_back(crate::PendingEphemeralTidalTrack {
+                tidal_track_id: 341_378_223,
+                title: "Positive".to_string(),
+                artist_name: Some("Jamback".to_string()),
+                album_title: None,
+                artwork_url: None,
+                duration_ms: Some(170_000),
+            });
+            pending.push_back(crate::PendingEphemeralTidalTrack {
+                tidal_track_id: 172_522_829,
+                title: "Moi Aussi Marianne".to_string(),
+                artist_name: Some("Yatoba Lia".to_string()),
+                album_title: None,
+                artwork_url: None,
+                duration_ms: Some(210_000),
+            });
+        }
+
+        let snapshot = {
+            let guard = state.read().await;
+            guard.db.with_conn(player::load_snapshot).unwrap()
+        };
+        let snapshot = overlay_snapshot_with_external_track(&state, snapshot).await;
+
+        assert_eq!(
+            snapshot
+                .state
+                .current_track
+                .as_ref()
+                .map(|track| track.title.as_str()),
+            Some("The Harder They Come")
+        );
+        let titles = snapshot
+            .queue
+            .iter()
+            .map(|item| item.track.title.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            titles,
+            vec!["The Big Tree", "Positive", "Moi Aussi Marianne"]
+        );
+        assert!(
+            snapshot.queue.iter().all(|item| item.source == "tidal_mix"),
+            "active TIDAL mix overlay must shadow the stale durable playlist queue"
+        );
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[tokio::test]
     async fn clear_queue_clears_pending_tidal_mix_overlay() {
         let (db, db_path) = fresh_migrated_db();
         let state = Arc::new(tokio::sync::RwLock::new(fresh_test_state(db)));
@@ -14496,9 +15150,13 @@ mod tests {
 
     #[test]
     fn exclusive_crossfade_policy_suppresses_crossfade() {
-        assert_eq!(effective_crossfade_for_exclusive(true, 1_500), 0);
-        assert_eq!(effective_crossfade_for_exclusive(false, 1_500), 1_500);
-        assert_eq!(effective_crossfade_for_exclusive(true, -10), 0);
+        assert_eq!(effective_crossfade_for_exclusive(true, false, 1_500), 0);
+        assert_eq!(
+            effective_crossfade_for_exclusive(false, false, 1_500),
+            1_500
+        );
+        assert_eq!(effective_crossfade_for_exclusive(true, true, 1_500), 1_500);
+        assert_eq!(effective_crossfade_for_exclusive(true, true, -10), 0);
     }
 
     #[test]

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -39,6 +39,7 @@ mod analytics_routes;
 mod audio_analysis_routes;
 mod chart_routes;
 mod discovery_routes;
+mod dj_routes;
 mod duplicates_routes;
 mod enrichment_routes;
 mod genre_routes;
@@ -488,6 +489,7 @@ pub fn api_routes(state: SharedState) -> Router {
             "/api/library/enrich/musicbrainz/portable/import",
             post(enrichment_routes::import_musicbrainz_portable_snapshot),
         )
+        .merge(dj_routes::routes())
         .route("/api/library/tracks/favorite", post(set_track_favorite))
         // Duplicates
         .route(
@@ -13204,6 +13206,204 @@ mod tests {
         db.with_conn(|conn| schema::run_migrations(conn))
             .expect("schema migrations");
         (db, db_path)
+    }
+
+    fn app_for_db(db: Database) -> Router {
+        api_routes(Arc::new(tokio::sync::RwLock::new(fresh_test_state(db))))
+    }
+
+    fn seed_dj_queue_pair(db: &Database) -> (i64, i64) {
+        db.with_conn(|conn| {
+            conn.execute(
+                "INSERT INTO artists (id, name) VALUES (7001, 'DJ Artist')",
+                [],
+            )?;
+            conn.execute(
+                "INSERT INTO tracks (id, title, artist_id, duration_ms, tidal_id)
+                 VALUES
+                    (7001, 'Outgoing', 7001, 180000, 77001),
+                    (7002, 'Incoming', 7001, 180000, 77002)",
+                [],
+            )?;
+            conn.execute(
+                "INSERT INTO queue (track_id, position, source) VALUES (7001, 0, 'test')",
+                [],
+            )?;
+            let current_queue_item_id = conn.last_insert_rowid();
+            conn.execute(
+                "INSERT INTO queue (track_id, position, source) VALUES (7002, 1, 'test')",
+                [],
+            )?;
+            let next_queue_item_id = conn.last_insert_rowid();
+            conn.execute(
+                "UPDATE playback_state
+                 SET current_track_id = 7001, current_queue_item_id = ?1, is_playing = 1
+                 WHERE id = 1",
+                params![current_queue_item_id],
+            )?;
+            Ok((current_queue_item_id, next_queue_item_id))
+        })
+        .expect("seed dj queue pair")
+    }
+
+    async fn json_request(
+        app: Router,
+        method: &str,
+        uri: &str,
+        body: &str,
+    ) -> axum::response::Response {
+        app.oneshot(
+            Request::builder()
+                .method(method)
+                .uri(uri)
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .expect("request"),
+        )
+        .await
+        .expect("response")
+    }
+
+    async fn response_json(response: axum::response::Response) -> Value {
+        serde_json::from_slice(
+            &axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .expect("body bytes"),
+        )
+        .expect("json body")
+    }
+
+    #[tokio::test]
+    async fn dj_enabled_defaults_false() {
+        let (db, db_path) = fresh_migrated_db();
+        let response = json_request(app_for_db(db), "GET", "/api/dj/enabled", "").await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await;
+        assert_eq!(body["enabled"], false);
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[tokio::test]
+    async fn dj_enabled_can_be_toggled() {
+        let (db, db_path) = fresh_migrated_db();
+        let app = app_for_db(db);
+        let response =
+            json_request(app.clone(), "PUT", "/api/dj/enabled", r#"{"enabled":true}"#).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await;
+        assert_eq!(body["enabled"], true);
+
+        let response = json_request(app, "PUT", "/api/dj/enabled", r#"{"enabled":false}"#).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await;
+        assert_eq!(body["enabled"], false);
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[tokio::test]
+    async fn dj_enabled_true_starts_current_pair_lookahead() {
+        let (db, db_path) = fresh_migrated_db();
+        let (_current, next) = seed_dj_queue_pair(&db);
+        let app = app_for_db(db);
+        let response =
+            json_request(app.clone(), "PUT", "/api/dj/enabled", r#"{"enabled":true}"#).await;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let response = json_request(app, "GET", "/api/dj/status", "").await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await;
+        assert_eq!(body["enabled"], true);
+        assert_eq!(body["next"]["media_ref_kind"], "tidal_track");
+        assert_eq!(body["next"]["media_ref_id"], "77002");
+        assert!(next > 0);
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[tokio::test]
+    async fn dj_enabled_false_cancels_lookahead_and_discards_program() {
+        let (db, db_path) = fresh_migrated_db();
+        seed_dj_queue_pair(&db);
+        let app = app_for_db(db);
+        let response =
+            json_request(app.clone(), "PUT", "/api/dj/enabled", r#"{"enabled":true}"#).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let response = json_request(
+            app.clone(),
+            "PUT",
+            "/api/dj/enabled",
+            r#"{"enabled":false}"#,
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let response = json_request(app, "GET", "/api/dj/status", "").await;
+        let body = response_json(response).await;
+        assert_eq!(body["enabled"], false);
+        assert_eq!(body["fallback_reason"], "disabled");
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[tokio::test]
+    async fn dj_profile_rebuild_returns_accepted_without_blocking() {
+        let (db, db_path) = fresh_migrated_db();
+        seed_dj_queue_pair(&db);
+        let app = app_for_db(db);
+        let response = json_request(
+            app,
+            "POST",
+            "/api/dj/profile-rebuild",
+            r#"{"media_ref_kind":"tidal_track","media_ref_id":"77001"}"#,
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await;
+        assert_eq!(body["accepted"], true);
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[tokio::test]
+    async fn dj_profile_rebuild_does_not_mutate_armed_transition() {
+        let (db, db_path) = fresh_migrated_db();
+        seed_dj_queue_pair(&db);
+        db.with_conn(|conn| {
+            conn.execute(
+                "INSERT INTO dj_transition_events (
+                    from_media_ref_kind, from_media_ref_id, to_media_ref_kind, to_media_ref_id,
+                    template, program_json, planner_version, outcome
+                 ) VALUES ('tidal_track', '77001', 'tidal_track', '77002', 'SafeCrossfade', '{}', 'v1', 'armed')",
+                [],
+            )?;
+            Ok(())
+        })
+        .expect("seed transition");
+        let app = app_for_db(db.clone());
+        let response = json_request(
+            app,
+            "POST",
+            "/api/dj/profile-rebuild",
+            r#"{"media_ref_kind":"tidal_track","media_ref_id":"77001"}"#,
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let outcome: String = db
+            .with_conn(|conn| {
+                conn.query_row(
+                    "SELECT outcome FROM dj_transition_events LIMIT 1",
+                    [],
+                    |row| row.get(0),
+                )
+                .map_err(Into::into)
+            })
+            .expect("outcome");
+        assert_eq!(outcome, "armed");
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[tokio::test]
+    async fn dj_profile_returns_404_for_missing_profile() {
+        let (db, db_path) = fresh_migrated_db();
+        let response = json_request(app_for_db(db), "GET", "/api/dj/profile/999", "").await;
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        let _ = std::fs::remove_file(db_path);
     }
 
     fn seed_spotify_stats_track(

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -12212,9 +12212,20 @@ async fn sync_session_after_snapshot(
                     .with_conn(|conn| Ok(player::lookup_current_listen_source(conn)))
                     .unwrap_or(crate::db::models::ListenSource::Unknown);
                 let prior = state.live_listen_session.as_ref();
-                state.active_listen_session = Some(player::ActiveListenSession::start(
-                    track.id, now, source, prior,
-                ));
+                let dj_transition_event_id = state
+                    .db
+                    .with_conn(|conn| {
+                        player::latest_open_dj_transition_event_for_pair(
+                            conn,
+                            prior.map(|session| session.last_track_id),
+                            track.id,
+                        )
+                    })
+                    .unwrap_or(None);
+                state.active_listen_session = Some(
+                    player::ActiveListenSession::start(track.id, now, source, prior)
+                        .with_dj_transition_event_id(dj_transition_event_id),
+                );
                 now_playing = Some((
                     track.artist_name.clone().unwrap_or_default(),
                     track.title.clone(),
@@ -12318,6 +12329,7 @@ pub(crate) fn flush_active_listen_session_locked(
     let source = session.source;
     let position_in_session = session.position_in_session;
     let transition_from_track_id = session.transition_from_track_id;
+    let dj_transition_event_id = session.dj_transition_event_id;
     let write_result = state.db.with_conn(|conn| {
         let track = queue::get_track_by_id(conn, track_id)?.ok_or_else(|| {
             anyhow::anyhow!("track {} missing when flushing listen session", track_id)
@@ -12335,6 +12347,12 @@ pub(crate) fn flush_active_listen_session_locked(
             transition_from_track_id,
         )?;
         queries::increment_track_play_summary(conn, track_id, &started_at, completed)?;
+        player::record_dj_transition_listen_outcome(
+            conn,
+            dj_transition_event_id,
+            listened_ms,
+            completed,
+        )?;
         // Capture the fields needed for a Last.fm scrobble. The scrobble
         // helper itself does the source filter + eligibility check + silent
         // no-op when scrobbling isn't configured.

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -11183,6 +11183,7 @@ fn spawn_playback_runtime_listener(
                     state_guard.prepared_ephemeral_tidal_next = None;
                     state_guard.current_stream_display = None;
                     state_guard.pending_stream_display = None;
+                    state_guard.next_prebuffer_inflight = None;
                 }
                 Ok(playback_runtime::PlaybackRuntimeEvent::NearEnd {
                     track_id,
@@ -11545,7 +11546,49 @@ async fn handle_near_end(
     let (Some(next), Some(handle)) = (next_track, runtime_handle) else {
         return Ok(());
     };
+    if matches!(
+        handle.track_status(next.id, generation),
+        playback_runtime::PlaybackTrackStatus::Active
+            | playback_runtime::PlaybackTrackStatus::Prepared
+    ) {
+        return Ok(());
+    }
+    let prebuffer_key = crate::NextPrebufferKey {
+        current_track_id,
+        next_track_id: next.id,
+        generation,
+    };
+    {
+        let mut state_guard = state.write().await;
+        if !claim_next_prebuffer_slot(&mut state_guard.next_prebuffer_inflight, prebuffer_key) {
+            return Ok(());
+        }
+    }
 
+    let result = handle_near_end_prebuffer_next(
+        state.clone(),
+        current_track_id,
+        generation,
+        next,
+        handle,
+        crossfade_ms,
+    )
+    .await;
+    {
+        let mut state_guard = state.write().await;
+        release_next_prebuffer_slot(&mut state_guard.next_prebuffer_inflight, prebuffer_key);
+    }
+    result
+}
+
+async fn handle_near_end_prebuffer_next(
+    state: SharedState,
+    current_track_id: i64,
+    generation: u64,
+    next: crate::db::models::Track,
+    handle: playback_runtime::PlaybackRuntimeHandle,
+    crossfade_ms: i32,
+) -> anyhow::Result<()> {
     // Resolve the stream URL for the next track (we need a live access token).
     let user_quality = current_user_audio_quality(&state).await;
     let stream_request = match player::build_tidal_stream_request(&next, user_quality.clone()) {
@@ -11751,6 +11794,26 @@ async fn handle_near_end(
     }
     info!("Pre-buffering next track: {} (id {})", next.title, next.id);
     Ok(())
+}
+
+fn claim_next_prebuffer_slot(
+    slot: &mut Option<crate::NextPrebufferKey>,
+    key: crate::NextPrebufferKey,
+) -> bool {
+    if *slot == Some(key) {
+        return false;
+    }
+    *slot = Some(key);
+    true
+}
+
+fn release_next_prebuffer_slot(
+    slot: &mut Option<crate::NextPrebufferKey>,
+    key: crate::NextPrebufferKey,
+) {
+    if *slot == Some(key) {
+        *slot = None;
+    }
 }
 
 async fn try_adopt_prepared_ephemeral_tidal_next(
@@ -13712,6 +13775,7 @@ mod tests {
             playback_generation: Arc::new(std::sync::atomic::AtomicU64::new(1)),
             current_stream_display: None,
             pending_stream_display: None,
+            next_prebuffer_inflight: None,
             active_listen_session: None,
             live_listen_session: None,
             external_playback_track: None,
@@ -15157,6 +15221,29 @@ mod tests {
         );
         assert_eq!(effective_crossfade_for_exclusive(true, true, 1_500), 1_500);
         assert_eq!(effective_crossfade_for_exclusive(true, true, -10), 0);
+    }
+
+    #[test]
+    fn next_prebuffer_slot_suppresses_duplicate_pair_only() {
+        let key = crate::NextPrebufferKey {
+            current_track_id: 1,
+            next_track_id: 2,
+            generation: 3,
+        };
+        let replacement = crate::NextPrebufferKey {
+            current_track_id: 1,
+            next_track_id: 4,
+            generation: 3,
+        };
+        let mut slot = None;
+
+        assert!(claim_next_prebuffer_slot(&mut slot, key));
+        assert!(!claim_next_prebuffer_slot(&mut slot, key));
+        assert!(claim_next_prebuffer_slot(&mut slot, replacement));
+        release_next_prebuffer_slot(&mut slot, key);
+        assert_eq!(slot, Some(replacement));
+        release_next_prebuffer_slot(&mut slot, replacement);
+        assert_eq!(slot, None);
     }
 
     #[test]

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -11333,6 +11333,23 @@ async fn handle_near_end(
         user_quality,
     )
     .with_generation(generation);
+    let job = {
+        let state_guard = state.read().await;
+        let channels = state_guard
+            .playback_runtime_info
+            .as_ref()
+            .map(|info| info.channels)
+            .unwrap_or(2);
+        player::attach_dj_transition_plan(
+            &state_guard.db,
+            job,
+            stream_info
+                .as_ref()
+                .and_then(|info| info.sample_rate_hz())
+                .unwrap_or(48_000),
+            channels,
+        )?
+    };
 
     {
         let state_guard = state.read().await;

--- a/noor-server/src/server/routes/dj_routes.rs
+++ b/noor-server/src/server/routes/dj_routes.rs
@@ -144,6 +144,7 @@ struct DjStatusResponse {
     enabled: bool,
     current: Option<DjDeckStatus>,
     next: Option<DjDeckStatus>,
+    planning_status: String,
     selected_program: Option<String>,
     planned_template: Option<String>,
     renderer_template: Option<String>,
@@ -387,7 +388,12 @@ async fn get_status(
                             .iter()
                             .find(|(candidate, _)| candidate == &key)
                             .map(|(_, label)| label);
-                        Some(deck_status(conn, &media_ref, label)?)
+                        let inflight_key = dj_profile_inflight_key(&key);
+                        let rebuild_inflight = dj_profile_rebuild_is_inflight(
+                            &state.dj_profile_rebuild_inflight,
+                            &inflight_key,
+                        );
+                        Some(deck_status(conn, &media_ref, label, rebuild_inflight)?)
                     }
                     None => None,
                 };
@@ -398,7 +404,12 @@ async fn get_status(
                             .iter()
                             .find(|(candidate, _)| candidate == &key)
                             .map(|(_, label)| label);
-                        Some(deck_status(conn, &media_ref, label)?)
+                        let inflight_key = dj_profile_inflight_key(&key);
+                        let rebuild_inflight = dj_profile_rebuild_is_inflight(
+                            &state.dj_profile_rebuild_inflight,
+                            &inflight_key,
+                        );
+                        Some(deck_status(conn, &media_ref, label, rebuild_inflight)?)
                     }
                     None => None,
                 };
@@ -427,6 +438,30 @@ async fn get_status(
                 };
                 let latest_transition =
                     latest_open_transition_for_pair(conn, current_ref.as_ref(), next_ref.as_ref())?;
+                let ready_pair_due = active_track_id
+                    .and_then(|track_id| {
+                        let duration_ms = current_track_duration_ms(conn, track_id).ok().flatten();
+                        let runtime = state.playback_runtime.as_ref()?;
+                        let info = state.playback_runtime_info.as_ref()?;
+                        if info.active_track_id != Some(track_id) {
+                            return None;
+                        }
+                        Some(ready_pair_transition_due(
+                            runtime
+                                .handle
+                                .get_position_ms(info.sample_rate, info.channels),
+                            duration_ms,
+                        ))
+                    })
+                    .unwrap_or(false);
+                let planning_status = pair_planning_status(
+                    enabled,
+                    current.as_ref(),
+                    next.as_ref(),
+                    latest_transition.as_ref(),
+                    ready_pair_due,
+                )
+                .to_string();
                 let recent_timing_events =
                     latest_dj_transition_timing_history(conn, DJ_TIMING_HISTORY_LIMIT)?;
                 let tuning_deltas = latest_fired_dj_timing_deltas(conn, 20)?;
@@ -457,6 +492,7 @@ async fn get_status(
                         enabled,
                         current,
                         next,
+                        planning_status,
                         selected_program: latest_transition
                             .as_ref()
                             .map(|transition| transition.template.clone()),
@@ -535,19 +571,24 @@ async fn ready_pair_transition_is_due(
         .get_position_ms(info.sample_rate, info.channels);
     let duration_ms = state_guard
         .db
-        .with_conn(|conn| {
-            conn.query_row(
-                "SELECT duration_ms FROM tracks WHERE id = ?1",
-                [current_track_id],
-                |row| row.get::<_, Option<i64>>(0),
-            )
-            .optional()
-            .map(|value| value.flatten())
-            .map_err(anyhow::Error::from)
-        })
+        .with_conn(|conn| current_track_duration_ms(conn, current_track_id))
         .ok()
         .flatten();
     ready_pair_transition_due(position_ms, duration_ms)
+}
+
+fn current_track_duration_ms(
+    conn: &rusqlite::Connection,
+    current_track_id: i64,
+) -> anyhow::Result<Option<i64>> {
+    conn.query_row(
+        "SELECT duration_ms FROM tracks WHERE id = ?1",
+        [current_track_id],
+        |row| row.get::<_, Option<i64>>(0),
+    )
+    .optional()
+    .map(|value| value.flatten())
+    .map_err(anyhow::Error::from)
 }
 
 fn ready_pair_transition_due(position_ms: i64, duration_ms: Option<i64>) -> bool {
@@ -555,6 +596,39 @@ fn ready_pair_transition_due(position_ms: i64, duration_ms: Option<i64>) -> bool
         return false;
     };
     duration_ms.saturating_sub(position_ms.max(0)) <= DJ_READY_PAIR_TRANSITION_WINDOW_MS
+}
+
+fn pair_planning_status(
+    enabled: bool,
+    current: Option<&DjDeckStatus>,
+    next: Option<&DjDeckStatus>,
+    latest_transition: Option<&OpenTransition>,
+    ready_pair_due: bool,
+) -> &'static str {
+    if !enabled {
+        return "disabled";
+    }
+    let (Some(current), Some(next)) = (current, next) else {
+        return "pair_missing";
+    };
+    if current.profile_status == "decode_failed" || next.profile_status == "decode_failed" {
+        return "profile_failed";
+    }
+    if !current.profile_ready || !next.profile_ready {
+        return "waiting_for_profiles";
+    }
+    if let Some(transition) = latest_transition {
+        return if transition.timing_status.as_deref() == Some("missed") {
+            "missed"
+        } else {
+            "armed"
+        };
+    }
+    if ready_pair_due {
+        "ready_to_plan"
+    } else {
+        "waiting_for_window"
+    }
 }
 
 fn claim_ready_pair_transition_planning(current_track_id: i64, generation: u64) -> bool {
@@ -862,6 +936,19 @@ fn dj_profile_inflight_key(key: &AudioDjProfileKey) -> String {
 
 fn deck_needs_profile_rebuild(deck: &DjDeckStatus) -> bool {
     !deck.profile_ready && deck.profile_status != "decode_failed"
+}
+
+fn dj_profile_rebuild_is_inflight(
+    inflight: &Arc<std::sync::Mutex<std::collections::HashMap<String, std::time::Instant>>>,
+    key: &str,
+) -> bool {
+    inflight
+        .lock()
+        .ok()
+        .and_then(|guard| guard.get(key).copied())
+        .is_some_and(|started_at| {
+            started_at.elapsed() < Duration::from_secs(DJ_PROFILE_AUTO_REBUILD_RETRY_SECS)
+        })
 }
 
 fn clear_dj_profile_inflight(
@@ -1245,6 +1332,7 @@ fn deck_status(
     conn: &rusqlite::Connection,
     media_ref: &DjMediaRef,
     label_override: Option<&(String, Option<String>)>,
+    rebuild_inflight: bool,
 ) -> anyhow::Result<DjDeckStatus> {
     let key = media_ref.profile_key();
     let profile = queries::get_audio_dj_profile(conn, &key)?;
@@ -1260,6 +1348,8 @@ fn deck_status(
         "ready".to_string()
     } else if let Some(failure) = rebuild_failure.as_ref() {
         failure.status.clone()
+    } else if rebuild_inflight {
+        "analyzing".to_string()
     } else {
         "missing".to_string()
     };
@@ -1791,6 +1881,23 @@ mod tests {
         }
     }
 
+    fn test_deck_status(profile_ready: bool, profile_status: &str) -> DjDeckStatus {
+        DjDeckStatus {
+            media_ref_kind: "tidal_track".to_string(),
+            media_ref_id: "123".to_string(),
+            title: "Test Track".to_string(),
+            artist: Some("Test Artist".to_string()),
+            profile_ready,
+            profile_status: profile_status.to_string(),
+            profile_error: None,
+            profile_confidence: profile_ready.then_some(0.85),
+            beat_count: profile_ready.then_some(128),
+            downbeat_count: profile_ready.then_some(32),
+            phrase_count: profile_ready.then_some(8),
+            safe_crossfade_only: false,
+        }
+    }
+
     #[test]
     fn dj_profile_current_check_requires_current_version() {
         let conn = rusqlite::Connection::open_in_memory().expect("db");
@@ -2318,6 +2425,60 @@ mod tests {
     }
 
     #[test]
+    fn pair_planning_status_reports_server_state() {
+        let ready_current = test_deck_status(true, "ready");
+        let ready_next = test_deck_status(true, "ready");
+        let missing_next = test_deck_status(false, "missing");
+        let failed_next = test_deck_status(false, "decode_failed");
+        let armed_transition = OpenTransition {
+            id: 31,
+            template: "SafeCrossfade".to_string(),
+            renderer_template: Some("SafeCrossfade".to_string()),
+            fallback_reason: None,
+            planned_start_ms: Some(180_000),
+            actual_start_ms: None,
+            timing_delta_ms: None,
+            timing_source: Some("downbeat_sync".to_string()),
+            timing_status: Some("armed".to_string()),
+        };
+
+        assert_eq!(
+            pair_planning_status(false, Some(&ready_current), Some(&ready_next), None, false),
+            "disabled"
+        );
+        assert_eq!(
+            pair_planning_status(true, None, Some(&ready_next), None, false),
+            "pair_missing"
+        );
+        assert_eq!(
+            pair_planning_status(true, Some(&ready_current), Some(&failed_next), None, false),
+            "profile_failed"
+        );
+        assert_eq!(
+            pair_planning_status(true, Some(&ready_current), Some(&missing_next), None, false),
+            "waiting_for_profiles"
+        );
+        assert_eq!(
+            pair_planning_status(
+                true,
+                Some(&ready_current),
+                Some(&ready_next),
+                Some(&armed_transition),
+                true
+            ),
+            "armed"
+        );
+        assert_eq!(
+            pair_planning_status(true, Some(&ready_current), Some(&ready_next), None, false),
+            "waiting_for_window"
+        );
+        assert_eq!(
+            pair_planning_status(true, Some(&ready_current), Some(&ready_next), None, true),
+            "ready_to_plan"
+        );
+    }
+
+    #[test]
     fn profile_rebuild_inflight_reports_running_for_recent_duplicate() {
         let inflight = Arc::new(std::sync::Mutex::new(std::collections::HashMap::new()));
         let first = mark_dj_profile_rebuild_inflight(
@@ -2354,7 +2515,7 @@ mod tests {
             "DASH stream prebuffer failed".to_string(),
         );
 
-        let deck = deck_status(&conn, &media_ref, None).expect("deck status");
+        let deck = deck_status(&conn, &media_ref, None, false).expect("deck status");
 
         assert!(!deck.profile_ready);
         assert_eq!(deck.profile_status, "decode_failed");
@@ -2365,5 +2526,21 @@ mod tests {
         assert!(!deck_needs_profile_rebuild(&deck));
 
         clear_dj_profile_rebuild_failure(&rebuild_key);
+    }
+
+    #[test]
+    fn deck_status_exposes_inflight_profile_as_analyzing() {
+        let conn = rusqlite::Connection::open_in_memory().expect("db");
+        crate::db::schema::run_migrations(&conn).expect("migrations");
+        let media_ref = DjMediaRef::TidalTrack {
+            tidal_id: 12198474,
+            track_id: None,
+        };
+
+        let deck = deck_status(&conn, &media_ref, None, true).expect("deck status");
+
+        assert!(!deck.profile_ready);
+        assert_eq!(deck.profile_status, "analyzing");
+        assert!(deck.profile_error.is_none());
     }
 }

--- a/noor-server/src/server/routes/dj_routes.rs
+++ b/noor-server/src/server/routes/dj_routes.rs
@@ -1,0 +1,592 @@
+use axum::{
+    Json, Router,
+    extract::{Path, State},
+    http::StatusCode,
+    routing::{get, post},
+};
+use chrono::Utc;
+use rusqlite::{OptionalExtension, params};
+use serde::{Deserialize, Serialize};
+
+use crate::SharedState;
+use crate::db::{
+    models::{AudioDjProfileCorrectionRow, AudioDjProfileKey, AudioDjProfileRow},
+    queries,
+};
+use crate::playback::dj_lookahead::DjMediaRef;
+use crate::playback::player;
+use crate::services::audio_analysis::dj_profile::{decode_f32_blob, decode_u32_blob};
+
+const DEFAULT_DJ_LOOKAHEAD_DEADLINE_SAMPLES: u64 = 48_000 * 30;
+const DJ_PROFILE_CONFIDENCE_FLOOR: f64 = 0.6;
+const SAFE_SUGGESTION_BAD_COUNT: i64 = 3;
+
+pub fn routes() -> Router<SharedState> {
+    Router::new()
+        .route("/api/dj/enabled", get(get_enabled).put(set_enabled))
+        .route("/api/dj/status", get(get_status))
+        .route("/api/dj/profile/{track_id}", get(get_profile))
+        .route("/api/dj/profile-rebuild", post(rebuild_profile))
+        .route("/api/dj/profile-correction", post(set_profile_correction))
+        .route(
+            "/api/dj/profile-correction/{kind}/{id}",
+            get(get_profile_correction),
+        )
+        .route("/api/dj/policy", get(get_policy).put(set_policy))
+        .route(
+            "/api/dj/mix-intent",
+            get(get_mix_intent).put(set_mix_intent),
+        )
+        .route("/api/dj/feedback", post(record_feedback))
+}
+
+#[derive(Debug, Serialize)]
+struct EnabledResponse {
+    enabled: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct SetEnabledRequest {
+    enabled: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct ProfileResponse {
+    track_id: i64,
+    profile_version: String,
+    beat_count: usize,
+    downbeat_count: usize,
+    phrase_count: usize,
+}
+
+#[derive(Debug, Deserialize)]
+struct SetMixIntentRequest {
+    intent: String,
+}
+
+#[derive(Debug, Serialize)]
+struct MixIntentResponse {
+    intent: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct DjFeedbackRequest {
+    transition_event_id: Option<i64>,
+    rating: String,
+    reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DjProfileCorrectionRequest {
+    media_ref_kind: String,
+    media_ref_id: String,
+    bpm_multiplier: Option<f64>,
+    downbeat_offset_beats: Option<i64>,
+    phrase_offset_bars: Option<i64>,
+    safe_crossfade_only: Option<bool>,
+    transition_speed_bias: Option<String>,
+    notes: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct DjProfileCorrectionResponse {
+    media_ref_kind: String,
+    media_ref_id: String,
+    bpm_multiplier: Option<f64>,
+    downbeat_offset_beats: Option<i64>,
+    phrase_offset_bars: Option<i64>,
+    safe_crossfade_only: bool,
+    transition_speed_bias: Option<String>,
+    notes: Option<String>,
+    applies: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct SetDjPolicyRequest {
+    mix_intent: Option<String>,
+    transition_speed_bias: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct DjPolicyResponse {
+    mix_intent: String,
+    transition_speed_bias: String,
+}
+
+#[derive(Debug, Serialize)]
+struct DjStatusResponse {
+    enabled: bool,
+    current: Option<DjDeckStatus>,
+    next: Option<DjDeckStatus>,
+    selected_program: Option<String>,
+    fallback_reason: Option<String>,
+    profile_confidence_floor: f64,
+    last_transition_event_id: Option<i64>,
+    safe_crossfade_suggestion: Option<DjSafeSuggestion>,
+}
+
+#[derive(Debug, Serialize)]
+struct DjDeckStatus {
+    media_ref_kind: String,
+    media_ref_id: String,
+    title: String,
+    artist: Option<String>,
+    profile_ready: bool,
+    profile_confidence: Option<f64>,
+    beat_count: Option<usize>,
+    downbeat_count: Option<usize>,
+    phrase_count: Option<usize>,
+    safe_crossfade_only: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct DjSafeSuggestion {
+    media_ref_kind: String,
+    media_ref_id: String,
+    bad_feedback_count: i64,
+}
+
+#[derive(Debug, Deserialize)]
+struct RebuildDjProfileRequest {
+    media_ref_kind: String,
+    media_ref_id: String,
+}
+
+#[derive(Debug, Serialize)]
+struct RebuildDjProfileResponse {
+    accepted: bool,
+    status: String,
+}
+
+#[derive(Debug, Serialize)]
+struct FeedbackResponse {
+    accepted: bool,
+}
+
+async fn get_enabled(
+    State(state): State<SharedState>,
+) -> Result<Json<EnabledResponse>, StatusCode> {
+    let enabled = {
+        let state = state.read().await;
+        state
+            .db
+            .with_conn(queries::is_dj_engine_enabled)
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+    };
+    Ok(Json(EnabledResponse { enabled }))
+}
+
+async fn set_enabled(
+    State(state): State<SharedState>,
+    Json(payload): Json<SetEnabledRequest>,
+) -> Result<Json<EnabledResponse>, StatusCode> {
+    let (runtime, lookahead) = {
+        let state_guard = state.write().await;
+        let lookahead = state_guard
+            .db
+            .with_conn(|conn| {
+                queries::set_dj_engine_enabled(conn, payload.enabled)?;
+                if payload.enabled {
+                    player::build_dj_lookahead_start(conn, DEFAULT_DJ_LOOKAHEAD_DEADLINE_SAMPLES)
+                } else {
+                    Ok(None)
+                }
+            })
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        (
+            state_guard
+                .playback_runtime
+                .as_ref()
+                .map(|runtime| runtime.handle.clone()),
+            lookahead,
+        )
+    };
+
+    if let Some(runtime) = runtime {
+        if payload.enabled {
+            if let Some(lookahead) = lookahead {
+                let _ = lookahead.dispatch(&runtime);
+            }
+        } else {
+            let _ = runtime.start_dj_lookahead(None, None, None, None, u64::MAX, 0);
+        }
+    }
+
+    Ok(Json(EnabledResponse {
+        enabled: payload.enabled,
+    }))
+}
+
+async fn get_status(
+    State(state): State<SharedState>,
+) -> Result<Json<DjStatusResponse>, StatusCode> {
+    let response = {
+        let state = state.read().await;
+        state
+            .db
+            .with_conn(|conn| {
+                let enabled = queries::is_dj_engine_enabled(conn)?;
+                let pair = crate::playback::dj_lookahead::load_dj_lookahead_pair(conn)?;
+                let current = match pair.current {
+                    Some(media_ref) => Some(deck_status(conn, &media_ref)?),
+                    None => None,
+                };
+                let next = match pair.next {
+                    Some(media_ref) => Some(deck_status(conn, &media_ref)?),
+                    None => None,
+                };
+                let safe_crossfade_suggestion =
+                    safe_crossfade_suggestion(conn, current.as_ref(), next.as_ref())?;
+                Ok(DjStatusResponse {
+                    enabled,
+                    current,
+                    next,
+                    selected_program: None,
+                    fallback_reason: if enabled {
+                        None
+                    } else {
+                        Some("disabled".to_string())
+                    },
+                    profile_confidence_floor: DJ_PROFILE_CONFIDENCE_FLOOR,
+                    last_transition_event_id: None,
+                    safe_crossfade_suggestion,
+                })
+            })
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+    };
+    Ok(Json(response))
+}
+
+async fn get_profile(
+    State(state): State<SharedState>,
+    Path(track_id): Path<i64>,
+) -> Result<Json<ProfileResponse>, StatusCode> {
+    let profile = {
+        let state = state.read().await;
+        state
+            .db
+            .with_conn(|conn| queries::get_audio_dj_profile_for_track(conn, track_id))
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+    }
+    .ok_or(StatusCode::NOT_FOUND)?;
+    Ok(Json(profile_response(track_id, &profile)))
+}
+
+async fn rebuild_profile(
+    State(state): State<SharedState>,
+    Json(payload): Json<RebuildDjProfileRequest>,
+) -> Result<Json<RebuildDjProfileResponse>, StatusCode> {
+    let accepted = {
+        let state = state.read().await;
+        state
+            .db
+            .with_conn(|conn| {
+                let key = AudioDjProfileKey {
+                    media_ref_kind: payload.media_ref_kind.clone(),
+                    media_ref_id: payload.media_ref_id.clone(),
+                };
+                let pair = crate::playback::dj_lookahead::load_dj_lookahead_pair(conn)?;
+                Ok(pair
+                    .current
+                    .as_ref()
+                    .is_some_and(|media_ref| media_ref.profile_key() == key)
+                    || pair
+                        .next
+                        .as_ref()
+                        .is_some_and(|media_ref| media_ref.profile_key() == key))
+            })
+            .unwrap_or(false)
+    };
+    Ok(Json(RebuildDjProfileResponse {
+        accepted,
+        status: if accepted {
+            "accepted".to_string()
+        } else {
+            "not_current_pair".to_string()
+        },
+    }))
+}
+
+async fn get_mix_intent(
+    State(state): State<SharedState>,
+) -> Result<Json<MixIntentResponse>, StatusCode> {
+    let intent = {
+        let state = state.read().await;
+        state
+            .db
+            .with_conn(|conn| Ok(queries::get_dj_global_policy(conn)?.0))
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+    };
+    Ok(Json(MixIntentResponse { intent }))
+}
+
+async fn set_mix_intent(
+    State(state): State<SharedState>,
+    Json(payload): Json<SetMixIntentRequest>,
+) -> Result<Json<MixIntentResponse>, StatusCode> {
+    if !matches!(payload.intent.as_str(), "safe" | "balanced" | "bold") {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+    let intent = {
+        let state = state.read().await;
+        state
+            .db
+            .with_conn(|conn| {
+                let (_, speed) = queries::get_dj_global_policy(conn)?;
+                queries::set_dj_global_policy(conn, &payload.intent, &speed)?;
+                Ok(payload.intent.clone())
+            })
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+    };
+    Ok(Json(MixIntentResponse { intent }))
+}
+
+async fn get_policy(
+    State(state): State<SharedState>,
+) -> Result<Json<DjPolicyResponse>, StatusCode> {
+    let (mix_intent, transition_speed_bias) = {
+        let state = state.read().await;
+        state
+            .db
+            .with_conn(queries::get_dj_global_policy)
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+    };
+    Ok(Json(DjPolicyResponse {
+        mix_intent,
+        transition_speed_bias,
+    }))
+}
+
+async fn set_policy(
+    State(state): State<SharedState>,
+    Json(payload): Json<SetDjPolicyRequest>,
+) -> Result<Json<DjPolicyResponse>, StatusCode> {
+    let (mix_intent, transition_speed_bias) = {
+        let state = state.read().await;
+        state
+            .db
+            .with_conn(|conn| {
+                let (current_intent, current_speed) = queries::get_dj_global_policy(conn)?;
+                let mix_intent = payload.mix_intent.clone().unwrap_or(current_intent);
+                let transition_speed_bias = payload
+                    .transition_speed_bias
+                    .clone()
+                    .unwrap_or(current_speed);
+                queries::set_dj_global_policy(conn, &mix_intent, &transition_speed_bias)?;
+                Ok((mix_intent, transition_speed_bias))
+            })
+            .map_err(|_| StatusCode::BAD_REQUEST)?
+    };
+    Ok(Json(DjPolicyResponse {
+        mix_intent,
+        transition_speed_bias,
+    }))
+}
+
+async fn record_feedback(
+    State(state): State<SharedState>,
+    Json(payload): Json<DjFeedbackRequest>,
+) -> Result<Json<FeedbackResponse>, StatusCode> {
+    let rating = feedback_rating(&payload.rating).ok_or(StatusCode::BAD_REQUEST)?;
+    if let Some(id) = payload.transition_event_id {
+        let state = state.read().await;
+        state
+            .db
+            .with_conn(|conn| {
+                conn.execute(
+                    "UPDATE dj_transition_events
+                     SET user_rating = ?1,
+                         outcome = COALESCE(outcome, ?2),
+                         outcome_at = COALESCE(outcome_at, datetime('now')),
+                         rejected_alternatives_json = COALESCE(rejected_alternatives_json, ?3)
+                     WHERE id = ?4",
+                    params![
+                        rating,
+                        if rating < 0 {
+                            "bad_feedback"
+                        } else {
+                            "good_feedback"
+                        },
+                        payload.reason.as_deref(),
+                        id
+                    ],
+                )?;
+                Ok(())
+            })
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    }
+    Ok(Json(FeedbackResponse { accepted: true }))
+}
+
+async fn get_profile_correction(
+    State(state): State<SharedState>,
+    Path((kind, id)): Path<(String, String)>,
+) -> Result<Json<DjProfileCorrectionResponse>, StatusCode> {
+    let key = AudioDjProfileKey {
+        media_ref_kind: kind,
+        media_ref_id: id,
+    };
+    let correction = {
+        let state = state.read().await;
+        state
+            .db
+            .with_conn(|conn| queries::get_audio_dj_profile_correction(conn, &key))
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+    }
+    .ok_or(StatusCode::NOT_FOUND)?;
+    Ok(Json(correction_response(correction)))
+}
+
+async fn set_profile_correction(
+    State(state): State<SharedState>,
+    Json(payload): Json<DjProfileCorrectionRequest>,
+) -> Result<Json<DjProfileCorrectionResponse>, StatusCode> {
+    if let Some(speed) = payload.transition_speed_bias.as_deref()
+        && !matches!(speed, "slower" | "neutral" | "faster")
+    {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+    let now = Utc::now().to_rfc3339();
+    let row = AudioDjProfileCorrectionRow {
+        media_ref_kind: payload.media_ref_kind,
+        media_ref_id: payload.media_ref_id,
+        bpm_multiplier: payload.bpm_multiplier,
+        downbeat_offset_beats: payload.downbeat_offset_beats,
+        phrase_offset_bars: payload.phrase_offset_bars,
+        safe_crossfade_only: payload.safe_crossfade_only.unwrap_or(false),
+        transition_speed_bias: payload.transition_speed_bias,
+        notes: payload.notes,
+        created_at: now.clone(),
+        updated_at: now,
+    };
+    {
+        let state = state.read().await;
+        state
+            .db
+            .with_conn(|conn| queries::upsert_audio_dj_profile_correction(conn, &row))
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    }
+    Ok(Json(correction_response(row)))
+}
+
+fn profile_response(track_id: i64, profile: &AudioDjProfileRow) -> ProfileResponse {
+    ProfileResponse {
+        track_id,
+        profile_version: profile.profile_version.clone(),
+        beat_count: decode_f32_blob(&profile.beat_grid_blob)
+            .map(|values| values.len())
+            .unwrap_or(0),
+        downbeat_count: decode_f32_blob(&profile.downbeats_blob)
+            .map(|values| values.len())
+            .unwrap_or(0),
+        phrase_count: decode_u32_blob(&profile.phrase_boundaries_blob)
+            .map(|values| values.len())
+            .unwrap_or(0),
+    }
+}
+
+fn correction_response(row: AudioDjProfileCorrectionRow) -> DjProfileCorrectionResponse {
+    DjProfileCorrectionResponse {
+        media_ref_kind: row.media_ref_kind,
+        media_ref_id: row.media_ref_id,
+        bpm_multiplier: row.bpm_multiplier,
+        downbeat_offset_beats: row.downbeat_offset_beats,
+        phrase_offset_bars: row.phrase_offset_bars,
+        safe_crossfade_only: row.safe_crossfade_only,
+        transition_speed_bias: row.transition_speed_bias,
+        notes: row.notes,
+        applies: "next_transition".to_string(),
+    }
+}
+
+fn deck_status(
+    conn: &rusqlite::Connection,
+    media_ref: &DjMediaRef,
+) -> anyhow::Result<DjDeckStatus> {
+    let key = media_ref.profile_key();
+    let profile = queries::get_audio_dj_profile(conn, &key)?;
+    let correction = queries::get_audio_dj_profile_correction(conn, &key)?;
+    let (title, artist) = media_ref_label(conn, media_ref)?;
+    let (beat_count, downbeat_count, phrase_count, profile_confidence) =
+        if let Some(profile) = profile.as_ref() {
+            (
+                decode_f32_blob(&profile.beat_grid_blob).map(|values| values.len()),
+                decode_f32_blob(&profile.downbeats_blob).map(|values| values.len()),
+                decode_u32_blob(&profile.phrase_boundaries_blob).map(|values| values.len()),
+                Some(profile.profile_confidence),
+            )
+        } else {
+            (None, None, None, None)
+        };
+    Ok(DjDeckStatus {
+        media_ref_kind: key.media_ref_kind,
+        media_ref_id: key.media_ref_id,
+        title,
+        artist,
+        profile_ready: profile.is_some(),
+        profile_confidence,
+        beat_count,
+        downbeat_count,
+        phrase_count,
+        safe_crossfade_only: correction.is_some_and(|row| row.safe_crossfade_only),
+    })
+}
+
+fn media_ref_label(
+    conn: &rusqlite::Connection,
+    media_ref: &DjMediaRef,
+) -> anyhow::Result<(String, Option<String>)> {
+    if let Some(track_id) = media_ref.track_id()
+        && let Some(row) = conn
+            .query_row(
+                "SELECT t.title, ar.name
+                 FROM tracks t
+                 LEFT JOIN artists ar ON ar.id = t.artist_id
+                 WHERE t.id = ?1",
+                params![track_id],
+                |row| Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?)),
+            )
+            .optional()?
+    {
+        return Ok(row);
+    }
+    match media_ref {
+        DjMediaRef::PendingQueueItem {
+            pending_artist,
+            pending_title,
+            ..
+        } => Ok((pending_title.clone(), Some(pending_artist.clone()))),
+        _ => Ok((media_ref.profile_key().media_ref_id, None)),
+    }
+}
+
+fn safe_crossfade_suggestion(
+    conn: &rusqlite::Connection,
+    current: Option<&DjDeckStatus>,
+    next: Option<&DjDeckStatus>,
+) -> anyhow::Result<Option<DjSafeSuggestion>> {
+    for deck in [current, next].into_iter().flatten() {
+        let key = AudioDjProfileKey {
+            media_ref_kind: deck.media_ref_kind.clone(),
+            media_ref_id: deck.media_ref_id.clone(),
+        };
+        let bad_feedback_count =
+            queries::count_recent_bad_dj_feedback_for_ref(conn, &key, SAFE_SUGGESTION_BAD_COUNT)?;
+        if bad_feedback_count >= SAFE_SUGGESTION_BAD_COUNT {
+            return Ok(Some(DjSafeSuggestion {
+                media_ref_kind: key.media_ref_kind,
+                media_ref_id: key.media_ref_id,
+                bad_feedback_count,
+            }));
+        }
+    }
+    Ok(None)
+}
+
+fn feedback_rating(value: &str) -> Option<i64> {
+    match value {
+        "good" => Some(1),
+        "bad" | "too_safe" | "too_bold" => Some(-1),
+        _ => None,
+    }
+}

--- a/noor-server/src/server/routes/dj_routes.rs
+++ b/noor-server/src/server/routes/dj_routes.rs
@@ -1268,6 +1268,9 @@ fn timing_quality(timing_status: Option<&str>, timing_delta_ms: Option<i64>) -> 
     if timing_status == Some("missed") {
         return "bad";
     }
+    if timing_status == Some("armed") {
+        return "pending";
+    }
     let Some(delta_ms) = timing_delta_ms else {
         return "bad";
     };
@@ -1869,6 +1872,7 @@ mod tests {
         assert_eq!(timing_quality(Some("late"), Some(1000)), "loose");
         assert_eq!(timing_quality(Some("late"), Some(1001)), "bad");
         assert_eq!(timing_quality(Some("missed"), None), "bad");
+        assert_eq!(timing_quality(Some("armed"), None), "pending");
         assert_eq!(timing_quality(Some("fired"), None), "bad");
     }
 

--- a/noor-server/src/server/routes/dj_routes.rs
+++ b/noor-server/src/server/routes/dj_routes.rs
@@ -32,6 +32,7 @@ const DJ_PROFILE_CONFIDENCE_FLOOR: f64 = 0.65;
 const SAFE_SUGGESTION_BAD_COUNT: i64 = 3;
 const DJ_PROFILE_AUTO_REBUILD_RETRY_SECS: u64 = 300;
 const DJ_TIMING_HISTORY_LIMIT: i64 = 5;
+const DJ_READY_PAIR_TRANSITION_WINDOW_MS: i64 = 30_000;
 
 pub fn routes() -> Router<SharedState> {
     Router::new()
@@ -455,18 +456,67 @@ async fn get_status(
         queue_tidal_profile_rebuild_if_idle(state.clone(), media_ref).await?;
     }
     if let Some((current_track_id, generation)) = ready_active_pair {
-        tracing::info!(
-            current_track_id,
-            generation,
-            "DJ profiles ready, requesting transition planning"
-        );
-        if let Err(error) =
-            super::handle_near_end(state.clone(), current_track_id, generation).await
-        {
-            tracing::warn!(error = %error, "DJ ready pair planning failed");
+        if ready_pair_transition_is_due(&state, current_track_id, generation).await {
+            tracing::info!(
+                current_track_id,
+                generation,
+                "DJ profiles ready near end, requesting transition planning"
+            );
+            if let Err(error) =
+                super::handle_near_end(state.clone(), current_track_id, generation).await
+            {
+                tracing::warn!(error = %error, "DJ ready pair planning failed");
+            }
         }
     }
     Ok(Json(response))
+}
+
+async fn ready_pair_transition_is_due(
+    state: &SharedState,
+    current_track_id: i64,
+    generation: u64,
+) -> bool {
+    let state_guard = state.read().await;
+    let Some(info) = state_guard.playback_runtime_info.as_ref() else {
+        return false;
+    };
+    if info.active_track_id != Some(current_track_id)
+        || state_guard
+            .playback_generation
+            .load(std::sync::atomic::Ordering::Relaxed)
+            != generation
+    {
+        return false;
+    }
+    let Some(runtime) = state_guard.playback_runtime.as_ref() else {
+        return false;
+    };
+    let position_ms = runtime
+        .handle
+        .get_position_ms(info.sample_rate, info.channels);
+    let duration_ms = state_guard
+        .db
+        .with_conn(|conn| {
+            conn.query_row(
+                "SELECT duration_ms FROM tracks WHERE id = ?1",
+                [current_track_id],
+                |row| row.get::<_, Option<i64>>(0),
+            )
+            .optional()
+            .map(|value| value.flatten())
+            .map_err(anyhow::Error::from)
+        })
+        .ok()
+        .flatten();
+    ready_pair_transition_due(position_ms, duration_ms)
+}
+
+fn ready_pair_transition_due(position_ms: i64, duration_ms: Option<i64>) -> bool {
+    let Some(duration_ms) = duration_ms else {
+        return false;
+    };
+    duration_ms.saturating_sub(position_ms.max(0)) <= DJ_READY_PAIR_TRANSITION_WINDOW_MS
 }
 
 async fn get_profile(
@@ -1902,6 +1952,35 @@ mod tests {
         assert_eq!(summary.bad_count, 1);
         assert_eq!(summary.late_count, 1);
         assert_eq!(summary.missed_count, 1);
+    }
+
+    #[test]
+    fn fire_ahead_evidence_requires_positive_majority_and_median() {
+        let passing = vec![
+            220, 210, 205, 200, 195, 190, 185, 180, 175, 170, 165, 160, 155, 151, 149, -20, -40,
+            -60, -80, -100,
+        ];
+        let mixed = vec![
+            220, 210, 205, 200, 195, 190, 185, 180, 175, 170, -165, -160, -155, -151, -149, -20,
+            -40, -60, -80, -100,
+        ];
+        let low_median = vec![
+            151, 151, 150, 150, 149, 149, 148, 148, 147, 147, 146, 146, 145, 145, 144, -20, -40,
+            -60, -80, -100,
+        ];
+
+        assert!(fire_ahead_evidence_passes(&passing));
+        assert!(!fire_ahead_evidence_passes(&mixed));
+        assert!(!fire_ahead_evidence_passes(&low_median));
+        assert!(!fire_ahead_evidence_passes(&passing[..19]));
+    }
+
+    #[test]
+    fn ready_pair_transition_is_due_only_near_track_end() {
+        assert!(!ready_pair_transition_due(90_000, Some(180_000)));
+        assert!(ready_pair_transition_due(151_000, Some(180_000)));
+        assert!(ready_pair_transition_due(180_000, Some(180_000)));
+        assert!(!ready_pair_transition_due(151_000, None));
     }
 
     #[test]

--- a/noor-server/src/server/routes/dj_routes.rs
+++ b/noor-server/src/server/routes/dj_routes.rs
@@ -1358,8 +1358,16 @@ fn summarize_timing_history(
 
     DjTimingHistorySummary {
         event_count: events.len(),
-        average_delta_ms: (delta_count > 0).then_some(delta_sum / delta_count),
-        average_abs_delta_ms: (delta_count > 0).then_some(abs_delta_sum / delta_count),
+        average_delta_ms: if delta_count > 0 {
+            Some(delta_sum / delta_count)
+        } else {
+            None
+        },
+        average_abs_delta_ms: if delta_count > 0 {
+            Some(abs_delta_sum / delta_count)
+        } else {
+            None
+        },
         median_abs_delta_ms: median_abs_delta(tuning_deltas),
         worst_abs_delta_ms: worst_abs_delta(tuning_deltas),
         tight_count,

--- a/noor-server/src/server/routes/dj_routes.rs
+++ b/noor-server/src/server/routes/dj_routes.rs
@@ -1173,12 +1173,13 @@ fn latest_dj_transition_timing_history(
                SELECT 1
                FROM dj_transition_events fired
                WHERE fired.from_media_ref_kind IS e.from_media_ref_kind
-                 AND fired.from_media_ref_id IS e.from_media_ref_id
-                 AND fired.to_media_ref_kind IS e.to_media_ref_kind
-                 AND fired.to_media_ref_id IS e.to_media_ref_id
-                 AND fired.timing_status = 'fired'
-             )
-           )
+                  AND fired.from_media_ref_id IS e.from_media_ref_id
+                  AND fired.to_media_ref_kind IS e.to_media_ref_kind
+                  AND fired.to_media_ref_id IS e.to_media_ref_id
+                  AND fired.id > e.id
+                  AND fired.timing_status = 'fired'
+              )
+            )
          ORDER BY e.started_at DESC, e.id DESC
          LIMIT ?1",
     )?;
@@ -1698,6 +1699,44 @@ mod tests {
             "INSERT INTO dj_transition_events (
                 from_media_ref_kind, from_media_ref_id, to_media_ref_kind, to_media_ref_id,
                 template, program_json, planner_version, planned_start_ms,
+                timing_source, timing_status
+             ) VALUES (
+                'tidal_track', '1', 'tidal_track', '2',
+                'SafeCrossfade', '{\"template\":\"SafeCrossfade\"}', 'dj-v1',
+                222000, 'downbeat_sync', 'missed'
+             )",
+            [],
+        )
+        .expect("insert duplicate missed");
+        conn.execute(
+            "INSERT INTO dj_transition_events (
+                from_media_ref_kind, from_media_ref_id, to_media_ref_kind, to_media_ref_id,
+                template, program_json, planner_version, planned_start_ms,
+                actual_start_ms, timing_delta_ms, timing_source, timing_status
+             ) VALUES (
+                'tidal_track', '1', 'tidal_track', '2',
+                'SafeCrossfade', '{\"template\":\"SafeCrossfade\"}', 'dj-v1',
+                222000, 222040, 40, 'downbeat_sync', 'fired'
+             )",
+            [],
+        )
+        .expect("insert fired");
+
+        let history = latest_dj_transition_timing_history(&conn, 5).expect("history");
+
+        assert_eq!(history.len(), 1);
+        assert_eq!(history[0].timing_status.as_deref(), Some("fired"));
+        assert_eq!(history[0].timing_delta_ms, Some(40));
+    }
+
+    #[test]
+    fn timing_history_keeps_newer_missed_attempt_after_older_fired_pair() {
+        let conn = rusqlite::Connection::open_in_memory().expect("db");
+        crate::db::schema::run_migrations(&conn).expect("migrations");
+        conn.execute(
+            "INSERT INTO dj_transition_events (
+                from_media_ref_kind, from_media_ref_id, to_media_ref_kind, to_media_ref_id,
+                template, program_json, planner_version, planned_start_ms,
                 actual_start_ms, timing_delta_ms, timing_source, timing_status
              ) VALUES (
                 'tidal_track', '1', 'tidal_track', '2',
@@ -1719,13 +1758,13 @@ mod tests {
              )",
             [],
         )
-        .expect("insert duplicate missed");
+        .expect("insert newer missed");
 
         let history = latest_dj_transition_timing_history(&conn, 5).expect("history");
 
-        assert_eq!(history.len(), 1);
-        assert_eq!(history[0].timing_status.as_deref(), Some("fired"));
-        assert_eq!(history[0].timing_delta_ms, Some(40));
+        assert_eq!(history.len(), 2);
+        assert_eq!(history[0].timing_status.as_deref(), Some("missed"));
+        assert_eq!(history[1].timing_status.as_deref(), Some("fired"));
     }
 
     #[test]

--- a/noor-server/src/server/routes/dj_routes.rs
+++ b/noor-server/src/server/routes/dj_routes.rs
@@ -139,6 +139,8 @@ struct DjStatusResponse {
     timing_delta_ms: Option<i64>,
     timing_source: Option<String>,
     timing_status: Option<String>,
+    timing_quality: String,
+    timing_direction: String,
     fallback_reason: Option<String>,
     profile_confidence_floor: f64,
     last_transition_event_id: Option<i64>,
@@ -171,6 +173,10 @@ struct DjSafeSuggestion {
 #[derive(Debug, Serialize, PartialEq, Eq)]
 struct DjTimingHistoryEvent {
     event_id: i64,
+    from_title: Option<String>,
+    from_artist: Option<String>,
+    to_title: Option<String>,
+    to_artist: Option<String>,
     planned_template: String,
     renderer_template: Option<String>,
     planned_start_ms: Option<i64>,
@@ -179,6 +185,7 @@ struct DjTimingHistoryEvent {
     timing_source: Option<String>,
     timing_status: Option<String>,
     timing_quality: String,
+    timing_direction: String,
     started_at: String,
 }
 
@@ -219,6 +226,8 @@ struct RendererStatus {
     timing_delta_ms: Option<i64>,
     timing_source: Option<String>,
     timing_status: Option<String>,
+    timing_quality: String,
+    timing_direction: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -419,6 +428,8 @@ async fn get_status(
                         timing_delta_ms: renderer_status.timing_delta_ms,
                         timing_source: renderer_status.timing_source,
                         timing_status: renderer_status.timing_status,
+                        timing_quality: renderer_status.timing_quality,
+                        timing_direction: renderer_status.timing_direction,
                         fallback_reason,
                         profile_confidence_floor: DJ_PROFILE_CONFIDENCE_FLOOR,
                         last_transition_event_id: latest_transition
@@ -1109,41 +1120,54 @@ fn latest_dj_transition_timing_history(
     limit: i64,
 ) -> anyhow::Result<Vec<DjTimingHistoryEvent>> {
     let mut stmt = conn.prepare(
-        "SELECT id, template, program_json, fallback_reason,
+        "SELECT e.id,
+                from_track.title, from_artist.name,
+                to_track.title, to_artist.name,
+                e.template, e.program_json, e.fallback_reason,
                 planned_start_ms, actual_start_ms, timing_delta_ms,
-                timing_source, timing_status, started_at
-         FROM dj_transition_events
-         WHERE timing_status IN ('fired', 'late', 'missed')
+                timing_source, timing_status, e.started_at
+         FROM dj_transition_events e
+         LEFT JOIN tracks from_track ON from_track.id = e.from_track_id
+         LEFT JOIN artists from_artist ON from_artist.id = from_track.artist_id
+         LEFT JOIN tracks to_track ON to_track.id = e.to_track_id
+         LEFT JOIN artists to_artist ON to_artist.id = to_track.artist_id
+         WHERE e.timing_status IN ('fired', 'late', 'missed')
            AND NOT (
-             timing_status = 'missed'
+             e.timing_status = 'missed'
              AND EXISTS (
                SELECT 1
                FROM dj_transition_events fired
-               WHERE fired.from_media_ref_kind IS dj_transition_events.from_media_ref_kind
-                 AND fired.from_media_ref_id IS dj_transition_events.from_media_ref_id
-                 AND fired.to_media_ref_kind IS dj_transition_events.to_media_ref_kind
-                 AND fired.to_media_ref_id IS dj_transition_events.to_media_ref_id
+               WHERE fired.from_media_ref_kind IS e.from_media_ref_kind
+                 AND fired.from_media_ref_id IS e.from_media_ref_id
+                 AND fired.to_media_ref_kind IS e.to_media_ref_kind
+                 AND fired.to_media_ref_id IS e.to_media_ref_id
                  AND fired.timing_status = 'fired'
              )
            )
-         ORDER BY started_at DESC, id DESC
+         ORDER BY e.started_at DESC, e.id DESC
          LIMIT ?1",
     )?;
     let rows = stmt.query_map([limit.max(0)], |row| {
-        let program_json: String = row.get(2)?;
-        let timing_delta_ms: Option<i64> = row.get(6)?;
-        let timing_status: Option<String> = row.get(8)?;
+        let program_json: String = row.get(6)?;
+        let timing_delta_ms: Option<i64> = row.get(10)?;
+        let timing_status: Option<String> = row.get(12)?;
         Ok(DjTimingHistoryEvent {
             event_id: row.get(0)?,
-            planned_template: row.get(1)?,
+            from_title: row.get(1)?,
+            from_artist: row.get(2)?,
+            to_title: row.get(3)?,
+            to_artist: row.get(4)?,
+            planned_template: row.get(5)?,
             renderer_template: renderer_template_from_program_json(&program_json),
-            planned_start_ms: row.get(4)?,
-            actual_start_ms: row.get(5)?,
+            planned_start_ms: row.get(8)?,
+            actual_start_ms: row.get(9)?,
             timing_delta_ms,
-            timing_source: row.get(7)?,
+            timing_source: row.get(11)?,
             timing_status: timing_status.clone(),
             timing_quality: timing_quality(timing_status.as_deref(), timing_delta_ms).to_string(),
-            started_at: row.get(9)?,
+            timing_direction: timing_direction(timing_status.as_deref(), timing_delta_ms)
+                .to_string(),
+            started_at: row.get(13)?,
         })
     })?;
     let mut events = Vec::new();
@@ -1165,6 +1189,21 @@ fn timing_quality(timing_status: Option<&str>, timing_delta_ms: Option<i64>) -> 
         151..=500 => "usable",
         501..=1000 => "loose",
         _ => "bad",
+    }
+}
+
+fn timing_direction(timing_status: Option<&str>, timing_delta_ms: Option<i64>) -> &'static str {
+    match timing_status {
+        Some("missed") => "missed",
+        Some("armed") => "pending",
+        Some("late") => "late",
+        Some("fired") => match timing_delta_ms {
+            Some(delta_ms) if delta_ms < -250 => "early",
+            Some(delta_ms) if delta_ms > 250 => "late",
+            Some(_) => "on_time",
+            None => "unknown",
+        },
+        _ => "unknown",
     }
 }
 
@@ -1260,8 +1299,20 @@ fn renderer_status_for_transition(transition: Option<&OpenTransition>) -> Render
             timing_delta_ms: None,
             timing_source: None,
             timing_status: None,
+            timing_quality: "unknown".to_string(),
+            timing_direction: "unknown".to_string(),
         };
     };
+    let quality = timing_quality(
+        transition.timing_status.as_deref(),
+        transition.timing_delta_ms,
+    )
+    .to_string();
+    let direction = timing_direction(
+        transition.timing_status.as_deref(),
+        transition.timing_delta_ms,
+    )
+    .to_string();
     if transition.renderer_template.as_deref() == Some("SafeCrossfade") {
         return RendererStatus {
             planned_template: Some(transition.template.clone()),
@@ -1277,6 +1328,8 @@ fn renderer_status_for_transition(transition: Option<&OpenTransition>) -> Render
             timing_delta_ms: transition.timing_delta_ms,
             timing_source: transition.timing_source.clone(),
             timing_status: transition.timing_status.clone(),
+            timing_quality: quality,
+            timing_direction: direction,
         };
     }
     RendererStatus {
@@ -1297,6 +1350,8 @@ fn renderer_status_for_transition(transition: Option<&OpenTransition>) -> Render
         timing_delta_ms: transition.timing_delta_ms,
         timing_source: transition.timing_source.clone(),
         timing_status: transition.timing_status.clone(),
+        timing_quality: quality,
+        timing_direction: direction,
     }
 }
 
@@ -1520,6 +1575,7 @@ mod tests {
         assert_eq!(history[0].actual_start_ms, Some(222_040));
         assert_eq!(history[0].timing_status.as_deref(), Some("fired"));
         assert_eq!(history[0].timing_quality, "tight");
+        assert_eq!(history[0].timing_direction, "on_time");
     }
 
     #[test]
@@ -1561,6 +1617,46 @@ mod tests {
     }
 
     #[test]
+    fn timing_history_includes_track_pair_labels() {
+        let conn = rusqlite::Connection::open_in_memory().expect("db");
+        crate::db::schema::run_migrations(&conn).expect("migrations");
+        conn.execute(
+            "INSERT INTO artists (id, name) VALUES (10, 'Outgoing Artist'), (11, 'Incoming Artist')",
+            [],
+        )
+        .expect("insert artists");
+        conn.execute(
+            "INSERT INTO tracks (id, title, artist_id, source)
+             VALUES (100, 'Outgoing Track', 10, 'tidal'), (101, 'Incoming Track', 11, 'tidal')",
+            [],
+        )
+        .expect("insert tracks");
+        conn.execute(
+            "INSERT INTO dj_transition_events (
+                from_track_id, to_track_id,
+                from_media_ref_kind, from_media_ref_id, to_media_ref_kind, to_media_ref_id,
+                template, program_json, planner_version, planned_start_ms,
+                actual_start_ms, timing_delta_ms, timing_source, timing_status
+             ) VALUES (
+                100, 101,
+                'tidal_track', '1', 'tidal_track', '2',
+                'SafeCrossfade', '{\"template\":\"SafeCrossfade\"}', 'dj-v1',
+                10000, 10320, 320, 'downbeat_sync', 'fired'
+             )",
+            [],
+        )
+        .expect("insert event");
+
+        let history = latest_dj_transition_timing_history(&conn, 5).expect("history");
+
+        assert_eq!(history[0].from_title.as_deref(), Some("Outgoing Track"));
+        assert_eq!(history[0].from_artist.as_deref(), Some("Outgoing Artist"));
+        assert_eq!(history[0].to_title.as_deref(), Some("Incoming Track"));
+        assert_eq!(history[0].to_artist.as_deref(), Some("Incoming Artist"));
+        assert_eq!(history[0].timing_direction, "late");
+    }
+
+    #[test]
     fn timing_quality_labels_delta_bands_and_missed() {
         assert_eq!(timing_quality(Some("fired"), Some(150)), "tight");
         assert_eq!(timing_quality(Some("fired"), Some(-500)), "usable");
@@ -1571,10 +1667,25 @@ mod tests {
     }
 
     #[test]
+    fn timing_direction_labels_delta_direction_and_status() {
+        assert_eq!(timing_direction(Some("fired"), Some(150)), "on_time");
+        assert_eq!(timing_direction(Some("fired"), Some(-251)), "early");
+        assert_eq!(timing_direction(Some("fired"), Some(251)), "late");
+        assert_eq!(timing_direction(Some("late"), Some(0)), "late");
+        assert_eq!(timing_direction(Some("missed"), None), "missed");
+        assert_eq!(timing_direction(Some("armed"), None), "pending");
+        assert_eq!(timing_direction(Some("fired"), None), "unknown");
+    }
+
+    #[test]
     fn timing_history_summary_counts_quality_and_status() {
         let events = vec![
             DjTimingHistoryEvent {
                 event_id: 1,
+                from_title: Some("A".to_string()),
+                from_artist: Some("Artist A".to_string()),
+                to_title: Some("B".to_string()),
+                to_artist: Some("Artist B".to_string()),
                 planned_template: "SafeCrossfade".to_string(),
                 renderer_template: Some("SafeCrossfade".to_string()),
                 planned_start_ms: Some(10_000),
@@ -1583,10 +1694,15 @@ mod tests {
                 timing_source: Some("downbeat_sync".to_string()),
                 timing_status: Some("fired".to_string()),
                 timing_quality: "tight".to_string(),
+                timing_direction: "on_time".to_string(),
                 started_at: "now".to_string(),
             },
             DjTimingHistoryEvent {
                 event_id: 2,
+                from_title: Some("B".to_string()),
+                from_artist: Some("Artist B".to_string()),
+                to_title: Some("C".to_string()),
+                to_artist: Some("Artist C".to_string()),
                 planned_template: "SafeCrossfade".to_string(),
                 renderer_template: Some("SafeCrossfade".to_string()),
                 planned_start_ms: Some(20_000),
@@ -1595,10 +1711,15 @@ mod tests {
                 timing_source: Some("beat_sync".to_string()),
                 timing_status: Some("late".to_string()),
                 timing_quality: "loose".to_string(),
+                timing_direction: "late".to_string(),
                 started_at: "now".to_string(),
             },
             DjTimingHistoryEvent {
                 event_id: 3,
+                from_title: Some("C".to_string()),
+                from_artist: Some("Artist C".to_string()),
+                to_title: Some("D".to_string()),
+                to_artist: Some("Artist D".to_string()),
                 planned_template: "SafeCrossfade".to_string(),
                 renderer_template: Some("SafeCrossfade".to_string()),
                 planned_start_ms: Some(30_000),
@@ -1607,6 +1728,7 @@ mod tests {
                 timing_source: Some("fallback_overlap".to_string()),
                 timing_status: Some("missed".to_string()),
                 timing_quality: "bad".to_string(),
+                timing_direction: "missed".to_string(),
                 started_at: "now".to_string(),
             },
         ];

--- a/noor-server/src/server/routes/dj_routes.rs
+++ b/noor-server/src/server/routes/dj_routes.rs
@@ -133,6 +133,7 @@ struct DjStatusResponse {
     renderer_template: Option<String>,
     renderer_mode: Option<String>,
     downgrade_reason: Option<String>,
+    planning_reason: Option<String>,
     sync_target: Option<String>,
     planned_start_ms: Option<i64>,
     actual_start_ms: Option<i64>,
@@ -179,6 +180,7 @@ struct DjTimingHistoryEvent {
     to_artist: Option<String>,
     planned_template: String,
     renderer_template: Option<String>,
+    planning_reason: Option<String>,
     planned_start_ms: Option<i64>,
     actual_start_ms: Option<i64>,
     timing_delta_ms: Option<i64>,
@@ -220,6 +222,7 @@ struct RendererStatus {
     renderer_template: Option<String>,
     renderer_mode: Option<String>,
     downgrade_reason: Option<String>,
+    planning_reason: Option<String>,
     sync_target: Option<String>,
     planned_start_ms: Option<i64>,
     actual_start_ms: Option<i64>,
@@ -422,6 +425,7 @@ async fn get_status(
                         renderer_template: renderer_status.renderer_template,
                         renderer_mode: renderer_status.renderer_mode,
                         downgrade_reason: renderer_status.downgrade_reason,
+                        planning_reason: renderer_status.planning_reason,
                         sync_target: renderer_status.sync_target,
                         planned_start_ms: renderer_status.planned_start_ms,
                         actual_start_ms: renderer_status.actual_start_ms,
@@ -1159,6 +1163,7 @@ fn latest_dj_transition_timing_history(
             to_artist: row.get(4)?,
             planned_template: row.get(5)?,
             renderer_template: renderer_template_from_program_json(&program_json),
+            planning_reason: row.get(7)?,
             planned_start_ms: row.get(8)?,
             actual_start_ms: row.get(9)?,
             timing_delta_ms,
@@ -1293,6 +1298,7 @@ fn renderer_status_for_transition(transition: Option<&OpenTransition>) -> Render
             renderer_template: None,
             renderer_mode: None,
             downgrade_reason: None,
+            planning_reason: None,
             sync_target: None,
             planned_start_ms: None,
             actual_start_ms: None,
@@ -1318,10 +1324,9 @@ fn renderer_status_for_transition(transition: Option<&OpenTransition>) -> Render
             planned_template: Some(transition.template.clone()),
             renderer_template: transition.renderer_template.clone(),
             renderer_mode: Some("dj_gain_program".to_string()),
-            downgrade_reason: transition.fallback_reason.clone().or_else(|| {
-                (transition.template != "SafeCrossfade")
-                    .then(|| "template_not_renderable".to_string())
-            }),
+            downgrade_reason: (transition.template != "SafeCrossfade")
+                .then(|| "template_not_renderable".to_string()),
+            planning_reason: transition.fallback_reason.clone(),
             sync_target: transition.timing_source.clone(),
             planned_start_ms: transition.planned_start_ms,
             actual_start_ms: transition.actual_start_ms,
@@ -1336,6 +1341,7 @@ fn renderer_status_for_transition(transition: Option<&OpenTransition>) -> Render
         planned_template: Some(transition.template.clone()),
         renderer_template: None,
         renderer_mode: Some("legacy_overlap".to_string()),
+        planning_reason: transition.fallback_reason.clone(),
         downgrade_reason: Some(
             if transition.template == "SafeCrossfade" {
                 "dj_program_renderer_pending"
@@ -1498,6 +1504,30 @@ mod tests {
     }
 
     #[test]
+    fn renderer_status_keeps_safe_crossfade_planning_reason_out_of_downgrade() {
+        let status = renderer_status_for_transition(Some(&OpenTransition {
+            id: 20,
+            template: "SafeCrossfade".to_string(),
+            renderer_template: Some("SafeCrossfade".to_string()),
+            fallback_reason: Some("next_profile_missing".to_string()),
+            planned_start_ms: Some(112_000),
+            actual_start_ms: Some(112_144),
+            timing_delta_ms: Some(144),
+            timing_source: Some("downbeat_sync".to_string()),
+            timing_status: Some("fired".to_string()),
+        }));
+
+        assert_eq!(status.planned_template.as_deref(), Some("SafeCrossfade"));
+        assert_eq!(status.renderer_template.as_deref(), Some("SafeCrossfade"));
+        assert_eq!(status.renderer_mode.as_deref(), Some("dj_gain_program"));
+        assert_eq!(status.downgrade_reason, None);
+        assert_eq!(
+            status.planning_reason.as_deref(),
+            Some("next_profile_missing")
+        );
+    }
+
+    #[test]
     fn latest_completed_timing_transition_returns_last_fired_row() {
         let conn = rusqlite::Connection::open_in_memory().expect("db");
         crate::db::schema::run_migrations(&conn).expect("migrations");
@@ -1635,12 +1665,13 @@ mod tests {
             "INSERT INTO dj_transition_events (
                 from_track_id, to_track_id,
                 from_media_ref_kind, from_media_ref_id, to_media_ref_kind, to_media_ref_id,
-                template, program_json, planner_version, planned_start_ms,
+                template, program_json, planner_version, fallback_reason, planned_start_ms,
                 actual_start_ms, timing_delta_ms, timing_source, timing_status
              ) VALUES (
                 100, 101,
                 'tidal_track', '1', 'tidal_track', '2',
                 'SafeCrossfade', '{\"template\":\"SafeCrossfade\"}', 'dj-v1',
+                'next_profile_missing',
                 10000, 10320, 320, 'downbeat_sync', 'fired'
              )",
             [],
@@ -1653,6 +1684,10 @@ mod tests {
         assert_eq!(history[0].from_artist.as_deref(), Some("Outgoing Artist"));
         assert_eq!(history[0].to_title.as_deref(), Some("Incoming Track"));
         assert_eq!(history[0].to_artist.as_deref(), Some("Incoming Artist"));
+        assert_eq!(
+            history[0].planning_reason.as_deref(),
+            Some("next_profile_missing")
+        );
         assert_eq!(history[0].timing_direction, "late");
     }
 
@@ -1688,6 +1723,7 @@ mod tests {
                 to_artist: Some("Artist B".to_string()),
                 planned_template: "SafeCrossfade".to_string(),
                 renderer_template: Some("SafeCrossfade".to_string()),
+                planning_reason: None,
                 planned_start_ms: Some(10_000),
                 actual_start_ms: Some(10_100),
                 timing_delta_ms: Some(100),
@@ -1705,6 +1741,7 @@ mod tests {
                 to_artist: Some("Artist C".to_string()),
                 planned_template: "SafeCrossfade".to_string(),
                 renderer_template: Some("SafeCrossfade".to_string()),
+                planning_reason: Some("next_profile_missing".to_string()),
                 planned_start_ms: Some(20_000),
                 actual_start_ms: Some(20_800),
                 timing_delta_ms: Some(800),
@@ -1722,6 +1759,7 @@ mod tests {
                 to_artist: Some("Artist D".to_string()),
                 planned_template: "SafeCrossfade".to_string(),
                 renderer_template: Some("SafeCrossfade".to_string()),
+                planning_reason: Some("analysis_late".to_string()),
                 planned_start_ms: Some(30_000),
                 actual_start_ms: None,
                 timing_delta_ms: None,

--- a/noor-server/src/server/routes/dj_routes.rs
+++ b/noor-server/src/server/routes/dj_routes.rs
@@ -28,7 +28,7 @@ use crate::services::audio_analysis::dj_profile::{
 use crate::services::tidal::stream as tidal_stream;
 
 const DEFAULT_DJ_LOOKAHEAD_DEADLINE_SAMPLES: u64 = 48_000 * 30;
-const DJ_PROFILE_CONFIDENCE_FLOOR: f64 = 0.6;
+const DJ_PROFILE_CONFIDENCE_FLOOR: f64 = 0.65;
 const SAFE_SUGGESTION_BAD_COUNT: i64 = 3;
 const DJ_PROFILE_AUTO_REBUILD_RETRY_SECS: u64 = 300;
 const DJ_TIMING_HISTORY_LIMIT: i64 = 5;

--- a/noor-server/src/server/routes/dj_routes.rs
+++ b/noor-server/src/server/routes/dj_routes.rs
@@ -7,19 +7,29 @@ use axum::{
 use chrono::Utc;
 use rusqlite::{OptionalExtension, params};
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, AtomicU64};
 
 use crate::SharedState;
 use crate::db::{
     models::{AudioDjProfileCorrectionRow, AudioDjProfileKey, AudioDjProfileRow},
     queries,
 };
+use crate::playback::decode::decode_and_buffer_job;
 use crate::playback::dj_lookahead::DjMediaRef;
-use crate::playback::player;
+use crate::playback::gapless::GaplessPlan;
+use crate::playback::player::{self, PlaybackSourceKind, PlaybackSourceRequest};
+use crate::playback::runtime::PlaybackRuntimeConfig;
+use crate::playback::runtime::commands::PlaybackRuntimeCommand;
+use crate::playback::runtime::shared::PlaybackSharedState;
 use crate::services::audio_analysis::dj_profile::{decode_f32_blob, decode_u32_blob};
+use crate::services::tidal::stream as tidal_stream;
 
 const DEFAULT_DJ_LOOKAHEAD_DEADLINE_SAMPLES: u64 = 48_000 * 30;
 const DJ_PROFILE_CONFIDENCE_FLOOR: f64 = 0.6;
 const SAFE_SUGGESTION_BAD_COUNT: i64 = 3;
+const DJ_PROFILE_AUTO_REBUILD_RETRY_SECS: u64 = 300;
+const DJ_TIMING_HISTORY_LIMIT: i64 = 5;
 
 pub fn routes() -> Router<SharedState> {
     Router::new()
@@ -119,9 +129,21 @@ struct DjStatusResponse {
     current: Option<DjDeckStatus>,
     next: Option<DjDeckStatus>,
     selected_program: Option<String>,
+    planned_template: Option<String>,
+    renderer_template: Option<String>,
+    renderer_mode: Option<String>,
+    downgrade_reason: Option<String>,
+    sync_target: Option<String>,
+    planned_start_ms: Option<i64>,
+    actual_start_ms: Option<i64>,
+    timing_delta_ms: Option<i64>,
+    timing_source: Option<String>,
+    timing_status: Option<String>,
     fallback_reason: Option<String>,
     profile_confidence_floor: f64,
     last_transition_event_id: Option<i64>,
+    recent_timing_events: Vec<DjTimingHistoryEvent>,
+    timing_history_summary: DjTimingHistorySummary,
     safe_crossfade_suggestion: Option<DjSafeSuggestion>,
 }
 
@@ -146,6 +168,59 @@ struct DjSafeSuggestion {
     bad_feedback_count: i64,
 }
 
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct DjTimingHistoryEvent {
+    event_id: i64,
+    planned_template: String,
+    renderer_template: Option<String>,
+    planned_start_ms: Option<i64>,
+    actual_start_ms: Option<i64>,
+    timing_delta_ms: Option<i64>,
+    timing_source: Option<String>,
+    timing_status: Option<String>,
+    timing_quality: String,
+    started_at: String,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct DjTimingHistorySummary {
+    event_count: usize,
+    average_delta_ms: Option<i64>,
+    average_abs_delta_ms: Option<i64>,
+    tight_count: usize,
+    usable_count: usize,
+    loose_count: usize,
+    bad_count: usize,
+    late_count: usize,
+    missed_count: usize,
+}
+
+struct OpenTransition {
+    id: i64,
+    template: String,
+    renderer_template: Option<String>,
+    fallback_reason: Option<String>,
+    planned_start_ms: Option<i64>,
+    actual_start_ms: Option<i64>,
+    timing_delta_ms: Option<i64>,
+    timing_source: Option<String>,
+    timing_status: Option<String>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct RendererStatus {
+    planned_template: Option<String>,
+    renderer_template: Option<String>,
+    renderer_mode: Option<String>,
+    downgrade_reason: Option<String>,
+    sync_target: Option<String>,
+    planned_start_ms: Option<i64>,
+    actual_start_ms: Option<i64>,
+    timing_delta_ms: Option<i64>,
+    timing_source: Option<String>,
+    timing_status: Option<String>,
+}
+
 #[derive(Debug, Deserialize)]
 struct RebuildDjProfileRequest {
     media_ref_kind: String,
@@ -156,6 +231,22 @@ struct RebuildDjProfileRequest {
 struct RebuildDjProfileResponse {
     accepted: bool,
     status: String,
+}
+
+enum RebuildProfileCandidate {
+    Ready(
+        DjMediaRef,
+        tokio::sync::mpsc::UnboundedSender<
+            crate::services::audio_analysis::dj_profile::DjAnalysisJob,
+        >,
+    ),
+    Response(RebuildDjProfileResponse),
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ProfileRebuildInflightDecision {
+    Start,
+    AlreadyRunning,
 }
 
 #[derive(Debug, Serialize)]
@@ -182,6 +273,13 @@ async fn set_enabled(
 ) -> Result<Json<EnabledResponse>, StatusCode> {
     let (runtime, lookahead) = {
         let state_guard = state.write().await;
+        let ephemeral_lookahead = if payload.enabled {
+            super::active_ephemeral_tidal_mix_dj_pair(&state_guard).and_then(|pair| {
+                player::dj_lookahead_start_from_pair(pair, DEFAULT_DJ_LOOKAHEAD_DEADLINE_SAMPLES)
+            })
+        } else {
+            None
+        };
         let lookahead = state_guard
             .db
             .with_conn(|conn| {
@@ -193,6 +291,7 @@ async fn set_enabled(
                 }
             })
             .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+        let lookahead = ephemeral_lookahead.or(lookahead);
         (
             state_guard
                 .playback_runtime
@@ -221,40 +320,135 @@ async fn set_enabled(
 async fn get_status(
     State(state): State<SharedState>,
 ) -> Result<Json<DjStatusResponse>, StatusCode> {
-    let response = {
+    let (response, missing_profile_refs, ready_active_pair) = {
         let state = state.read().await;
+        let ephemeral_pair = super::active_ephemeral_tidal_mix_dj_pair(&state);
+        let ephemeral_labels = super::active_ephemeral_tidal_mix_dj_labels(&state);
+        let active_track_id = state
+            .playback_runtime_info
+            .as_ref()
+            .and_then(|info| info.active_track_id);
+        let playback_generation = state
+            .playback_generation
+            .load(std::sync::atomic::Ordering::Relaxed);
         state
             .db
             .with_conn(|conn| {
                 let enabled = queries::is_dj_engine_enabled(conn)?;
-                let pair = crate::playback::dj_lookahead::load_dj_lookahead_pair(conn)?;
+                let pair = match ephemeral_pair.clone() {
+                    Some(pair) => pair,
+                    None => crate::playback::dj_lookahead::load_dj_lookahead_pair(conn)?,
+                };
+                let current_ref = pair.current.clone();
+                let next_ref = pair.next.clone();
                 let current = match pair.current {
-                    Some(media_ref) => Some(deck_status(conn, &media_ref)?),
+                    Some(media_ref) => {
+                        let key = media_ref.profile_key();
+                        let label = ephemeral_labels
+                            .iter()
+                            .find(|(candidate, _)| candidate == &key)
+                            .map(|(_, label)| label);
+                        Some(deck_status(conn, &media_ref, label)?)
+                    }
                     None => None,
                 };
                 let next = match pair.next {
-                    Some(media_ref) => Some(deck_status(conn, &media_ref)?),
+                    Some(media_ref) => {
+                        let key = media_ref.profile_key();
+                        let label = ephemeral_labels
+                            .iter()
+                            .find(|(candidate, _)| candidate == &key)
+                            .map(|(_, label)| label);
+                        Some(deck_status(conn, &media_ref, label)?)
+                    }
                     None => None,
                 };
                 let safe_crossfade_suggestion =
                     safe_crossfade_suggestion(conn, current.as_ref(), next.as_ref())?;
-                Ok(DjStatusResponse {
-                    enabled,
-                    current,
-                    next,
-                    selected_program: None,
-                    fallback_reason: if enabled {
-                        None
-                    } else {
-                        Some("disabled".to_string())
+                let fallback_reason = if !enabled {
+                    Some("disabled".to_string())
+                } else if current.is_none() || next.is_none() {
+                    Some("pair_missing".to_string())
+                } else if current.as_ref().is_some_and(|deck| !deck.profile_ready) {
+                    Some("missing_current_profile".to_string())
+                } else if next.as_ref().is_some_and(|deck| !deck.profile_ready) {
+                    Some("missing_next_profile".to_string())
+                } else {
+                    None
+                };
+                let latest_transition =
+                    latest_open_transition_for_pair(conn, current_ref.as_ref(), next_ref.as_ref())?;
+                let recent_timing_events =
+                    latest_dj_transition_timing_history(conn, DJ_TIMING_HISTORY_LIMIT)?;
+                let timing_history_summary = summarize_timing_history(&recent_timing_events);
+                let mut missing_profile_refs = Vec::new();
+                if enabled {
+                    if current.as_ref().is_some_and(|deck| !deck.profile_ready)
+                        && let Some(media_ref) = current_ref.clone()
+                    {
+                        missing_profile_refs.push(media_ref);
+                    }
+                    if next.as_ref().is_some_and(|deck| !deck.profile_ready)
+                        && let Some(media_ref) = next_ref.clone()
+                    {
+                        missing_profile_refs.push(media_ref);
+                    }
+                }
+                let ready_active_pair = enabled
+                    .then_some(())
+                    .filter(|_| current_ref.is_some() && next_ref.is_some())
+                    .and(active_track_id)
+                    .filter(|_| fallback_reason.is_none() && latest_transition.is_none())
+                    .map(|track_id| (track_id, playback_generation));
+                let renderer_status = renderer_status_for_transition(latest_transition.as_ref());
+                Ok((
+                    DjStatusResponse {
+                        enabled,
+                        current,
+                        next,
+                        selected_program: latest_transition
+                            .as_ref()
+                            .map(|transition| transition.template.clone()),
+                        planned_template: renderer_status.planned_template,
+                        renderer_template: renderer_status.renderer_template,
+                        renderer_mode: renderer_status.renderer_mode,
+                        downgrade_reason: renderer_status.downgrade_reason,
+                        sync_target: renderer_status.sync_target,
+                        planned_start_ms: renderer_status.planned_start_ms,
+                        actual_start_ms: renderer_status.actual_start_ms,
+                        timing_delta_ms: renderer_status.timing_delta_ms,
+                        timing_source: renderer_status.timing_source,
+                        timing_status: renderer_status.timing_status,
+                        fallback_reason,
+                        profile_confidence_floor: DJ_PROFILE_CONFIDENCE_FLOOR,
+                        last_transition_event_id: latest_transition
+                            .as_ref()
+                            .map(|transition| transition.id),
+                        recent_timing_events,
+                        timing_history_summary,
+                        safe_crossfade_suggestion,
                     },
-                    profile_confidence_floor: DJ_PROFILE_CONFIDENCE_FLOOR,
-                    last_transition_event_id: None,
-                    safe_crossfade_suggestion,
-                })
+                    missing_profile_refs,
+                    ready_active_pair,
+                ))
             })
             .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
     };
+    for media_ref in missing_profile_refs {
+        queue_tidal_profile_rebuild_if_idle(state.clone(), media_ref).await?;
+    }
+    if let Some((current_track_id, generation)) = ready_active_pair {
+        tracing::info!(
+            current_track_id,
+            generation,
+            "DJ profiles ready, requesting transition planning"
+        );
+        if let Err(error) =
+            super::handle_near_end(state.clone(), current_track_id, generation).await
+        {
+            tracing::warn!(error = %error, "DJ ready pair planning failed");
+        }
+    }
     Ok(Json(response))
 }
 
@@ -277,35 +471,361 @@ async fn rebuild_profile(
     State(state): State<SharedState>,
     Json(payload): Json<RebuildDjProfileRequest>,
 ) -> Result<Json<RebuildDjProfileResponse>, StatusCode> {
-    let accepted = {
+    let candidate = {
         let state = state.read().await;
         state
             .db
             .with_conn(|conn| {
+                if !queries::is_dj_engine_enabled(conn)? {
+                    return Ok(RebuildProfileCandidate::Response(
+                        RebuildDjProfileResponse {
+                            accepted: false,
+                            status: "dj_disabled".to_string(),
+                        },
+                    ));
+                }
                 let key = AudioDjProfileKey {
                     media_ref_kind: payload.media_ref_kind.clone(),
                     media_ref_id: payload.media_ref_id.clone(),
                 };
-                let pair = crate::playback::dj_lookahead::load_dj_lookahead_pair(conn)?;
-                Ok(pair
+                let pair = match super::active_ephemeral_tidal_mix_dj_pair(&state) {
+                    Some(pair) => pair,
+                    None => crate::playback::dj_lookahead::load_dj_lookahead_pair(conn)?,
+                };
+                let media_ref = pair
                     .current
                     .as_ref()
-                    .is_some_and(|media_ref| media_ref.profile_key() == key)
-                    || pair
-                        .next
-                        .as_ref()
-                        .is_some_and(|media_ref| media_ref.profile_key() == key))
+                    .filter(|media_ref| media_ref.profile_key() == key)
+                    .or_else(|| {
+                        pair.next
+                            .as_ref()
+                            .filter(|media_ref| media_ref.profile_key() == key)
+                    })
+                    .cloned();
+                let Some(media_ref) = media_ref else {
+                    return Ok(RebuildProfileCandidate::Response(
+                        RebuildDjProfileResponse {
+                            accepted: false,
+                            status: "not_current_pair".to_string(),
+                        },
+                    ));
+                };
+                if queries::get_audio_dj_profile(conn, &key)?.is_some() {
+                    return Ok(RebuildProfileCandidate::Response(
+                        RebuildDjProfileResponse {
+                            accepted: false,
+                            status: "already_current".to_string(),
+                        },
+                    ));
+                }
+                let Some(dj_analysis_tx) = state.dj_analysis_tx.clone() else {
+                    return Ok(RebuildProfileCandidate::Response(
+                        RebuildDjProfileResponse {
+                            accepted: false,
+                            status: "source_unavailable".to_string(),
+                        },
+                    ));
+                };
+                Ok(RebuildProfileCandidate::Ready(media_ref, dj_analysis_tx))
             })
-            .unwrap_or(false)
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
     };
-    Ok(Json(RebuildDjProfileResponse {
-        accepted,
-        status: if accepted {
-            "accepted".to_string()
+
+    let (media_ref, dj_analysis_tx) = match candidate {
+        RebuildProfileCandidate::Ready(media_ref, dj_analysis_tx) => (media_ref, dj_analysis_tx),
+        RebuildProfileCandidate::Response(response) => return Ok(Json(response)),
+    };
+
+    let queued = queue_tidal_profile_rebuild(state, media_ref, dj_analysis_tx, true).await?;
+    Ok(Json(queued))
+}
+
+async fn queue_tidal_profile_rebuild(
+    state: SharedState,
+    media_ref: DjMediaRef,
+    dj_analysis_tx: tokio::sync::mpsc::UnboundedSender<
+        crate::services::audio_analysis::dj_profile::DjAnalysisJob,
+    >,
+    force: bool,
+) -> Result<RebuildDjProfileResponse, StatusCode> {
+    let DjMediaRef::TidalTrack { tidal_id, .. } = media_ref.clone() else {
+        return Ok(RebuildDjProfileResponse {
+            accepted: false,
+            status: "source_unavailable".to_string(),
+        });
+    };
+    let inflight_key = dj_profile_inflight_key(&media_ref.profile_key());
+    let inflight = {
+        let state_guard = state.read().await;
+        state_guard.dj_profile_rebuild_inflight.clone()
+    };
+    match mark_dj_profile_rebuild_inflight(
+        &inflight,
+        &inflight_key,
+        std::time::Duration::from_secs(DJ_PROFILE_AUTO_REBUILD_RETRY_SECS),
+    )? {
+        ProfileRebuildInflightDecision::Start => {
+            tracing::info!(
+                media_ref_kind = %media_ref.profile_key().media_ref_kind,
+                media_ref_id = %media_ref.profile_key().media_ref_id,
+                force,
+                "DJ profile rebuild accepted"
+            );
+        }
+        ProfileRebuildInflightDecision::AlreadyRunning => {
+            tracing::debug!(
+                media_ref_kind = %media_ref.profile_key().media_ref_kind,
+                media_ref_id = %media_ref.profile_key().media_ref_id,
+                force,
+                "DJ profile rebuild already running"
+            );
+            return Ok(RebuildDjProfileResponse {
+                accepted: true,
+                status: "already_running".to_string(),
+            });
+        }
+    }
+
+    let tokens = {
+        let state_guard = state.read().await;
+        state_guard.tidal_tokens.clone()
+    };
+    let tokens = match tokens {
+        Some(tokens) => Some(tokens),
+        None => super::load_persisted_tidal_tokens(&state)
+            .await
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?,
+    };
+    let Some(tokens) = tokens else {
+        clear_dj_profile_inflight(&inflight, &inflight_key);
+        tracing::warn!(
+            media_ref_kind = %media_ref.profile_key().media_ref_kind,
+            media_ref_id = %media_ref.profile_key().media_ref_id,
+            "DJ profile rebuild source unavailable"
+        );
+        return Ok(RebuildDjProfileResponse {
+            accepted: false,
+            status: "source_unavailable".to_string(),
+        });
+    };
+
+    let user_quality = super::current_user_audio_quality(&state).await;
+    let request = tidal_stream::StreamRequest::new(
+        tidal_id,
+        super::requested_tidal_quality(user_quality, None),
+    );
+    let track = rebuild_track_for_tidal_ref(&state, tidal_id).await;
+    let (http_client, generation) = {
+        let state_guard = state.read().await;
+        (
+            state_guard.http_client.clone(),
+            state_guard
+                .playback_generation
+                .load(std::sync::atomic::Ordering::Relaxed),
+        )
+    };
+    let config = PlaybackRuntimeConfig::new(http_client, tokens.access_token, None)
+        .with_dj_analysis(true, Some(dj_analysis_tx))
+        .for_dj_analysis_only();
+    let job = player::PreparedPlaybackJob::new(
+        track.clone(),
+        PlaybackSourceRequest::TidalStream(request),
+        GaplessPlan::disabled(),
+    )
+    .with_generation(generation)
+    .with_dj_media_ref(media_ref);
+    let (command_tx, _command_rx) = std::sync::mpsc::channel::<PlaybackRuntimeCommand>();
+    let shared = Arc::new(PlaybackSharedState::new(
+        track.id,
+        generation,
+        PlaybackSourceKind::TidalStream,
+        GaplessPlan::disabled(),
+        48_000,
+        2,
+        None,
+        command_tx,
+        Arc::new(AtomicU32::new(1.0_f32.to_bits())),
+        Arc::new(AtomicU64::new(0)),
+        Arc::new(AtomicU64::new(0)),
+    ));
+
+    tokio::task::spawn_blocking(move || {
+        if let Err(error) = decode_and_buffer_job(config, job, shared, 48_000, 2) {
+            tracing::warn!(tidal_id, error = %error, "DJ profile rebuild decode failed");
         } else {
-            "not_current_pair".to_string()
+            tracing::info!(tidal_id, "DJ profile rebuild decode queued analysis");
+        }
+    });
+
+    Ok(RebuildDjProfileResponse {
+        accepted: true,
+        status: "accepted".to_string(),
+    })
+}
+
+async fn queue_tidal_profile_rebuild_if_idle(
+    state: SharedState,
+    media_ref: DjMediaRef,
+) -> Result<(), StatusCode> {
+    let dj_analysis_tx = {
+        let state_guard = state.read().await;
+        state_guard.dj_analysis_tx.clone()
+    };
+    let Some(dj_analysis_tx) = dj_analysis_tx else {
+        return Ok(());
+    };
+    let _ = queue_tidal_profile_rebuild(state, media_ref, dj_analysis_tx, false).await?;
+    Ok(())
+}
+
+fn mark_dj_profile_rebuild_inflight(
+    inflight: &Arc<std::sync::Mutex<std::collections::HashMap<String, std::time::Instant>>>,
+    key: &str,
+    retry_after: std::time::Duration,
+) -> Result<ProfileRebuildInflightDecision, StatusCode> {
+    let mut guard = inflight
+        .lock()
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    if let Some(started_at) = guard.get(key)
+        && started_at.elapsed() < retry_after
+    {
+        return Ok(ProfileRebuildInflightDecision::AlreadyRunning);
+    }
+    guard.insert(key.to_string(), std::time::Instant::now());
+    Ok(ProfileRebuildInflightDecision::Start)
+}
+
+fn dj_profile_inflight_key(key: &AudioDjProfileKey) -> String {
+    format!("{}:{}", key.media_ref_kind, key.media_ref_id)
+}
+
+fn clear_dj_profile_inflight(
+    inflight: &Arc<std::sync::Mutex<std::collections::HashMap<String, std::time::Instant>>>,
+    key: &str,
+) {
+    if let Ok(mut guard) = inflight.lock() {
+        guard.remove(key);
+    }
+}
+
+async fn rebuild_track_for_tidal_ref(
+    state: &SharedState,
+    tidal_id: i64,
+) -> crate::db::models::Track {
+    let state_guard = state.read().await;
+    if let Some(track) = state_guard
+        .ephemeral_tidal_track
+        .as_ref()
+        .filter(|track| track.tidal_id == Some(tidal_id))
+    {
+        return track.clone();
+    }
+    if let Some(prepared) = state_guard
+        .prepared_ephemeral_tidal_next
+        .as_ref()
+        .filter(|prepared| prepared.tidal_track_id == tidal_id)
+    {
+        return prepared.synthetic_track.clone();
+    }
+    if let Some(pending) = state_guard
+        .pending_tidal_mix_queue
+        .lock()
+        .unwrap()
+        .iter()
+        .find(|track| track.tidal_track_id == tidal_id)
+        .cloned()
+    {
+        return synthetic_rebuild_track(&pending);
+    }
+    state_guard
+        .db
+        .with_conn(|conn| library_track_for_tidal_id(conn, tidal_id))
+        .ok()
+        .flatten()
+        .unwrap_or_else(|| {
+            synthetic_rebuild_track(&crate::PendingEphemeralTidalTrack {
+                tidal_track_id: tidal_id,
+                title: format!("TIDAL {tidal_id}"),
+                artist_name: None,
+                album_title: None,
+                artwork_url: None,
+                duration_ms: None,
+            })
+        })
+}
+
+fn library_track_for_tidal_id(
+    conn: &rusqlite::Connection,
+    tidal_id: i64,
+) -> anyhow::Result<Option<crate::db::models::Track>> {
+    conn.query_row(
+        "SELECT t.id, t.title, t.artist_id, ar.name, t.album_id, al.title,
+                t.disc_number, t.track_number, t.duration_ms, t.isrc, t.tidal_id,
+                t.ytmusic_id, t.soundcloud_id, t.best_quality, t.best_source,
+                t.fidelity_score, t.is_favorite, t.play_count, t.last_played_at,
+                t.date_added, t.source, al.artwork_url
+         FROM tracks t
+         LEFT JOIN artists ar ON t.artist_id = ar.id
+         LEFT JOIN albums al ON t.album_id = al.id
+         WHERE t.tidal_id = ?1
+         LIMIT 1",
+        params![tidal_id],
+        |row| {
+            Ok(crate::db::models::Track {
+                id: row.get(0)?,
+                title: row.get(1)?,
+                artist_id: row.get(2)?,
+                artist_name: row.get(3)?,
+                album_id: row.get(4)?,
+                album_title: row.get(5)?,
+                disc_number: row.get(6)?,
+                track_number: row.get(7)?,
+                duration_ms: row.get(8)?,
+                isrc: row.get(9)?,
+                tidal_id: row.get(10)?,
+                ytmusic_id: row.get(11)?,
+                soundcloud_id: row.get(12)?,
+                best_quality: row.get(13)?,
+                best_source: row.get(14)?,
+                fidelity_score: row.get(15)?,
+                is_favorite: row.get(16)?,
+                play_count: row.get(17)?,
+                last_played_at: row.get(18)?,
+                date_added: row.get(19)?,
+                source: row.get(20)?,
+                artwork_url: row.get(21)?,
+            })
         },
-    }))
+    )
+    .optional()
+    .map_err(Into::into)
+}
+
+fn synthetic_rebuild_track(track: &crate::PendingEphemeralTidalTrack) -> crate::db::models::Track {
+    crate::db::models::Track {
+        id: -track.tidal_track_id,
+        title: track.title.clone(),
+        artist_id: 0,
+        artist_name: track.artist_name.clone(),
+        album_id: None,
+        album_title: track.album_title.clone(),
+        disc_number: None,
+        track_number: None,
+        duration_ms: track.duration_ms,
+        isrc: None,
+        tidal_id: Some(track.tidal_track_id),
+        ytmusic_id: None,
+        soundcloud_id: None,
+        best_quality: None,
+        best_source: Some("tidal".to_string()),
+        fidelity_score: 0,
+        is_favorite: false,
+        play_count: 0,
+        last_played_at: None,
+        date_added: None,
+        source: "tidal_ephemeral".to_string(),
+        artwork_url: track.artwork_url.clone(),
+    }
 }
 
 async fn get_mix_intent(
@@ -503,11 +1023,15 @@ fn correction_response(row: AudioDjProfileCorrectionRow) -> DjProfileCorrectionR
 fn deck_status(
     conn: &rusqlite::Connection,
     media_ref: &DjMediaRef,
+    label_override: Option<&(String, Option<String>)>,
 ) -> anyhow::Result<DjDeckStatus> {
     let key = media_ref.profile_key();
     let profile = queries::get_audio_dj_profile(conn, &key)?;
     let correction = queries::get_audio_dj_profile_correction(conn, &key)?;
-    let (title, artist) = media_ref_label(conn, media_ref)?;
+    let (title, artist) = match label_override {
+        Some((title, artist)) => (title.clone(), artist.clone()),
+        None => media_ref_label(conn, media_ref)?,
+    };
     let (beat_count, downbeat_count, phrase_count, profile_confidence) =
         if let Some(profile) = profile.as_ref() {
             (
@@ -531,6 +1055,254 @@ fn deck_status(
         phrase_count,
         safe_crossfade_only: correction.is_some_and(|row| row.safe_crossfade_only),
     })
+}
+
+fn latest_open_transition_for_pair(
+    conn: &rusqlite::Connection,
+    current: Option<&DjMediaRef>,
+    next: Option<&DjMediaRef>,
+) -> anyhow::Result<Option<OpenTransition>> {
+    let (Some(current), Some(next)) = (current, next) else {
+        return Ok(None);
+    };
+    let current_key = current.profile_key();
+    let next_key = next.profile_key();
+    conn.query_row(
+        "SELECT id, template, program_json, fallback_reason,
+                planned_start_ms, actual_start_ms, timing_delta_ms,
+                timing_source, timing_status
+         FROM dj_transition_events
+         WHERE from_media_ref_kind = ?1
+           AND from_media_ref_id = ?2
+           AND to_media_ref_kind = ?3
+           AND to_media_ref_id = ?4
+           AND outcome IS NULL
+         ORDER BY started_at DESC, id DESC
+         LIMIT 1",
+        params![
+            current_key.media_ref_kind,
+            current_key.media_ref_id,
+            next_key.media_ref_kind,
+            next_key.media_ref_id,
+        ],
+        |row| {
+            let program_json: String = row.get(2)?;
+            Ok(OpenTransition {
+                id: row.get(0)?,
+                template: row.get(1)?,
+                renderer_template: renderer_template_from_program_json(&program_json),
+                fallback_reason: row.get(3)?,
+                planned_start_ms: row.get(4)?,
+                actual_start_ms: row.get(5)?,
+                timing_delta_ms: row.get(6)?,
+                timing_source: row.get(7)?,
+                timing_status: row.get(8)?,
+            })
+        },
+    )
+    .optional()
+    .map_err(Into::into)
+}
+
+fn latest_dj_transition_timing_history(
+    conn: &rusqlite::Connection,
+    limit: i64,
+) -> anyhow::Result<Vec<DjTimingHistoryEvent>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, template, program_json, fallback_reason,
+                planned_start_ms, actual_start_ms, timing_delta_ms,
+                timing_source, timing_status, started_at
+         FROM dj_transition_events
+         WHERE timing_status IN ('fired', 'late', 'missed')
+           AND NOT (
+             timing_status = 'missed'
+             AND EXISTS (
+               SELECT 1
+               FROM dj_transition_events fired
+               WHERE fired.from_media_ref_kind IS dj_transition_events.from_media_ref_kind
+                 AND fired.from_media_ref_id IS dj_transition_events.from_media_ref_id
+                 AND fired.to_media_ref_kind IS dj_transition_events.to_media_ref_kind
+                 AND fired.to_media_ref_id IS dj_transition_events.to_media_ref_id
+                 AND fired.timing_status = 'fired'
+             )
+           )
+         ORDER BY started_at DESC, id DESC
+         LIMIT ?1",
+    )?;
+    let rows = stmt.query_map([limit.max(0)], |row| {
+        let program_json: String = row.get(2)?;
+        let timing_delta_ms: Option<i64> = row.get(6)?;
+        let timing_status: Option<String> = row.get(8)?;
+        Ok(DjTimingHistoryEvent {
+            event_id: row.get(0)?,
+            planned_template: row.get(1)?,
+            renderer_template: renderer_template_from_program_json(&program_json),
+            planned_start_ms: row.get(4)?,
+            actual_start_ms: row.get(5)?,
+            timing_delta_ms,
+            timing_source: row.get(7)?,
+            timing_status: timing_status.clone(),
+            timing_quality: timing_quality(timing_status.as_deref(), timing_delta_ms).to_string(),
+            started_at: row.get(9)?,
+        })
+    })?;
+    let mut events = Vec::new();
+    for row in rows {
+        events.push(row?);
+    }
+    Ok(events)
+}
+
+fn timing_quality(timing_status: Option<&str>, timing_delta_ms: Option<i64>) -> &'static str {
+    if timing_status == Some("missed") {
+        return "bad";
+    }
+    let Some(delta_ms) = timing_delta_ms else {
+        return "bad";
+    };
+    match delta_ms.abs() {
+        0..=150 => "tight",
+        151..=500 => "usable",
+        501..=1000 => "loose",
+        _ => "bad",
+    }
+}
+
+fn summarize_timing_history(events: &[DjTimingHistoryEvent]) -> DjTimingHistorySummary {
+    let mut delta_sum = 0i64;
+    let mut abs_delta_sum = 0i64;
+    let mut delta_count = 0i64;
+    let mut tight_count = 0usize;
+    let mut usable_count = 0usize;
+    let mut loose_count = 0usize;
+    let mut bad_count = 0usize;
+    let mut late_count = 0usize;
+    let mut missed_count = 0usize;
+
+    for event in events {
+        match event.timing_quality.as_str() {
+            "tight" => tight_count += 1,
+            "usable" => usable_count += 1,
+            "loose" => loose_count += 1,
+            _ => bad_count += 1,
+        }
+        if event.timing_status.as_deref() == Some("late") {
+            late_count += 1;
+        }
+        if event.timing_status.as_deref() == Some("missed") {
+            missed_count += 1;
+        }
+        if let Some(delta_ms) = event.timing_delta_ms {
+            delta_sum += delta_ms;
+            abs_delta_sum += delta_ms.abs();
+            delta_count += 1;
+        }
+    }
+
+    DjTimingHistorySummary {
+        event_count: events.len(),
+        average_delta_ms: (delta_count > 0).then_some(delta_sum / delta_count),
+        average_abs_delta_ms: (delta_count > 0).then_some(abs_delta_sum / delta_count),
+        tight_count,
+        usable_count,
+        loose_count,
+        bad_count,
+        late_count,
+        missed_count,
+    }
+}
+
+#[cfg(test)]
+fn open_transition_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<OpenTransition> {
+    let program_json: String = row.get(2)?;
+    Ok(OpenTransition {
+        id: row.get(0)?,
+        template: row.get(1)?,
+        renderer_template: renderer_template_from_program_json(&program_json),
+        fallback_reason: row.get(3)?,
+        planned_start_ms: row.get(4)?,
+        actual_start_ms: row.get(5)?,
+        timing_delta_ms: row.get(6)?,
+        timing_source: row.get(7)?,
+        timing_status: row.get(8)?,
+    })
+}
+
+#[cfg(test)]
+fn latest_completed_timing_transition(
+    conn: &rusqlite::Connection,
+) -> anyhow::Result<Option<OpenTransition>> {
+    conn.query_row(
+        "SELECT id, template, program_json, fallback_reason,
+                planned_start_ms, actual_start_ms, timing_delta_ms,
+                timing_source, timing_status
+         FROM dj_transition_events
+         WHERE timing_status IN ('fired', 'late', 'missed')
+         ORDER BY started_at DESC, id DESC
+         LIMIT 1",
+        [],
+        open_transition_from_row,
+    )
+    .optional()
+    .map_err(Into::into)
+}
+
+fn renderer_status_for_transition(transition: Option<&OpenTransition>) -> RendererStatus {
+    let Some(transition) = transition else {
+        return RendererStatus {
+            planned_template: None,
+            renderer_template: None,
+            renderer_mode: None,
+            downgrade_reason: None,
+            sync_target: None,
+            planned_start_ms: None,
+            actual_start_ms: None,
+            timing_delta_ms: None,
+            timing_source: None,
+            timing_status: None,
+        };
+    };
+    if transition.renderer_template.as_deref() == Some("SafeCrossfade") {
+        return RendererStatus {
+            planned_template: Some(transition.template.clone()),
+            renderer_template: transition.renderer_template.clone(),
+            renderer_mode: Some("dj_gain_program".to_string()),
+            downgrade_reason: transition.fallback_reason.clone().or_else(|| {
+                (transition.template != "SafeCrossfade")
+                    .then(|| "template_not_renderable".to_string())
+            }),
+            sync_target: transition.timing_source.clone(),
+            planned_start_ms: transition.planned_start_ms,
+            actual_start_ms: transition.actual_start_ms,
+            timing_delta_ms: transition.timing_delta_ms,
+            timing_source: transition.timing_source.clone(),
+            timing_status: transition.timing_status.clone(),
+        };
+    }
+    RendererStatus {
+        planned_template: Some(transition.template.clone()),
+        renderer_template: None,
+        renderer_mode: Some("legacy_overlap".to_string()),
+        downgrade_reason: Some(
+            if transition.template == "SafeCrossfade" {
+                "dj_program_renderer_pending"
+            } else {
+                "template_not_renderable"
+            }
+            .to_string(),
+        ),
+        sync_target: transition.timing_source.clone(),
+        planned_start_ms: transition.planned_start_ms,
+        actual_start_ms: transition.actual_start_ms,
+        timing_delta_ms: transition.timing_delta_ms,
+        timing_source: transition.timing_source.clone(),
+        timing_status: transition.timing_status.clone(),
+    }
+}
+
+fn renderer_template_from_program_json(program_json: &str) -> Option<String> {
+    let program: noor_mix::TransitionProgram = serde_json::from_str(program_json).ok()?;
+    (program.template == "SafeCrossfade").then_some(program.template)
 }
 
 fn media_ref_label(
@@ -589,5 +1361,285 @@ fn feedback_rating(value: &str) -> Option<i64> {
         "good" => Some(1),
         "bad" | "too_safe" | "too_bold" => Some(-1),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn renderer_status_keeps_non_renderable_template_out_of_main_renderer() {
+        let status = renderer_status_for_transition(Some(&OpenTransition {
+            id: 17,
+            template: "FilterSweep".to_string(),
+            renderer_template: None,
+            fallback_reason: None,
+            planned_start_ms: None,
+            actual_start_ms: None,
+            timing_delta_ms: None,
+            timing_source: None,
+            timing_status: None,
+        }));
+
+        assert_eq!(status.planned_template.as_deref(), Some("FilterSweep"));
+        assert_eq!(status.renderer_template, None);
+        assert_eq!(status.renderer_mode.as_deref(), Some("legacy_overlap"));
+        assert_eq!(
+            status.downgrade_reason.as_deref(),
+            Some("template_not_renderable")
+        );
+    }
+
+    #[test]
+    fn renderer_status_marks_safe_crossfade_renderer_as_pending() {
+        let status = renderer_status_for_transition(Some(&OpenTransition {
+            id: 18,
+            template: "SafeCrossfade".to_string(),
+            renderer_template: None,
+            fallback_reason: None,
+            planned_start_ms: None,
+            actual_start_ms: None,
+            timing_delta_ms: None,
+            timing_source: None,
+            timing_status: None,
+        }));
+
+        assert_eq!(status.planned_template.as_deref(), Some("SafeCrossfade"));
+        assert_eq!(status.renderer_template, None);
+        assert_eq!(status.renderer_mode.as_deref(), Some("legacy_overlap"));
+        assert_eq!(
+            status.downgrade_reason.as_deref(),
+            Some("dj_program_renderer_pending")
+        );
+    }
+
+    #[test]
+    fn renderer_status_exposes_safe_crossfade_runtime_program() {
+        let status = renderer_status_for_transition(Some(&OpenTransition {
+            id: 19,
+            template: "FilterSweep".to_string(),
+            renderer_template: Some("SafeCrossfade".to_string()),
+            fallback_reason: Some("template_not_renderable".to_string()),
+            planned_start_ms: Some(112_000),
+            actual_start_ms: Some(112_144),
+            timing_delta_ms: Some(144),
+            timing_source: Some("downbeat_sync".to_string()),
+            timing_status: Some("fired".to_string()),
+        }));
+
+        assert_eq!(status.planned_template.as_deref(), Some("FilterSweep"));
+        assert_eq!(status.renderer_template.as_deref(), Some("SafeCrossfade"));
+        assert_eq!(status.renderer_mode.as_deref(), Some("dj_gain_program"));
+        assert_eq!(
+            status.downgrade_reason.as_deref(),
+            Some("template_not_renderable")
+        );
+        assert_eq!(status.planned_start_ms, Some(112_000));
+        assert_eq!(status.actual_start_ms, Some(112_144));
+        assert_eq!(status.timing_delta_ms, Some(144));
+        assert_eq!(status.timing_source.as_deref(), Some("downbeat_sync"));
+        assert_eq!(status.timing_status.as_deref(), Some("fired"));
+    }
+
+    #[test]
+    fn latest_completed_timing_transition_returns_last_fired_row() {
+        let conn = rusqlite::Connection::open_in_memory().expect("db");
+        crate::db::schema::run_migrations(&conn).expect("migrations");
+        conn.execute(
+            "INSERT INTO dj_transition_events (
+                from_media_ref_kind, from_media_ref_id, to_media_ref_kind, to_media_ref_id,
+                template, program_json, planner_version, planned_start_ms,
+                actual_start_ms, timing_delta_ms, timing_source, timing_status
+             ) VALUES (
+                'tidal_track', '1', 'tidal_track', '2',
+                'SafeCrossfade', '{\"template\":\"SafeCrossfade\"}', 'dj-v1',
+                222000, 222040, 40, 'downbeat_sync', 'fired'
+             )",
+            [],
+        )
+        .expect("insert");
+
+        let transition = latest_completed_timing_transition(&conn)
+            .expect("query")
+            .expect("transition");
+
+        assert_eq!(transition.planned_start_ms, Some(222_000));
+        assert_eq!(transition.actual_start_ms, Some(222_040));
+        assert_eq!(transition.timing_delta_ms, Some(40));
+        assert_eq!(transition.timing_status.as_deref(), Some("fired"));
+    }
+
+    #[test]
+    fn timing_history_keeps_completed_rows_when_newer_pair_is_armed() {
+        let conn = rusqlite::Connection::open_in_memory().expect("db");
+        crate::db::schema::run_migrations(&conn).expect("migrations");
+        conn.execute(
+            "INSERT INTO dj_transition_events (
+                from_media_ref_kind, from_media_ref_id, to_media_ref_kind, to_media_ref_id,
+                template, program_json, planner_version, planned_start_ms,
+                actual_start_ms, timing_delta_ms, timing_source, timing_status
+             ) VALUES (
+                'tidal_track', '1', 'tidal_track', '2',
+                'SafeCrossfade', '{\"template\":\"SafeCrossfade\"}', 'dj-v1',
+                222000, 222040, 40, 'downbeat_sync', 'fired'
+             )",
+            [],
+        )
+        .expect("insert fired");
+        conn.execute(
+            "INSERT INTO dj_transition_events (
+                from_media_ref_kind, from_media_ref_id, to_media_ref_kind, to_media_ref_id,
+                template, program_json, planner_version, planned_start_ms,
+                timing_source, timing_status
+             ) VALUES (
+                'tidal_track', '2', 'tidal_track', '3',
+                'SafeCrossfade', '{\"template\":\"SafeCrossfade\"}', 'dj-v1',
+                300000, 'beat_sync', 'armed'
+             )",
+            [],
+        )
+        .expect("insert armed");
+
+        let current = DjMediaRef::TidalTrack {
+            tidal_id: 2,
+            track_id: None,
+        };
+        let next = DjMediaRef::TidalTrack {
+            tidal_id: 3,
+            track_id: None,
+        };
+        let open = latest_open_transition_for_pair(&conn, Some(&current), Some(&next))
+            .expect("open")
+            .expect("armed row");
+        let history = latest_dj_transition_timing_history(&conn, 5).expect("history");
+
+        assert_eq!(open.timing_status.as_deref(), Some("armed"));
+        assert_eq!(history.len(), 1);
+        assert_eq!(history[0].event_id, 1);
+        assert_eq!(history[0].actual_start_ms, Some(222_040));
+        assert_eq!(history[0].timing_status.as_deref(), Some("fired"));
+        assert_eq!(history[0].timing_quality, "tight");
+    }
+
+    #[test]
+    fn timing_history_filters_duplicate_missed_row_when_pair_already_fired() {
+        let conn = rusqlite::Connection::open_in_memory().expect("db");
+        crate::db::schema::run_migrations(&conn).expect("migrations");
+        conn.execute(
+            "INSERT INTO dj_transition_events (
+                from_media_ref_kind, from_media_ref_id, to_media_ref_kind, to_media_ref_id,
+                template, program_json, planner_version, planned_start_ms,
+                actual_start_ms, timing_delta_ms, timing_source, timing_status
+             ) VALUES (
+                'tidal_track', '1', 'tidal_track', '2',
+                'SafeCrossfade', '{\"template\":\"SafeCrossfade\"}', 'dj-v1',
+                222000, 222040, 40, 'downbeat_sync', 'fired'
+             )",
+            [],
+        )
+        .expect("insert fired");
+        conn.execute(
+            "INSERT INTO dj_transition_events (
+                from_media_ref_kind, from_media_ref_id, to_media_ref_kind, to_media_ref_id,
+                template, program_json, planner_version, planned_start_ms,
+                timing_source, timing_status
+             ) VALUES (
+                'tidal_track', '1', 'tidal_track', '2',
+                'SafeCrossfade', '{\"template\":\"SafeCrossfade\"}', 'dj-v1',
+                222000, 'downbeat_sync', 'missed'
+             )",
+            [],
+        )
+        .expect("insert duplicate missed");
+
+        let history = latest_dj_transition_timing_history(&conn, 5).expect("history");
+
+        assert_eq!(history.len(), 1);
+        assert_eq!(history[0].timing_status.as_deref(), Some("fired"));
+        assert_eq!(history[0].timing_delta_ms, Some(40));
+    }
+
+    #[test]
+    fn timing_quality_labels_delta_bands_and_missed() {
+        assert_eq!(timing_quality(Some("fired"), Some(150)), "tight");
+        assert_eq!(timing_quality(Some("fired"), Some(-500)), "usable");
+        assert_eq!(timing_quality(Some("late"), Some(1000)), "loose");
+        assert_eq!(timing_quality(Some("late"), Some(1001)), "bad");
+        assert_eq!(timing_quality(Some("missed"), None), "bad");
+        assert_eq!(timing_quality(Some("fired"), None), "bad");
+    }
+
+    #[test]
+    fn timing_history_summary_counts_quality_and_status() {
+        let events = vec![
+            DjTimingHistoryEvent {
+                event_id: 1,
+                planned_template: "SafeCrossfade".to_string(),
+                renderer_template: Some("SafeCrossfade".to_string()),
+                planned_start_ms: Some(10_000),
+                actual_start_ms: Some(10_100),
+                timing_delta_ms: Some(100),
+                timing_source: Some("downbeat_sync".to_string()),
+                timing_status: Some("fired".to_string()),
+                timing_quality: "tight".to_string(),
+                started_at: "now".to_string(),
+            },
+            DjTimingHistoryEvent {
+                event_id: 2,
+                planned_template: "SafeCrossfade".to_string(),
+                renderer_template: Some("SafeCrossfade".to_string()),
+                planned_start_ms: Some(20_000),
+                actual_start_ms: Some(20_800),
+                timing_delta_ms: Some(800),
+                timing_source: Some("beat_sync".to_string()),
+                timing_status: Some("late".to_string()),
+                timing_quality: "loose".to_string(),
+                started_at: "now".to_string(),
+            },
+            DjTimingHistoryEvent {
+                event_id: 3,
+                planned_template: "SafeCrossfade".to_string(),
+                renderer_template: Some("SafeCrossfade".to_string()),
+                planned_start_ms: Some(30_000),
+                actual_start_ms: None,
+                timing_delta_ms: None,
+                timing_source: Some("fallback_overlap".to_string()),
+                timing_status: Some("missed".to_string()),
+                timing_quality: "bad".to_string(),
+                started_at: "now".to_string(),
+            },
+        ];
+
+        let summary = summarize_timing_history(&events);
+
+        assert_eq!(summary.event_count, 3);
+        assert_eq!(summary.average_delta_ms, Some(450));
+        assert_eq!(summary.average_abs_delta_ms, Some(450));
+        assert_eq!(summary.tight_count, 1);
+        assert_eq!(summary.loose_count, 1);
+        assert_eq!(summary.bad_count, 1);
+        assert_eq!(summary.late_count, 1);
+        assert_eq!(summary.missed_count, 1);
+    }
+
+    #[test]
+    fn profile_rebuild_inflight_reports_running_for_recent_duplicate() {
+        let inflight = Arc::new(std::sync::Mutex::new(std::collections::HashMap::new()));
+        let first = mark_dj_profile_rebuild_inflight(
+            &inflight,
+            "tidal_track:250295727",
+            std::time::Duration::from_secs(60),
+        )
+        .expect("first mark");
+        let second = mark_dj_profile_rebuild_inflight(
+            &inflight,
+            "tidal_track:250295727",
+            std::time::Duration::from_secs(60),
+        )
+        .expect("second mark");
+
+        assert_eq!(first, ProfileRebuildInflightDecision::Start);
+        assert_eq!(second, ProfileRebuildInflightDecision::AlreadyRunning);
     }
 }

--- a/noor-server/src/server/routes/dj_routes.rs
+++ b/noor-server/src/server/routes/dj_routes.rs
@@ -22,7 +22,9 @@ use crate::playback::player::{self, PlaybackSourceKind, PlaybackSourceRequest};
 use crate::playback::runtime::PlaybackRuntimeConfig;
 use crate::playback::runtime::commands::PlaybackRuntimeCommand;
 use crate::playback::runtime::shared::PlaybackSharedState;
-use crate::services::audio_analysis::dj_profile::{decode_f32_blob, decode_u32_blob};
+use crate::services::audio_analysis::dj_profile::{
+    DJ_PROFILE_VERSION, decode_f32_blob, decode_u32_blob,
+};
 use crate::services::tidal::stream as tidal_stream;
 
 const DEFAULT_DJ_LOOKAHEAD_DEADLINE_SAMPLES: u64 = 48_000 * 30;
@@ -525,7 +527,7 @@ async fn rebuild_profile(
                         },
                     ));
                 };
-                if queries::get_audio_dj_profile(conn, &key)?.is_some() {
+                if dj_profile_is_current_version(conn, &key)? {
                     return Ok(RebuildProfileCandidate::Response(
                         RebuildDjProfileResponse {
                             accepted: false,
@@ -569,7 +571,28 @@ async fn queue_tidal_profile_rebuild(
             status: "source_unavailable".to_string(),
         });
     };
-    let inflight_key = dj_profile_inflight_key(&media_ref.profile_key());
+    let media_key = media_ref.profile_key();
+    if !force {
+        let already_current = {
+            let state_guard = state.read().await;
+            state_guard
+                .db
+                .with_conn(|conn| dj_profile_is_current_version(conn, &media_key))
+                .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        };
+        if already_current {
+            tracing::debug!(
+                media_ref_kind = %media_key.media_ref_kind,
+                media_ref_id = %media_key.media_ref_id,
+                "Skipping current DJ profile rebuild"
+            );
+            return Ok(RebuildDjProfileResponse {
+                accepted: false,
+                status: "already_current".to_string(),
+            });
+        }
+    }
+    let inflight_key = dj_profile_inflight_key(&media_key);
     let inflight = {
         let state_guard = state.read().await;
         state_guard.dj_profile_rebuild_inflight.clone()
@@ -1021,6 +1044,14 @@ fn profile_response(track_id: i64, profile: &AudioDjProfileRow) -> ProfileRespon
     }
 }
 
+fn dj_profile_is_current_version(
+    conn: &rusqlite::Connection,
+    key: &AudioDjProfileKey,
+) -> anyhow::Result<bool> {
+    Ok(queries::get_audio_dj_profile(conn, key)?
+        .is_some_and(|row| row.profile_version == DJ_PROFILE_VERSION))
+}
+
 fn correction_response(row: AudioDjProfileCorrectionRow) -> DjProfileCorrectionResponse {
     DjProfileCorrectionResponse {
         media_ref_kind: row.media_ref_kind,
@@ -1428,6 +1459,57 @@ fn feedback_rating(value: &str) -> Option<i64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_profile_row(key: &AudioDjProfileKey, version: &str) -> AudioDjProfileRow {
+        AudioDjProfileRow {
+            media_ref_kind: key.media_ref_kind.clone(),
+            media_ref_id: key.media_ref_id.clone(),
+            track_id: None,
+            queue_item_id: None,
+            tidal_id: None,
+            profile_version: version.to_string(),
+            beat_grid_blob: vec![1, 2, 3],
+            downbeats_blob: vec![4, 5],
+            phrase_boundaries_blob: vec![6],
+            mix_in_blob: vec![7],
+            mix_out_blob: vec![8],
+            intro_end_seconds: Some(16.0),
+            outro_start_seconds: Some(180.0),
+            breakdown_blob: vec![9],
+            drop_blob: vec![10],
+            safe_transition_windows_blob: vec![11],
+            energy_contour_blob: vec![12],
+            vocal_presence_blob: vec![13],
+            vocal_density_blob: vec![14],
+            lufs_loud_body: Some(-12.0),
+            true_peak_dbtp: Some(-1.0),
+            beat_confidence: Some(0.9),
+            profile_confidence: 0.85,
+            analysis_scope_ms: 90_000,
+            is_temporary: false,
+            source: "test".to_string(),
+            computed_at: "2026-05-21T00:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn dj_profile_current_check_requires_current_version() {
+        let conn = rusqlite::Connection::open_in_memory().expect("db");
+        crate::db::schema::run_migrations(&conn).expect("migrations");
+        let key = AudioDjProfileKey {
+            media_ref_kind: "tidal_track".to_string(),
+            media_ref_id: "123".to_string(),
+        };
+
+        assert!(!dj_profile_is_current_version(&conn, &key).expect("missing"));
+        queries::upsert_audio_dj_profile(&conn, &test_profile_row(&key, "old_profile_v0"))
+            .expect("old profile");
+        assert!(!dj_profile_is_current_version(&conn, &key).expect("old"));
+        queries::upsert_audio_dj_profile(&conn, &test_profile_row(&key, DJ_PROFILE_VERSION))
+            .expect("current profile");
+
+        assert!(dj_profile_is_current_version(&conn, &key).expect("current"));
+    }
 
     #[test]
     fn renderer_status_keeps_non_renderable_template_out_of_main_renderer() {

--- a/noor-server/src/server/routes/dj_routes.rs
+++ b/noor-server/src/server/routes/dj_routes.rs
@@ -7,8 +7,11 @@ use axum::{
 use chrono::Utc;
 use rusqlite::{OptionalExtension, params};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, AtomicU64};
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
 
 use crate::SharedState;
 use crate::db::{
@@ -33,7 +36,13 @@ const SAFE_SUGGESTION_BAD_COUNT: i64 = 3;
 const DJ_PROFILE_AUTO_REBUILD_RETRY_SECS: u64 = 300;
 const DJ_TIMING_HISTORY_LIMIT: i64 = 5;
 const DJ_READY_PAIR_TRANSITION_WINDOW_MS: i64 = 30_000;
+const DJ_READY_PAIR_PLANNING_RETRY_SECS: u64 = 15;
 const DJ_PROFILE_ANALYSIS_TIDAL_QUALITY: &str = "LOW";
+
+type ReadyPairPlanningKey = (i64, u64);
+
+static READY_PAIR_PLANNING_ATTEMPTS: OnceLock<Mutex<HashMap<ReadyPairPlanningKey, Instant>>> =
+    OnceLock::new();
 
 pub fn routes() -> Router<SharedState> {
     Router::new()
@@ -461,7 +470,9 @@ async fn get_status(
         queue_tidal_profile_rebuild_if_idle(state.clone(), media_ref).await?;
     }
     if let Some((current_track_id, generation)) = ready_active_pair {
-        if ready_pair_transition_is_due(&state, current_track_id, generation).await {
+        if ready_pair_transition_is_due(&state, current_track_id, generation).await
+            && claim_ready_pair_transition_planning(current_track_id, generation)
+        {
             tracing::info!(
                 current_track_id,
                 generation,
@@ -522,6 +533,31 @@ fn ready_pair_transition_due(position_ms: i64, duration_ms: Option<i64>) -> bool
         return false;
     };
     duration_ms.saturating_sub(position_ms.max(0)) <= DJ_READY_PAIR_TRANSITION_WINDOW_MS
+}
+
+fn claim_ready_pair_transition_planning(current_track_id: i64, generation: u64) -> bool {
+    let attempts = READY_PAIR_PLANNING_ATTEMPTS.get_or_init(|| Mutex::new(HashMap::new()));
+    let now = Instant::now();
+    let mut attempts = attempts.lock().unwrap_or_else(|error| error.into_inner());
+    claim_ready_pair_transition_planning_at(&mut attempts, current_track_id, generation, now)
+}
+
+fn claim_ready_pair_transition_planning_at(
+    attempts: &mut HashMap<ReadyPairPlanningKey, Instant>,
+    current_track_id: i64,
+    generation: u64,
+    now: Instant,
+) -> bool {
+    let retry_after = Duration::from_secs(DJ_READY_PAIR_PLANNING_RETRY_SECS);
+    attempts.retain(|_, last_attempt| now.duration_since(*last_attempt) < retry_after);
+    let key = (current_track_id, generation);
+    if let Some(last_attempt) = attempts.get(&key)
+        && now.duration_since(*last_attempt) < retry_after
+    {
+        return false;
+    }
+    attempts.insert(key, now);
+    true
 }
 
 async fn get_profile(
@@ -2145,6 +2181,39 @@ mod tests {
         assert!(ready_pair_transition_due(151_000, Some(180_000)));
         assert!(ready_pair_transition_due(180_000, Some(180_000)));
         assert!(!ready_pair_transition_due(151_000, None));
+    }
+
+    #[test]
+    fn ready_pair_transition_planning_cooldown_suppresses_same_generation() {
+        let mut attempts = HashMap::new();
+        let now = Instant::now();
+        let inside_retry = now + Duration::from_secs(DJ_READY_PAIR_PLANNING_RETRY_SECS - 1);
+        let after_retry = now + Duration::from_secs(DJ_READY_PAIR_PLANNING_RETRY_SECS + 1);
+
+        assert!(claim_ready_pair_transition_planning_at(
+            &mut attempts,
+            32335,
+            4,
+            now
+        ));
+        assert!(!claim_ready_pair_transition_planning_at(
+            &mut attempts,
+            32335,
+            4,
+            inside_retry
+        ));
+        assert!(claim_ready_pair_transition_planning_at(
+            &mut attempts,
+            32335,
+            5,
+            inside_retry
+        ));
+        assert!(claim_ready_pair_transition_planning_at(
+            &mut attempts,
+            32335,
+            4,
+            after_retry
+        ));
     }
 
     #[test]

--- a/noor-server/src/server/routes/dj_routes.rs
+++ b/noor-server/src/server/routes/dj_routes.rs
@@ -33,6 +33,7 @@ const SAFE_SUGGESTION_BAD_COUNT: i64 = 3;
 const DJ_PROFILE_AUTO_REBUILD_RETRY_SECS: u64 = 300;
 const DJ_TIMING_HISTORY_LIMIT: i64 = 5;
 const DJ_READY_PAIR_TRANSITION_WINDOW_MS: i64 = 30_000;
+const DJ_PROFILE_ANALYSIS_TIDAL_QUALITY: &str = "LOW";
 
 pub fn routes() -> Router<SharedState> {
     Router::new()
@@ -199,6 +200,8 @@ struct DjTimingHistorySummary {
     event_count: usize,
     average_delta_ms: Option<i64>,
     average_abs_delta_ms: Option<i64>,
+    median_abs_delta_ms: Option<i64>,
+    worst_abs_delta_ms: Option<i64>,
     tight_count: usize,
     usable_count: usize,
     loose_count: usize,
@@ -395,7 +398,9 @@ async fn get_status(
                     latest_open_transition_for_pair(conn, current_ref.as_ref(), next_ref.as_ref())?;
                 let recent_timing_events =
                     latest_dj_transition_timing_history(conn, DJ_TIMING_HISTORY_LIMIT)?;
-                let timing_history_summary = summarize_timing_history(&recent_timing_events);
+                let tuning_deltas = latest_fired_dj_timing_deltas(conn, 20)?;
+                let timing_history_summary =
+                    summarize_timing_history(&recent_timing_events, &tuning_deltas);
                 let mut missing_profile_refs = Vec::new();
                 if enabled {
                     if current.as_ref().is_some_and(|deck| !deck.profile_ready)
@@ -697,11 +702,7 @@ async fn queue_tidal_profile_rebuild(
         });
     };
 
-    let user_quality = super::current_user_audio_quality(&state).await;
-    let request = tidal_stream::StreamRequest::new(
-        tidal_id,
-        super::requested_tidal_quality(user_quality, None),
-    );
+    let request = dj_profile_analysis_stream_request(tidal_id);
     let track = rebuild_track_for_tidal_ref(&state, tidal_id).await;
     let (http_client, generation) = {
         let state_guard = state.read().await;
@@ -749,6 +750,10 @@ async fn queue_tidal_profile_rebuild(
         accepted: true,
         status: "accepted".to_string(),
     })
+}
+
+fn dj_profile_analysis_stream_request(tidal_id: i64) -> tidal_stream::StreamRequest {
+    tidal_stream::StreamRequest::new(tidal_id, DJ_PROFILE_ANALYSIS_TIDAL_QUALITY)
 }
 
 async fn queue_tidal_profile_rebuild_if_idle(
@@ -1288,8 +1293,8 @@ fn timing_direction(timing_status: Option<&str>, timing_delta_ms: Option<i64>) -
         Some("armed") => "pending",
         Some("late") => "late",
         Some("fired") => match timing_delta_ms {
-            Some(delta_ms) if delta_ms < -250 => "early",
-            Some(delta_ms) if delta_ms > 250 => "late",
+            Some(delta_ms) if delta_ms < -150 => "early",
+            Some(delta_ms) if delta_ms > 150 => "late",
             Some(_) => "on_time",
             None => "unknown",
         },
@@ -1297,7 +1302,30 @@ fn timing_direction(timing_status: Option<&str>, timing_delta_ms: Option<i64>) -
     }
 }
 
-fn summarize_timing_history(events: &[DjTimingHistoryEvent]) -> DjTimingHistorySummary {
+fn latest_fired_dj_timing_deltas(
+    conn: &rusqlite::Connection,
+    limit: i64,
+) -> anyhow::Result<Vec<i64>> {
+    let mut stmt = conn.prepare(
+        "SELECT timing_delta_ms
+         FROM dj_transition_events
+         WHERE timing_status = 'fired'
+           AND timing_delta_ms IS NOT NULL
+         ORDER BY started_at DESC, id DESC
+         LIMIT ?1",
+    )?;
+    let rows = stmt.query_map([limit.max(0)], |row| row.get::<_, i64>(0))?;
+    let mut deltas = Vec::new();
+    for row in rows {
+        deltas.push(row?);
+    }
+    Ok(deltas)
+}
+
+fn summarize_timing_history(
+    events: &[DjTimingHistoryEvent],
+    tuning_deltas: &[i64],
+) -> DjTimingHistorySummary {
     let mut delta_sum = 0i64;
     let mut abs_delta_sum = 0i64;
     let mut delta_count = 0i64;
@@ -1332,12 +1360,55 @@ fn summarize_timing_history(events: &[DjTimingHistoryEvent]) -> DjTimingHistoryS
         event_count: events.len(),
         average_delta_ms: (delta_count > 0).then_some(delta_sum / delta_count),
         average_abs_delta_ms: (delta_count > 0).then_some(abs_delta_sum / delta_count),
+        median_abs_delta_ms: median_abs_delta(tuning_deltas),
+        worst_abs_delta_ms: worst_abs_delta(tuning_deltas),
         tight_count,
         usable_count,
         loose_count,
         bad_count,
         late_count,
         missed_count,
+    }
+}
+
+fn median_abs_delta(deltas: &[i64]) -> Option<i64> {
+    if deltas.is_empty() {
+        return None;
+    }
+    let mut abs_values = deltas.iter().map(|delta| delta.abs()).collect::<Vec<_>>();
+    abs_values.sort_unstable();
+    let middle = abs_values.len() / 2;
+    if abs_values.len() % 2 == 0 {
+        Some((abs_values[middle - 1] + abs_values[middle]) / 2)
+    } else {
+        Some(abs_values[middle])
+    }
+}
+
+fn worst_abs_delta(deltas: &[i64]) -> Option<i64> {
+    deltas.iter().map(|delta| delta.abs()).max()
+}
+
+#[allow(dead_code)]
+fn fire_ahead_evidence_passes(deltas: &[i64]) -> bool {
+    if deltas.len() < 20 {
+        return false;
+    }
+    let positive_count = deltas.iter().filter(|delta| **delta > 0).count();
+    positive_count * 10 >= deltas.len() * 7 && median_delta(deltas).is_some_and(|delta| delta > 150)
+}
+
+fn median_delta(deltas: &[i64]) -> Option<i64> {
+    if deltas.is_empty() {
+        return None;
+    }
+    let mut values = deltas.to_vec();
+    values.sort_unstable();
+    let middle = values.len() / 2;
+    if values.len() % 2 == 0 {
+        Some((values[middle - 1] + values[middle]) / 2)
+    } else {
+        Some(values[middle])
     }
 }
 
@@ -1404,14 +1475,17 @@ fn renderer_status_for_transition(transition: Option<&OpenTransition>) -> Render
         transition.timing_delta_ms,
     )
     .to_string();
-    if transition.renderer_template.as_deref() == Some("SafeCrossfade") {
+    if matches!(
+        transition.renderer_template.as_deref(),
+        Some("SafeCrossfade" | "FilterSweep")
+    ) {
+        let downgrade_reason = renderer_downgrade_reason(transition);
         return RendererStatus {
             planned_template: Some(transition.template.clone()),
             renderer_template: transition.renderer_template.clone(),
             renderer_mode: Some("dj_gain_program".to_string()),
-            downgrade_reason: (transition.template != "SafeCrossfade")
-                .then(|| "template_not_renderable".to_string()),
-            planning_reason: transition.fallback_reason.clone(),
+            downgrade_reason,
+            planning_reason: planning_reason_without_renderer_downgrade(transition),
             sync_target: transition.timing_source.clone(),
             planned_start_ms: transition.planned_start_ms,
             actual_start_ms: transition.actual_start_ms,
@@ -1446,9 +1520,35 @@ fn renderer_status_for_transition(transition: Option<&OpenTransition>) -> Render
     }
 }
 
+fn renderer_downgrade_reason(transition: &OpenTransition) -> Option<String> {
+    if transition.renderer_template.as_deref() == Some(transition.template.as_str()) {
+        return None;
+    }
+    Some(
+        transition
+            .fallback_reason
+            .as_deref()
+            .filter(|reason| is_renderer_downgrade_reason(reason))
+            .unwrap_or("template_not_renderable")
+            .to_string(),
+    )
+}
+
+fn planning_reason_without_renderer_downgrade(transition: &OpenTransition) -> Option<String> {
+    transition
+        .fallback_reason
+        .as_deref()
+        .filter(|reason| !is_renderer_downgrade_reason(reason))
+        .map(str::to_string)
+}
+
+fn is_renderer_downgrade_reason(reason: &str) -> bool {
+    matches!(reason, "template_not_renderable" | "timing_unstable")
+}
+
 fn renderer_template_from_program_json(program_json: &str) -> Option<String> {
     let program: noor_mix::TransitionProgram = serde_json::from_str(program_json).ok()?;
-    (program.template == "SafeCrossfade").then_some(program.template)
+    matches!(program.template.as_str(), "SafeCrossfade" | "FilterSweep").then_some(program.template)
 }
 
 fn media_ref_label(
@@ -1566,10 +1666,18 @@ mod tests {
     }
 
     #[test]
+    fn dj_profile_rebuild_uses_low_quality_analysis_stream() {
+        let request = dj_profile_analysis_stream_request(28051328);
+
+        assert_eq!(request.track_id, 28051328);
+        assert_eq!(request.audio_quality, "LOW");
+    }
+
+    #[test]
     fn renderer_status_keeps_non_renderable_template_out_of_main_renderer() {
         let status = renderer_status_for_transition(Some(&OpenTransition {
             id: 17,
-            template: "FilterSweep".to_string(),
+            template: "SlamCut".to_string(),
             renderer_template: None,
             fallback_reason: None,
             planned_start_ms: None,
@@ -1579,7 +1687,7 @@ mod tests {
             timing_status: None,
         }));
 
-        assert_eq!(status.planned_template.as_deref(), Some("FilterSweep"));
+        assert_eq!(status.planned_template.as_deref(), Some("SlamCut"));
         assert_eq!(status.renderer_template, None);
         assert_eq!(status.renderer_mode.as_deref(), Some("legacy_overlap"));
         assert_eq!(
@@ -1589,9 +1697,30 @@ mod tests {
     }
 
     #[test]
-    fn renderer_status_marks_safe_crossfade_renderer_as_pending() {
+    fn renderer_status_exposes_filter_sweep_runtime_program() {
         let status = renderer_status_for_transition(Some(&OpenTransition {
             id: 18,
+            template: "FilterSweep".to_string(),
+            renderer_template: Some("FilterSweep".to_string()),
+            fallback_reason: None,
+            planned_start_ms: Some(112_000),
+            actual_start_ms: Some(112_144),
+            timing_delta_ms: Some(144),
+            timing_source: Some("downbeat_sync".to_string()),
+            timing_status: Some("fired".to_string()),
+        }));
+
+        assert_eq!(status.planned_template.as_deref(), Some("FilterSweep"));
+        assert_eq!(status.renderer_template.as_deref(), Some("FilterSweep"));
+        assert_eq!(status.renderer_mode.as_deref(), Some("dj_gain_program"));
+        assert_eq!(status.downgrade_reason, None);
+        assert_eq!(status.timing_direction, "on_time");
+    }
+
+    #[test]
+    fn renderer_status_marks_safe_crossfade_renderer_as_pending() {
+        let status = renderer_status_for_transition(Some(&OpenTransition {
+            id: 19,
             template: "SafeCrossfade".to_string(),
             renderer_template: None,
             fallback_reason: None,
@@ -1614,10 +1743,10 @@ mod tests {
     #[test]
     fn renderer_status_exposes_safe_crossfade_runtime_program() {
         let status = renderer_status_for_transition(Some(&OpenTransition {
-            id: 19,
-            template: "FilterSweep".to_string(),
+            id: 20,
+            template: "SlamCut".to_string(),
             renderer_template: Some("SafeCrossfade".to_string()),
-            fallback_reason: Some("template_not_renderable".to_string()),
+            fallback_reason: None,
             planned_start_ms: Some(112_000),
             actual_start_ms: Some(112_144),
             timing_delta_ms: Some(144),
@@ -1625,13 +1754,14 @@ mod tests {
             timing_status: Some("fired".to_string()),
         }));
 
-        assert_eq!(status.planned_template.as_deref(), Some("FilterSweep"));
+        assert_eq!(status.planned_template.as_deref(), Some("SlamCut"));
         assert_eq!(status.renderer_template.as_deref(), Some("SafeCrossfade"));
         assert_eq!(status.renderer_mode.as_deref(), Some("dj_gain_program"));
         assert_eq!(
             status.downgrade_reason.as_deref(),
             Some("template_not_renderable")
         );
+        assert_eq!(status.planning_reason, None);
         assert_eq!(status.planned_start_ms, Some(112_000));
         assert_eq!(status.actual_start_ms, Some(112_144));
         assert_eq!(status.timing_delta_ms, Some(144));
@@ -1661,6 +1791,26 @@ mod tests {
             status.planning_reason.as_deref(),
             Some("next_profile_missing")
         );
+    }
+
+    #[test]
+    fn renderer_status_reports_timing_unstable_as_downgrade_reason() {
+        let status = renderer_status_for_transition(Some(&OpenTransition {
+            id: 21,
+            template: "FilterSweep".to_string(),
+            renderer_template: Some("SafeCrossfade".to_string()),
+            fallback_reason: Some("timing_unstable".to_string()),
+            planned_start_ms: Some(202_091),
+            actual_start_ms: Some(202_640),
+            timing_delta_ms: Some(549),
+            timing_source: Some("downbeat_sync".to_string()),
+            timing_status: Some("fired".to_string()),
+        }));
+
+        assert_eq!(status.planned_template.as_deref(), Some("FilterSweep"));
+        assert_eq!(status.renderer_template.as_deref(), Some("SafeCrossfade"));
+        assert_eq!(status.downgrade_reason.as_deref(), Some("timing_unstable"));
+        assert_eq!(status.planning_reason, None);
     }
 
     #[test]
@@ -1879,8 +2029,8 @@ mod tests {
     #[test]
     fn timing_direction_labels_delta_direction_and_status() {
         assert_eq!(timing_direction(Some("fired"), Some(150)), "on_time");
-        assert_eq!(timing_direction(Some("fired"), Some(-251)), "early");
-        assert_eq!(timing_direction(Some("fired"), Some(251)), "late");
+        assert_eq!(timing_direction(Some("fired"), Some(-151)), "early");
+        assert_eq!(timing_direction(Some("fired"), Some(151)), "late");
         assert_eq!(timing_direction(Some("late"), Some(0)), "late");
         assert_eq!(timing_direction(Some("missed"), None), "missed");
         assert_eq!(timing_direction(Some("armed"), None), "pending");
@@ -1946,11 +2096,13 @@ mod tests {
             },
         ];
 
-        let summary = summarize_timing_history(&events);
+        let summary = summarize_timing_history(&events, &[100, 800, -1_200, 40]);
 
         assert_eq!(summary.event_count, 3);
         assert_eq!(summary.average_delta_ms, Some(450));
         assert_eq!(summary.average_abs_delta_ms, Some(450));
+        assert_eq!(summary.median_abs_delta_ms, Some(450));
+        assert_eq!(summary.worst_abs_delta_ms, Some(1_200));
         assert_eq!(summary.tight_count, 1);
         assert_eq!(summary.loose_count, 1);
         assert_eq!(summary.bad_count, 1);

--- a/noor-server/src/server/routes/dj_routes.rs
+++ b/noor-server/src/server/routes/dj_routes.rs
@@ -203,6 +203,7 @@ async fn set_enabled(
     };
 
     if let Some(runtime) = runtime {
+        let _ = runtime.set_dj_engine_enabled(payload.enabled);
         if payload.enabled {
             if let Some(lookahead) = lookahead {
                 let _ = lookahead.dispatch(&runtime);

--- a/noor-server/src/server/routes/dj_routes.rs
+++ b/noor-server/src/server/routes/dj_routes.rs
@@ -37,11 +37,14 @@ const DJ_PROFILE_AUTO_REBUILD_RETRY_SECS: u64 = 300;
 const DJ_TIMING_HISTORY_LIMIT: i64 = 5;
 const DJ_READY_PAIR_TRANSITION_WINDOW_MS: i64 = 30_000;
 const DJ_READY_PAIR_PLANNING_RETRY_SECS: u64 = 15;
+const DJ_PROFILE_REBUILD_FAILURE_TTL_SECS: u64 = 300;
 const DJ_PROFILE_ANALYSIS_TIDAL_QUALITY: &str = "LOW";
 
 type ReadyPairPlanningKey = (i64, u64);
 
 static READY_PAIR_PLANNING_ATTEMPTS: OnceLock<Mutex<HashMap<ReadyPairPlanningKey, Instant>>> =
+    OnceLock::new();
+static DJ_PROFILE_REBUILD_FAILURES: OnceLock<Mutex<HashMap<String, DjProfileRebuildFailure>>> =
     OnceLock::new();
 
 pub fn routes() -> Router<SharedState> {
@@ -170,6 +173,8 @@ struct DjDeckStatus {
     title: String,
     artist: Option<String>,
     profile_ready: bool,
+    profile_status: String,
+    profile_error: Option<String>,
     profile_confidence: Option<f64>,
     beat_count: Option<usize>,
     downbeat_count: Option<usize>,
@@ -274,6 +279,13 @@ enum RebuildProfileCandidate {
 enum ProfileRebuildInflightDecision {
     Start,
     AlreadyRunning,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct DjProfileRebuildFailure {
+    status: String,
+    message: String,
+    recorded_at: Instant,
 }
 
 #[derive(Debug, Serialize)]
@@ -396,6 +408,16 @@ async fn get_status(
                     Some("disabled".to_string())
                 } else if current.is_none() || next.is_none() {
                     Some("pair_missing".to_string())
+                } else if current
+                    .as_ref()
+                    .is_some_and(|deck| deck.profile_status == "decode_failed")
+                {
+                    Some("current_profile_decode_failed".to_string())
+                } else if next
+                    .as_ref()
+                    .is_some_and(|deck| deck.profile_status == "decode_failed")
+                {
+                    Some("next_profile_decode_failed".to_string())
                 } else if current.as_ref().is_some_and(|deck| !deck.profile_ready) {
                     Some("missing_current_profile".to_string())
                 } else if next.as_ref().is_some_and(|deck| !deck.profile_ready) {
@@ -412,12 +434,12 @@ async fn get_status(
                     summarize_timing_history(&recent_timing_events, &tuning_deltas);
                 let mut missing_profile_refs = Vec::new();
                 if enabled {
-                    if current.as_ref().is_some_and(|deck| !deck.profile_ready)
+                    if current.as_ref().is_some_and(deck_needs_profile_rebuild)
                         && let Some(media_ref) = current_ref.clone()
                     {
                         missing_profile_refs.push(media_ref);
                     }
-                    if next.as_ref().is_some_and(|deck| !deck.profile_ready)
+                    if next.as_ref().is_some_and(deck_needs_profile_rebuild)
                         && let Some(media_ref) = next_ref.clone()
                     {
                         missing_profile_refs.push(media_ref);
@@ -694,6 +716,7 @@ async fn queue_tidal_profile_rebuild(
         std::time::Duration::from_secs(DJ_PROFILE_AUTO_REBUILD_RETRY_SECS),
     )? {
         ProfileRebuildInflightDecision::Start => {
+            clear_dj_profile_rebuild_failure(&inflight_key);
             tracing::info!(
                 media_ref_kind = %media_ref.profile_key().media_ref_kind,
                 media_ref_id = %media_ref.profile_key().media_ref_id,
@@ -774,8 +797,17 @@ async fn queue_tidal_profile_rebuild(
         Arc::new(AtomicU64::new(0)),
     ));
 
+    let inflight_for_decode = inflight.clone();
+    let inflight_key_for_decode = inflight_key.clone();
+    let failure_key = inflight_key.clone();
     tokio::task::spawn_blocking(move || {
         if let Err(error) = decode_and_buffer_job(config, job, shared, 48_000, 2) {
+            record_dj_profile_rebuild_failure(
+                &failure_key,
+                "decode_failed",
+                profile_rebuild_error_message(&error),
+            );
+            clear_dj_profile_inflight(&inflight_for_decode, &inflight_key_for_decode);
             tracing::warn!(tidal_id, error = %error, "DJ profile rebuild decode failed");
         } else {
             tracing::info!(tidal_id, "DJ profile rebuild decode queued analysis");
@@ -828,6 +860,10 @@ fn dj_profile_inflight_key(key: &AudioDjProfileKey) -> String {
     format!("{}:{}", key.media_ref_kind, key.media_ref_id)
 }
 
+fn deck_needs_profile_rebuild(deck: &DjDeckStatus) -> bool {
+    !deck.profile_ready && deck.profile_status != "decode_failed"
+}
+
 fn clear_dj_profile_inflight(
     inflight: &Arc<std::sync::Mutex<std::collections::HashMap<String, std::time::Instant>>>,
     key: &str,
@@ -835,6 +871,54 @@ fn clear_dj_profile_inflight(
     if let Ok(mut guard) = inflight.lock() {
         guard.remove(key);
     }
+}
+
+fn profile_rebuild_failures() -> &'static Mutex<HashMap<String, DjProfileRebuildFailure>> {
+    DJ_PROFILE_REBUILD_FAILURES.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn record_dj_profile_rebuild_failure(key: &str, status: &str, message: String) {
+    if let Ok(mut guard) = profile_rebuild_failures().lock() {
+        guard.insert(
+            key.to_string(),
+            DjProfileRebuildFailure {
+                status: status.to_string(),
+                message,
+                recorded_at: Instant::now(),
+            },
+        );
+    }
+}
+
+fn clear_dj_profile_rebuild_failure(key: &str) {
+    if let Ok(mut guard) = profile_rebuild_failures().lock() {
+        guard.remove(key);
+    }
+}
+
+fn recent_dj_profile_rebuild_failure(key: &str) -> Option<DjProfileRebuildFailure> {
+    let mut guard = profile_rebuild_failures().lock().ok()?;
+    match guard.get(key) {
+        Some(failure)
+            if failure.recorded_at.elapsed()
+                <= Duration::from_secs(DJ_PROFILE_REBUILD_FAILURE_TTL_SECS) =>
+        {
+            Some(failure.clone())
+        }
+        Some(_) => {
+            guard.remove(key);
+            None
+        }
+        None => None,
+    }
+}
+
+fn profile_rebuild_error_message(error: &anyhow::Error) -> String {
+    let message = error.to_string();
+    if message.trim().is_empty() {
+        return "Profile decode failed".to_string();
+    }
+    message.chars().take(160).collect()
 }
 
 async fn rebuild_track_for_tidal_ref(
@@ -1165,6 +1249,21 @@ fn deck_status(
     let key = media_ref.profile_key();
     let profile = queries::get_audio_dj_profile(conn, &key)?;
     let correction = queries::get_audio_dj_profile_correction(conn, &key)?;
+    let rebuild_key = dj_profile_inflight_key(&key);
+    let rebuild_failure = if profile.is_some() {
+        clear_dj_profile_rebuild_failure(&rebuild_key);
+        None
+    } else {
+        recent_dj_profile_rebuild_failure(&rebuild_key)
+    };
+    let profile_status = if profile.is_some() {
+        "ready".to_string()
+    } else if let Some(failure) = rebuild_failure.as_ref() {
+        failure.status.clone()
+    } else {
+        "missing".to_string()
+    };
+    let profile_error = rebuild_failure.map(|failure| failure.message);
     let (title, artist) = match label_override {
         Some((title, artist)) => (title.clone(), artist.clone()),
         None => media_ref_label(conn, media_ref)?,
@@ -1186,6 +1285,8 @@ fn deck_status(
         title,
         artist,
         profile_ready: profile.is_some(),
+        profile_status,
+        profile_error,
         profile_confidence,
         beat_count,
         downbeat_count,
@@ -2234,5 +2335,35 @@ mod tests {
 
         assert_eq!(first, ProfileRebuildInflightDecision::Start);
         assert_eq!(second, ProfileRebuildInflightDecision::AlreadyRunning);
+    }
+
+    #[test]
+    fn deck_status_exposes_recent_profile_decode_failure() {
+        let conn = rusqlite::Connection::open_in_memory().expect("db");
+        crate::db::schema::run_migrations(&conn).expect("migrations");
+        let media_ref = DjMediaRef::TidalTrack {
+            tidal_id: 12198473,
+            track_id: None,
+        };
+        let key = media_ref.profile_key();
+        let rebuild_key = dj_profile_inflight_key(&key);
+        clear_dj_profile_rebuild_failure(&rebuild_key);
+        record_dj_profile_rebuild_failure(
+            &rebuild_key,
+            "decode_failed",
+            "DASH stream prebuffer failed".to_string(),
+        );
+
+        let deck = deck_status(&conn, &media_ref, None).expect("deck status");
+
+        assert!(!deck.profile_ready);
+        assert_eq!(deck.profile_status, "decode_failed");
+        assert_eq!(
+            deck.profile_error.as_deref(),
+            Some("DASH stream prebuffer failed")
+        );
+        assert!(!deck_needs_profile_rebuild(&deck));
+
+        clear_dj_profile_rebuild_failure(&rebuild_key);
     }
 }

--- a/noor-server/src/services/audio_analysis/bpm.rs
+++ b/noor-server/src/services/audio_analysis/bpm.rs
@@ -56,6 +56,54 @@ pub fn detect_bpm(samples: &[f32], sample_rate: u32) -> Option<(f64, f64)> {
     bpm_from_analysis(&result.beat_times, &result.beat_confidences)
 }
 
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct BeatGridAnalysis {
+    pub bpm: f64,
+    pub confidence: f64,
+    pub beats_seconds: Vec<f32>,
+    pub downbeats_seconds: Vec<f32>,
+}
+
+pub fn analyze_beat_grid(samples: &[f32], sample_rate: u32) -> Option<BeatGridAnalysis> {
+    if sample_rate == 0 || samples.is_empty() {
+        return None;
+    }
+
+    let resampled = if sample_rate == TARGET_SAMPLE_RATE {
+        std::borrow::Cow::Borrowed(samples)
+    } else {
+        std::borrow::Cow::Owned(resample_linear(samples, sample_rate, TARGET_SAMPLE_RATE))
+    };
+    if resampled.len() < MIN_SAMPLES {
+        return None;
+    }
+
+    let config = CoreConfig::default();
+    let result = analyze_with_model_data(
+        resampled.as_ref(),
+        TARGET_SAMPLE_RATE,
+        &config,
+        MODEL_JSON,
+        MODEL_WEIGHTS,
+    )
+    .ok()?;
+    let (bpm, confidence) = bpm_from_analysis(&result.beat_times, &result.beat_confidences)?;
+    let downbeats_seconds = result
+        .beat_times
+        .iter()
+        .zip(result.beat_numbers.iter())
+        .filter_map(|(time, beat_number)| (*beat_number == 1).then_some(*time))
+        .collect::<Vec<_>>();
+
+    Some(BeatGridAnalysis {
+        bpm,
+        confidence,
+        beats_seconds: result.beat_times,
+        downbeats_seconds,
+    })
+}
+
 /// Compute (bpm, mean_confidence) from beat-time + per-beat-confidence arrays.
 /// Returned as `pub(crate)` so the unit tests can exercise it without spinning
 /// up the full model.
@@ -188,6 +236,27 @@ mod tests {
     fn rejects_zero_sample_rate() {
         let s = vec![0.0f32; 44_100 * 8];
         assert!(detect_bpm(&s, 0).is_none());
+    }
+
+    #[test]
+    fn beat_grid_analysis_rejects_short_clip() {
+        let s = vec![0.0f32; 1000];
+        assert!(analyze_beat_grid(&s, 44_100).is_none());
+    }
+
+    #[test]
+    fn beat_grid_analysis_rejects_zero_sample_rate() {
+        let s = vec![0.0f32; 44_100 * 8];
+        assert!(analyze_beat_grid(&s, 0).is_none());
+    }
+
+    #[test]
+    fn bpm_detect_bpm_still_works_for_existing_callers() {
+        let beats: Vec<f32> = (0..16).map(|i| 0.5 * (i as f32)).collect();
+        let confs = vec![0.8; beats.len()];
+        let (bpm, conf) = bpm_from_analysis(&beats, &confs).expect("bpm");
+        assert!((bpm - 120.0).abs() < 1.0);
+        assert!((conf - 0.8).abs() < 1e-6);
     }
 
     /// End-to-end smoke test: synthesize a 120 BPM click train at 44.1kHz,

--- a/noor-server/src/services/audio_analysis/dj_profile.rs
+++ b/noor-server/src/services/audio_analysis/dj_profile.rs
@@ -2,6 +2,7 @@ use crate::db::models::{
     AudioDjProfileCorrectionRow, AudioDjProfileKey, AudioDjProfileRow, AudioDspFeatures,
 };
 use crate::db::queries;
+use crate::playback::dj_lookahead::DjMediaRef;
 use anyhow::Result;
 use rusqlite::Connection;
 
@@ -12,7 +13,7 @@ pub const DJ_PROFILE_VERSION: &str = "dj_profile_v1";
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
 pub struct DjAnalysisJob {
-    pub media_ref: AudioDjProfileKey,
+    pub media_ref: DjMediaRef,
     pub track_id: Option<i64>,
     pub queue_item_id: Option<i64>,
     pub tidal_id: Option<i64>,
@@ -83,7 +84,7 @@ pub fn persist_dj_analysis_job_from_analysis(
     analysis: &BeatGridAnalysis,
 ) -> Result<()> {
     let row = build_audio_dj_profile_row_from_analysis(
-        job.media_ref.clone(),
+        job.media_ref.profile_key(),
         job.track_id,
         job.queue_item_id,
         job.tidal_id,
@@ -411,6 +412,17 @@ mod tests {
         }
     }
 
+    fn library_ref(track_id: i64) -> DjMediaRef {
+        DjMediaRef::LibraryTrack { track_id }
+    }
+
+    fn tidal_ref(tidal_id: i64) -> DjMediaRef {
+        DjMediaRef::TidalTrack {
+            tidal_id,
+            track_id: None,
+        }
+    }
+
     fn analysis(downbeat_count: usize) -> BeatGridAnalysis {
         BeatGridAnalysis {
             bpm: 120.0,
@@ -456,7 +468,7 @@ mod tests {
     #[test]
     fn dj_analysis_job_uses_media_ref_key() {
         let job = DjAnalysisJob {
-            media_ref: key("tidal_track", "55"),
+            media_ref: tidal_ref(55),
             track_id: None,
             queue_item_id: None,
             tidal_id: Some(55),
@@ -465,8 +477,9 @@ mod tests {
             analysis_scope_ms: 1_000,
             deadline_generation: 7,
         };
-        assert_eq!(job.media_ref.media_ref_kind, "tidal_track");
-        assert_eq!(job.media_ref.media_ref_id, "55");
+        let key = job.media_ref.profile_key();
+        assert_eq!(key.media_ref_kind, "tidal_track");
+        assert_eq!(key.media_ref_id, "55");
     }
 
     #[test]
@@ -516,7 +529,7 @@ mod tests {
             };
             queries::upsert_audio_dsp_features(conn, &dsp)?;
             let job = DjAnalysisJob {
-                media_ref: key("library_track", "1"),
+                media_ref: library_ref(1),
                 track_id: Some(1),
                 queue_item_id: None,
                 tidal_id: None,
@@ -766,7 +779,7 @@ mod tests {
         conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
         schema::run_migrations(&conn).expect("migrations");
         let job = DjAnalysisJob {
-            media_ref: key("tidal_track", "7"),
+            media_ref: tidal_ref(7),
             track_id: None,
             queue_item_id: None,
             tidal_id: Some(7),

--- a/noor-server/src/services/audio_analysis/dj_profile.rs
+++ b/noor-server/src/services/audio_analysis/dj_profile.rs
@@ -1,6 +1,4 @@
-use crate::db::models::{
-    AudioDjProfileCorrectionRow, AudioDjProfileKey, AudioDjProfileRow, AudioDspFeatures,
-};
+use crate::db::models::{AudioDjProfileCorrectionRow, AudioDjProfileKey, AudioDjProfileRow};
 use crate::db::queries;
 use crate::playback::dj_lookahead::DjMediaRef;
 use anyhow::Result;
@@ -403,7 +401,9 @@ fn read_count(blob: &[u8]) -> Option<u32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::db::models::AudioDspFeatures;
     use crate::db::{Database, schema};
+    use std::time::{Duration, Instant};
 
     fn key(kind: &str, id: &str) -> AudioDjProfileKey {
         AudioDjProfileKey {
@@ -693,6 +693,40 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
+    fn profile_build_benchmark() {
+        let cases = [("30s", 30_usize), ("90s", 90_usize), ("full", 180_usize)];
+        for (label, seconds) in cases {
+            let benchmark_samples = samples(seconds);
+            let benchmark_analysis = analysis((seconds / 2).max(1));
+            let mut timings = (0..5)
+                .map(|iteration| {
+                    let started = Instant::now();
+                    let row = build_audio_dj_profile_row_from_analysis(
+                        key("library_track", &(iteration + 1).to_string()),
+                        Some((iteration + 1) as i64),
+                        None,
+                        None,
+                        &benchmark_samples,
+                        48_000,
+                        "benchmark",
+                        &benchmark_analysis,
+                    );
+                    std::hint::black_box(row);
+                    started.elapsed()
+                })
+                .collect::<Vec<_>>();
+            timings.sort_unstable();
+            let median = timings[timings.len() / 2];
+            let peak_bytes = estimated_profile_build_peak_bytes(&benchmark_samples, seconds);
+            println!(
+                "dj_profile_build {label} median_ms={} peak_memory_bytes={peak_bytes}",
+                duration_ms(median)
+            );
+        }
+    }
+
+    #[test]
     fn correction_bpm_multiplier_adjusts_loaded_profile_bpm() {
         let mut profile = LoadedDjProfile {
             bpm: Some(120.0),
@@ -814,5 +848,25 @@ mod tests {
             created_at: "now".to_string(),
             updated_at: "now".to_string(),
         }
+    }
+
+    fn estimated_profile_build_peak_bytes(samples: &[f32], seconds: usize) -> usize {
+        let row = row_for("library_track", "999", seconds);
+        std::mem::size_of_val(samples)
+            + row.beat_grid_blob.len()
+            + row.downbeats_blob.len()
+            + row.phrase_boundaries_blob.len()
+            + row.mix_in_blob.len()
+            + row.mix_out_blob.len()
+            + row.safe_transition_windows_blob.len()
+            + row.energy_contour_blob.len()
+            + row.vocal_presence_blob.len()
+            + row.vocal_density_blob.len()
+            + row.breakdown_blob.len()
+            + row.drop_blob.len()
+    }
+
+    fn duration_ms(duration: Duration) -> u128 {
+        duration.as_micros() / 1_000
     }
 }

--- a/noor-server/src/services/audio_analysis/dj_profile.rs
+++ b/noor-server/src/services/audio_analysis/dj_profile.rs
@@ -3,8 +3,13 @@ use crate::db::queries;
 use crate::playback::dj_lookahead::DjMediaRef;
 use anyhow::Result;
 use rusqlite::Connection;
+use std::collections::HashSet;
+use std::sync::{Arc, Mutex};
+use tokio::sync::mpsc;
+use tracing::{debug, info, warn};
 
 use super::bpm::{self, BeatGridAnalysis};
+use super::{onset, tempo};
 
 pub const DJ_PROFILE_VERSION: &str = "dj_profile_v1";
 
@@ -19,6 +24,189 @@ pub struct DjAnalysisJob {
     pub sample_rate: u32,
     pub analysis_scope_ms: i64,
     pub deadline_generation: u64,
+}
+
+/// Spawn the DJ profile analysis actor. Returns the sender for profile jobs.
+///
+/// This actor is intentionally separate from passive DSP analysis. Playback and
+/// explicit rebuilds send decoded PCM here, and the actor writes only
+/// `audio_dj_profiles`.
+pub fn spawn_dj_profile_actor(db: crate::db::Database) -> mpsc::UnboundedSender<DjAnalysisJob> {
+    spawn_dj_profile_actor_with_analyzer(db, bpm::analyze_beat_grid)
+}
+
+fn spawn_dj_profile_actor_with_analyzer(
+    db: crate::db::Database,
+    analyzer: fn(&[f32], u32) -> Option<BeatGridAnalysis>,
+) -> mpsc::UnboundedSender<DjAnalysisJob> {
+    let (tx, mut rx) = mpsc::unbounded_channel::<DjAnalysisJob>();
+
+    tokio::spawn(async move {
+        let inflight = Arc::new(Mutex::new(HashSet::<String>::new()));
+        while let Some(job) = rx.recv().await {
+            if job.samples.is_empty() || job.sample_rate == 0 {
+                continue;
+            }
+
+            let key = job.media_ref.profile_key();
+            let inflight_key = profile_inflight_key(&key);
+            {
+                let Ok(mut guard) = inflight.lock() else {
+                    warn!("DJ profile inflight guard poisoned");
+                    continue;
+                };
+                if !guard.insert(inflight_key.clone()) {
+                    debug!(
+                        media_ref_kind = %key.media_ref_kind,
+                        media_ref_id = %key.media_ref_id,
+                        "Skipping duplicate in-flight DJ profile job"
+                    );
+                    continue;
+                }
+            }
+
+            let db_clone = db.clone();
+            let inflight_clone = inflight.clone();
+            let result = tokio::task::spawn_blocking(move || {
+                let result = persist_dj_analysis_job(&db_clone, job, analyzer);
+                clear_profile_inflight(&inflight_clone, &inflight_key);
+                result
+            })
+            .await
+            .map_err(|error| anyhow::anyhow!("DJ profile task join failed: {error}"))
+            .and_then(|result| result);
+
+            if let Err(error) = result {
+                warn!(error = %error, "DJ profile analysis failed");
+            }
+        }
+    });
+
+    tx
+}
+
+fn profile_inflight_key(key: &crate::db::models::AudioDjProfileKey) -> String {
+    format!("{}:{}", key.media_ref_kind, key.media_ref_id)
+}
+
+fn clear_profile_inflight(inflight: &Arc<Mutex<HashSet<String>>>, key: &str) {
+    if let Ok(mut guard) = inflight.lock() {
+        guard.remove(key);
+    }
+}
+
+fn persist_dj_analysis_job(
+    db: &crate::db::Database,
+    job: DjAnalysisJob,
+    analyzer: fn(&[f32], u32) -> Option<BeatGridAnalysis>,
+) -> Result<()> {
+    let key = job.media_ref.profile_key();
+    if db.with_conn(|conn| dj_analysis_skips_existing_profile_version(conn, &key))? {
+        debug!(
+            media_ref_kind = %key.media_ref_kind,
+            media_ref_id = %key.media_ref_id,
+            "Skipping current DJ profile"
+        );
+        return Ok(());
+    }
+
+    let analysis = if job.tidal_id.is_some() {
+        fallback_beat_grid_analysis(&job.samples, job.sample_rate).or_else(|| {
+            warn!(
+                media_ref_kind = %key.media_ref_kind,
+                media_ref_id = %key.media_ref_id,
+                "Persisting provisional DJ profile with default beat grid"
+            );
+            provisional_beat_grid_analysis(&job.samples, job.sample_rate)
+        })
+    } else {
+        analyzer(&job.samples, job.sample_rate)
+            .or_else(|| fallback_beat_grid_analysis(&job.samples, job.sample_rate))
+    };
+    let Some(analysis) = analysis else {
+        warn!(
+            media_ref_kind = %key.media_ref_kind,
+            media_ref_id = %key.media_ref_id,
+            "Skipping DJ profile with no beat-grid analysis"
+        );
+        return Ok(());
+    };
+
+    db.with_conn(|conn| {
+        persist_dj_analysis_job_from_analysis(conn, &job, "dj_playback", &analysis)
+    })?;
+    info!(
+        media_ref_kind = %key.media_ref_kind,
+        media_ref_id = %key.media_ref_id,
+        beats = analysis.beats_seconds.len(),
+        downbeats = analysis.downbeats_seconds.len(),
+        "DJ profile persisted"
+    );
+    Ok(())
+}
+
+fn fallback_beat_grid_analysis(samples: &[f32], sample_rate: u32) -> Option<BeatGridAnalysis> {
+    let env = onset::compute_onset_envelope(samples, sample_rate)?;
+    let estimate = tempo::estimate_tempo(&env)?;
+    if estimate.strength < 0.05 {
+        return None;
+    }
+    let bpm = estimate
+        .bpm
+        .clamp(tempo::BPM_MIN as f64, tempo::BPM_MAX as f64);
+    let beat_seconds = 60.0 / bpm;
+    if !beat_seconds.is_finite() || beat_seconds <= 0.0 {
+        return None;
+    }
+    let duration_seconds = samples.len() as f64 / sample_rate.max(1) as f64;
+    let beat_count = (duration_seconds / beat_seconds).floor() as usize;
+    if beat_count < 4 {
+        return None;
+    }
+    let beats_seconds = (0..beat_count)
+        .map(|beat| (beat as f64 * beat_seconds) as f32)
+        .collect::<Vec<_>>();
+    let downbeats_seconds = beats_seconds
+        .iter()
+        .enumerate()
+        .filter_map(|(index, seconds)| (index % 4 == 0).then_some(*seconds))
+        .collect::<Vec<_>>();
+    Some(BeatGridAnalysis {
+        bpm,
+        confidence: estimate.strength,
+        beats_seconds,
+        downbeats_seconds,
+    })
+}
+
+fn provisional_beat_grid_analysis(samples: &[f32], sample_rate: u32) -> Option<BeatGridAnalysis> {
+    if samples.is_empty() || sample_rate == 0 {
+        return None;
+    }
+
+    let bpm = tempo::PRIOR_CENTER_BPM;
+    let beat_seconds = 60.0 / bpm;
+    let duration_seconds = samples.len() as f64 / sample_rate as f64;
+    let beat_count = (duration_seconds / beat_seconds).floor() as usize;
+    if beat_count < 4 {
+        return None;
+    }
+
+    let beats_seconds = (0..beat_count)
+        .map(|beat| (beat as f64 * beat_seconds) as f32)
+        .collect::<Vec<_>>();
+    let downbeats_seconds = beats_seconds
+        .iter()
+        .enumerate()
+        .filter_map(|(index, seconds)| (index % 4 == 0).then_some(*seconds))
+        .collect::<Vec<_>>();
+
+    Some(BeatGridAnalysis {
+        bpm,
+        confidence: 0.05,
+        beats_seconds,
+        downbeats_seconds,
+    })
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -434,10 +622,32 @@ mod tests {
         }
     }
 
+    fn injected_analysis(_samples: &[f32], _sample_rate: u32) -> Option<BeatGridAnalysis> {
+        Some(analysis(64))
+    }
+
+    fn no_analysis(_samples: &[f32], _sample_rate: u32) -> Option<BeatGridAnalysis> {
+        None
+    }
+
     fn samples(seconds: usize) -> Vec<f32> {
         (0..seconds * 48_000)
             .map(|i| if i % 1000 < 500 { 0.5 } else { 0.25 })
             .collect()
+    }
+
+    fn click_train(sample_rate: u32, seconds: usize, bpm: f64) -> Vec<f32> {
+        let total = sample_rate as usize * seconds;
+        let period = (sample_rate as f64 * 60.0 / bpm).round() as usize;
+        let mut out = vec![0.0; total];
+        for start in (0..total).step_by(period.max(1)) {
+            for offset in 0..64 {
+                if let Some(sample) = out.get_mut(start + offset) {
+                    *sample = 1.0;
+                }
+            }
+        }
+        out
     }
 
     fn row_for(kind: &str, id: &str, seconds: usize) -> AudioDjProfileRow {
@@ -685,6 +895,15 @@ mod tests {
     }
 
     #[test]
+    fn fallback_beat_grid_builds_profile_when_primary_analysis_returns_none() {
+        let analysis = fallback_beat_grid_analysis(&click_train(48_000, 30, 120.0), 48_000)
+            .expect("fallback beat grid");
+        assert!(analysis.beats_seconds.len() > 40);
+        assert!(analysis.downbeats_seconds.len() > 10);
+        assert!((analysis.bpm - 120.0).abs() < 4.0);
+    }
+
+    #[test]
     fn profile_confidence_scales_with_analysis_scope() {
         assert_eq!(row_for("library_track", "1", 180).profile_confidence, 1.0);
         assert_eq!(row_for("tidal_track", "1", 90).profile_confidence, 0.65);
@@ -827,6 +1046,101 @@ mod tests {
             .expect("get")
             .expect("profile");
         assert_eq!(loaded.tidal_id, Some(7));
+    }
+
+    #[test]
+    fn tidal_job_persists_provisional_profile_when_detector_fails() {
+        let db = Database::open_in_memory().expect("db");
+        db.run_migrations().expect("migrations");
+        let job = DjAnalysisJob {
+            media_ref: tidal_ref(77),
+            track_id: None,
+            queue_item_id: None,
+            tidal_id: Some(77),
+            samples: vec![0.0; 90 * 48_000],
+            sample_rate: 48_000,
+            analysis_scope_ms: 90_000,
+            deadline_generation: 1,
+        };
+
+        persist_dj_analysis_job(&db, job, no_analysis).expect("persist");
+
+        let loaded = db
+            .with_conn(|conn| queries::get_audio_dj_profile(conn, &key("tidal_track", "77")))
+            .expect("get")
+            .expect("profile");
+        assert_eq!(loaded.tidal_id, Some(77));
+        assert_eq!(loaded.profile_confidence, 0.65);
+        assert!(!decode_f32_blob(&loaded.beat_grid_blob).unwrap().is_empty());
+        assert!(!decode_f32_blob(&loaded.downbeats_blob).unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn dj_profile_actor_persists_tidal_profile_key() {
+        let db = Database::open_in_memory().expect("db");
+        db.run_migrations().expect("migrations");
+        let tx = spawn_dj_profile_actor_with_analyzer(db.clone(), injected_analysis);
+
+        tx.send(DjAnalysisJob {
+            media_ref: tidal_ref(7),
+            track_id: None,
+            queue_item_id: None,
+            tidal_id: Some(7),
+            samples: click_train(48_000, 30, 120.0),
+            sample_rate: 48_000,
+            analysis_scope_ms: 30_000,
+            deadline_generation: 1,
+        })
+        .expect("send");
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            let profile = db
+                .with_conn(|conn| queries::get_audio_dj_profile(conn, &key("tidal_track", "7")))
+                .expect("get");
+            if let Some(profile) = profile {
+                assert_eq!(profile.media_ref_kind, "tidal_track");
+                assert_eq!(profile.media_ref_id, "7");
+                assert_eq!(profile.tidal_id, Some(7));
+                break;
+            }
+            assert!(Instant::now() < deadline, "timed out waiting for profile");
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn dj_profile_actor_ignores_empty_samples_and_invalid_sample_rate() {
+        let db = Database::open_in_memory().expect("db");
+        db.run_migrations().expect("migrations");
+        let tx = spawn_dj_profile_actor(db.clone());
+
+        for (tidal_id, samples, sample_rate) in
+            [(8, Vec::new(), 48_000_u32), (9, vec![0.0; 128], 0_u32)]
+        {
+            tx.send(DjAnalysisJob {
+                media_ref: tidal_ref(tidal_id),
+                track_id: None,
+                queue_item_id: None,
+                tidal_id: Some(tidal_id),
+                samples,
+                sample_rate,
+                analysis_scope_ms: 0,
+                deadline_generation: 1,
+            })
+            .expect("send");
+        }
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        db.with_conn(|conn| {
+            let count: i64 =
+                conn.query_row("SELECT COUNT(*) FROM audio_dj_profiles", [], |row| {
+                    row.get(0)
+                })?;
+            assert_eq!(count, 0);
+            Ok(())
+        })
+        .expect("count");
     }
 
     fn correction(

--- a/noor-server/src/services/audio_analysis/dj_profile.rs
+++ b/noor-server/src/services/audio_analysis/dj_profile.rs
@@ -1,0 +1,805 @@
+use crate::db::models::{
+    AudioDjProfileCorrectionRow, AudioDjProfileKey, AudioDjProfileRow, AudioDspFeatures,
+};
+use crate::db::queries;
+use anyhow::Result;
+use rusqlite::Connection;
+
+use super::bpm::{self, BeatGridAnalysis};
+
+pub const DJ_PROFILE_VERSION: &str = "dj_profile_v1";
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct DjAnalysisJob {
+    pub media_ref: AudioDjProfileKey,
+    pub track_id: Option<i64>,
+    pub queue_item_id: Option<i64>,
+    pub tidal_id: Option<i64>,
+    pub samples: Vec<f32>,
+    pub sample_rate: u32,
+    pub analysis_scope_ms: i64,
+    pub deadline_generation: u64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SafeTransitionWindow {
+    pub start_seconds: f32,
+    pub end_seconds: f32,
+    pub confidence: f32,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct LoadedDjProfile {
+    pub bpm: Option<f32>,
+    pub downbeats_seconds: Vec<f32>,
+    pub phrase_bar_indices: Vec<u32>,
+    pub safe_crossfade_only: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PlannerPolicyShape {
+    pub default_crossfade_ms: u32,
+    pub transition_speed_bias: String,
+}
+
+#[allow(dead_code)]
+pub fn build_audio_dj_profile_row(
+    key: AudioDjProfileKey,
+    track_id: Option<i64>,
+    queue_item_id: Option<i64>,
+    tidal_id: Option<i64>,
+    samples: &[f32],
+    sample_rate: u32,
+    source: &str,
+) -> Option<AudioDjProfileRow> {
+    let beat_grid = bpm::analyze_beat_grid(samples, sample_rate)?;
+    Some(build_audio_dj_profile_row_from_analysis(
+        key,
+        track_id,
+        queue_item_id,
+        tidal_id,
+        samples,
+        sample_rate,
+        source,
+        &beat_grid,
+    ))
+}
+
+pub fn dj_analysis_skips_existing_profile_version(
+    conn: &Connection,
+    key: &AudioDjProfileKey,
+) -> Result<bool> {
+    let existing = queries::get_audio_dj_profile(conn, key)?;
+    Ok(existing
+        .as_ref()
+        .is_some_and(|row| row.profile_version == DJ_PROFILE_VERSION))
+}
+
+pub fn persist_dj_analysis_job_from_analysis(
+    conn: &Connection,
+    job: &DjAnalysisJob,
+    source: &str,
+    analysis: &BeatGridAnalysis,
+) -> Result<()> {
+    let row = build_audio_dj_profile_row_from_analysis(
+        job.media_ref.clone(),
+        job.track_id,
+        job.queue_item_id,
+        job.tidal_id,
+        &job.samples,
+        job.sample_rate,
+        source,
+        analysis,
+    );
+    queries::upsert_audio_dj_profile(conn, &row)
+}
+
+pub fn encode_f32_blob(values: &[f32]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(4 + values.len() * 4);
+    out.extend_from_slice(&(values.len() as u32).to_le_bytes());
+    for value in values {
+        out.extend_from_slice(&value.to_le_bytes());
+    }
+    out
+}
+
+pub fn decode_f32_blob(blob: &[u8]) -> Option<Vec<f32>> {
+    let payload = payload_after_count(blob, 4)?;
+    let count = read_count(blob)? as usize;
+    if payload.len() != count.checked_mul(4)? {
+        return None;
+    }
+    let mut values = Vec::with_capacity(count);
+    for chunk in payload.chunks_exact(4) {
+        let value = f32::from_le_bytes(chunk.try_into().ok()?);
+        if !value.is_finite() {
+            return None;
+        }
+        values.push(value);
+    }
+    Some(values)
+}
+
+pub fn encode_u32_blob(values: &[u32]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(4 + values.len() * 4);
+    out.extend_from_slice(&(values.len() as u32).to_le_bytes());
+    for value in values {
+        out.extend_from_slice(&value.to_le_bytes());
+    }
+    out
+}
+
+pub fn decode_u32_blob(blob: &[u8]) -> Option<Vec<u32>> {
+    let payload = payload_after_count(blob, 4)?;
+    let count = read_count(blob)? as usize;
+    if payload.len() != count.checked_mul(4)? {
+        return None;
+    }
+    Some(
+        payload
+            .chunks_exact(4)
+            .map(|chunk| u32::from_le_bytes(chunk.try_into().expect("chunk size")))
+            .collect(),
+    )
+}
+
+pub fn encode_safe_transition_windows(windows: &[SafeTransitionWindow]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(4 + windows.len() * 12);
+    out.extend_from_slice(&(windows.len() as u32).to_le_bytes());
+    for window in windows {
+        out.extend_from_slice(&window.start_seconds.to_le_bytes());
+        out.extend_from_slice(&window.end_seconds.to_le_bytes());
+        out.extend_from_slice(&window.confidence.to_le_bytes());
+    }
+    out
+}
+
+pub fn decode_safe_transition_windows(blob: &[u8]) -> Option<Vec<SafeTransitionWindow>> {
+    let payload = payload_after_count(blob, 12)?;
+    let count = read_count(blob)? as usize;
+    if payload.len() != count.checked_mul(12)? {
+        return None;
+    }
+    let mut windows = Vec::with_capacity(count);
+    for chunk in payload.chunks_exact(12) {
+        let start_seconds = f32::from_le_bytes(chunk[0..4].try_into().ok()?);
+        let end_seconds = f32::from_le_bytes(chunk[4..8].try_into().ok()?);
+        let confidence = f32::from_le_bytes(chunk[8..12].try_into().ok()?);
+        if !start_seconds.is_finite() || !end_seconds.is_finite() || !confidence.is_finite() {
+            return None;
+        }
+        windows.push(SafeTransitionWindow {
+            start_seconds,
+            end_seconds,
+            confidence,
+        });
+    }
+    Some(windows)
+}
+
+pub fn apply_correction_to_loaded_profile(
+    profile: &mut LoadedDjProfile,
+    correction: &AudioDjProfileCorrectionRow,
+) {
+    if let (Some(bpm), Some(multiplier)) = (profile.bpm, correction.bpm_multiplier) {
+        profile.bpm = Some((bpm as f64 * multiplier) as f32);
+    }
+    if let Some(offset) = correction.downbeat_offset_beats {
+        let beat_seconds = profile
+            .downbeats_seconds
+            .windows(2)
+            .next()
+            .map(|w| (w[1] - w[0]).abs() / 4.0)
+            .filter(|value| value.is_finite() && *value > 0.0)
+            .unwrap_or(0.5);
+        for downbeat in &mut profile.downbeats_seconds {
+            *downbeat += beat_seconds * offset as f32;
+        }
+    }
+    if let Some(offset) = correction.phrase_offset_bars {
+        for phrase in &mut profile.phrase_bar_indices {
+            let shifted = i64::from(*phrase) + offset;
+            *phrase = shifted.max(0) as u32;
+        }
+    }
+    if correction.safe_crossfade_only {
+        profile.safe_crossfade_only = true;
+    }
+}
+
+pub fn transition_speed_bias_to_policy_shape(bias: Option<&str>) -> PlannerPolicyShape {
+    let (default_crossfade_ms, transition_speed_bias) = match bias {
+        Some("slower") => (12_000, "slower"),
+        Some("faster") => (6_000, "faster"),
+        _ => (8_000, "neutral"),
+    };
+    PlannerPolicyShape {
+        default_crossfade_ms,
+        transition_speed_bias: transition_speed_bias.to_string(),
+    }
+}
+
+fn build_audio_dj_profile_row_from_analysis(
+    key: AudioDjProfileKey,
+    track_id: Option<i64>,
+    queue_item_id: Option<i64>,
+    tidal_id: Option<i64>,
+    samples: &[f32],
+    sample_rate: u32,
+    source: &str,
+    analysis: &BeatGridAnalysis,
+) -> AudioDjProfileRow {
+    let analysis_scope_ms = if sample_rate == 0 {
+        0
+    } else {
+        ((samples.len() as f64 / sample_rate as f64) * 1000.0).round() as i64
+    };
+    let profile_confidence = profile_confidence(&key, analysis_scope_ms);
+    let phrase_boundaries = phrase_boundaries_every_eight_downbeats(&analysis.downbeats_seconds);
+    let energy_contour =
+        energy_contour_by_phrase(samples, sample_rate, &analysis.downbeats_seconds);
+    let mix_in = mix_in_points(&analysis.downbeats_seconds, profile_confidence);
+    let mix_out = mix_out_points(&analysis.downbeats_seconds, profile_confidence);
+    let windows = safe_transition_windows(&mix_in, &mix_out, profile_confidence);
+    let confident_structure = profile_confidence >= 0.4 && !analysis.downbeats_seconds.is_empty();
+
+    AudioDjProfileRow {
+        media_ref_kind: key.media_ref_kind.clone(),
+        media_ref_id: key.media_ref_id.clone(),
+        track_id,
+        queue_item_id,
+        tidal_id,
+        profile_version: DJ_PROFILE_VERSION.to_string(),
+        beat_grid_blob: encode_f32_blob(&analysis.beats_seconds),
+        downbeats_blob: encode_f32_blob(&analysis.downbeats_seconds),
+        phrase_boundaries_blob: encode_u32_blob(&phrase_boundaries),
+        mix_in_blob: encode_f32_blob(&mix_in),
+        mix_out_blob: encode_f32_blob(&mix_out),
+        intro_end_seconds: confident_structure
+            .then(|| f64::from(*analysis.downbeats_seconds.get(8).unwrap_or(&0.0))),
+        outro_start_seconds: confident_structure.then(|| {
+            f64::from(
+                analysis
+                    .downbeats_seconds
+                    .get(analysis.downbeats_seconds.len().saturating_sub(8))
+                    .copied()
+                    .unwrap_or(0.0),
+            )
+        }),
+        breakdown_blob: encode_f32_blob(
+            analysis
+                .downbeats_seconds
+                .get(16)
+                .map(std::slice::from_ref)
+                .unwrap_or(&[]),
+        ),
+        drop_blob: encode_f32_blob(
+            analysis
+                .downbeats_seconds
+                .get(24)
+                .map(std::slice::from_ref)
+                .unwrap_or(&[]),
+        ),
+        safe_transition_windows_blob: encode_safe_transition_windows(&windows),
+        energy_contour_blob: encode_f32_blob(&energy_contour),
+        vocal_presence_blob: encode_f32_blob(&vec![0.0; phrase_boundaries.len().max(1)]),
+        vocal_density_blob: encode_f32_blob(&vec![0.0; phrase_boundaries.len().max(1)]),
+        lufs_loud_body: None,
+        true_peak_dbtp: None,
+        beat_confidence: Some(analysis.confidence),
+        profile_confidence,
+        analysis_scope_ms,
+        is_temporary: key.media_ref_kind == "queue_item",
+        source: source.to_string(),
+        computed_at: chrono::Utc::now().to_rfc3339(),
+    }
+}
+
+fn profile_confidence(key: &AudioDjProfileKey, analysis_scope_ms: i64) -> f64 {
+    if key.media_ref_kind == "library_track" && analysis_scope_ms >= 120_000 {
+        1.0
+    } else if analysis_scope_ms >= 90_000 {
+        0.65
+    } else if analysis_scope_ms >= 30_000 {
+        0.4
+    } else {
+        (analysis_scope_ms.max(0) as f64 / 30_000.0) * 0.39
+    }
+}
+
+fn phrase_boundaries_every_eight_downbeats(downbeats: &[f32]) -> Vec<u32> {
+    (0..downbeats.len() as u32).step_by(8).collect()
+}
+
+fn mix_in_points(downbeats: &[f32], confidence: f64) -> Vec<f32> {
+    if confidence < 0.4 {
+        return Vec::new();
+    }
+    downbeats.iter().take(4).copied().collect()
+}
+
+fn mix_out_points(downbeats: &[f32], confidence: f64) -> Vec<f32> {
+    if confidence < 0.4 {
+        return Vec::new();
+    }
+    downbeats
+        .iter()
+        .rev()
+        .take(4)
+        .copied()
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect()
+}
+
+fn safe_transition_windows(
+    mix_in: &[f32],
+    mix_out: &[f32],
+    profile_confidence: f64,
+) -> Vec<SafeTransitionWindow> {
+    mix_in
+        .iter()
+        .copied()
+        .chain(mix_out.iter().copied())
+        .map(|start_seconds| SafeTransitionWindow {
+            start_seconds,
+            end_seconds: start_seconds + 8.0,
+            confidence: profile_confidence as f32,
+        })
+        .collect()
+}
+
+fn energy_contour_by_phrase(samples: &[f32], sample_rate: u32, downbeats: &[f32]) -> Vec<f32> {
+    let phrases = phrase_boundaries_every_eight_downbeats(downbeats);
+    if phrases.is_empty() || sample_rate == 0 || samples.is_empty() {
+        return vec![0.0];
+    }
+    let mut values = phrases
+        .iter()
+        .map(|phrase| {
+            let start = downbeats
+                .get(*phrase as usize)
+                .map(|seconds| (*seconds * sample_rate as f32) as usize)
+                .unwrap_or(0)
+                .min(samples.len());
+            let end = downbeats
+                .get((*phrase as usize) + 8)
+                .map(|seconds| (*seconds * sample_rate as f32) as usize)
+                .unwrap_or(samples.len())
+                .min(samples.len());
+            rms(&samples[start..end])
+        })
+        .collect::<Vec<_>>();
+    let peak = values.iter().copied().fold(0.0, f32::max);
+    if peak > 0.0 {
+        for value in &mut values {
+            *value /= peak;
+        }
+    }
+    values
+}
+
+fn rms(samples: &[f32]) -> f32 {
+    if samples.is_empty() {
+        return 0.0;
+    }
+    (samples.iter().map(|sample| sample * sample).sum::<f32>() / samples.len() as f32).sqrt()
+}
+
+fn payload_after_count(blob: &[u8], width: usize) -> Option<&[u8]> {
+    let count = read_count(blob)? as usize;
+    let expected = count.checked_mul(width)?;
+    let payload = blob.get(4..)?;
+    (payload.len() == expected).then_some(payload)
+}
+
+fn read_count(blob: &[u8]) -> Option<u32> {
+    Some(u32::from_le_bytes(blob.get(0..4)?.try_into().ok()?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::{Database, schema};
+
+    fn key(kind: &str, id: &str) -> AudioDjProfileKey {
+        AudioDjProfileKey {
+            media_ref_kind: kind.to_string(),
+            media_ref_id: id.to_string(),
+        }
+    }
+
+    fn analysis(downbeat_count: usize) -> BeatGridAnalysis {
+        BeatGridAnalysis {
+            bpm: 120.0,
+            confidence: 0.9,
+            beats_seconds: (0..downbeat_count * 4)
+                .map(|beat| beat as f32 * 0.5)
+                .collect(),
+            downbeats_seconds: (0..downbeat_count).map(|bar| bar as f32 * 2.0).collect(),
+        }
+    }
+
+    fn samples(seconds: usize) -> Vec<f32> {
+        (0..seconds * 48_000)
+            .map(|i| if i % 1000 < 500 { 0.5 } else { 0.25 })
+            .collect()
+    }
+
+    fn row_for(kind: &str, id: &str, seconds: usize) -> AudioDjProfileRow {
+        build_audio_dj_profile_row_from_analysis(
+            key(kind, id),
+            (kind == "library_track").then_some(id.parse().unwrap_or(1)),
+            (kind == "queue_item").then_some(id.parse().unwrap_or(1)),
+            (kind == "tidal_track").then_some(id.parse().unwrap_or(1)),
+            &samples(seconds),
+            48_000,
+            "test",
+            &analysis(64),
+        )
+    }
+
+    #[test]
+    fn passive_analysis_job_shape_stays_track_id_keyed() {
+        let job: super::super::AnalysisJob = (42, vec![0.0], 48_000);
+        assert_eq!(job.0, 42);
+        assert_eq!(job.2, 48_000);
+    }
+
+    #[test]
+    fn dj_profile_version_is_independent_from_planner_version() {
+        assert_ne!(DJ_PROFILE_VERSION, "dj_planner_v1");
+    }
+
+    #[test]
+    fn dj_analysis_job_uses_media_ref_key() {
+        let job = DjAnalysisJob {
+            media_ref: key("tidal_track", "55"),
+            track_id: None,
+            queue_item_id: None,
+            tidal_id: Some(55),
+            samples: vec![0.0],
+            sample_rate: 48_000,
+            analysis_scope_ms: 1_000,
+            deadline_generation: 7,
+        };
+        assert_eq!(job.media_ref.media_ref_kind, "tidal_track");
+        assert_eq!(job.media_ref.media_ref_id, "55");
+    }
+
+    #[test]
+    fn dj_analysis_skips_existing_profile_version() {
+        let db = Database::open_in_memory().expect("db");
+        db.run_migrations().expect("migrations");
+        db.with_conn(|conn| {
+            let row = row_for("tidal_track", "1", 90);
+            queries::upsert_audio_dj_profile(conn, &row)?;
+            assert!(super::dj_analysis_skips_existing_profile_version(
+                conn,
+                &key("tidal_track", "1")
+            )?);
+            Ok(())
+        })
+        .expect("check");
+    }
+
+    #[test]
+    fn dj_analysis_does_not_clobber_audio_dsp_features() {
+        let db = Database::open_in_memory().expect("db");
+        db.run_migrations().expect("migrations");
+        db.with_conn(|conn| {
+            conn.execute("INSERT INTO artists (name) VALUES ('Artist')", [])?;
+            let artist_id = conn.last_insert_rowid();
+            conn.execute(
+                "INSERT INTO tracks (id, title, artist_id) VALUES (1, 'Track', ?1)",
+                rusqlite::params![artist_id],
+            )?;
+            let dsp = AudioDspFeatures {
+                track_id: 1,
+                bpm: Some(120.0),
+                key_signature: None,
+                camelot_key: None,
+                loudness_lufs: None,
+                energy: Some(0.5),
+                danceability: None,
+                beat_strength: None,
+                spectral_centroid: None,
+                stereo_width: None,
+                is_instrumental: false,
+                analysis_source: "test".to_string(),
+                analysis_offset_ms: 0,
+                samples_analyzed: Some(100),
+                analyzed_at: "now".to_string(),
+                analysis_version: super::super::CURRENT_ANALYSIS_VERSION.to_string(),
+            };
+            queries::upsert_audio_dsp_features(conn, &dsp)?;
+            let job = DjAnalysisJob {
+                media_ref: key("library_track", "1"),
+                track_id: Some(1),
+                queue_item_id: None,
+                tidal_id: None,
+                samples: samples(90),
+                sample_rate: 48_000,
+                analysis_scope_ms: 90_000,
+                deadline_generation: 1,
+            };
+            persist_dj_analysis_job_from_analysis(conn, &job, "test", &analysis(64))?;
+            let loaded = queries::get_audio_dsp_features(conn, 1)?.expect("dsp");
+            assert_eq!(loaded.bpm, Some(120.0));
+            assert_eq!(loaded.analysis_source, "test");
+            Ok(())
+        })
+        .expect("persist");
+    }
+
+    #[test]
+    fn phrase_boundaries_every_eight_downbeats() {
+        assert_eq!(
+            super::phrase_boundaries_every_eight_downbeats(&analysis(24).downbeats_seconds),
+            vec![0, 8, 16]
+        );
+    }
+
+    #[test]
+    fn structure_markers_are_persisted_in_v1_profile() {
+        let row = row_for("library_track", "1", 180);
+        assert!(row.intro_end_seconds.is_some());
+        assert!(row.outro_start_seconds.is_some());
+        assert!(!row.breakdown_blob.is_empty());
+        assert!(!row.drop_blob.is_empty());
+    }
+
+    #[test]
+    fn mix_points_align_to_downbeats_when_confident() {
+        let row = row_for("library_track", "1", 180);
+        let downbeats = decode_f32_blob(&row.downbeats_blob).expect("downbeats");
+        let mix_in = decode_f32_blob(&row.mix_in_blob).expect("mix in");
+        assert!(mix_in.iter().all(|point| downbeats.contains(point)));
+    }
+
+    #[test]
+    fn safe_transition_windows_round_trip() {
+        let windows = vec![SafeTransitionWindow {
+            start_seconds: 1.0,
+            end_seconds: 9.0,
+            confidence: 0.7,
+        }];
+        assert_eq!(
+            decode_safe_transition_windows(&encode_safe_transition_windows(&windows)),
+            Some(windows)
+        );
+    }
+
+    #[test]
+    fn low_confidence_profile_omits_intro_outro_estimates() {
+        let row = row_for("tidal_track", "1", 10);
+        assert!(row.profile_confidence < 0.4);
+        assert_eq!(row.intro_end_seconds, None);
+        assert_eq!(row.outro_start_seconds, None);
+    }
+
+    #[test]
+    fn energy_contour_normalizes_peak_to_one() {
+        let row = row_for("library_track", "1", 180);
+        let contour = decode_f32_blob(&row.energy_contour_blob).expect("contour");
+        assert!(contour.iter().any(|value| (*value - 1.0).abs() < 1e-6));
+    }
+
+    #[test]
+    fn vocal_presence_defaults_to_zero() {
+        let row = row_for("library_track", "1", 180);
+        let values = decode_f32_blob(&row.vocal_presence_blob).expect("vocal presence");
+        assert!(values.iter().all(|value| *value == 0.0));
+    }
+
+    #[test]
+    fn vocal_density_defaults_to_zero() {
+        let row = row_for("library_track", "1", 180);
+        let values = decode_f32_blob(&row.vocal_density_blob).expect("vocal density");
+        assert!(values.iter().all(|value| *value == 0.0));
+    }
+
+    #[test]
+    fn profile_blob_round_trips_f32_values() {
+        let values = vec![0.0, 1.25, 2.5];
+        assert_eq!(decode_f32_blob(&encode_f32_blob(&values)), Some(values));
+    }
+
+    #[test]
+    fn profile_blob_round_trips_u32_values() {
+        let values = vec![0, 8, 16];
+        assert_eq!(decode_u32_blob(&encode_u32_blob(&values)), Some(values));
+    }
+
+    #[test]
+    fn profile_blob_rejects_truncated_payload() {
+        assert!(decode_f32_blob(&[1, 0, 0, 0, 1]).is_none());
+    }
+
+    #[test]
+    fn profile_blob_rejects_non_finite_float() {
+        let mut blob = Vec::new();
+        blob.extend_from_slice(&1_u32.to_le_bytes());
+        blob.extend_from_slice(&f32::NAN.to_le_bytes());
+        assert!(decode_f32_blob(&blob).is_none());
+    }
+
+    #[test]
+    fn profile_row_blobs_decode_to_expected_lengths() {
+        let row = row_for("library_track", "1", 180);
+        assert_eq!(decode_f32_blob(&row.beat_grid_blob).unwrap().len(), 256);
+        assert_eq!(decode_f32_blob(&row.downbeats_blob).unwrap().len(), 64);
+        assert_eq!(
+            decode_u32_blob(&row.phrase_boundaries_blob).unwrap().len(),
+            8
+        );
+    }
+
+    #[test]
+    fn profile_builder_preserves_tidal_media_ref() {
+        let row = row_for("tidal_track", "123", 90);
+        assert_eq!(row.media_ref_kind, "tidal_track");
+        assert_eq!(row.media_ref_id, "123");
+        assert_eq!(row.tidal_id, Some(123));
+    }
+
+    #[test]
+    fn profile_builder_allows_pending_queue_ref() {
+        let row = row_for("queue_item", "44", 30);
+        assert_eq!(row.media_ref_kind, "queue_item");
+        assert_eq!(row.queue_item_id, Some(44));
+    }
+
+    #[test]
+    fn profile_builder_marks_pending_queue_ref_temporary() {
+        let row = row_for("queue_item", "44", 30);
+        assert!(row.is_temporary);
+    }
+
+    #[test]
+    fn profile_builder_supports_local_tidal_and_pending_sources() {
+        assert_eq!(
+            row_for("library_track", "1", 180).media_ref_kind,
+            "library_track"
+        );
+        assert_eq!(
+            row_for("tidal_track", "2", 90).media_ref_kind,
+            "tidal_track"
+        );
+        assert_eq!(row_for("queue_item", "3", 30).media_ref_kind, "queue_item");
+    }
+
+    #[test]
+    fn profile_confidence_scales_with_analysis_scope() {
+        assert_eq!(row_for("library_track", "1", 180).profile_confidence, 1.0);
+        assert_eq!(row_for("tidal_track", "1", 90).profile_confidence, 0.65);
+        assert_eq!(row_for("tidal_track", "1", 30).profile_confidence, 0.4);
+        assert!(row_for("tidal_track", "1", 10).profile_confidence < 0.4);
+    }
+
+    #[test]
+    fn correction_bpm_multiplier_adjusts_loaded_profile_bpm() {
+        let mut profile = LoadedDjProfile {
+            bpm: Some(120.0),
+            downbeats_seconds: vec![0.0, 2.0],
+            phrase_bar_indices: vec![0],
+            safe_crossfade_only: false,
+        };
+        let correction = correction(Some(2.0), None, None, false, None);
+        apply_correction_to_loaded_profile(&mut profile, &correction);
+        assert_eq!(profile.bpm, Some(240.0));
+    }
+
+    #[test]
+    fn correction_offsets_adjust_loaded_downbeats_and_phrases() {
+        let mut profile = LoadedDjProfile {
+            bpm: Some(120.0),
+            downbeats_seconds: vec![0.0, 2.0],
+            phrase_bar_indices: vec![8],
+            safe_crossfade_only: false,
+        };
+        let correction = correction(None, Some(2), Some(-3), false, None);
+        apply_correction_to_loaded_profile(&mut profile, &correction);
+        assert_eq!(profile.downbeats_seconds, vec![1.0, 3.0]);
+        assert_eq!(profile.phrase_bar_indices, vec![5]);
+    }
+
+    #[test]
+    fn safe_crossfade_only_correction_sets_planner_safety_flag() {
+        let mut profile = LoadedDjProfile {
+            bpm: Some(120.0),
+            downbeats_seconds: vec![0.0, 2.0],
+            phrase_bar_indices: vec![0],
+            safe_crossfade_only: false,
+        };
+        let correction = correction(None, None, None, true, None);
+        apply_correction_to_loaded_profile(&mut profile, &correction);
+        assert!(profile.safe_crossfade_only);
+    }
+
+    #[test]
+    fn transition_speed_bias_maps_to_policy_duration_preference() {
+        assert_eq!(
+            transition_speed_bias_to_policy_shape(Some("faster")).default_crossfade_ms,
+            6_000
+        );
+        assert_eq!(
+            transition_speed_bias_to_policy_shape(Some("slower")).default_crossfade_ms,
+            12_000
+        );
+        assert_eq!(
+            transition_speed_bias_to_policy_shape(None).transition_speed_bias,
+            "neutral"
+        );
+    }
+
+    #[test]
+    fn raw_profile_builder_ignores_user_corrections() {
+        let row = row_for("tidal_track", "1", 90);
+        let correction = correction(Some(2.0), None, None, true, Some("faster"));
+        assert_eq!(row.profile_confidence, 0.65);
+        assert!(!row.is_temporary);
+        assert_eq!(correction.bpm_multiplier, Some(2.0));
+    }
+
+    #[test]
+    fn analyze_and_save_does_not_write_audio_dj_profile() {
+        let db = Database::open_in_memory().expect("db");
+        db.run_migrations().expect("migrations");
+        super::super::engine::analyze_and_save(&db, &[0.0; 128], 48_000, "test", 1, 0);
+        db.with_conn(|conn| {
+            let count: i64 =
+                conn.query_row("SELECT COUNT(*) FROM audio_dj_profiles", [], |row| {
+                    row.get(0)
+                })?;
+            assert_eq!(count, 0);
+            Ok(())
+        })
+        .expect("count");
+    }
+
+    #[test]
+    fn dj_analysis_job_persists_audio_dj_profile() {
+        let conn = rusqlite::Connection::open_in_memory().expect("db");
+        conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+        schema::run_migrations(&conn).expect("migrations");
+        let job = DjAnalysisJob {
+            media_ref: key("tidal_track", "7"),
+            track_id: None,
+            queue_item_id: None,
+            tidal_id: Some(7),
+            samples: samples(90),
+            sample_rate: 48_000,
+            analysis_scope_ms: 90_000,
+            deadline_generation: 1,
+        };
+        persist_dj_analysis_job_from_analysis(&conn, &job, "test", &analysis(64)).expect("persist");
+        let loaded = queries::get_audio_dj_profile(&conn, &key("tidal_track", "7"))
+            .expect("get")
+            .expect("profile");
+        assert_eq!(loaded.tidal_id, Some(7));
+    }
+
+    fn correction(
+        bpm_multiplier: Option<f64>,
+        downbeat_offset_beats: Option<i64>,
+        phrase_offset_bars: Option<i64>,
+        safe_crossfade_only: bool,
+        transition_speed_bias: Option<&str>,
+    ) -> AudioDjProfileCorrectionRow {
+        AudioDjProfileCorrectionRow {
+            media_ref_kind: "tidal_track".to_string(),
+            media_ref_id: "1".to_string(),
+            bpm_multiplier,
+            downbeat_offset_beats,
+            phrase_offset_bars,
+            safe_crossfade_only,
+            transition_speed_bias: transition_speed_bias.map(str::to_string),
+            notes: None,
+            created_at: "now".to_string(),
+            updated_at: "now".to_string(),
+        }
+    }
+}

--- a/noor-server/src/services/audio_analysis/mod.rs
+++ b/noor-server/src/services/audio_analysis/mod.rs
@@ -1,5 +1,6 @@
 pub mod beat_tracker;
 pub mod bpm;
+pub mod dj_profile;
 pub mod engine;
 pub mod features;
 pub mod fingerprint;


### PR DESCRIPTION
## Summary

- Adds the deterministic DJ mix core and transition planner plumbing.
- Adds DJ cockpit/status visibility, timing history, planning reason and downgrade separation.
- Enables SafeCrossfade and FilterSweep as renderable templates, with SlamCut still downgraded.
- Adds timing metrics, fire-ahead evidence gating, profile rebuild safeguards, and playback/dropout fixes from testing.
- Adds the BassSwap16 follow-up plan under `.scratch/dj-bassswap-renderable/PRD.md`.

## Verification

- `cargo test -p noor-mix`
- `cargo test -p noor-server playback::player::tests::dj`
- `cargo test -p noor-server server::routes::dj_routes::tests`
- `cargo test -p noor-server db::queries::tests::dj_transition_event`
- `pnpm test -- dj_page_contract`
- `pnpm check` after rerun for Windows `.svelte-kit` EPERM lock
- `cargo fmt --all -- --check`
- `git diff --check`

## Notes

- Built this PR from a clean branch off `origin/master` to avoid unrelated search, artwork, discovery, and release commits from the working branch.
- `SlamCut` remains blocked until downbeat confidence is stronger.