### PR TITLE
feat(dj): render BassSwap16 transitions

### DIFF
--- a/noor-mix/src/planner/mod.rs
+++ b/noor-mix/src/planner/mod.rs
@@ -124,7 +124,9 @@ fn build_program(
         template,
         TransitionTemplate::BassSwap16 | TransitionTemplate::BassSwap32
     ) {
-        program.automation.extend(low_band_swap(swap_start));
+        program
+            .automation
+            .extend(bass_swap_eq_handoff(duration_samples));
     }
 
     if matches!(template, TransitionTemplate::FilterSweep) {
@@ -147,6 +149,35 @@ fn build_program(
         });
     }
 
+    program
+}
+
+pub fn bass_swap_16_program(
+    sample_rate: u32,
+    channels: u16,
+    duration_ms: u32,
+) -> TransitionProgram {
+    let sample_rate = sample_rate.max(1);
+    let channels = channels.max(1);
+    let duration_samples =
+        (u64::from(duration_ms).saturating_mul(u64::from(sample_rate)) / 1_000).max(1);
+    let swap_start = duration_samples / 2;
+    let mut program = TransitionProgram {
+        tier: Tier::FullBlend,
+        template: "BassSwap16".to_string(),
+        sample_rate,
+        channels,
+        sync_start: 0,
+        intro_start: 0,
+        swap_start,
+        fade_start: swap_start,
+        resolve_at: duration_samples,
+        loops: vec![],
+        automation: deck_gain_automation(duration_samples),
+    };
+    program
+        .automation
+        .extend(bass_swap_eq_handoff(duration_samples));
     program
 }
 
@@ -235,25 +266,88 @@ fn deck_gain_automation(duration_samples: u64) -> Vec<AutomationEvent> {
     ]
 }
 
