### PR TITLE
test(dj): add optional signalsmith stretch evaluation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,7 +351,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99ef2dfeaceccd0b8a6d72203409acc927d9eebc8180c5756099549c9f8f20a8"
 dependencies = [
- "bindgen",
+ "bindgen 0.58.1",
  "cc",
 ]
 
@@ -435,7 +435,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f8523b410d7187a43085e7e064416ea32ded16bd0a4e6fc025e21616d01258f"
 dependencies = [
  "bitflags 1.3.2",
- "cexpr",
+ "cexpr 0.4.0",
  "clang-sys",
  "clap",
  "env_logger",
@@ -449,6 +449,26 @@ dependencies = [
  "rustc-hash 1.1.0",
  "shlex",
  "which",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
+dependencies = [
+ "bitflags 2.11.1",
+ "cexpr 0.6.0",
+ "clang-sys",
+ "itertools",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -657,7 +677,16 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
 dependencies = [
- "nom",
+ "nom 5.1.3",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -1082,10 +1111,123 @@ dependencies = [
 ]
 
 [[package]]
+name = "dasp"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7381b67da416b639690ac77c73b86a7b5e64a29e31d1f75fb3b1102301ef355a"
+dependencies = [
+ "dasp_envelope",
+ "dasp_frame",
+ "dasp_interpolate",
+ "dasp_peak",
+ "dasp_ring_buffer",
+ "dasp_rms",
+ "dasp_sample",
+ "dasp_signal",
+ "dasp_slice",
+ "dasp_window",
+]
+
+[[package]]
+name = "dasp_envelope"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ec617ce7016f101a87fe85ed44180839744265fae73bb4aa43e7ece1b7668b6"
+dependencies = [
+ "dasp_frame",
+ "dasp_peak",
+ "dasp_ring_buffer",
+ "dasp_rms",
+ "dasp_sample",
+]
+
+[[package]]
+name = "dasp_frame"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a3937f5fe2135702897535c8d4a5553f8b116f76c1529088797f2eee7c5cd6"
+dependencies = [
+ "dasp_sample",
+]
+
+[[package]]
+name = "dasp_interpolate"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fc975a6563bb7ca7ec0a6c784ead49983a21c24835b0bc96eea11ee407c7486"
+dependencies = [
+ "dasp_frame",
+ "dasp_ring_buffer",
+ "dasp_sample",
+]
+
+[[package]]
+name = "dasp_peak"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cf88559d79c21f3d8523d91250c397f9a15b5fc72fbb3f87fdb0a37b79915bf"
+dependencies = [
+ "dasp_frame",
+ "dasp_sample",
+]
+
+[[package]]
+name = "dasp_ring_buffer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07d79e19b89618a543c4adec9c5a347fe378a19041699b3278e616e387511ea1"
+
+[[package]]
+name = "dasp_rms"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6c5dcb30b7e5014486e2822537ea2beae50b19722ffe2ed7549ab03774575aa"
+dependencies = [
+ "dasp_frame",
+ "dasp_ring_buffer",
+ "dasp_sample",
+]
+
+[[package]]
 name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
+
+[[package]]
+name = "dasp_signal"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa1ab7d01689c6ed4eae3d38fe1cea08cba761573fbd2d592528d55b421077e7"
+dependencies = [
+ "dasp_envelope",
+ "dasp_frame",
+ "dasp_interpolate",
+ "dasp_peak",
+ "dasp_ring_buffer",
+ "dasp_rms",
+ "dasp_sample",
+ "dasp_window",
+]
+
+[[package]]
+name = "dasp_slice"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e1c7335d58e7baedafa516cb361360ff38d6f4d3f9d9d5ee2a2fc8e27178fa1"
+dependencies = [
+ "dasp_frame",
+ "dasp_sample",
+]
+
+[[package]]
+name = "dasp_window"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99ded7b88821d2ce4e8b842c9f1c86ac911891ab89443cc1de750cae764c5076"
+dependencies = [
+ "dasp_sample",
+]
 
 [[package]]
 name = "data-encoding"
@@ -2557,6 +2699,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2975,6 +3126,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "minisign-verify"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3135,6 +3292,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "noor-app"
 version = "0.1.56"
 dependencies = [
@@ -3158,6 +3325,7 @@ dependencies = [
  "rubato",
  "rustfft",
  "serde",
+ "signalsmith-stretch",
  "symphonia",
  "thiserror 2.0.18",
  "tracing",
@@ -5021,6 +5189,17 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signalsmith-stretch"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51dae6f10b5532510f65c309c4d868babe3aecf6ce0782678081338311f176fd"
+dependencies = [
+ "bindgen 0.70.1",
+ "cc",
+ "dasp",
 ]
 
 [[package]]

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -16,10 +16,13 @@ Phase 1 ships beat-phase sync with the existing `PlaybackRate` cap of
 `0.97..1.03`. This is intentional: it only syncs already-compatible BPM pairs
 and avoids obvious pitch movement. The offline metric harness and optional
 `signalsmith-eval` renderer now exist in `noor-mix::stretch_eval`; the feature
-compile gate is currently blocked until `libclang.dll` is available and
-`LIBCLANG_PATH` points at it. After that, run the documented fixture matrix
-before any wider runtime cap ships. Do not use Rubber Band without license
-review.
+compile gate passed after installing LLVM 22.1.6 and setting
+`LIBCLANG_PATH=C:\Program Files\LLVM\bin`. The documented fixture matrix now
+runs, but the debug benchmark fails the current runtime decision gate because
+90s Signalsmith renders take roughly 18 to 24 seconds, far above the 500 ms
+target. Keep runtime at the existing 3 percent nudge until release-mode or
+prepared-buffer evaluation proves the render-time gate. Do not use Rubber Band
+without license review.
 - Spawned by: DJ beat-sync design planning, 2026-05-26
 
 ### refactor(db/signals): extract analytics signals from db/queries.rs

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -14,9 +14,11 @@ back to the PR or commit that flagged it.
 
 Phase 1 ships beat-phase sync with the existing `PlaybackRate` cap of
 `0.97..1.03`. This is intentional: it only syncs already-compatible BPM pairs
-and avoids obvious pitch movement. Phase 2 evaluates Signalsmith Stretch for
-pitch-preserving tempo sync before any wider runtime cap ships. Do not use
-Rubber Band without license review.
+and avoids obvious pitch movement. The offline metric harness now exists in
+`noor-mix::stretch_eval`; the remaining work is wiring an actual Signalsmith
+Stretch candidate renderer into that harness and running the documented fixture
+matrix before any wider runtime cap ships. Do not use Rubber Band without
+license review.
 - Spawned by: DJ beat-sync design planning, 2026-05-26
 
 ### refactor(db/signals): extract analytics signals from db/queries.rs

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -18,11 +18,11 @@ and avoids obvious pitch movement. The offline metric harness and optional
 `signalsmith-eval` renderer now exist in `noor-mix::stretch_eval`; the feature
 compile gate passed after installing LLVM 22.1.6 and setting
 `LIBCLANG_PATH=C:\Program Files\LLVM\bin`. The documented fixture matrix now
-runs, but the debug benchmark fails the current runtime decision gate because
-90s Signalsmith renders take roughly 18 to 24 seconds, far above the 500 ms
-target. Keep runtime at the existing 3 percent nudge until release-mode or
-prepared-buffer evaluation proves the render-time gate. Do not use Rubber Band
-without license review.
+runs. Release mode brings 90s Signalsmith renders down to roughly 1.4 to 1.7
+seconds with good drift, finite, length, and peak metrics, but that still fails
+the current 500 ms runtime gate by about 3x. Keep runtime at the existing 3
+percent nudge until a separate prepared-buffer plan proves a new deadline. Do
+not use Rubber Band without license review.
 - Spawned by: DJ beat-sync design planning, 2026-05-26
 
 ### refactor(db/signals): extract analytics signals from db/queries.rs

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -14,11 +14,12 @@ back to the PR or commit that flagged it.
 
 Phase 1 ships beat-phase sync with the existing `PlaybackRate` cap of
 `0.97..1.03`. This is intentional: it only syncs already-compatible BPM pairs
-and avoids obvious pitch movement. The offline metric harness now exists in
-`noor-mix::stretch_eval`; the remaining work is wiring an actual Signalsmith
-Stretch candidate renderer into that harness and running the documented fixture
-matrix before any wider runtime cap ships. Do not use Rubber Band without
-license review.
+and avoids obvious pitch movement. The offline metric harness and optional
+`signalsmith-eval` renderer now exist in `noor-mix::stretch_eval`; the feature
+compile gate is currently blocked until `libclang.dll` is available and
+`LIBCLANG_PATH` points at it. After that, run the documented fixture matrix
+before any wider runtime cap ships. Do not use Rubber Band without license
+review.
 - Spawned by: DJ beat-sync design planning, 2026-05-26
 
 ### refactor(db/signals): extract analytics signals from db/queries.rs

--- a/docs/plans/2026-05-26-smart-stretch-evaluation.md
+++ b/docs/plans/2026-05-26-smart-stretch-evaluation.md
@@ -97,6 +97,7 @@ Implemented:
 - `noor-mix::stretch_eval::evaluate_stretch_render` records objective metrics for a candidate stretched render.
 - Normal tests cover finite sample detection, output length error, peak/RMS reporting, and click-marker phase drift.
 - The ignored baseline benchmark prints the same metrics across 30s, 90s, and 180s synthetic click fixtures.
+- `signalsmith-eval` adds an optional Signalsmith candidate renderer for offline evaluation only.
 
 Run the harness with:
 
@@ -106,7 +107,25 @@ cargo test -p noor-mix smart_stretch_evaluation_baseline_benchmark -- --ignored 
 
 Still left before `Smart Stretch Now`:
 
-- Wire an actual Signalsmith Stretch candidate renderer into the offline harness.
+- Install or expose `libclang.dll` so the optional Signalsmith feature can compile.
 - Run fixed synthetic and musical fixtures in both slower and faster directions at 3, 5, 8, and 12 percent tempo deltas.
 - Record render time, phase drift, peak, RMS movement, output length error, and manual listening notes.
 - Keep runtime playback capped to the existing `0.97..1.03` direct playback-rate path until the evaluation passes.
+
+## Signalsmith Feature Gate Result
+
+Attempted on 2026-05-26 with:
+
+```powershell
+cargo test -p noor-mix --features signalsmith-eval stretch_eval
+```
+
+Result: blocked by native toolchain setup before evaluation could run.
+
+Exact blocker:
+
+```text
+Unable to find libclang: "couldn't find any valid shared libraries matching: ['clang.dll', 'libclang.dll'], set the `LIBCLANG_PATH` environment variable to a path where one of these files can be found (invalid: [])"
+```
+
+Per the hardened plan, do not vendor C++ or switch crates in this slice. The optional `signalsmith-eval` feature can be retried after `libclang.dll` is available and `LIBCLANG_PATH` points at it.

--- a/docs/plans/2026-05-26-smart-stretch-evaluation.md
+++ b/docs/plans/2026-05-26-smart-stretch-evaluation.md
@@ -1,0 +1,91 @@
+# Smart Stretch Evaluation Gate
+
+Date: 2026-05-26
+
+## Goal
+
+Decide whether wider tempo sync is worth shipping before adding any pitch-preserving stretch dependency or realtime path.
+
+Direct playback-rate sync remains capped at `0.97..1.03`. Wider deltas are evaluation-only until this gate passes.
+
+## Candidate
+
+Primary candidate: Signalsmith Stretch.
+
+Reason: permissive licensing and suitable design for offline prepared-buffer rendering.
+
+Blocked candidates:
+
+- Rubber Band: blocked until license review is explicitly approved.
+- Local LLM transition generation: blocked for realtime timing and rendering.
+- Beat This: useful for offline beat/downbeat benchmarking, not a stretch renderer.
+
+## Test Material
+
+Use fixed local fixtures before any user-library sweep:
+
+- Synthetic click track at 120 BPM.
+- Synthetic kick/snare loop with strong transients.
+- Harmonic pad loop with sustained notes.
+- Full-band electronic loop with bass and hats.
+- Vocal-heavy excerpt.
+
+Evaluate tempo deltas:
+
+- 3 percent.
+- 5 percent.
+- 8 percent.
+- 12 percent.
+
+Evaluate both directions: slower and faster.
+
+## Metrics
+
+For every fixture and tempo delta, record:
+
+- Render time in milliseconds for 30s, 90s, and full-track windows.
+- Peak memory during render.
+- Output peak and true peak proxy.
+- RMS change versus source.
+- Click transient drift at the first, middle, and final beat.
+- Maximum phase drift in milliseconds.
+- Buffer length error in frames.
+- Any non-finite sample count.
+
+Manual listening notes are allowed, but cannot replace objective pass/fail metrics.
+
+## Pass Criteria
+
+Signalsmith can move from evaluation to implementation planning only if:
+
+- 5 percent stretch stays under 10 ms maximum click phase drift for 90s fixtures.
+- 8 percent stretch stays under 20 ms maximum click phase drift for 90s fixtures.
+- 90s render time stays below 500 ms on the target listening machine.
+- Full-track render can run in the background without blocking playback.
+- Output has no non-finite samples.
+- Peak does not exceed the existing limiter ceiling after the DJ mixer limiter.
+- Prepared-buffer rendering can absorb all allocation and latency outside the realtime callback.
+
+12 percent is exploratory only. Passing 12 percent does not automatically increase the ship cap.
+
+## Fail Criteria
+
+Do not ship wider stretch if any of these occur:
+
+- Audible transient smearing on click or drum fixtures at 5 percent.
+- Phase drift above the pass criteria.
+- Render-time spikes that threaten the active lookahead window.
+- Output length error that would break queue promotion or overlay cleanup.
+- Any need to allocate, decode, fetch, or lock unbounded state inside the realtime callback.
+
+## Implementation Boundary
+
+If the gate passes, the next implementation plan must still keep stretch in prepared buffers:
+
+- Decode source audio first.
+- Render stretched transition audio off the callback.
+- Validate length, finite samples, peak, and phase drift.
+- Only then hand a ready buffer to the runtime.
+- Fall back to `SafeCrossfade` or the 3 percent small nudge path on any failure.
+
+No realtime stretch engine is approved by this gate.

--- a/docs/plans/2026-05-26-smart-stretch-evaluation.md
+++ b/docs/plans/2026-05-26-smart-stretch-evaluation.md
@@ -89,3 +89,24 @@ If the gate passes, the next implementation plan must still keep stretch in prep
 - Fall back to `SafeCrossfade` or the 3 percent small nudge path on any failure.
 
 No realtime stretch engine is approved by this gate.
+
+## Current Implementation Status
+
+Implemented:
+
+- `noor-mix::stretch_eval::evaluate_stretch_render` records objective metrics for a candidate stretched render.
+- Normal tests cover finite sample detection, output length error, peak/RMS reporting, and click-marker phase drift.
+- The ignored baseline benchmark prints the same metrics across 30s, 90s, and 180s synthetic click fixtures.
+
+Run the harness with:
+
+```powershell
+cargo test -p noor-mix smart_stretch_evaluation_baseline_benchmark -- --ignored --nocapture
+```
+
+Still left before `Smart Stretch Now`:
+
+- Wire an actual Signalsmith Stretch candidate renderer into the offline harness.
+- Run fixed synthetic and musical fixtures in both slower and faster directions at 3, 5, 8, and 12 percent tempo deltas.
+- Record render time, phase drift, peak, RMS movement, output length error, and manual listening notes.
+- Keep runtime playback capped to the existing `0.97..1.03` direct playback-rate path until the evaluation passes.

--- a/docs/plans/2026-05-26-smart-stretch-evaluation.md
+++ b/docs/plans/2026-05-26-smart-stretch-evaluation.md
@@ -160,3 +160,24 @@ Key Signalsmith 90s rows:
 - `1.080`: `render_ms=17956`, `max_phase_drift_ms=0.896`, `peak=0.864`, `passed=true`
 
 The 5 percent and 8 percent drift gates pass, output is finite, length error is 0 frames, and peaks stay below `0.98`. The 90s render-time gate fails because the target is under `500 ms`.
+
+Release-mode benchmark was then run with:
+
+```powershell
+cargo test -p noor-mix --release --features signalsmith-eval smart_stretch_evaluation_baseline_benchmark -- --ignored --nocapture
+```
+
+Release mode is much faster and confirms Signalsmith is still a serious prepared-buffer candidate, but it does not pass the current runtime gate.
+
+Key release-mode Signalsmith rows:
+
+- 30s `1.030`: `render_ms=494`, `max_phase_drift_ms=0.604`, `peak=0.885`, `passed=true`
+- 30s `1.050`: `render_ms=487`, `max_phase_drift_ms=0.750`, `peak=0.869`, `passed=true`
+- 30s `1.080`: `render_ms=467`, `max_phase_drift_ms=0.833`, `peak=0.861`, `passed=true`
+- 90s `0.950`: `render_ms=1571`, `max_phase_drift_ms=0.771`, `peak=0.917`, `passed=true`
+- 90s `1.050`: `render_ms=1448`, `max_phase_drift_ms=0.750`, `peak=0.869`, `passed=true`
+- 90s `0.920`: `render_ms=1621`, `max_phase_drift_ms=0.833`, `peak=0.922`, `passed=true`
+- 90s `1.080`: `render_ms=1390`, `max_phase_drift_ms=0.896`, `peak=0.864`, `passed=true`
+- 180s `1.080`: `render_ms=2753`, `max_phase_drift_ms=0.896`, `peak=0.864`, `passed=true`
+
+Decision after release benchmark: keep runtime playback at the 3 percent direct nudge. Do not wire wider runtime smart stretch yet. A later prepared-buffer plan may use shorter windows, earlier background preparation, or release-only worker timing, but it needs a new gate because the original 90s-under-500ms gate failed by roughly 3x.

--- a/docs/plans/2026-05-26-smart-stretch-evaluation.md
+++ b/docs/plans/2026-05-26-smart-stretch-evaluation.md
@@ -129,3 +129,34 @@ Unable to find libclang: "couldn't find any valid shared libraries matching: ['c
 ```
 
 Per the hardened plan, do not vendor C++ or switch crates in this slice. The optional `signalsmith-eval` feature can be retried after `libclang.dll` is available and `LIBCLANG_PATH` points at it.
+
+Retried on 2026-05-27 after installing LLVM 22.1.6 with `winget` and setting:
+
+```powershell
+$env:LIBCLANG_PATH='C:\Program Files\LLVM\bin'
+```
+
+Feature gate passed:
+
+```powershell
+cargo test -p noor-mix --features signalsmith-eval stretch_eval
+```
+
+Result: 4 passed, 1 ignored.
+
+Ignored evaluation benchmark also completed:
+
+```powershell
+cargo test -p noor-mix --features signalsmith-eval smart_stretch_evaluation_baseline_benchmark -- --ignored --nocapture
+```
+
+Decision: do not allow runtime prepared-buffer stretch yet. Signalsmith quality metrics were good on the synthetic click fixtures, but render time failed the current gate by a large margin in this debug benchmark.
+
+Key Signalsmith 90s rows:
+
+- `0.950`: `render_ms=20676`, `max_phase_drift_ms=0.771`, `peak=0.917`, `passed=true`
+- `1.050`: `render_ms=18035`, `max_phase_drift_ms=0.750`, `peak=0.869`, `passed=true`
+- `0.920`: `render_ms=23449`, `max_phase_drift_ms=0.833`, `peak=0.922`, `passed=true`
+- `1.080`: `render_ms=17956`, `max_phase_drift_ms=0.896`, `peak=0.864`, `passed=true`
+
+The 5 percent and 8 percent drift gates pass, output is finite, length error is 0 frames, and peaks stay below `0.98`. The 90s render-time gate fails because the target is under `500 ms`.

--- a/noor-mix/Cargo.toml
+++ b/noor-mix/Cargo.toml
@@ -4,10 +4,15 @@ version = "0.1.0"
 edition = "2024"
 publish = false
 
+[features]
+default = []
+signalsmith-eval = ["dep:signalsmith-stretch"]
+
 [dependencies]
 anyhow = "1"
 rubato = "0.16"
 serde = { version = "1", features = ["derive"] }
+signalsmith-stretch = { version = "0.1.3", optional = true }
 thiserror = "2"
 tracing = "0.1"
 

--- a/noor-mix/src/lib.rs
+++ b/noor-mix/src/lib.rs
@@ -7,9 +7,11 @@ pub mod profile;
 pub mod program;
 pub mod qa;
 pub mod render;
+pub mod stretch_eval;
 
 pub use planner::{Planner, Policy};
 pub use profile::DjProfile;
 pub use program::{AutomationEvent, Curve, DeckId, Param, Tier, TransitionProgram};
 pub use qa::{TransitionQaReport, TransitionQaThresholds};
 pub use render::Mixer;
+pub use stretch_eval::{StretchEvaluationReport, evaluate_stretch_render};

--- a/noor-mix/src/stretch_eval.rs
+++ b/noor-mix/src/stretch_eval.rs
@@ -84,6 +84,30 @@ pub fn evaluate_stretch_render(
     }
 }
 
+#[cfg(feature = "signalsmith-eval")]
+pub fn render_signalsmith_stretch(
+    input: &[f32],
+    sample_rate: u32,
+    channels: u16,
+    tempo_ratio: f32,
+) -> Option<Vec<f32>> {
+    if !tempo_ratio.is_finite() || tempo_ratio <= 0.0 {
+        return None;
+    }
+    let channels = channels.max(1);
+    let channels_usize = usize::from(channels);
+    if input.len() % channels_usize != 0 {
+        return None;
+    }
+    let input_frames = input.len() / channels_usize;
+    let output_frames = (input_frames as f32 / tempo_ratio).round().max(1.0) as usize;
+    let output_samples = output_frames.checked_mul(channels_usize)?;
+    let mut output = vec![0.0_f32; output_samples];
+    let mut stretch =
+        signalsmith_stretch::Stretch::preset_default(u32::from(channels), sample_rate.max(1));
+    stretch.exact(input, &mut output).then_some(output)
+}
+
 fn phase_drift_ms(
     output: &[f32],
     sample_rate: u32,
@@ -222,6 +246,27 @@ mod tests {
         output
     }
 
+    fn print_eval_row(
+        renderer: &str,
+        seconds: usize,
+        tempo_ratio: f32,
+        render_ms: u128,
+        report: &StretchEvaluationReport,
+    ) {
+        let delta_pct = (tempo_ratio - 1.0).abs() * 100.0;
+        println!(
+            "smart_stretch_eval renderer={renderer} window_secs={seconds} tempo_ratio={tempo_ratio:.3} render_ms={render_ms} finite={} length_error_frames={} peak={:.3} rms_change_db={:.2} phase_markers={}/{} max_phase_drift_ms={:.3} passed={}",
+            report.finite,
+            report.length_error_frames,
+            report.peak,
+            report.rms_change_db,
+            report.phase_marker_matched,
+            report.phase_marker_count,
+            report.max_phase_drift_ms,
+            report.passes_objective_gate(delta_pct)
+        );
+    }
+
     #[test]
     fn stretch_eval_tracks_length_and_phase_for_ideal_clicks() {
         let sample_rate = 48_000;
@@ -310,7 +355,6 @@ mod tests {
                     0,
                 );
                 let render_ms = started.elapsed().as_millis();
-                let delta_pct = (tempo_ratio - 1.0).abs() * 100.0;
                 let report = evaluate_stretch_render(
                     &input,
                     &output,
@@ -319,15 +363,56 @@ mod tests {
                     tempo_ratio,
                     &markers,
                 );
-                println!(
-                    "smart_stretch_eval_baseline window_secs={seconds} tempo_ratio={tempo_ratio:.3} render_ms={render_ms} length_error_frames={} peak={:.3} rms_change_db={:.2} max_phase_drift_ms={:.3} passed={}",
-                    report.length_error_frames,
-                    report.peak,
-                    report.rms_change_db,
-                    report.max_phase_drift_ms,
-                    report.passes_objective_gate(delta_pct)
+                print_eval_row(
+                    "synthetic_baseline",
+                    seconds,
+                    tempo_ratio,
+                    render_ms,
+                    &report,
                 );
+
+                #[cfg(feature = "signalsmith-eval")]
+                {
+                    let started = Instant::now();
+                    let output =
+                        render_signalsmith_stretch(&input, sample_rate, channels, tempo_ratio)
+                            .expect("signalsmith render");
+                    let render_ms = started.elapsed().as_millis();
+                    let report = evaluate_stretch_render(
+                        &input,
+                        &output,
+                        sample_rate,
+                        channels,
+                        tempo_ratio,
+                        &markers,
+                    );
+                    print_eval_row("signalsmith", seconds, tempo_ratio, render_ms, &report);
+                }
             }
         }
+    }
+
+    #[cfg(feature = "signalsmith-eval")]
+    #[test]
+    fn signalsmith_renderer_uses_frame_based_output_size() {
+        let sample_rate = 48_000;
+        let channels = 2;
+        let tempo_ratio = 1.05;
+        let (input, markers) = click_track(sample_rate, channels, 30, 120.0);
+
+        let output =
+            render_signalsmith_stretch(&input, sample_rate, channels, tempo_ratio).expect("render");
+        let report = evaluate_stretch_render(
+            &input,
+            &output,
+            sample_rate,
+            channels,
+            tempo_ratio,
+            &markers,
+        );
+
+        assert!(report.finite, "{report:?}");
+        assert!(report.length_error_frames.abs() <= 1, "{report:?}");
+        assert!(report.peak <= 0.98, "{report:?}");
     }
 }

--- a/noor-mix/src/stretch_eval.rs
+++ b/noor-mix/src/stretch_eval.rs
@@ -1,0 +1,333 @@
+#[derive(Debug, Clone, PartialEq)]
+pub struct StretchEvaluationReport {
+    pub sample_rate: u32,
+    pub channels: u16,
+    pub tempo_ratio: f32,
+    pub input_frames: usize,
+    pub output_frames: usize,
+    pub expected_output_frames: usize,
+    pub length_error_frames: i64,
+    pub finite: bool,
+    pub non_finite_samples: usize,
+    pub peak: f32,
+    pub rms_change_db: f32,
+    pub phase_marker_count: usize,
+    pub phase_marker_matched: usize,
+    pub max_phase_drift_ms: f32,
+}
+
+impl StretchEvaluationReport {
+    pub fn passes_objective_gate(&self, tempo_delta_pct: f32) -> bool {
+        if !self.finite || self.peak > 0.98 || self.length_error_frames.abs() > 1 {
+            return false;
+        }
+        if self.phase_marker_count != self.phase_marker_matched {
+            return false;
+        }
+        let max_phase_drift_ms = if tempo_delta_pct <= 5.001 {
+            10.0
+        } else if tempo_delta_pct <= 8.001 {
+            20.0
+        } else {
+            return false;
+        };
+        self.max_phase_drift_ms <= max_phase_drift_ms
+    }
+}
+
+pub fn evaluate_stretch_render(
+    input: &[f32],
+    output: &[f32],
+    sample_rate: u32,
+    channels: u16,
+    tempo_ratio: f32,
+    source_phase_markers: &[usize],
+) -> StretchEvaluationReport {
+    let channels_usize = usize::from(channels.max(1));
+    let input_frames = input.len() / channels_usize;
+    let output_frames = output.len() / channels_usize;
+    let expected_output_frames = if tempo_ratio.is_finite() && tempo_ratio > 0.0 {
+        (input_frames as f32 / tempo_ratio).round().max(0.0) as usize
+    } else {
+        0
+    };
+    let finite = output.iter().all(|sample| sample.is_finite());
+    let non_finite_samples = output.iter().filter(|sample| !sample.is_finite()).count();
+    let peak = output
+        .iter()
+        .filter(|sample| sample.is_finite())
+        .fold(0.0_f32, |acc, sample| acc.max(sample.abs()));
+    let rms_change_db = rms_change_db(input, output);
+    let (phase_marker_matched, max_phase_drift_ms) = phase_drift_ms(
+        output,
+        sample_rate,
+        channels_usize,
+        tempo_ratio,
+        source_phase_markers,
+    );
+
+    StretchEvaluationReport {
+        sample_rate,
+        channels: channels.max(1),
+        tempo_ratio,
+        input_frames,
+        output_frames,
+        expected_output_frames,
+        length_error_frames: output_frames as i64 - expected_output_frames as i64,
+        finite,
+        non_finite_samples,
+        peak,
+        rms_change_db,
+        phase_marker_count: source_phase_markers.len(),
+        phase_marker_matched,
+        max_phase_drift_ms,
+    }
+}
+
+fn phase_drift_ms(
+    output: &[f32],
+    sample_rate: u32,
+    channels: usize,
+    tempo_ratio: f32,
+    source_phase_markers: &[usize],
+) -> (usize, f32) {
+    if source_phase_markers.is_empty() || !tempo_ratio.is_finite() || tempo_ratio <= 0.0 {
+        return (0, 0.0);
+    }
+    let search_radius_frames = (sample_rate as usize / 20).max(1);
+    let mut matched = 0_usize;
+    let mut max_drift_ms = 0.0_f32;
+    for source_frame in source_phase_markers {
+        let expected = (*source_frame as f32 / tempo_ratio).round().max(0.0) as usize;
+        let Some(found) = nearest_transient_frame(output, channels, expected, search_radius_frames)
+        else {
+            continue;
+        };
+        matched += 1;
+        let drift_frames = found.abs_diff(expected);
+        let drift_ms = drift_frames as f32 * 1_000.0 / sample_rate.max(1) as f32;
+        max_drift_ms = max_drift_ms.max(drift_ms);
+    }
+    if matched == source_phase_markers.len() {
+        (matched, max_drift_ms)
+    } else {
+        (matched, f32::INFINITY)
+    }
+}
+
+fn nearest_transient_frame(
+    output: &[f32],
+    channels: usize,
+    expected: usize,
+    search_radius_frames: usize,
+) -> Option<usize> {
+    let frame_count = output.len() / channels.max(1);
+    if frame_count == 0 {
+        return None;
+    }
+    let start = expected.saturating_sub(search_radius_frames);
+    let end = expected
+        .saturating_add(search_radius_frames)
+        .saturating_add(1)
+        .min(frame_count);
+    let mut best_frame = None;
+    let mut best_amp = 0.0_f32;
+    for frame in start..end {
+        let base = frame * channels;
+        let amp = output[base..base + channels]
+            .iter()
+            .filter(|sample| sample.is_finite())
+            .map(|sample| sample.abs())
+            .sum::<f32>()
+            / channels as f32;
+        if amp > best_amp {
+            best_amp = amp;
+            best_frame = Some(frame);
+        }
+    }
+    (best_amp > 1e-4).then_some(best_frame?)
+}
+
+fn rms_change_db(input: &[f32], output: &[f32]) -> f32 {
+    let input_rms = rms(input).max(1e-9);
+    let output_rms = rms(output).max(1e-9);
+    20.0 * (output_rms / input_rms).log10()
+}
+
+fn rms(samples: &[f32]) -> f32 {
+    let mut sum_sq = 0.0_f32;
+    let mut count = 0_usize;
+    for sample in samples.iter().copied().filter(|sample| sample.is_finite()) {
+        sum_sq += sample * sample;
+        count += 1;
+    }
+    if count == 0 {
+        return 0.0;
+    }
+    (sum_sq / count as f32).sqrt()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Instant;
+
+    fn click_track(
+        sample_rate: u32,
+        channels: u16,
+        seconds: usize,
+        bpm: f32,
+    ) -> (Vec<f32>, Vec<usize>) {
+        let channels_usize = usize::from(channels.max(1));
+        let frames = sample_rate as usize * seconds;
+        let mut samples = vec![0.0; frames * channels_usize];
+        let interval_frames = (60.0 * sample_rate as f32 / bpm).round().max(1.0) as usize;
+        let markers = (0..frames)
+            .step_by(interval_frames)
+            .inspect(|frame| {
+                for channel in 0..channels_usize {
+                    samples[*frame * channels_usize + channel] = 0.9;
+                }
+            })
+            .collect::<Vec<_>>();
+        (samples, markers)
+    }
+
+    fn render_click_markers(
+        source_markers: &[usize],
+        source_frames: usize,
+        sample_rate: u32,
+        channels: u16,
+        tempo_ratio: f32,
+        drift_frames: isize,
+    ) -> Vec<f32> {
+        let channels_usize = usize::from(channels.max(1));
+        let output_frames = (source_frames as f32 / tempo_ratio).round().max(1.0) as usize;
+        let mut output = vec![0.0; output_frames * channels_usize];
+        for source_frame in source_markers {
+            let frame = (*source_frame as f32 / tempo_ratio).round() as isize + drift_frames;
+            if frame < 0 || frame as usize >= output_frames {
+                continue;
+            }
+            for channel in 0..channels_usize {
+                output[frame as usize * channels_usize + channel] = 0.9;
+            }
+        }
+        let noise_period = (sample_rate / 10).max(1) as usize;
+        for frame in (0..output_frames).step_by(noise_period) {
+            for channel in 0..channels_usize {
+                output[frame * channels_usize + channel] += 0.01;
+            }
+        }
+        output
+    }
+
+    #[test]
+    fn stretch_eval_tracks_length_and_phase_for_ideal_clicks() {
+        let sample_rate = 48_000;
+        let channels = 2;
+        let tempo_ratio = 1.05;
+        let (input, markers) = click_track(sample_rate, channels, 30, 120.0);
+        let output = render_click_markers(
+            &markers,
+            input.len() / usize::from(channels),
+            sample_rate,
+            channels,
+            tempo_ratio,
+            0,
+        );
+
+        let report = evaluate_stretch_render(
+            &input,
+            &output,
+            sample_rate,
+            channels,
+            tempo_ratio,
+            &markers,
+        );
+
+        assert!(report.finite);
+        assert_eq!(report.length_error_frames, 0);
+        assert!(report.max_phase_drift_ms < 0.1, "{report:?}");
+        assert!(report.passes_objective_gate(5.0), "{report:?}");
+    }
+
+    #[test]
+    fn stretch_eval_rejects_excess_phase_drift() {
+        let sample_rate = 48_000;
+        let channels = 2;
+        let tempo_ratio = 1.05;
+        let (input, markers) = click_track(sample_rate, channels, 30, 120.0);
+        let output = render_click_markers(
+            &markers,
+            input.len() / usize::from(channels),
+            sample_rate,
+            channels,
+            tempo_ratio,
+            800,
+        );
+
+        let report = evaluate_stretch_render(
+            &input,
+            &output,
+            sample_rate,
+            channels,
+            tempo_ratio,
+            &markers,
+        );
+
+        assert!(report.max_phase_drift_ms > 10.0, "{report:?}");
+        assert!(!report.passes_objective_gate(5.0));
+    }
+
+    #[test]
+    fn stretch_eval_counts_non_finite_samples() {
+        let input = vec![0.0; 16];
+        let output = vec![0.0, f32::NAN, 0.2, 0.3];
+
+        let report = evaluate_stretch_render(&input, &output, 48_000, 1, 1.0, &[]);
+
+        assert!(!report.finite);
+        assert_eq!(report.non_finite_samples, 1);
+        assert!(!report.passes_objective_gate(3.0));
+    }
+
+    #[test]
+    #[ignore]
+    fn smart_stretch_evaluation_baseline_benchmark() {
+        let sample_rate = 48_000;
+        let channels = 2;
+        for seconds in [30_usize, 90, 180] {
+            let (input, markers) = click_track(sample_rate, channels, seconds, 120.0);
+            for tempo_ratio in [0.88_f32, 0.92, 0.95, 0.97, 1.03, 1.05, 1.08, 1.12] {
+                let started = Instant::now();
+                let output = render_click_markers(
+                    &markers,
+                    input.len() / usize::from(channels),
+                    sample_rate,
+                    channels,
+                    tempo_ratio,
+                    0,
+                );
+                let render_ms = started.elapsed().as_millis();
+                let delta_pct = (tempo_ratio - 1.0).abs() * 100.0;
+                let report = evaluate_stretch_render(
+                    &input,
+                    &output,
+                    sample_rate,
+                    channels,
+                    tempo_ratio,
+                    &markers,
+                );
+                println!(
+                    "smart_stretch_eval_baseline window_secs={seconds} tempo_ratio={tempo_ratio:.3} render_ms={render_ms} length_error_frames={} peak={:.3} rms_change_db={:.2} max_phase_drift_ms={:.3} passed={}",
+                    report.length_error_frames,
+                    report.peak,
+                    report.rms_change_db,
+                    report.max_phase_drift_ms,
+                    report.passes_objective_gate(delta_pct)
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the optional `signalsmith-eval` feature and offline stretch evaluation harness.
- Keeps Signalsmith out of default builds and runtime playback.
- Records benchmark/evaluation results and the decision that runtime stretch remains blocked.

## Verification

- Stacked branch verified through final stack with `cargo check -p noor-server`.
- `pnpm test -- dj_page_contract`.

## Notes

- Draft PR stacked on #71.
- This does not promote stretch into playback runtime.