### PR TITLE
feat(dj): rank queue candidates and queue pair profiles

### DIFF
--- a/docs/plans/2026-05-27-dj-aware-queue-candidate-ranking.md
+++ b/docs/plans/2026-05-27-dj-aware-queue-candidate-ranking.md
@@ -1,0 +1,40 @@
+# DJ-Aware Queue Candidate Ranking Plan
+
+Date: 2026-05-27
+
+## Summary
+
+Add DJ-aware ranking before automix, radio, or discovery candidates are inserted into the queue. This is not a transition planner change and it must never reshuffle the current plus next pair. User-selected order stays authoritative.
+
+The goal is to feed the DJ planner better adjacent candidates: compatible tempo, compatible Camelot key, usable profile confidence, and structure facts when available.
+
+## Implementation
+
+- Add a ranking helper that scores candidate media refs before queue insertion. Keep it side-effect free: input candidates plus current context, output ranked candidates plus score reasons.
+- Use existing facts only: BPM, Camelot/key compatibility, DJ profile status, profile confidence, safe-crossfade-only flags, phrase/drop facts when present, source freshness, and library/listening penalties already used by the caller.
+- Scope the first wiring to generated queues only: automix extension, radio, and discovery insertion paths. Do not apply it to explicit user enqueues, drag/drop reorder, play-next, or the already-current next row.
+- Keep missing facts conservative. Unknown BPM or key should not hard reject a candidate, but ready profiles with compatible BPM and key should outrank unknowns.
+- Emit a short reason string for the top ranked insertions so cockpit/debug logs can explain why a candidate was preferred.
+
+## API And Data Shape
+
+- No DB migration for v1.
+- No `/api/dj/status` contract change for v1 unless score reasons are later surfaced in debug.
+- Candidate score output should include `score`, `reasons`, and the original media ref or queue insert payload.
+- Reuse existing profile lookup keys for local tracks, TIDAL tracks, and pending queue items.
+
+## Tests
+
+- Unit test ranks an inside-cap BPM and compatible Camelot candidate above a BPM/key clash.
+- Unit test keeps original order stable when candidates have equal DJ scores.
+- Unit test does not reject candidates with missing BPM/key, but ranks ready compatible profiles higher.
+- Integration test for one generated queue path proves user-selected queue rows and the current plus next pair are untouched.
+- Regression test covers pending or TIDAL-only refs so ranking is source agnostic.
+
+## Guardrails
+
+- Do not mutate current playback state or queue rows already visible to the user.
+- Do not call network, decode audio, or rebuild profiles during ranking.
+- Do not claim ML learning. This is deterministic candidate scoring.
+- Keep direct runtime tempo sync capped at `0.97..1.03`; wider sync remains blocked by the Signalsmith gate.
+- If ranking cannot prove a better candidate, preserve caller order.

--- a/noor-server/src/playback/automix.rs
+++ b/noor-server/src/playback/automix.rs
@@ -17,6 +17,9 @@ use crate::db::{
     models::{AudioDspFeatures, QueueItem, Track},
     queries,
 };