-fn low_band_swap(swap_start: u64) -> Vec<AutomationEvent> {
-    let start_sample = swap_start.saturating_sub(1);
-    let end_sample = (swap_start + 1).max(1);
+fn bass_swap_eq_handoff(duration_samples: u64) -> Vec<AutomationEvent> {
+    let end_sample = duration_samples.max(1);
+    if end_sample < 8 {
+        return vec![
+            AutomationEvent {
+                param: Param::LowGain(DeckId::A),
+                start_sample: 0,
+                end_sample,
+                from: 1.0,
+                to: 0.05,
+                curve: Curve::Cosine,
+            },
+            AutomationEvent {
+                param: Param::LowGain(DeckId::B),
+                start_sample: 0,
+                end_sample,
+                from: 0.0,
+                to: 1.0,
+                curve: Curve::Cosine,
+            },
+        ];
+    }
+
+    let swap_point = end_sample / 2;
+    let outgoing_low_start = end_sample * 3 / 8;
+    let incoming_low_end = (end_sample * 5 / 8).max(swap_point + 1);
     vec![
         AutomationEvent {
             param: Param::LowGain(DeckId::A),
-            start_sample,
-            end_sample,
+            start_sample: outgoing_low_start,
+            end_sample: swap_point.max(outgoing_low_start + 1),
             from: 1.0,
+            to: 0.05,
+            curve: Curve::Cosine,
+        },
+        AutomationEvent {
+            param: Param::LowGain(DeckId::B),
+            start_sample: 0,
+            end_sample: swap_point.max(1),
+            from: 0.0,
             to: 0.0,
             curve: Curve::Linear,
         },
         AutomationEvent {
             param: Param::LowGain(DeckId::B),
-            start_sample,
-            end_sample,
+            start_sample: swap_point,
+            end_sample: incoming_low_end,
             from: 0.0,
             to: 1.0,
-            curve: Curve::Linear,
+            curve: Curve::Cosine,
+        },
+        AutomationEvent {
+            param: Param::MidGain(DeckId::A),
+            start_sample: swap_point,
+            end_sample,
+            from: 1.0,
+            to: 0.35,
+            curve: Curve::Cosine,
+        },
+        AutomationEvent {
+            param: Param::HighGain(DeckId::A),
+            start_sample: swap_point,
+            end_sample,
+            from: 1.0,
+            to: 0.35,
+            curve: Curve::Cosine,
+        },
+        AutomationEvent {
+            param: Param::MidGain(DeckId::B),
+            start_sample: 0,
+            end_sample,
+            from: 0.55,
+            to: 1.0,
+            curve: Curve::Cosine,
+        },
+        AutomationEvent {
+            param: Param::HighGain(DeckId::B),
+            start_sample: 0,
+            end_sample,
+            from: 0.45,
+            to: 1.0,
+            curve: Curve::Cosine,
         },
     ]
 }
@@ -609,6 +703,73 @@ mod tests {
                 .any(|event| event.param == Param::LowGain(DeckId::A)
                     && event.start_sample <= program.swap_start
                     && event.end_sample >= program.swap_start)
+        );
+    }
+
+    #[test]
+    fn bass_swap_16_shapes_clean_low_ownership_handoff() {
+        let program = Planner::plan(
+            &profile(Some(120.0), Some("8A"), 16),
+            &profile(Some(121.0), Some("8A"), 16),
+            &Policy::default(),
+        );
+
+        let outgoing_low = program
+            .automation
+            .iter()
+            .find(|event| event.param == Param::LowGain(DeckId::A))
+            .expect("outgoing low handoff");
+        let incoming_low_hold = program
+            .automation
+            .iter()
+            .find(|event| event.param == Param::LowGain(DeckId::B) && event.to == 0.0)
+            .expect("incoming low hold");
+        let incoming_low_rise = program
+            .automation
+            .iter()
+            .find(|event| event.param == Param::LowGain(DeckId::B) && event.to == 1.0)
+            .expect("incoming low rise");
+
+        assert_eq!(outgoing_low.end_sample, program.swap_start);
+        assert_eq!(incoming_low_hold.end_sample, program.swap_start);
+        assert_eq!(incoming_low_rise.start_sample, program.swap_start);
+        assert_eq!(outgoing_low.to, 0.05);
+        assert_eq!(incoming_low_hold.from, 0.0);
+        assert_eq!(incoming_low_hold.to, 0.0);
+        assert_eq!(incoming_low_rise.from, 0.0);
+        assert!(
+            program
+                .automation
+                .iter()
+                .any(|event| event.param == Param::MidGain(DeckId::A)
+                    && event.start_sample == program.swap_start
+                    && event.to < 1.0)
+        );
+        assert!(
+            program
+                .automation
+                .iter()
+                .any(|event| event.param == Param::MidGain(DeckId::B)
+                    && event.from < 1.0
+                    && event.to == 1.0)
+        );
+    }
+
+    #[test]
+    fn bass_swap_16_program_uses_requested_duration() {
+        let program = bass_swap_16_program(48_000, 2, 16_000);
+
+        assert_eq!(program.template, "BassSwap16");
+        assert_eq!(program.resolve_at, 768_000);
+        assert_eq!(program.tier, Tier::FullBlend);
+        program.validate().expect("bass swap 16");
+        assert!(
+            program
+                .automation
+                .iter()
+                .any(|event| event.param == Param::LowGain(DeckId::B)
+                    && event.start_sample == program.swap_start
+                    && event.to == 1.0)
         );
     }
 

--- a/noor-mix/src/render.rs
+++ b/noor-mix/src/render.rs
@@ -1,4 +1,5 @@
 use crate::automation::interpolate;
+use crate::eq::{BandGains, IsolatorEq};
 use crate::limiter::SafetyLimiter;
 use crate::program::{AutomationEvent, DeckId, Param, TransitionProgram};
 
