### PR TITLE
fix(dj): keep segment-restart active deck audible when DJ arms

### DIFF
--- a/noor-server/src/playback/decode/mod.rs
+++ b/noor-server/src/playback/decode/mod.rs
@@ -558,7 +558,7 @@ pub(crate) fn decode_and_buffer_job(
             }
 
             // Apply fade-in / fade-out ramps and mark the stream complete.
-            let total = {
+            let buffer_len = {
                 let mut guard = shared
                     .buffer
                     .lock()
@@ -569,13 +569,24 @@ pub(crate) fn decode_and_buffer_job(
                 guard.mark_finished();
                 guard.samples.len() as u64
             };
-            shared.total_samples.store(total, Ordering::Relaxed);
-            let total_secs = total as f64
+            // total_samples is ABSOLUTE (offset + local count) to match
+            // position_samples, which is also ABSOLUTE. For a fresh play the
+            // offset is 0 and the two are equal; for a segment-restart engine
+            // (option C) the offset is non-zero, so storing LOCAL count here
+            // would race position past total and make the fade-out branch in
+            // write_output_buffer immediately compute remaining=0 (silence)
+            // as soon as crossfade_samples gets armed.
+            let offset = shared.position_offset_samples.load(Ordering::Relaxed);
+            let absolute_total = offset.saturating_add(buffer_len);
+            shared
+                .total_samples
+                .store(absolute_total, Ordering::Relaxed);
+            let total_secs = absolute_total as f64
                 / (shared.target_sample_rate.load(Ordering::Relaxed).max(1) as f64
                     * device_channels.max(1) as f64);
             debug!(
-                "Playback decoder finished: track_id={}, packets={}, buffered_samples={}, duration_secs={:.3}",
-                shared.track_id, decoded_packets, total, total_secs
+                "Playback decoder finished: track_id={}, packets={}, buffered_samples={}, offset_samples={}, total_samples={}, duration_secs={:.3}",
+                shared.track_id, decoded_packets, buffer_len, offset, absolute_total, total_secs
             );
 
             // Notify the runtime loop that this engine's decode is complete.

--- a/noor-server/src/playback/runtime/shared.rs
+++ b/noor-server/src/playback/runtime/shared.rs
@@ -657,6 +657,114 @@ mod tests {
         assert_eq!(out, [0.125, 0.25, 0.5, 1.0]);
     }
 
+    /// Regression: a segment-restart engine (offset > 0) plus an armed DJ
+    /// crossfade must not immediately mute the active track. The bug was that
+    /// the decoder used to store LOCAL `samples.len()` into `total_samples`
+    /// while `position_samples` is ABSOLUTE (offset + local). When DJ arming
+    /// then set `crossfade_samples > 0`, the fade-out branch computed
+    /// `remaining = total.saturating_sub(pos)` which saturated to 0, dropping
+    /// fade_gain to sin(0) = 0 — audible silence for the entire window
+    /// between arming and the actual transition. The fix is that the decoder
+    /// stores ABSOLUTE total (offset + samples.len()), so this test simulates
+    /// the post-fix invariant and asserts no premature attenuation.
+    #[test]
+    fn armed_crossfade_does_not_mute_segment_restart_active() {
+        let shared = test_shared_state();
+        // Mimic a segment-restart engine: offset is the segment start in
+        // absolute samples (e.g. 120s into a track at 48000 Hz / 2 ch).
+        let offset_samples: u64 = 120 * 48_000 * 2;
+        shared
+            .position_offset_samples
+            .store(offset_samples, Ordering::Relaxed);
+
+        // Local buffer covers the remaining 60s of the track.
+        let local_samples: u64 = 60 * 48_000 * 2;
+        // Decoder-stored total is ABSOLUTE (offset + local) per the contract.
+        shared
+            .total_samples
+            .store(offset_samples + local_samples, Ordering::Relaxed);
+
+        // Position: ~30s into this segment's playback (still ABSOLUTE).
+        let played_samples: u64 = 30 * 48_000 * 2;
+        shared
+            .position_samples
+            .store(offset_samples + played_samples, Ordering::Relaxed);
+
+        // DJ arming for a 13s overlap (matches the BassSwap16 user log).
+        let xfade: u64 = 13 * 48_000 * 2;
+        shared.crossfade_samples.store(xfade, Ordering::Relaxed);
+        shared
+            .crossfade_start_signaled
+            .store(false, Ordering::Relaxed);
+
+        // 30s into the segment, 30s remaining, xfade=13s — gain must be 1.0.
+        {
+            let mut buffer = shared.buffer.lock().expect("buffer lock");
+            buffer.samples.extend_from_slice(&[1.0, 1.0, 1.0, 1.0]);
+        }
+
+        let (command_tx, _) = mpsc::channel();
+        let (event_tx, _) = tokio::sync::broadcast::channel(8);
+        let mut out = [0.0_f32; 4];
+        write_output_f32(&mut out, &shared, &command_tx, &event_tx);
+
+        assert_eq!(
+            out,
+            [1.0, 1.0, 1.0, 1.0],
+            "armed but pre-fire-window active deck must play full-volume"
+        );
+    }
+
+    /// Regression: the crossfade-start signal must not fire prematurely on a
+    /// segment-restart engine. Same root cause as the fade-out mute bug — if
+    /// `total_samples` was LOCAL while `position_samples` is ABSOLUTE,
+    /// `total - pos` would saturate to 0 < xfade and CrossfadeStart would be
+    /// emitted immediately, causing the runtime to promote the next engine
+    /// before the actual transition window opened.
+    #[test]
+    fn crossfade_start_does_not_fire_early_on_segment_restart() {
+        let shared = test_shared_state();
+        let offset_samples: u64 = 120 * 48_000 * 2;
+        shared
+            .position_offset_samples
+            .store(offset_samples, Ordering::Relaxed);
+
+        let local_samples: u64 = 60 * 48_000 * 2;
+        shared
+            .total_samples
+            .store(offset_samples + local_samples, Ordering::Relaxed);
+
+        let played_samples: u64 = 30 * 48_000 * 2;
+        shared
+            .position_samples
+            .store(offset_samples + played_samples, Ordering::Relaxed);
+
+        let xfade: u64 = 13 * 48_000 * 2;
+        shared.crossfade_samples.store(xfade, Ordering::Relaxed);
+        shared
+            .crossfade_start_signaled
+            .store(false, Ordering::Relaxed);
+
+        {
+            let mut buffer = shared.buffer.lock().expect("buffer lock");
+            buffer.samples.extend_from_slice(&[0.5, 0.5, 0.5, 0.5]);
+        }
+
+        let (command_tx, command_rx) = mpsc::channel();
+        let (event_tx, _) = tokio::sync::broadcast::channel(8);
+        let mut out = [0.0_f32; 4];
+        write_output_f32(&mut out, &shared, &command_tx, &event_tx);
+
+        assert!(
+            !shared.crossfade_start_signaled.load(Ordering::Relaxed),
+            "30s remaining with 13s xfade must leave the start-signal pending"
+        );
+        assert!(
+            command_rx.try_recv().is_err(),
+            "no CrossfadeStart command should be queued yet"
+        );
+    }
+
     #[test]
     fn seek_to_decoded_position_applies_immediately() {
         let mut buffer = PlaybackBuffer::new(0);


### PR DESCRIPTION
## Summary

- DJ mode could mute the current track at near-end (and emit a silent "transition") if the user had seeked out-of-buffer earlier in the track.
- Root cause: when a segment-restart engine's decoder finished, it stored `total_samples = samples.len()` (LOCAL count) while `position_samples` is ABSOLUTE (offset + local). `arm_active_transition_window` then set `crossfade_samples > 0`, the fade-out branch computed `remaining = total.saturating_sub(pos)` which saturated to 0, dropping fade_gain to `sin(0)` = 0. The same broken math also tripped `CrossfadeStart` instantly, so the next engine promoted via the "late" path with no audible transition.
- Fix: decoder now stores `offset + buffer_len` (ABSOLUTE total) when it finishes, matching the contract that `position_samples` already followed. Initial estimate in `start_decoder_only` was already ABSOLUTE, so this just preserves the invariant across decoder completion.

This replaces the three emergency commits from the abandoned `codex/dj-bassswap16-renderable` branch (disable SRF in DJ, skip mixer build, delay fade-out gate). Those were workarounds for the same underlying contract violation; once total/position units agree, none are needed.

## Test plan

- [x] `cargo test -p noor-server playback::runtime` (73 passed; 2 new regression tests added)
- [x] `cargo test -p noor-server playback::player::tests::dj` (37 passed)
- [x] `cargo test -p noor-server server::routes::dj_routes::tests` (23 passed)
- [x] `cargo test -p noor-server playback` (263 passed)
- [x] `cargo check -p noor-server`
- [x] `cargo fmt --all -- --check`
- [ ] Manual audio: enable DJ, play a queue pair, seek current to ~60s remaining, watch near-end planning around 30s remaining. Current audio must stay full-volume until ~13s remaining, then audibly transition (or fall back without silence).
- [ ] Manual audio: repeat once with sample-rate-follow ON and once with it OFF.

## Regression tests added

- `armed_crossfade_does_not_mute_segment_restart_active` — a segment-restart engine with offset > 0 and an armed 13s crossfade at 30s remaining must output full-volume audio (post-fix invariant).
- `crossfade_start_does_not_fire_early_on_segment_restart` — the start-signal must stay pending until the actual fire window opens.