+use crate::playback::dj_queue_ranker::{
+    GeneratedCandidate, append_dj_reason, rank_generated_candidates,
+};
 use crate::playback::player::{
     PlaybackSnapshot, build_session_taste_profile, load_snapshot, load_state, normalize_genre_key,
     playback_anchor_index,
@@ -242,7 +245,7 @@ fn append_automix_external_candidates(
         (limit.max(1) * 4).max(12) as i64,
         true,
     )?;
-    let mut appended = 0usize;
+    let mut candidates = Vec::new();
     for row in rows {
         if let Some(tidal_id) = row.tidal_id
             && queued_tidal_ids.contains(&tidal_id)
@@ -253,13 +256,48 @@ fn append_automix_external_candidates(
         if queued_pairs.contains(&pair) {
             continue;
         }
+        candidates.push(row);
+    }
+
+    let generated = candidates
+        .into_iter()
+        .map(|row| GeneratedCandidate {
+            track_id: None,
+            tidal_id: row.tidal_id,
+            item: row,
+        })
+        .collect::<Vec<_>>();
+    let fallback = generated
+        .iter()
+        .map(|candidate| RankedExternalCandidate {
+            row: candidate.item.clone(),
+            score: 1.0,
+            reasons: Vec::new(),
+        })
+        .collect::<Vec<_>>();
+    let ranked = rank_generated_candidates(conn, seed_track_id, generated)
+        .map(|ranked| {
+            ranked
+                .into_iter()
+                .map(|ranked| RankedExternalCandidate {
+                    row: ranked.item,
+                    score: ranked.score,
+                    reasons: ranked.reasons,
+                })
+                .collect()
+        })
+        .unwrap_or(fallback);
+    let mut appended = 0usize;
+    for ranked in ranked {
+        let row = ranked.row;
+        let reason = append_dj_reason("external similarity", ranked.score, &ranked.reasons);
         queue::append_external_track(
             conn,
             &queue::ExternalTrackInsert {
                 artist: &row.artist_name,
                 title: &row.title,
                 source: "automix-new",
-                reason: Some("external similarity"),
+                reason: Some(&reason),
                 tidal_id_hint: row.tidal_id,
                 local_track_id: None,
             },
@@ -270,6 +308,46 @@ fn append_automix_external_candidates(
         }
     }
     Ok(appended)
+}
+
+struct RankedExternalCandidate {
+    row: queries::ExternalCandidateNeighborRow,
+    score: f64,
+    reasons: Vec<&'static str>,
+}
+
+fn rank_automix_selections(
+    conn: &Connection,
+    seed_track_id: i64,
+    selections: Vec<AutomixSelection>,
+) -> Vec<AutomixSelection> {
+    let generated = selections
+        .into_iter()
+        .map(|selection| GeneratedCandidate {
+            track_id: Some(selection.track.id),
+            tidal_id: selection.track.tidal_id,
+            item: selection,
+        })
+        .collect::<Vec<_>>();
+    let fallback = generated
+        .iter()
+        .map(|candidate| candidate.item.clone())
+        .collect::<Vec<_>>();
+    rank_generated_candidates(conn, seed_track_id, generated)
+        .map(|ranked| {
+            ranked
+                .into_iter()
+                .map(|ranked| {
+                    let mut selection = ranked.item;
+                    if let Some(reason) = selection.reason.as_deref() {
+                        selection.reason =
+                            Some(append_dj_reason(reason, ranked.score, &ranked.reasons));
+                    }
+                    selection
+                })
+                .collect()
+        })
+        .unwrap_or(fallback)
 }
 
 fn load_queued_external_identities(
@@ -379,6 +457,7 @@ pub(crate) fn build_automix_extension_with_reasons(
                     .filter_map(|track| by_track.remove(&track.id))
                     .collect();
             }
+            ordered = rank_automix_selections(conn, current_track.id, ordered);
             ordered.truncate(needed);
             if !ordered.is_empty() {
                 return Ok(ordered);

--- a/noor-server/src/playback/dj_queue_ranker.rs
+++ b/noor-server/src/playback/dj_queue_ranker.rs
@@ -1,0 +1,488 @@
+use crate::db::models::{AudioDjProfileKey, AudioDspFeatures};
+use crate::db::queries;
+use crate::services::audio_analysis::{CamelotRelation, camelot_relation};
+use anyhow::Result;
+use rusqlite::{Connection, OptionalExtension, params};
+use std::cmp::Ordering;
+
+const READY_PROFILE_CONFIDENCE: f64 = 0.65;
+const PARTIAL_PROFILE_CONFIDENCE: f64 = 0.4;
+
+#[derive(Debug, Clone)]
+pub(crate) struct GeneratedCandidate<T> {
+    pub(crate) item: T,
+    pub(crate) track_id: Option<i64>,
+    pub(crate) tidal_id: Option<i64>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RankedGeneratedCandidate<T> {
+    pub(crate) item: T,
+    pub(crate) score: f64,
+    pub(crate) reasons: Vec<&'static str>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct DjQueueFacts {
+    features: Option<AudioDspFeatures>,
+    profile_confidence: Option<f64>,
+    safe_crossfade_only: bool,
+    phrase_count: usize,
+    drop_count: usize,
+}
+
+#[derive(Debug, Clone)]
+struct ScoredCandidate<T> {
+    ordinal: usize,
+    ranked: RankedGeneratedCandidate<T>,
+}
+
+pub(crate) fn rank_generated_candidates<T>(
+    conn: &Connection,
+    seed_track_id: i64,
+    candidates: Vec<GeneratedCandidate<T>>,
+) -> Result<Vec<RankedGeneratedCandidate<T>>> {
+    if candidates.len() <= 1 {
+        return Ok(candidates
+            .into_iter()
+            .map(|candidate| RankedGeneratedCandidate {
+                item: candidate.item,
+                score: 1.0,
+                reasons: Vec::new(),
+            })
+            .collect());
+    }
+
+    let seed = load_facts_for_track(conn, seed_track_id)?;
+    let mut scored = candidates
+        .into_iter()
+        .enumerate()
+        .map(|(ordinal, candidate)| {
+            let facts = load_facts(conn, candidate.track_id, candidate.tidal_id)?;
+            let (score, reasons) = score_facts(&seed, &facts);
+            Ok(ScoredCandidate {
+                ordinal,
+                ranked: RankedGeneratedCandidate {
+                    item: candidate.item,
+                    score,
+                    reasons,
+                },
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    scored.sort_by(|left, right| {
+        right
+            .ranked
+            .score
+            .partial_cmp(&left.ranked.score)
+            .unwrap_or(Ordering::Equal)
+            .then_with(|| left.ordinal.cmp(&right.ordinal))
+    });
+
+    Ok(scored.into_iter().map(|entry| entry.ranked).collect())
+}
+
+pub(crate) fn append_dj_reason(existing: &str, score: f64, reasons: &[&'static str]) -> String {
+    if reasons.is_empty() {
+        return existing.to_string();
+    }
+    format!(
+        "{} | dj: {} | {{\"dj_score\":{:.4}}}",
+        existing,
+        reasons
+            .iter()
+            .take(3)
+            .copied()
+            .collect::<Vec<_>>()
+            .join(", "),
+        score
+    )
+}
+
+fn load_facts(
+    conn: &Connection,
+    track_id: Option<i64>,
+    tidal_id: Option<i64>,
+) -> Result<DjQueueFacts> {
+    let local_track_id = match (track_id, tidal_id) {
+        (Some(track_id), _) if track_id > 0 => Some(track_id),
+        (_, Some(tidal_id)) if tidal_id > 0 => local_track_id_for_tidal_id(conn, tidal_id)?,
+        _ => None,
+    };
+    if let Some(track_id) = local_track_id {
+        return load_facts_for_track(conn, track_id);
+    }
+    if let Some(tidal_id) = tidal_id.filter(|id| *id > 0) {
+        return load_facts_for_key(
+            conn,
+            AudioDjProfileKey {
+                media_ref_kind: "tidal_track".to_string(),
+                media_ref_id: tidal_id.to_string(),
+            },
+            None,
+        );
+    }
+    Ok(DjQueueFacts::default())
+}
+
+fn load_facts_for_track(conn: &Connection, track_id: i64) -> Result<DjQueueFacts> {
+    let features = queries::get_audio_dsp_features(conn, track_id)
+        .ok()
+        .flatten();
+    let profile = queries::get_audio_dj_profile_for_track(conn, track_id)
+        .ok()
+        .flatten();
+    let library_key = AudioDjProfileKey {
+        media_ref_kind: "library_track".to_string(),
+        media_ref_id: track_id.to_string(),
+    };
+    let correction = queries::get_audio_dj_profile_correction(conn, &library_key)
+        .ok()
+        .flatten()
+        .or_else(|| {
+            tidal_id_for_track(conn, track_id)
+                .ok()
+                .flatten()
+                .and_then(|tidal_id| {
+                    queries::get_audio_dj_profile_correction(
+                        conn,
+                        &AudioDjProfileKey {
+                            media_ref_kind: "tidal_track".to_string(),
+                            media_ref_id: tidal_id.to_string(),
+                        },
+                    )
+                    .ok()
+                    .flatten()
+                })
+        });
+    Ok(DjQueueFacts {
+        features,
+        profile_confidence: profile.as_ref().map(|profile| profile.profile_confidence),
+        safe_crossfade_only: correction
+            .as_ref()
+            .is_some_and(|correction| correction.safe_crossfade_only),
+        phrase_count: profile
+            .as_ref()
+            .map(|profile| profile.phrase_boundaries_blob.len() / 4)
+            .unwrap_or_default(),
+        drop_count: profile
+            .as_ref()
+            .map(|profile| profile.drop_blob.len() / 12)
+            .unwrap_or_default(),
+    })
+}
+
+fn load_facts_for_key(
+    conn: &Connection,
+    key: AudioDjProfileKey,
+    track_id: Option<i64>,
+) -> Result<DjQueueFacts> {
+    let features = track_id.and_then(|id| queries::get_audio_dsp_features(conn, id).ok().flatten());
+    let profile = queries::get_audio_dj_profile(conn, &key).ok().flatten();
+    let correction = queries::get_audio_dj_profile_correction(conn, &key)
+        .ok()
+        .flatten();
+    Ok(DjQueueFacts {
+        features,
+        profile_confidence: profile.as_ref().map(|profile| profile.profile_confidence),
+        safe_crossfade_only: correction
+            .as_ref()
+            .is_some_and(|correction| correction.safe_crossfade_only),
+        phrase_count: profile
+            .as_ref()
+            .map(|profile| profile.phrase_boundaries_blob.len() / 4)
+            .unwrap_or_default(),
+        drop_count: profile
+            .as_ref()
+            .map(|profile| profile.drop_blob.len() / 12)
+            .unwrap_or_default(),
+    })
+}
+
+fn local_track_id_for_tidal_id(conn: &Connection, tidal_id: i64) -> Result<Option<i64>> {
+    conn.query_row(
+        "SELECT id FROM tracks WHERE tidal_id = ?1 LIMIT 1",
+        params![tidal_id],
+        |row| row.get(0),
+    )
+    .optional()
+    .map_err(Into::into)
+}
+
+fn tidal_id_for_track(conn: &Connection, track_id: i64) -> Result<Option<i64>> {
+    conn.query_row(
+        "SELECT tidal_id FROM tracks WHERE id = ?1",
+        params![track_id],
+        |row| row.get(0),
+    )
+    .optional()
+    .map_err(Into::into)
+}
+
+fn score_facts(seed: &DjQueueFacts, candidate: &DjQueueFacts) -> (f64, Vec<&'static str>) {
+    let mut score = 1.0;
+    let mut reasons = Vec::new();
+
+    if let (Some(seed_features), Some(candidate_features)) =
+        (seed.features.as_ref(), candidate.features.as_ref())
+    {
+        if let (Some(seed_bpm), Some(candidate_bpm)) = (seed_features.bpm, candidate_features.bpm) {
+            match tempo_fit(seed_bpm, candidate_bpm) {
+                TempoFit::InsideNudge => {
+                    score *= 1.55;
+                    reasons.push("tempo inside 3 percent");
+                }
+                TempoFit::Near => {
+                    score *= 1.18;
+                    reasons.push("near tempo");
+                }
+                TempoFit::Wide => {
+                    score *= 0.72;
+                    reasons.push("wide tempo");
+                }
+            }
+        }
+
+        if let (Some(seed_key), Some(candidate_key)) = (
+            seed_features.camelot_key.as_deref(),
+            candidate_features.camelot_key.as_deref(),
+        ) {
+            match camelot_relation(seed_key, candidate_key) {
+                CamelotRelation::Compatible => {
+                    score *= 1.45;
+                    reasons.push("harmonic match");
+                }
+                CamelotRelation::Adjacent => {
+                    score *= 1.18;
+                    reasons.push("adjacent key");
+                }
+                CamelotRelation::Clash => {
+                    score *= 0.72;
+                    reasons.push("key clash");
+                }
+            }
+        }
+    }
+
+    if candidate.safe_crossfade_only {
+        score *= 0.55;
+        reasons.push("safe-only profile");
+    } else if let Some(confidence) = candidate.profile_confidence {
+        if confidence >= READY_PROFILE_CONFIDENCE {
+            score *= 1.28;
+            reasons.push("ready DJ profile");
+        } else if confidence >= PARTIAL_PROFILE_CONFIDENCE {
+            score *= 1.08;
+            reasons.push("partial DJ profile");
+        }
+    }
+
+    if candidate.drop_count > 0 {
+        score *= 1.08;
+        reasons.push("drop marker");
+    }
+    if candidate.phrase_count >= 4 {
+        score *= 1.05;
+        reasons.push("phrase markers");
+    }
+
+    (score, reasons)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TempoFit {
+    InsideNudge,
+    Near,
+    Wide,
+}
+
+fn tempo_fit(seed_bpm: f64, candidate_bpm: f64) -> TempoFit {
+    if !seed_bpm.is_finite()
+        || !candidate_bpm.is_finite()
+        || seed_bpm <= 0.0
+        || candidate_bpm <= 0.0
+    {
+        return TempoFit::Wide;
+    }
+    let best_ratio_delta = [0.5, 1.0, 2.0]
+        .into_iter()
+        .map(|family| ((candidate_bpm * family) / seed_bpm - 1.0).abs())
+        .fold(f64::INFINITY, f64::min);
+    if best_ratio_delta <= 0.03 {
+        TempoFit::InsideNudge
+    } else if best_ratio_delta <= 0.08 {
+        TempoFit::Near
+    } else {
+        TempoFit::Wide
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::models::AudioDspFeatures;
+
+    fn features(bpm: f64, key: &str) -> AudioDspFeatures {
+        AudioDspFeatures {
+            track_id: 0,
+            bpm: Some(bpm),
+            key_signature: None,
+            camelot_key: Some(key.to_string()),
+            loudness_lufs: None,
+            energy: None,
+            danceability: None,
+            beat_strength: None,
+            spectral_centroid: None,
+            stereo_width: None,
+            is_instrumental: false,
+            analysis_source: "test".to_string(),
+            analysis_offset_ms: 0,
+            samples_analyzed: None,
+            analyzed_at: "2026-01-01T00:00:00Z".to_string(),
+            analysis_version: "test".to_string(),
+        }
+    }
+
+    #[test]
+    fn score_prefers_inside_cap_bpm_and_compatible_camelot() {
+        let seed = DjQueueFacts {
+            features: Some(features(124.0, "8A")),
+            ..DjQueueFacts::default()
+        };
+        let compatible = DjQueueFacts {
+            features: Some(features(126.0, "8A")),
+            profile_confidence: Some(0.8),
+            phrase_count: 16,
+            drop_count: 1,
+            ..DjQueueFacts::default()
+        };
+        let clash = DjQueueFacts {
+            features: Some(features(145.0, "3B")),
+            profile_confidence: Some(0.8),
+            ..DjQueueFacts::default()
+        };
+
+        let (compatible_score, compatible_reasons) = score_facts(&seed, &compatible);
+        let (clash_score, clash_reasons) = score_facts(&seed, &clash);
+
+        assert!(compatible_score > clash_score);
+        assert!(compatible_reasons.contains(&"tempo inside 3 percent"));
+        assert!(compatible_reasons.contains(&"harmonic match"));
+        assert!(clash_reasons.contains(&"wide tempo"));
+        assert!(clash_reasons.contains(&"key clash"));
+    }
+
+    #[test]
+    fn score_keeps_missing_bpm_and_key_neutral() {
+        let seed = DjQueueFacts {
+            features: Some(features(124.0, "8A")),
+            ..DjQueueFacts::default()
+        };
+        let missing = DjQueueFacts {
+            profile_confidence: Some(0.8),
+            ..DjQueueFacts::default()
+        };
+        let ready = DjQueueFacts {
+            features: Some(features(124.5, "8A")),
+            profile_confidence: Some(0.8),
+            ..DjQueueFacts::default()
+        };
+
+        let (missing_score, missing_reasons) = score_facts(&seed, &missing);
+        let (ready_score, _) = score_facts(&seed, &ready);
+
+        assert!(missing_score > 1.0);
+        assert!(ready_score > missing_score);
+        assert!(!missing_reasons.contains(&"wide tempo"));
+        assert!(!missing_reasons.contains(&"key clash"));
+    }
+
+    #[test]
+    fn rank_generated_candidates_keeps_equal_scores_stable() {
+        let conn = Connection::open_in_memory().expect("db");
+        let ranked = rank_generated_candidates(
+            &conn,
+            1,
+            vec![
+                GeneratedCandidate {
+                    item: "first",
+                    track_id: None,
+                    tidal_id: None,
+                },
+                GeneratedCandidate {
+                    item: "second",
+                    track_id: None,
+                    tidal_id: None,
+                },
+            ],
+        )
+        .expect("rank");
+
+        assert_eq!(ranked[0].item, "first");
+        assert_eq!(ranked[1].item, "second");
+    }
+
+    #[test]
+    fn rank_generated_candidates_uses_tidal_id_for_local_facts() {
+        let conn = Connection::open_in_memory().expect("db");
+        conn.execute_batch(
+            "
+            CREATE TABLE tracks (id INTEGER PRIMARY KEY, tidal_id INTEGER);
+            CREATE TABLE audio_dsp_features (
+                track_id INTEGER PRIMARY KEY,
+                bpm REAL,
+                key_signature TEXT,
+                camelot_key TEXT,
+                loudness_lufs REAL,
+                energy REAL,
+                danceability REAL,
+                beat_strength REAL,
+                spectral_centroid REAL,
+                stereo_width REAL,
+                is_instrumental INTEGER NOT NULL DEFAULT 0,
+                analysis_source TEXT NOT NULL DEFAULT 'test',
+                analysis_offset_ms INTEGER NOT NULL DEFAULT 0,
+                samples_analyzed INTEGER,
+                analyzed_at TEXT NOT NULL DEFAULT '2026-01-01T00:00:00Z',
+                analysis_version TEXT NOT NULL DEFAULT 'test'
+            );
+            ",
+        )
+        .expect("schema");
+        conn.execute(
+            "INSERT INTO tracks (id, tidal_id) VALUES (2, 9002), (3, 9003)",
+            [],
+        )
+        .expect("tracks");
+        for (track_id, bpm, key) in [(1, 124.0, "8A"), (2, 125.0, "8A"), (3, 145.0, "3B")] {
+            conn.execute(
+                "INSERT INTO audio_dsp_features (track_id, bpm, camelot_key) VALUES (?1, ?2, ?3)",
+                params![track_id, bpm, key],
+            )
+            .expect("features");
+        }
+
+        let ranked = rank_generated_candidates(
+            &conn,
+            1,
+            vec![
+                GeneratedCandidate {
+                    item: "clash",
+                    track_id: Some(3),
+                    tidal_id: Some(9003),
+                },
+                GeneratedCandidate {
+                    item: "tidal-fit",
+                    track_id: None,
+                    tidal_id: Some(9002),
+                },
+            ],
+        )
+        .expect("rank");
+
+        assert_eq!(ranked[0].item, "tidal-fit");
+        assert!(ranked[0].reasons.contains(&"tempo inside 3 percent"));
+        assert!(ranked[0].reasons.contains(&"harmonic match"));
+    }
+}

--- a/noor-server/src/playback/mod.rs
+++ b/noor-server/src/playback/mod.rs
@@ -2,6 +2,7 @@ pub mod automix;
 pub mod decode;
 pub mod dj_engine;
 pub mod dj_lookahead;
+pub mod dj_queue_ranker;
 pub mod gapless;
 pub mod output;
 pub mod pending;

--- a/noor-server/src/server/radio_pipeline.rs
+++ b/noor-server/src/server/radio_pipeline.rs
@@ -1,3 +1,6 @@
+use crate::playback::dj_queue_ranker::{
+    GeneratedCandidate, append_dj_reason, rank_generated_candidates,
+};
 use crate::services::radio::RadioCandidate;
 use rusqlite::OptionalExtension;
 
@@ -21,10 +24,11 @@ pub fn build_radio_queue_from_candidates_with_seed(
 ) -> rusqlite::Result<RadioQueueBuild> {
     // Seed track leads the queue, matching the user's explicit radio seed.
     // orchestrate_song already excludes it; this filter is a defensive guard.
-    let (library_cands, pending_cands): (Vec<_>, Vec<_>) = candidates
+    let candidates = candidates
         .into_iter()
         .filter(|c| seed_track_id != Some(c.track_id))
-        .partition(|c| c.is_in_library && c.track_id > 0);
+        .collect::<Vec<_>>();
+    let candidates = rank_radio_candidates(conn, seed_track_id, candidates);
 
     let tx = conn.unchecked_transaction()?;
 
@@ -39,21 +43,8 @@ pub fn build_radio_queue_from_candidates_with_seed(
         pos += 1;
     }
 
-    for c in &library_cands {
-        tx.execute(
-            "INSERT INTO queue (track_id, position, source, reason) VALUES (?1, ?2, 'radio', ?3)",
-            rusqlite::params![c.track_id, pos, c.reason],
-        )?;
-        pos += 1;
-    }
-
-    for c in &pending_cands {
-        tx.execute(
-            "INSERT INTO queue (track_id, position, source, reason,
-                                pending_artist, pending_title, pending_at, tidal_id_hint)
-             VALUES (NULL, ?1, 'radio_pending', ?2, ?3, ?4, datetime('now'), ?5)",
-            rusqlite::params![pos, c.reason, c.artist_name, c.title, c.tidal_track_id],
-        )?;
+    for c in &candidates {
+        insert_radio_candidate(&tx, c, pos)?;
         pos += 1;
     }
 
@@ -82,9 +73,7 @@ pub fn append_radio_queue_from_candidates(
     conn: &rusqlite::Connection,
     candidates: Vec<RadioCandidate>,
 ) -> rusqlite::Result<RadioQueueBuild> {
-    let (library_cands, pending_cands): (Vec<_>, Vec<_>) = candidates
-        .into_iter()
-        .partition(|c| c.is_in_library && c.track_id > 0);
+    let candidates = rank_radio_candidates(conn, append_seed_track_id(conn), candidates);
 
     let tx = conn.unchecked_transaction()?;
     let mut pos: i32 = tx.query_row(
@@ -93,23 +82,11 @@ pub fn append_radio_queue_from_candidates(
         |row| row.get(0),
     )?;
 
-    for c in &library_cands {
-        tx.execute(
-            "INSERT INTO queue (track_id, position, source, reason) VALUES (?1, ?2, 'radio', ?3)",
-            rusqlite::params![c.track_id, pos, c.reason],
-        )?;
-        pos += 1;
-    }
-
     let mut pending_item_ids = Vec::new();
-    for c in &pending_cands {
-        tx.execute(
-            "INSERT INTO queue (track_id, position, source, reason,
-                                pending_artist, pending_title, pending_at, tidal_id_hint)
-             VALUES (NULL, ?1, 'radio_pending', ?2, ?3, ?4, datetime('now'), ?5)",
-            rusqlite::params![pos, c.reason, c.artist_name, c.title, c.tidal_track_id],
-        )?;
-        pending_item_ids.push(tx.last_insert_rowid());
+    for c in &candidates {
+        if insert_radio_candidate(&tx, c, pos)? {
+            pending_item_ids.push(tx.last_insert_rowid());
+        }
         pos += 1;
     }
 
@@ -127,6 +104,89 @@ pub fn append_radio_queue_from_candidates(
         first_item,
         pending_item_ids,
     })
+}
+
+fn insert_radio_candidate(
+    conn: &rusqlite::Connection,
+    candidate: &RadioCandidate,
+    position: i32,
+) -> rusqlite::Result<bool> {
+    if candidate.is_in_library && candidate.track_id > 0 {
+        conn.execute(
+            "INSERT INTO queue (track_id, position, source, reason) VALUES (?1, ?2, 'radio', ?3)",
+            rusqlite::params![candidate.track_id, position, candidate.reason],
+        )?;
+        return Ok(false);
+    }
+    conn.execute(
+        "INSERT INTO queue (track_id, position, source, reason,
+                            pending_artist, pending_title, pending_at, tidal_id_hint)
+         VALUES (NULL, ?1, 'radio_pending', ?2, ?3, ?4, datetime('now'), ?5)",
+        rusqlite::params![
+            position,
+            candidate.reason,
+            candidate.artist_name,
+            candidate.title,
+            candidate.tidal_track_id
+        ],
+    )?;
+    Ok(true)
+}
+
+fn append_seed_track_id(conn: &rusqlite::Connection) -> Option<i64> {
+    conn.query_row(
+        "SELECT current_track_id FROM playback_state WHERE id = 1",
+        [],
+        |row| row.get::<_, Option<i64>>(0),
+    )
+    .ok()
+    .flatten()
+    .or_else(|| {
+        conn.query_row(
+            "SELECT track_id FROM queue WHERE track_id IS NOT NULL ORDER BY position DESC, id DESC LIMIT 1",
+            [],
+            |row| row.get(0),
+        )
+        .optional()
+        .ok()
+        .flatten()
+    })
+}
+
+fn rank_radio_candidates(
+    conn: &rusqlite::Connection,
+    seed_track_id: Option<i64>,
+    candidates: Vec<RadioCandidate>,
+) -> Vec<RadioCandidate> {
+    let Some(seed_track_id) = seed_track_id else {
+        return candidates;
+    };
+    let generated = candidates
+        .into_iter()
+        .map(|candidate| GeneratedCandidate {
+            track_id: (candidate.is_in_library && candidate.track_id > 0)
+                .then_some(candidate.track_id),
+            tidal_id: candidate.tidal_track_id,
+            item: candidate,
+        })
+        .collect::<Vec<_>>();
+    let fallback = generated
+        .iter()
+        .map(|candidate| candidate.item.clone())
+        .collect::<Vec<_>>();
+    rank_generated_candidates(conn, seed_track_id, generated)
+        .map(|ranked| {
+            ranked
+                .into_iter()
+                .map(|ranked| {
+                    let mut candidate = ranked.item;
+                    candidate.reason =
+                        append_dj_reason(&candidate.reason, ranked.score, &ranked.reasons);
+                    candidate
+                })
+                .collect()
+        })
+        .unwrap_or(fallback)
 }
 
 #[cfg(test)]
@@ -187,6 +247,40 @@ mod tests {
         }
     }
 
+    fn add_dsp_table(conn: &rusqlite::Connection) {
+        conn.execute_batch(
+            "
+            CREATE TABLE audio_dsp_features (
+                track_id INTEGER PRIMARY KEY,
+                bpm REAL,
+                key_signature TEXT,
+                camelot_key TEXT,
+                loudness_lufs REAL,
+                energy REAL,
+                danceability REAL,
+                beat_strength REAL,
+                spectral_centroid REAL,
+                stereo_width REAL,
+                is_instrumental INTEGER NOT NULL DEFAULT 0,
+                analysis_source TEXT NOT NULL DEFAULT 'test',
+                analysis_offset_ms INTEGER NOT NULL DEFAULT 0,
+                samples_analyzed INTEGER,
+                analyzed_at TEXT NOT NULL DEFAULT '2026-01-01T00:00:00Z',
+                analysis_version TEXT NOT NULL DEFAULT 'test'
+            );
+            ",
+        )
+        .unwrap();
+    }
+
+    fn insert_features(conn: &rusqlite::Connection, track_id: i64, bpm: f64, key: &str) {
+        conn.execute(
+            "INSERT INTO audio_dsp_features (track_id, bpm, camelot_key) VALUES (?1, ?2, ?3)",
+            rusqlite::params![track_id, bpm, key],
+        )
+        .unwrap();
+    }
+
     #[test]
     fn optional_seed_builds_queue_from_candidates_without_seed_row() {
         let conn = conn_with_queue();
@@ -229,6 +323,43 @@ mod tests {
             )
             .unwrap();
         assert_eq!(hint, Some(9001));
+    }
+
+    #[test]
+    fn radio_queue_ranks_generated_candidates_by_dj_fit_after_seed() {
+        let conn = conn_with_queue();
+        add_dsp_table(&conn);
+        insert_features(&conn, 1, 124.0, "8A");
+        insert_features(&conn, 10, 126.0, "8A");
+        insert_features(&conn, 20, 145.0, "3B");
+
+        build_radio_queue_from_candidates_with_seed(
+            &conn,
+            Some(1),
+            vec![
+                candidate(20, true, "Clash Artist", "Clash Track"),
+                candidate(10, true, "Fit Artist", "Fit Track"),
+            ],
+        )
+        .unwrap();
+
+        let rows: Vec<(i32, Option<i64>, Option<String>)> = conn
+            .prepare("SELECT position, track_id, reason FROM queue ORDER BY position ASC")
+            .unwrap()
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap();
+
+        assert_eq!(rows[0], (0, Some(1), None));
+        assert_eq!(rows[1].1, Some(10));
+        assert_eq!(rows[2].1, Some(20));
+        assert!(
+            rows[1]
+                .2
+                .as_deref()
+                .is_some_and(|reason| reason.contains("dj: tempo inside 3 percent"))
+        );
     }
 
     #[test]

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -57,6 +57,15 @@ const EPHEMERAL_DJ_LOOKAHEAD_DEADLINE_SAMPLES: u64 = 48_000 * 30;
 const PLAYBACK_FINISH_DB_LOCK_RETRY_LIMIT: usize = 60;
 const PLAYBACK_FINISH_DB_LOCK_RETRY_DELAY_SECS: u64 = 2;
 
+async fn queue_missing_dj_profiles_after_pair_change(state: SharedState, context: &'static str) {
+    if let Err(status) = dj_routes::queue_missing_dj_profiles_for_current_pair(state).await {
+        warn!(
+            ?status,
+            context, "DJ profile queueing failed after pair change"
+        );
+    }
+}
+
 #[derive(Debug, Deserialize)]
 pub struct ListParams {
     sort_by: Option<String>,
@@ -10744,6 +10753,8 @@ async fn start_ephemeral_tidal_playback(
         };
         if let Some(lookahead) = lookahead {
             let _ = lookahead.dispatch(&runtime_handle);
+            queue_missing_dj_profiles_after_pair_change(state.clone(), "ephemeral_tidal_mix_start")
+                .await;
         }
     }
 
@@ -11474,6 +11485,10 @@ async fn handle_ephemeral_tidal_near_end(
     .context("ephemeral TIDAL mix pair unavailable")?;
     let lookahead_start =
         player::dj_lookahead_start_from_pair(pair.clone(), EPHEMERAL_DJ_LOOKAHEAD_DEADLINE_SAMPLES);
+    if lookahead_start.is_some() {
+        queue_missing_dj_profiles_after_pair_change(state.clone(), "ephemeral_tidal_mix_prebuffer")
+            .await;
+    }
     let effective_crossfade = current_crossfade_ms(&state).await;
     let mut job = player::build_playback_preparation(
         &synthetic,
@@ -11829,6 +11844,8 @@ async fn handle_near_end_prebuffer_next(
         && let Some(start) = lookahead_start
     {
         let _ = start.dispatch(&handle);
+        queue_missing_dj_profiles_after_pair_change(state.clone(), "prepared_next_transition")
+            .await;
     }
     let _ = handle.prepare_next(job);
     if let Some(ref si) = stream_info {

--- a/noor-server/src/server/routes/dj_routes.rs
+++ b/noor-server/src/server/routes/dj_routes.rs
@@ -549,7 +549,9 @@ async fn get_status(
     Ok(Json(response))
 }
 
-async fn queue_missing_dj_profiles_for_current_pair(state: SharedState) -> Result<(), StatusCode> {
+pub(super) async fn queue_missing_dj_profiles_for_current_pair(
+    state: SharedState,
+) -> Result<(), StatusCode> {
     let missing_profile_refs = {
         let state_guard = state.read().await;
         let ephemeral_pair = super::active_ephemeral_tidal_mix_dj_pair(&state_guard);

--- a/noor-server/src/services/audio_analysis/queue_prescanner.rs
+++ b/noor-server/src/services/audio_analysis/queue_prescanner.rs
@@ -23,12 +23,16 @@ pub const INTER_TRACK_DELAY: std::time::Duration = std::time::Duration::from_mil
 pub const BATCH_COOLDOWN: std::time::Duration = std::time::Duration::from_secs(30);
 /// Hard ceiling on the per-track preview download + decode chain. If TIDAL
 /// stalls a segment indefinitely (observed for some catalog rows), the actor
-/// gets stuck. 60 s comfortably exceeds the ~45 s nominal cost.
+/// gets stuck. Segment fetches use a shorter guard so one slow media segment
+/// does not consume the full per-track budget.
 pub const PREFETCH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+const SEGMENT_FETCH_TIMEOUT: Duration = Duration::from_secs(8);
 const MIN_PARTIAL_BYTES: usize = 32 * 1024;
+const MAX_BYTES: usize = 8 * 1024 * 1024;
+const MAX_DASH_MEDIA_SEGMENTS: usize = 12;
 const STREAM_REJECTED_CACHE_TTL: Duration = Duration::from_secs(30 * 60);
 const TRANSIENT_FAILURE_CACHE_TTL: Duration = Duration::from_secs(5 * 60);
-const MAX_TRANSIENT_FAILURES_PER_BATCH: usize = 2;
+const MAX_TRANSIENT_FAILURES_PER_BATCH: usize = LOOKAHEAD;
 
 static PRESCAN_NEGATIVE_CACHE: LazyLock<Mutex<HashMap<i64, PrescanNegativeCacheEntry>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
@@ -113,6 +117,10 @@ fn should_abort_prescan_batch(transient_failures: usize) -> bool {
     transient_failures >= MAX_TRANSIENT_FAILURES_PER_BATCH
 }
 
+fn prescan_dash_media_segments(total_segments: usize) -> usize {
+    total_segments.min(MAX_DASH_MEDIA_SEGMENTS)
+}
+
 fn reqwest_error_summary(error: &reqwest::Error) -> String {
     let kind = if error.is_timeout() {
         "timeout"
@@ -176,14 +184,28 @@ use crate::AppEvent;
 use crate::SharedState;
 use crate::db::queries;
 use anyhow::{Context, Result};
-use futures::StreamExt;
 use std::collections::HashMap;
 use std::sync::{LazyLock, Mutex};
 use std::time::{Duration, Instant as StdInstant};
 
-/// Resolve the TIDAL LOW-quality stream for `track_id`, pull the audio bytes
-/// (capped at 8 MB so the MP4 `moov` atom is included — see `scanner.rs` for
-/// the rationale), decode the first ~30 s to mono f32, run DSP, and persist.
+async fn fetch_prescan_segment(
+    http_client: &reqwest::Client,
+    seg_url: &str,
+) -> std::result::Result<Vec<u8>, String> {
+    let resp = tokio::time::timeout(SEGMENT_FETCH_TIMEOUT, http_client.get(seg_url).send())
+        .await
+        .map_err(|_| "timeout".to_string())?
+        .map_err(|error| reqwest_error_summary(&error))?;
+
+    tokio::time::timeout(SEGMENT_FETCH_TIMEOUT, resp.bytes())
+        .await
+        .map_err(|_| "timeout".to_string())?
+        .map(|bytes| bytes.to_vec())
+        .map_err(|error| reqwest_error_summary(&error))
+}
+
+/// Resolve the TIDAL LOW-quality stream for `track_id`, pull a bounded preview
+/// window, decode the first ~30 s to mono f32, run DSP, and persist.
 ///
 /// Skips silently (returns `Ok(false)`) when:
 /// - the track is already at `CURRENT_ANALYSIS_VERSION`
@@ -271,20 +293,29 @@ pub async fn prefetch_and_analyze_track(state: &SharedState, track_id: i64) -> R
         }
     };
 
-    // 8 MB ≈ 11 min of 96 kbps AAC; keeps the moov atom intact for Symphonia.
-    const MAX_BYTES: usize = 8 * 1024 * 1024;
+    // Keep the init segment plus enough media segments for a preview window.
+    // Walking the whole DASH manifest lets one slow catalog row starve the
+    // lookahead batch.
     let mut buf: Vec<u8> = Vec::with_capacity(512 * 1024);
-    'segments: for seg_url in
-        std::iter::once(&stream_info.url).chain(stream_info.segment_urls.iter())
+    let media_segments = prescan_dash_media_segments(stream_info.segment_urls.len());
+    for seg_url in std::iter::once(&stream_info.url)
+        .chain(stream_info.segment_urls.iter().take(media_segments))
     {
         if buf.len() >= MAX_BYTES {
             break;
         }
-        let resp = match http_client.get(seg_url).send().await {
-            Ok(resp) => resp,
-            Err(error) => {
+        match fetch_prescan_segment(&http_client, seg_url).await {
+            Ok(segment) => {
+                let remaining = MAX_BYTES.saturating_sub(buf.len());
+                if segment.len() <= remaining {
+                    buf.extend_from_slice(&segment);
+                } else {
+                    buf.extend_from_slice(&segment[..remaining]);
+                    break;
+                }
+            }
+            Err(error_summary) => {
                 cache_prescan_failure(track_id, PrescanFailureClass::TransientFailure);
-                let error_summary = reqwest_error_summary(&error);
                 if buf.len() >= MIN_PARTIAL_BYTES {
                     tracing::info!(
                         track_id,
@@ -295,33 +326,6 @@ pub async fn prefetch_and_analyze_track(state: &SharedState, track_id: i64) -> R
                     break;
                 }
                 return Err(anyhow::anyhow!("fetch segment: {error_summary}"));
-            }
-        };
-        let mut stream = resp.bytes_stream();
-        while let Some(chunk) = stream.next().await {
-            let c = match chunk {
-                Ok(chunk) => chunk,
-                Err(error) => {
-                    cache_prescan_failure(track_id, PrescanFailureClass::TransientFailure);
-                    let error_summary = reqwest_error_summary(&error);
-                    if buf.len() >= MIN_PARTIAL_BYTES {
-                        tracing::info!(
-                            track_id,
-                            bytes = buf.len(),
-                            error = %error_summary,
-                            "prescanner: continuing with partial clip after stream chunk failure"
-                        );
-                        break 'segments;
-                    }
-                    return Err(anyhow::anyhow!("stream chunk: {error_summary}"));
-                }
-            };
-            let remaining = MAX_BYTES.saturating_sub(buf.len());
-            if c.len() <= remaining {
-                buf.extend_from_slice(&c);
-            } else {
-                buf.extend_from_slice(&c[..remaining]);
-                break 'segments;
             }
         }
     }
@@ -692,6 +696,21 @@ mod tests {
             MAX_TRANSIENT_FAILURES_PER_BATCH - 1
         ));
         assert!(should_abort_prescan_batch(MAX_TRANSIENT_FAILURES_PER_BATCH));
+    }
+
+    #[test]
+    fn two_transient_failures_do_not_abort_prescan_batch() {
+        assert!(!should_abort_prescan_batch(2));
+    }
+
+    #[test]
+    fn dash_prescan_caps_media_segments_to_preview_window() {
+        assert_eq!(prescan_dash_media_segments(0), 0);
+        assert_eq!(prescan_dash_media_segments(5), 5);
+        assert_eq!(
+            prescan_dash_media_segments(MAX_DASH_MEDIA_SEGMENTS + 10),
+            MAX_DASH_MEDIA_SEGMENTS
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Keeps prescan batches moving after transient timeouts.
- Adds the DJ-aware queue candidate ranking plan and implementation.
- Queues DJ profiles after pair changes so the next transitions get profile lead time.

## Verification

- Stacked branch verified with `cargo check -p noor-server`.
- `pnpm test -- dj_page_contract`.

## Notes

- Draft PR stacked on #72.
- User-selected order stays authoritative. Ranking applies to generated automix/radio/discovery candidates before insertion.