@@ -8,6 +9,8 @@ pub struct Mixer {
     deck_b: crate::deck::DeckBuffer,
     scratch_a: Vec<f32>,
     scratch_b: Vec<f32>,
+    eq_a: IsolatorEq,
+    eq_b: IsolatorEq,
     limiter: SafetyLimiter,
 }
 
@@ -19,12 +22,16 @@ impl Mixer {
         max_block_samples: usize,
     ) -> anyhow::Result<Self> {
         program.validate()?;
+        let sample_rate = program.sample_rate;
+        let channels = program.channels;
         Ok(Self {
             program,
             deck_a,
             deck_b,
             scratch_a: vec![0.0; max_block_samples],
             scratch_b: vec![0.0; max_block_samples],
+            eq_a: IsolatorEq::new(sample_rate, channels),
+            eq_b: IsolatorEq::new(sample_rate, channels),
             limiter: SafetyLimiter::new(0.98),
         })
     }
@@ -42,6 +49,14 @@ impl Mixer {
         let rate_b = param_at(&self.program, Param::PlaybackRate(DeckId::B), master_sample);
         self.deck_a.tick_into(scratch_a, rate_a);
         self.deck_b.tick_into(scratch_b, rate_b);
+        self.eq_a.process_in_place(
+            scratch_a,
+            deck_band_gains(&self.program, DeckId::A, master_sample),
+        );
+        self.eq_b.process_in_place(
+            scratch_b,
+            deck_band_gains(&self.program, DeckId::B, master_sample),
+        );
 
         let channels = usize::from(self.program.channels);
         for (frame_index, (frame_out, (frame_a, frame_b))) in out
@@ -65,6 +80,14 @@ impl Mixer {
     #[cfg(test)]
     fn scratch_capacities(&self) -> (usize, usize) {
         (self.scratch_a.capacity(), self.scratch_b.capacity())
+    }
+}
+
+fn deck_band_gains(program: &TransitionProgram, deck: DeckId, sample: u64) -> BandGains {
+    BandGains {
+        low: param_at(program, Param::LowGain(deck), sample),
+        mid: param_at(program, Param::MidGain(deck), sample),
+        high: param_at(program, Param::HighGain(deck), sample),
     }
 }
 
@@ -186,6 +209,60 @@ mod tests {
         let mut out = [0.0; 4];
         mixer.render_block(&mut out, 0);
         assert!(out.iter().all(|sample| sample.abs() <= 0.98));
+    }
+
+    fn sine(freq: f32, frames: usize, sample_rate: u32) -> Vec<f32> {
+        (0..frames)
+            .map(|i| (2.0 * std::f32::consts::PI * freq * i as f32 / sample_rate as f32).sin())
+            .collect()
+    }
+
+    fn rms(samples: &[f32]) -> f32 {
+        (samples.iter().map(|value| value * value).sum::<f32>() / samples.len() as f32).sqrt()
+    }
+
+    #[test]
+    fn render_block_applies_low_gain_automation() {
+        let sample_rate = 48_000;
+        let frames = sample_rate as usize * 3;
+        let source = sine(50.0, frames, sample_rate);
+        let mut program = valid_program();
+        program.sample_rate = sample_rate;
+        program.resolve_at = frames as u64;
+        program.swap_start = frames as u64 / 2;
+        program.fade_start = program.swap_start;
+        program.automation = vec![
+            AutomationEvent {
+                param: Param::DeckGain(DeckId::A),
+                start_sample: 0,
+                end_sample: frames as u64,
+                from: 1.0,
+                to: 1.0,
+                curve: Curve::Linear,
+            },
+            AutomationEvent {
+                param: Param::LowGain(DeckId::A),
+                start_sample: 0,
+                end_sample: frames as u64,
+                from: 0.0,
+                to: 0.0,
+                curve: Curve::Linear,
+            },
+        ];
+        let mut mixer = Mixer::new(
+            program,
+            DeckBuffer::new(source.clone(), 1),
+            DeckBuffer::new(vec![0.0; frames], 1),
+            frames,
+        )
+        .expect("mixer");
+        let mut out = vec![0.0; frames];
+
+        mixer.render_block(&mut out, 0);
+
+        let input_tail = rms(&source[sample_rate as usize * 2..]);
+        let output_tail = rms(&out[sample_rate as usize * 2..]);
+        assert!(output_tail / input_tail < 0.05);
     }
 
     #[test]

--- a/noor-server/src/playback/player.rs
+++ b/noor-server/src/playback/player.rs
@@ -440,13 +440,14 @@ pub fn attach_dj_transition_plan_for_pair_with_current_duration(
         engine.plan_transition_details(current, next, sample_rate.max(1), channels.max(1))?
     {
         let planned_template = plan.program.template.clone();
-        let filter_sweep_unstable = planned_template == "FilterSweep"
-            && engine.db().with_conn(filter_sweep_timing_unstable)?;
+        let render_timing_unstable =
+            matches!(planned_template.as_str(), "FilterSweep" | "BassSwap16")
+                && engine.db().with_conn(render_timing_unstable)?;
         let (renderer_program, renderer_fallback_reason) = v1_renderable_program(
             &plan.program,
             sample_rate.max(1),
             channels.max(1),
-            filter_sweep_unstable,
+            render_timing_unstable,
         );
         let renderer_plan = DjTransitionPlan {
             program: renderer_program,
@@ -523,6 +524,7 @@ const DJ_FILTER_SWEEP_TIMING_MIN_ROWS: usize = 4;
 const DJ_FILTER_SWEEP_MEDIAN_ABS_MAX_MS: i64 = 300;
 const DJ_FILTER_SWEEP_WORST_ABS_MAX_MS: i64 = 750;
 const DJ_FILTER_SWEEP_RENDER_MS: u32 = 12_000;
+const DJ_BASS_SWAP_16_RENDER_MS: u32 = 16_000;
 
 fn dj_transition_fire_ahead_ms(conn: &Connection) -> Result<u32> {
     let mut stmt = conn.prepare(
@@ -541,7 +543,7 @@ fn dj_transition_fire_ahead_ms(conn: &Connection) -> Result<u32> {
     Ok(fire_ahead_ms_from_deltas(&deltas))
 }
 
-fn filter_sweep_timing_unstable(conn: &Connection) -> Result<bool> {
+fn render_timing_unstable(conn: &Connection) -> Result<bool> {
     let mut stmt = conn.prepare(
         "SELECT timing_delta_ms
          FROM dj_transition_events
@@ -555,10 +557,10 @@ fn filter_sweep_timing_unstable(conn: &Connection) -> Result<bool> {
     for row in rows {
         deltas.push(row?);
     }
-    Ok(filter_sweep_timing_unstable_from_deltas(&deltas))
+    Ok(render_timing_unstable_from_deltas(&deltas))
 }
 
-fn filter_sweep_timing_unstable_from_deltas(deltas: &[i64]) -> bool {
+fn render_timing_unstable_from_deltas(deltas: &[i64]) -> bool {
     if deltas.len() < DJ_FILTER_SWEEP_TIMING_MIN_ROWS {
         return false;
     }
@@ -807,13 +809,33 @@ fn v1_renderable_program(
     program: &noor_mix::TransitionProgram,
     sample_rate: u32,
     channels: u16,
-    filter_sweep_timing_unstable: bool,
+    render_timing_unstable: bool,
 ) -> (noor_mix::TransitionProgram, Option<&'static str>) {
     if program.template == "SafeCrossfade" {
         return (program.clone(), None);
     }
+    if program.template == "BassSwap16" {
+        if render_timing_unstable {
+            return (
+                crate::playback::dj_engine::safe_crossfade_program(
+                    sample_rate,
+                    channels,
+                    noor_mix::Policy::default(),
+                ),
+                Some("timing_unstable"),
+            );
+        }
+        return (
+            noor_mix::planner::bass_swap_16_program(
+                sample_rate,
+                channels,
+                DJ_BASS_SWAP_16_RENDER_MS,
+            ),
+            None,
+        );
+    }
     if program.template == "FilterSweep" {
-        if filter_sweep_timing_unstable {
+        if render_timing_unstable {
             return (
                 crate::playback::dj_engine::safe_crossfade_program(
                     sample_rate,
@@ -3415,6 +3437,32 @@ mod tests {
         }
 
         #[test]
+        fn v1_planner_logs_and_prepares_bass_swap_16_when_renderable() {
+            let db = db_with_pair();
+            let transition = plan(&db);
+
+            assert_eq!(transition.program.template, "BassSwap16");
+            let row: (String, String, Option<String>) = db
+                .with_conn(|conn| {
+                    conn.query_row(
+                        "SELECT template, program_json, fallback_reason
+                         FROM dj_transition_events WHERE id = ?1",
+                        params![transition.transition_event_id],
+                        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+                    )
+                    .map_err(Into::into)
+                })
+                .expect("event");
+            let renderer_program: noor_mix::TransitionProgram =
+                serde_json::from_str(&row.1).expect("program");
+
+            assert_eq!(row.0, "BassSwap16");
+            assert_eq!(renderer_program.template, "BassSwap16");
+            assert_eq!(renderer_program.resolve_at, 768_000);
+            assert_eq!(row.2, None);
+        }
+
+        #[test]
         fn v1_planner_logs_and_prepares_filter_sweep_when_renderable() {
             let db = db_with_pair();
             db.with_conn(|conn| {
@@ -3476,6 +3524,21 @@ mod tests {
         }
 
         #[test]
+        fn v1_renderable_program_passes_bass_swap_16_with_low_handoff() {
+            let input = noor_mix::planner::bass_swap_16_program(48_000, 2, 32_000);
+
+            let (program, reason) = v1_renderable_program(&input, 48_000, 2, false);
+
+            assert_eq!(program.template, "BassSwap16");
+            assert_eq!(program.resolve_at, 768_000);
+            assert_eq!(reason, None);
+            assert!(program.automation.iter().any(|event| event.param
+                == noor_mix::Param::LowGain(noor_mix::DeckId::B)
+                && event.start_sample == program.swap_start
+                && event.to == 1.0));
+        }
+
+        #[test]
         fn v1_renderable_program_downgrades_slam_cut_to_safe_crossfade() {
             let mut input = noor_mix::planner::filter_sweep_eq_wash_program(48_000, 2, 10_000);
             input.template = "SlamCut".to_string();
@@ -3497,7 +3560,17 @@ mod tests {
         }
 
         #[test]
-        fn filter_sweep_uses_wider_overlap_than_safe_crossfade() {
+        fn unstable_timing_downgrades_bass_swap_16_to_safe_crossfade() {
+            let input = noor_mix::planner::bass_swap_16_program(48_000, 2, 16_000);
+
+            let (program, reason) = v1_renderable_program(&input, 48_000, 2, true);
+
+            assert_eq!(program.template, "SafeCrossfade");
+            assert_eq!(reason, Some("timing_unstable"));
+        }
+
+        #[test]
+        fn dj_renderers_use_wider_overlap_than_safe_crossfade() {
             let safe = crate::playback::dj_engine::safe_crossfade_program(
                 48_000,
                 2,
@@ -3508,9 +3581,12 @@ mod tests {
                 2,
                 DJ_FILTER_SWEEP_RENDER_MS,
             );
+            let bass_swap =
+                noor_mix::planner::bass_swap_16_program(48_000, 2, DJ_BASS_SWAP_16_RENDER_MS);
 
             assert_eq!(dj_gapless_plan_from_program(&safe).overlap_ms, 8_000);
             assert_eq!(dj_gapless_plan_from_program(&filter).overlap_ms, 12_000);
+            assert_eq!(dj_gapless_plan_from_program(&bass_swap).overlap_ms, 16_000);
         }
 
         #[test]
@@ -3535,14 +3611,10 @@ mod tests {
         }
 
         #[test]
-        fn filter_sweep_timing_gate_uses_abs_error_not_signed_bias() {
-            assert!(filter_sweep_timing_unstable_from_deltas(&[
-                549, -399, 303, -375
-            ]));
-            assert!(!filter_sweep_timing_unstable_from_deltas(&[
-                140, -130, 75, -90
-            ]));
-            assert!(!filter_sweep_timing_unstable_from_deltas(&[549, -399, 303]));
+        fn renderer_timing_gate_uses_abs_error_not_signed_bias() {
+            assert!(render_timing_unstable_from_deltas(&[549, -399, 303, -375]));
+            assert!(!render_timing_unstable_from_deltas(&[140, -130, 75, -90]));
+            assert!(!render_timing_unstable_from_deltas(&[549, -399, 303]));
         }
 
         #[test]

--- a/noor-server/src/server/routes/dj_routes.rs
+++ b/noor-server/src/server/routes/dj_routes.rs
@@ -1712,7 +1712,7 @@ fn renderer_status_for_transition(transition: Option<&OpenTransition>) -> Render
     .to_string();
     if matches!(
         transition.renderer_template.as_deref(),
-        Some("SafeCrossfade" | "FilterSweep")
+        Some("SafeCrossfade" | "FilterSweep" | "BassSwap16")
     ) {
         let downgrade_reason = renderer_downgrade_reason(transition);
         return RendererStatus {
@@ -1783,7 +1783,11 @@ fn is_renderer_downgrade_reason(reason: &str) -> bool {
 
 fn renderer_template_from_program_json(program_json: &str) -> Option<String> {
     let program: noor_mix::TransitionProgram = serde_json::from_str(program_json).ok()?;
-    matches!(program.template.as_str(), "SafeCrossfade" | "FilterSweep").then_some(program.template)
+    matches!(
+        program.template.as_str(),
+        "SafeCrossfade" | "FilterSweep" | "BassSwap16"
+    )
+    .then_some(program.template)
 }
 
 fn media_ref_label(
@@ -1967,6 +1971,26 @@ mod tests {
         assert_eq!(status.renderer_mode.as_deref(), Some("dj_gain_program"));
         assert_eq!(status.downgrade_reason, None);
         assert_eq!(status.timing_direction, "on_time");
+    }
+
+    #[test]
+    fn renderer_status_exposes_bass_swap_16_runtime_program() {
+        let status = renderer_status_for_transition(Some(&OpenTransition {
+            id: 22,
+            template: "BassSwap16".to_string(),
+            renderer_template: Some("BassSwap16".to_string()),
+            fallback_reason: None,
+            planned_start_ms: Some(112_000),
+            actual_start_ms: Some(112_144),
+            timing_delta_ms: Some(144),
+            timing_source: Some("downbeat_sync".to_string()),
+            timing_status: Some("fired".to_string()),
+        }));
+
+        assert_eq!(status.planned_template.as_deref(), Some("BassSwap16"));
+        assert_eq!(status.renderer_template.as_deref(), Some("BassSwap16"));
+        assert_eq!(status.renderer_mode.as_deref(), Some("dj_gain_program"));
+        assert_eq!(status.downgrade_reason, None);
     }
 
     #[test]


### PR DESCRIPTION
Clean replacement BassSwap16 PR on current master. This intentionally includes only the BassSwap renderability commit over master and excludes the emergency runtime patches from codex/dj-bassswap16-renderable. Tests run: cargo test -p noor-mix, cargo test -p noor-server playback::player::tests::dj, cargo test -p noor-server server::routes::dj_routes::tests, cargo check -p noor-server, cargo fmt --all -- --check.