### PR TITLE
Fix DJ analysis retry and stale fallback handling

### DIFF
--- a/noor-server/src/db/queries.rs
+++ b/noor-server/src/db/queries.rs
@@ -7599,6 +7599,51 @@ pub fn update_dj_transition_outcome(
     Ok(())
 }
 
+pub fn replace_armed_dj_transition_event(
+    conn: &Connection,
+    id: i64,
+    template: &str,
+    program_json: &str,
+    rejected_alternatives_json: Option<&str>,
+    planner_version: &str,
+    fallback_reason: Option<&str>,
+    planned_start_ms: Option<i64>,
+    timing_source: Option<&str>,
+) -> Result<()> {
+    validate_dj_fallback_reason(fallback_reason)?;
+    validate_dj_timing_source(timing_source)?;
+    conn.execute(
+        "UPDATE dj_transition_events
+         SET template = ?2,
+             program_json = ?3,
+             rejected_alternatives_json = ?4,
+             planner_version = ?5,
+             fallback_reason = ?6,
+             planned_start_ms = ?7,
+             actual_start_ms = NULL,
+             timing_delta_ms = NULL,
+             timing_source = ?8,
+             runtime_rendered_dj_mixer = NULL,
+             runtime_renderer_status = NULL,
+             runtime_renderer_reason = NULL
+         WHERE id = ?1
+           AND timing_status = 'armed'
+           AND actual_start_ms IS NULL
+           AND outcome IS NULL",
+        params![
+            id,
+            template,
+            program_json,
+            rejected_alternatives_json,
+            planner_version,
+            fallback_reason,
+            planned_start_ms,
+            timing_source,
+        ],
+    )?;
+    Ok(())
+}
+
 pub fn update_dj_transition_fire_timing(
     conn: &Connection,
     id: i64,

--- a/noor-server/src/playback/player.rs
+++ b/noor-server/src/playback/player.rs
@@ -354,21 +354,36 @@ pub fn attach_dj_transition_plan_for_pair_with_current_duration(
     {
         return Ok(job);
     }
-    if let Some((existing_event_id, existing_program)) = engine
+    let existing_armed = engine
         .db()
-        .with_conn(|conn| latest_armed_dj_transition_event_for_pair(conn, current, next))?
-    {
-        let fire_ahead_ms = engine.db().with_conn(dj_transition_fire_ahead_ms)?;
-        job = job.with_prepared_transition(PreparedTransitionProgram {
-            program: existing_program,
-            transition_event_id: Some(existing_event_id),
-            fire_ahead_ms,
-            queue_generation: pair.queue_generation,
-            current_queue_item_id: pair.current_queue_item_id,
-            next_queue_item_id: Some(next_queue_item_id),
-        });
-        return Ok(job);
-    }
+        .with_conn(|conn| latest_armed_dj_transition_event_for_pair(conn, current, next))?;
+    let replace_armed_event_id = if let Some(existing) = existing_armed.as_ref() {
+        if engine.db().with_conn(|conn| {
+            missing_profile_fallback_resolved(
+                conn,
+                current,
+                next,
+                existing.fallback_reason.as_deref(),
+            )
+        })? {
+            Some(existing.id)
+        } else {
+            let existing_event_id = existing.id;
+            let existing_program = existing.program.clone();
+            let fire_ahead_ms = engine.db().with_conn(dj_transition_fire_ahead_ms)?;
+            job = job.with_prepared_transition(PreparedTransitionProgram {
+                program: existing_program,
+                transition_event_id: Some(existing_event_id),
+                fire_ahead_ms,
+                queue_generation: pair.queue_generation,
+                current_queue_item_id: pair.current_queue_item_id,
+                next_queue_item_id: Some(next_queue_item_id),
+            });
+            return Ok(job);
+        }
+    } else {
+        None
+    };
     if let Some(plan) =
         engine.plan_transition_details(current, next, sample_rate.max(1), channels.max(1))?
     {
@@ -393,6 +408,7 @@ pub fn attach_dj_transition_plan_for_pair_with_current_duration(
         job.gapless = timing_plan.gapless;
         let transition_event_id = log_dj_transition_event(
             engine,
+            replace_armed_event_id,
             current,
             next,
             &planned_template,
@@ -412,16 +428,23 @@ pub fn attach_dj_transition_plan_for_pair_with_current_duration(
     Ok(job)
 }
 
+#[derive(Debug, Clone)]
+struct ArmedDjTransitionEvent {
+    id: i64,
+    program: noor_mix::TransitionProgram,
+    fallback_reason: Option<String>,
+}
+
 fn latest_armed_dj_transition_event_for_pair(
     conn: &Connection,
     current: &DjMediaRef,
     next: &DjMediaRef,
-) -> Result<Option<(i64, noor_mix::TransitionProgram)>> {
+) -> Result<Option<ArmedDjTransitionEvent>> {
     let current_key = current.profile_key();
     let next_key = next.profile_key();
     let row = conn
         .query_row(
-            "SELECT id, program_json
+            "SELECT id, program_json, fallback_reason
          FROM dj_transition_events
          WHERE from_media_ref_kind = ?1
            AND from_media_ref_id = ?2
@@ -438,14 +461,40 @@ fn latest_armed_dj_transition_event_for_pair(
                 next_key.media_ref_kind,
                 next_key.media_ref_id,
             ],
-            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
+            |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, Option<String>>(2)?,
+                ))
+            },
         )
         .optional()?;
-    let Some((id, program_json)) = row else {
+    let Some((id, program_json, fallback_reason)) = row else {
         return Ok(None);
     };
     let program = serde_json::from_str(&program_json)?;
-    Ok(Some((id, program)))
+    Ok(Some(ArmedDjTransitionEvent {
+        id,
+        program,
+        fallback_reason,
+    }))
+}
+
+fn missing_profile_fallback_resolved(
+    conn: &Connection,
+    current: &DjMediaRef,
+    next: &DjMediaRef,
+    fallback_reason: Option<&str>,
+) -> Result<bool> {
+    let Some(media_ref) = (match fallback_reason {
+        Some("current_profile_missing") => Some(current),
+        Some("next_profile_missing") => Some(next),
+        _ => None,
+    }) else {
+        return Ok(false);
+    };
+    Ok(queries::get_audio_dj_profile(conn, &media_ref.profile_key())?.is_some())
 }
 
 const DJ_FIRE_AHEAD_WINDOW: i64 = 20;
@@ -870,6 +919,7 @@ fn preserve_planner_sync_fields(
 
 fn log_dj_transition_event(
     engine: &DjEngine,
+    replace_armed_event_id: Option<i64>,
     current: &DjMediaRef,
     next: &DjMediaRef,
     planned_template: &str,
@@ -881,23 +931,38 @@ fn log_dj_transition_event(
     let program_json = serde_json::to_string(&plan.program)?;
     let rejected_json = serde_json::to_string(&plan.rejected_alternatives)?;
     engine.db().with_conn(|conn| {
-        queries::insert_dj_transition_event(
-            conn,
-            current.track_id(),
-            next.track_id(),
-            Some(current_key.media_ref_kind.as_str()),
-            Some(current_key.media_ref_id.as_str()),
-            Some(next_key.media_ref_kind.as_str()),
-            Some(next_key.media_ref_id.as_str()),
-            planned_template,
-            program_json.as_str(),
-            Some(rejected_json.as_str()),
-            plan.planner_version,
-            plan.fallback_reason,
-            timing_plan.planned_start_ms,
-            Some(timing_plan.timing_source),
-            Some("armed"),
-        )
+        if let Some(id) = replace_armed_event_id {
+            queries::replace_armed_dj_transition_event(
+                conn,
+                id,
+                planned_template,
+                program_json.as_str(),
+                Some(rejected_json.as_str()),
+                plan.planner_version,
+                plan.fallback_reason,
+                timing_plan.planned_start_ms,
+                Some(timing_plan.timing_source),
+            )?;
+            Ok(id)
+        } else {
+            queries::insert_dj_transition_event(
+                conn,
+                current.track_id(),
+                next.track_id(),
+                Some(current_key.media_ref_kind.as_str()),
+                Some(current_key.media_ref_id.as_str()),
+                Some(next_key.media_ref_kind.as_str()),
+                Some(next_key.media_ref_id.as_str()),
+                planned_template,
+                program_json.as_str(),
+                Some(rejected_json.as_str()),
+                plan.planner_version,
+                plan.fallback_reason,
+                timing_plan.planned_start_ms,
+                Some(timing_plan.timing_source),
+                Some("armed"),
+            )
+        }
     })
 }
 
@@ -2506,6 +2571,56 @@ mod tests {
 
             assert_eq!(second.transition_event_id, first.transition_event_id);
             assert_eq!(event_count(&db), 1);
+        }
+
+        #[test]
+        fn missing_profile_armed_event_replans_when_profile_arrives() {
+            let db = db_with_pair();
+            db.with_conn(|conn| {
+                conn.execute(
+                    "DELETE FROM audio_dj_profiles
+                     WHERE media_ref_kind = 'tidal_track' AND media_ref_id = '2'",
+                    [],
+                )?;
+                Ok(())
+            })
+            .expect("remove next profile");
+
+            let fallback = plan(&db);
+            let fallback_id = fallback.transition_event_id.expect("fallback event");
+            assert_eq!(fallback.program.template, "SafeCrossfade");
+            let fallback_reason: Option<String> = db
+                .with_conn(|conn| {
+                    conn.query_row(
+                        "SELECT fallback_reason FROM dj_transition_events WHERE id = ?1",
+                        params![fallback_id],
+                        |row| row.get(0),
+                    )
+                    .map_err(Into::into)
+                })
+                .expect("fallback reason");
+            assert_eq!(fallback_reason.as_deref(), Some("next_profile_missing"));
+
+            db.with_conn(|conn| seed_profile(conn, "tidal_track", "2", Some(2)))
+                .expect("seed next profile");
+            let replanned = plan(&db);
+
+            assert_eq!(replanned.transition_event_id, Some(fallback_id));
+            assert_eq!(replanned.program.template, "BassSwap16");
+            assert_eq!(event_count(&db), 1);
+            let row: (String, Option<String>) = db
+                .with_conn(|conn| {
+                    conn.query_row(
+                        "SELECT template, fallback_reason
+                         FROM dj_transition_events WHERE id = ?1",
+                        params![fallback_id],
+                        |row| Ok((row.get(0)?, row.get(1)?)),
+                    )
+                    .map_err(Into::into)
+                })
+                .expect("replanned row");
+            assert_eq!(row.0, "BassSwap16");
+            assert_eq!(row.1, None);
         }
 
         #[test]

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -7293,6 +7293,9 @@ async fn play_track(
             ));
         }
     };
+    if !playback_generation_is_current(&state, playback_generation).await {
+        return current_playback_snapshot_json(&state).await;
+    }
     tracing::info!(
         target: "noor.playback.tidal",
         event = "playback_stream_ready",
@@ -7601,6 +7604,8 @@ fn tidal_playback_error_response(
 }
 
 async fn pause_playback(State(state): State<SharedState>) -> Result<Json<Value>, StatusCode> {
+    let _playback_generation = bump_playback_generation(&state).await;
+
     if let Some(runtime_handle) = current_playback_runtime(&state).await
         && let Err(error) = runtime_handle.pause()
     {
@@ -7637,6 +7642,8 @@ async fn pause_playback(State(state): State<SharedState>) -> Result<Json<Value>,
 }
 
 async fn resume_playback(State(state): State<SharedState>) -> Result<Json<Value>, StatusCode> {
+    let _playback_generation = bump_playback_generation(&state).await;
+
     if let Some(runtime_handle) = current_playback_runtime(&state).await
         && let Err(error) = runtime_handle.resume()
     {
@@ -8199,6 +8206,10 @@ async fn next_track(
             resolved
         };
 
+    if !playback_generation_is_current(&state, playback_generation).await {
+        return current_playback_snapshot_json(&state).await;
+    }
+
     record_transition_if_changed(&state, previous_track_id, &snapshot, "queue", true).await;
 
     // When "Include New" is enabled, search TIDAL for genre/artist-matched tracks and
@@ -8246,6 +8257,9 @@ async fn next_track(
                     "TIDAL stream could not be resolved while advancing playback.",
                 )
             })?;
+        if !playback_generation_is_current(&state, playback_generation).await {
+            return current_playback_snapshot_json(&state).await;
+        }
         let runtime_handle = ensure_playback_runtime_for_track(&state, track)
             .await
             .map_err(|_| {
@@ -8353,6 +8367,10 @@ async fn previous_track(
             resolved
         };
 
+    if !playback_generation_is_current(&state, playback_generation).await {
+        return current_playback_snapshot_json(&state).await;
+    }
+
     record_transition_if_changed(&state, previous_track_id, &snapshot, "user", false).await;
 
     sync_session_after_snapshot(
@@ -8387,6 +8405,9 @@ async fn previous_track(
                     "TIDAL stream could not be resolved while moving to the previous track.",
                 )
             })?;
+        if !playback_generation_is_current(&state, playback_generation).await {
+            return current_playback_snapshot_json(&state).await;
+        }
         let runtime_handle = ensure_playback_runtime_for_track(&state, track)
             .await
             .map_err(|_| {
@@ -11023,6 +11044,36 @@ async fn bump_playback_generation(state: &SharedState) -> u64 {
         + 1
 }
 
+async fn playback_generation_is_current(state: &SharedState, generation: u64) -> bool {
+    let state_guard = state.read().await;
+    current_playback_generation(&state_guard) == generation
+}
+
+async fn current_playback_snapshot_json(
+    state: &SharedState,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    let snapshot = {
+        let state_guard = state.read().await;
+        state_guard
+            .db
+            .with_conn(player::load_snapshot)
+            .map_err(|_| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({
+                        "status": "playback_state_load_failed",
+                        "message": "Failed to load the current playback state.",
+                    })),
+                )
+            })?
+    };
+    let snapshot = overlay_snapshot_with_external_track(state, snapshot).await;
+    Ok(Json(json!({
+        "state": snapshot.state,
+        "queue": snapshot.queue,
+    })))
+}
+
 async fn ensure_playback_runtime_for_track(
     state: &SharedState,
     track: &crate::db::models::Track,
@@ -13561,6 +13612,55 @@ mod tests {
         assert_eq!(status, StatusCode::BAD_GATEWAY);
         assert_eq!(body["status"], "manifest_decode_failed");
         assert_eq!(body["track_id"], 7);
+    }
+
+    #[tokio::test]
+    async fn pause_and_resume_playback_invalidate_inflight_generation() {
+        let (db, db_path) = fresh_migrated_db();
+        let state = Arc::new(tokio::sync::RwLock::new(fresh_test_state(db)));
+        let app = api_routes(state.clone());
+
+        let initial = {
+            let guard = state.read().await;
+            current_playback_generation(&guard)
+        };
+
+        let pause_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/playback/pause")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(pause_response.status(), StatusCode::OK);
+        let after_pause = {
+            let guard = state.read().await;
+            current_playback_generation(&guard)
+        };
+        assert!(after_pause > initial);
+
+        let resume_response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/playback/resume")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resume_response.status(), StatusCode::OK);
+        let after_resume = {
+            let guard = state.read().await;
+            current_playback_generation(&guard)
+        };
+        assert!(after_resume > after_pause);
+
+        let _ = std::fs::remove_file(db_path);
     }
 
     #[test]

--- a/noor-server/src/server/routes/dj_routes.rs
+++ b/noor-server/src/server/routes/dj_routes.rs
@@ -1078,16 +1078,25 @@ fn profile_rebuild_failure_status(error: &anyhow::Error) -> &'static str {
 }
 
 fn profile_rebuild_error_is_retryable(message: &str) -> bool {
+    let lower = message.to_ascii_lowercase();
     message.contains("DASH stream prebuffer failed")
         || message.contains("DASH segment")
-        || message.contains("timed out")
-        || message.contains("request failed")
-        || message.contains("chunk error")
-        || message.contains("returned error status")
+        || lower.contains("asset is not ready for playback")
+        || lower.contains("\"substatus\":4005")
+        || lower.contains("timed out")
+        || lower.contains("request failed")
+        || lower.contains("chunk error")
+        || lower.contains("returned error status")
 }
 
 fn profile_rebuild_error_message(error: &anyhow::Error, status: &str) -> String {
     if status == "retrying" {
+        let message = error.to_string().to_ascii_lowercase();
+        if message.contains("asset is not ready for playback")
+            || message.contains("\"substatus\":4005")
+        {
+            return "TIDAL asset is not ready. Retrying analysis.".to_string();
+        }
         return "DASH stream prebuffer failed. Retrying analysis.".to_string();
     }
     let message = error.to_string();
@@ -3035,6 +3044,19 @@ mod tests {
         assert_eq!(
             profile_rebuild_error_message(&error, "retrying"),
             "DASH stream prebuffer failed. Retrying analysis."
+        );
+    }
+
+    #[test]
+    fn asset_not_ready_profile_rebuild_errors_are_retrying() {
+        let error = anyhow::Error::msg(
+            r#"TIDAL playback request was rejected: TIDAL rejected playback request with 401 Unauthorized: {"status":401,"subStatus":4005,"userMessage":"Asset is not ready for playback"}"#,
+        );
+
+        assert_eq!(profile_rebuild_failure_status(&error), "retrying");
+        assert_eq!(
+            profile_rebuild_error_message(&error, "retrying"),
+            "TIDAL asset is not ready. Retrying analysis."
         );
     }
 

--- a/noor-server/src/services/audio_analysis/queue_prescanner.rs
+++ b/noor-server/src/services/audio_analysis/queue_prescanner.rs
@@ -45,6 +45,7 @@ enum PrescanFailureClass {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PrescanFailureReason {
+    AssetNotReady,
     StreamRejected,
     ResolveOkSegmentTimeout,
     ResolveOkSegmentFetchFailed,
@@ -54,6 +55,7 @@ enum PrescanFailureReason {
 impl PrescanFailureReason {
     fn as_str(self) -> &'static str {
         match self {
+            PrescanFailureReason::AssetNotReady => "asset_not_ready",
             PrescanFailureReason::StreamRejected => "stream_rejected",
             PrescanFailureReason::ResolveOkSegmentTimeout => "resolve_ok_segment_timeout",
             PrescanFailureReason::ResolveOkSegmentFetchFailed => "resolve_ok_segment_fetch_failed",
@@ -97,9 +99,17 @@ fn cache_prescan_failure(track_id: i64, class: PrescanFailureClass, reason: Pres
 
 fn classify_stream_resolve_for_prescan(
     error: &crate::services::tidal::stream::StreamResolveError,
-) -> Option<PrescanFailureClass> {
-    if error.is_stream_rejected() {
-        Some(PrescanFailureClass::PermanentSkip)
+) -> Option<(PrescanFailureClass, PrescanFailureReason)> {
+    if error.is_asset_not_ready() {
+        Some((
+            PrescanFailureClass::TransientFailure,
+            PrescanFailureReason::AssetNotReady,
+        ))
+    } else if error.is_stream_rejected() {
+        Some((
+            PrescanFailureClass::PermanentSkip,
+            PrescanFailureReason::StreamRejected,
+        ))
     } else {
         None
     }
@@ -334,13 +344,14 @@ pub async fn prefetch_and_analyze_track(state: &SharedState, track_id: i64) -> R
     {
         Ok(stream_info) => stream_info,
         Err(error) => {
-            if let Some(class) = classify_stream_resolve_for_prescan(&error) {
-                cache_prescan_failure(track_id, class, PrescanFailureReason::StreamRejected);
+            if let Some((class, reason)) = classify_stream_resolve_for_prescan(&error) {
+                cache_prescan_failure(track_id, class, reason);
                 tracing::info!(
                     track_id,
                     tidal_id,
+                    reason = reason.as_str(),
                     error = %error,
-                    "prescanner skip: TIDAL stream rejected"
+                    "prescanner skip: TIDAL stream unavailable"
                 );
                 return Ok(false);
             }
@@ -767,14 +778,40 @@ mod tests {
             message: "TIDAL rejected playback request with 401 Unauthorized".to_string(),
         };
 
-        let class = classify_stream_resolve_for_prescan(&error).expect("classified");
-        cache_prescan_failure(31985, class, PrescanFailureReason::StreamRejected);
+        let (class, reason) = classify_stream_resolve_for_prescan(&error).expect("classified");
+        cache_prescan_failure(31985, class, reason);
 
         assert_eq!(class, PrescanFailureClass::PermanentSkip);
+        assert_eq!(reason, PrescanFailureReason::StreamRejected);
         assert!(prescan_negative_cache_contains(31985));
         assert_eq!(
             cached_prescan_failure_class(31985),
             Some(PrescanFailureClass::PermanentSkip)
+        );
+        clear_prescan_negative_cache_for_tests();
+    }
+
+    #[test]
+    fn asset_not_ready_is_cached_as_transient_retrying() {
+        let _guard = prescan_cache_test_guard();
+        clear_prescan_negative_cache_for_tests();
+        let error = StreamResolveError::StreamRejected {
+            message:
+                r#"TIDAL rejected playback request with 401 Unauthorized: {"subStatus":4005,"userMessage":"Asset is not ready for playback"}"#
+                    .to_string(),
+        };
+
+        let (class, reason) = classify_stream_resolve_for_prescan(&error).expect("classified");
+        cache_prescan_failure(31987, class, reason);
+
+        assert_eq!(class, PrescanFailureClass::TransientFailure);
+        assert_eq!(reason, PrescanFailureReason::AssetNotReady);
+        assert_eq!(
+            prescan_status_for_track(31987),
+            Some(PrescanStatusSnapshot {
+                status: "retrying",
+                reason: "asset_not_ready"
+            })
         );
         clear_prescan_negative_cache_for_tests();
     }

--- a/noor-server/src/services/tidal/stream.rs
+++ b/noor-server/src/services/tidal/stream.rs
@@ -166,6 +166,14 @@ impl StreamResolveError {
     pub fn is_stream_rejected(&self) -> bool {
         matches!(self, Self::StreamRejected { .. })
     }
+
+    pub fn is_asset_not_ready(&self) -> bool {
+        match self {
+            Self::StreamRejected { message } => asset_not_ready_body(message),
+            Self::UpstreamHttp { body, .. } => asset_not_ready_body(body),
+            _ => false,
+        }
+    }
 }
 
 fn session_expired_body(body: &str) -> bool {
@@ -969,6 +977,18 @@ mod tests {
         };
         assert!(err.is_stream_rejected());
         assert!(!StreamResolveError::MissingManifest.is_stream_rejected());
+    }
+
+    #[test]
+    fn exposes_asset_not_ready_stream_rejections() {
+        let err = StreamResolveError::StreamRejected {
+            message:
+                r#"TIDAL rejected playback request with 401 Unauthorized: {"subStatus":4005,"userMessage":"Asset is not ready for playback"}"#
+                    .to_string(),
+        };
+
+        assert!(err.is_stream_rejected());
+        assert!(err.is_asset_not_ready());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- ignore stale playback stream generations after pause/resume or track changes
- replan armed DJ fallback events once missing profiles arrive
- classify TIDAL asset-not-ready analysis failures as retrying instead of hard failed/skipped

## Verification
- cargo test -p noor-server server::routes::tests::pause_and_resume_playback_invalidate_inflight_generation
- cargo test -p noor-server playback::player::tests::dj_transition_logging
- cargo test -p noor-server server::routes::dj_routes::tests
- cargo test -p noor-server services::audio_analysis::queue_prescanner::tests
- cargo test -p noor-server services::tidal::stream::tests
- cargo fmt --all -- --check
- cargo check -p noor-server