### PR TITLE
[codex] stabilize library home mural playback panels

### DIFF
--- a/frontend/src/lib/components/LibraryHero.svelte
+++ b/frontend/src/lib/components/LibraryHero.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { fade } from 'svelte/transition';
-  import { letterColor } from '$lib/utils/color';
+  import { upscaleTidalArtwork, type TidalArtworkSize } from '$lib/utils/artwork';
 
   interface Artist {
     id: number;
@@ -26,8 +26,32 @@
   let currentIndex = $state(0);
   let paused = $state(false);
   let timer: ReturnType<typeof setInterval> | undefined;
+  let failedImageUrls = $state<Set<string>>(new Set());
 
   const current = $derived(artists[currentIndex] ?? artists[0]);
+  const muralArtists = $derived.by<Artist[]>(() => {
+    const group: Artist[] = [];
+    const seen = new Set<number>();
+
+    for (const artist of artists) {
+      if (!artist || seen.has(artist.id)) continue;
+      group.push(artist);
+      seen.add(artist.id);
+      if (group.length >= 20) break;
+    }
+
+    return group;
+  });
+  const heroHasImage = $derived(muralArtists.some(artist => !!artistArtUrl(artist, 640)));
+  const heroKindLabel = $derived(
+    current?.kind === 'forgotten_favorite'
+      ? (muralArtists.length > 1 ? 'FEATURED ARTISTS' : 'FORGOTTEN FAVORITE')
+      : (muralArtists.length >= 20
+        ? 'YOUR TOP 20 ARTISTS'
+        : muralArtists.length > 1
+          ? 'YOUR TOP ARTISTS'
+          : 'YOUR TOP ARTIST')
+  );
 
   function initials(name: string): string {
     return name.split(/\s+/).map(p => p[0]?.toUpperCase() ?? '').join('').slice(0, 2) || '?';
@@ -52,11 +76,39 @@
     startTimer();
   }
 
+  function selectMuralArtist(artistId: number) {
+    const nextIndex = artists.findIndex(artist => artist.id === artistId);
+    if (nextIndex < 0) return;
+    currentIndex = nextIndex;
+    startTimer();
+  }
+
   function openHeroContextMenu(event: MouseEvent) {
-    if (!current || !onContextMenu) return;
+    if (!current) return;
+    openArtistContextMenu(event, current.id);
+  }
+
+  function openArtistContextMenu(event: MouseEvent, artistId: number) {
+    if (!onContextMenu) return;
     event.preventDefault();
     event.stopPropagation();
-    onContextMenu(event, current.id);
+    onContextMenu(event, artistId);
+  }
+
+  function rawArtistArtUrl(artist: Artist | undefined): string | null {
+    return artist?.photo_url ?? artist?.fallback_art_url ?? null;
+  }
+
+  function artistArtUrl(artist: Artist | undefined, size: TidalArtworkSize): string | null {
+    const rawUrl = rawArtistArtUrl(artist);
+    if (!rawUrl || failedImageUrls.has(rawUrl)) return null;
+    return upscaleTidalArtwork(rawUrl, size);
+  }
+
+  function markArtistArtFailed(artist: Artist) {
+    const rawUrl = rawArtistArtUrl(artist);
+    if (!rawUrl) return;
+    failedImageUrls = new Set([...failedImageUrls, rawUrl]);
   }
 
   $effect(() => {
@@ -71,47 +123,41 @@
 </script>
 
 {#if current}
-  {@const heroArt = current.photo_url ?? current.fallback_art_url ?? null}
   <div
     class="library-hero-card"
-    class:has-image={!!heroArt}
+    class:has-image={heroHasImage}
     onmouseenter={() => paused = true}
     onmouseleave={() => paused = false}
     oncontextmenu={openHeroContextMenu}
     role="region"
-    aria-label="Featured artist"
+    aria-label="Top artists"
   >
-    {#key currentIndex}
-      <div
-        class="hero-bg"
-        style={heroArt
-          ? `background-image: url('${heroArt}')`
-          : `background: ${letterColor(current.name)}`}
-        in:fade={{ duration: 600 }}
-      ></div>
-    {/key}
+    <div class="hero-bg-mural" in:fade={{ duration: 600 }} aria-label="Top artists mural">
+      {#each muralArtists as artist (artist.id)}
+        {@const panelArt = artistArtUrl(artist, 640)}
+        <button
+          class="mural-panel"
+          class:mural-panel--featured={current?.id === artist.id}
+          type="button"
+          onclick={() => selectMuralArtist(artist.id)}
+          oncontextmenu={(event) => openArtistContextMenu(event, artist.id)}
+          aria-label={`Select ${artist.name}`}
+        >
+          {#if panelArt}
+            <img src={panelArt} alt="" onerror={() => markArtistArtFailed(artist)} />
+          {:else}
+            <span class="mural-fallback">{initials(artist.name)}</span>
+          {/if}
+        </button>
+      {/each}
+    </div>
 
     <div class="hero-overlay"></div>
 
     <div class="hero-content">
-      <button
-        class="hero-art hero-artist-link"
-        type="button"
-        onclick={() => onArtistClick?.(current.id)}
-        aria-label={`Open ${current.name}`}
-      >
-        {#if heroArt}
-          <div class="hero-thumb" style="background-image: url('{heroArt}')"></div>
-        {:else}
-          <div class="hero-thumb hero-thumb--fallback" style="background: {letterColor(current.name)}">
-            <span>{initials(current.name)}</span>
-          </div>
-        {/if}
-      </button>
-
       <div class="hero-meta">
         <span class="hero-kind" class:hero-kind--forgotten={current.kind === 'forgotten_favorite'}>
-          {current.kind === 'forgotten_favorite' ? 'FORGOTTEN FAVORITE' : 'YOUR TOP ARTIST'}
+          {heroKindLabel}
         </span>
         <h2 class="hero-title">
           <button class="hero-title-link" type="button" onclick={() => onArtistClick?.(current.id)}>
@@ -134,11 +180,13 @@
     {#if artists.length > 1}
       <button class="hero-nav hero-nav--prev" onclick={() => jump(-1)} aria-label="Previous artist">‹</button>
       <button class="hero-nav hero-nav--next" onclick={() => jump(1)} aria-label="Next artist">›</button>
-      <div class="hero-dots" aria-hidden="true">
-        {#each artists as _, i}
-          <span class="hero-dot" class:active={i === currentIndex}></span>
-        {/each}
-      </div>
+      {#if artists.length <= 8}
+        <div class="hero-dots" aria-hidden="true">
+          {#each artists as _, i}
+            <span class="hero-dot" class:active={i === currentIndex}></span>
+          {/each}
+        </div>
+      {/if}
     {/if}
   </div>
 {/if}
@@ -153,13 +201,25 @@
     min-height: 200px;
   }
 
-  .hero-bg {
+  .hero-bg-mural {
     position: absolute;
-    inset: -8%;
-    background-size: cover;
-    background-position: center;
-    filter: blur(40px) saturate(1.4);
+    inset: -6%;
     z-index: 0;
+    display: grid;
+    grid-template-columns: repeat(10, minmax(0, 1fr));
+    grid-template-rows: repeat(2, minmax(0, 1fr));
+    overflow: hidden;
+    background: linear-gradient(120deg, var(--panel-bg), color-mix(in srgb, var(--accent-soft) 28%, transparent));
+  }
+
+  .hero-bg-mural::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background:
+      radial-gradient(circle at 78% 50%, rgba(255,255,255,0.24), transparent 28%),
+      linear-gradient(90deg, rgba(0,0,0,0.08), transparent 34%, rgba(0,0,0,0.04));
+    pointer-events: none;
   }
 
   .hero-overlay {
@@ -167,11 +227,13 @@
     inset: 0;
     background: linear-gradient(
       to right,
-      rgba(0,0,0,0.92) 0%,
-      rgba(0,0,0,0.6) 55%,
-      rgba(0,0,0,0.15) 100%
+      rgba(0,0,0,0.66) 0%,
+      rgba(0,0,0,0.34) 38%,
+      rgba(0,0,0,0.08) 68%,
+      transparent 100%
     );
     z-index: 1;
+    pointer-events: none;
   }
 
   .library-hero-card:not(.has-image) .hero-overlay {
@@ -181,23 +243,12 @@
   .hero-content {
     position: relative;
     z-index: 2;
-    display: flex;
+    display: grid;
     align-items: center;
-    gap: 28px;
     padding: 28px 32px;
+    pointer-events: none;
   }
 
-  .hero-thumb {
-    width: clamp(120px, 12vw, 180px);
-    aspect-ratio: 1 / 1;
-    border-radius: 8px;
-    background-size: cover;
-    background-position: center;
-    flex-shrink: 0;
-    box-shadow: 0 8px 32px rgba(0,0,0,0.5);
-  }
-
-  .hero-artist-link,
   .hero-title-link {
     appearance: none;
     border: 0;
@@ -206,38 +257,123 @@
     padding: 0;
     font: inherit;
     cursor: pointer;
+    pointer-events: auto;
   }
 
-  .hero-artist-link {
+  .mural-panel {
+    appearance: none;
+    position: relative;
+    min-width: 0;
+    min-height: 0;
+    padding: 0;
+    border: 0;
+    background: var(--bg-raised);
+    color: var(--text-primary);
+    cursor: pointer;
+    overflow: hidden;
+    transform: skewX(-8deg) scaleX(1.1);
+    transform-origin: center;
+    opacity: 0.96;
+    filter: saturate(1.18) brightness(1.16);
+    box-shadow: none;
+    transition:
+      opacity var(--motion-fast),
+      filter var(--motion-fast),
+      transform var(--motion-base),
+      box-shadow var(--motion-base);
+  }
+
+  .mural-panel::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(
+      90deg,
+      rgba(0,0,0,0.34),
+      rgba(0,0,0,0.05) 46%,
+      rgba(0,0,0,0.38)
+    );
+    opacity: 0.22;
+    pointer-events: none;
+  }
+
+  .mural-panel--featured {
+    z-index: var(--z-raised);
+    opacity: 1;
+    transform: skewX(-8deg) scaleX(1.1) scale(1.045);
+    filter: saturate(1.95) contrast(1.2) brightness(1.52);
+    box-shadow:
+      0 0 0 1px rgba(255,255,255,0.34),
+      0 14px 34px rgba(0,0,0,0.34),
+      0 0 30px color-mix(in srgb, var(--accent) 46%, transparent);
+  }
+
+  .mural-panel--featured::after {
+    opacity: 0.08;
+    background: linear-gradient(
+      90deg,
+      rgba(0,0,0,0.12),
+      rgba(255,255,255,0.08) 48%,
+      rgba(0,0,0,0.18)
+    );
+  }
+
+  .mural-panel img,
+  .mural-fallback {
     display: block;
+    width: 100%;
+    height: 100%;
   }
 
-  .hero-artist-link:focus-visible,
+  .mural-panel img {
+    object-fit: cover;
+    transform: skewX(8deg) scale(1.24);
+    transition: transform var(--motion-base), opacity var(--motion-fast);
+  }
+
+  .mural-panel:hover img,
+  .mural-panel:focus-visible img {
+    transform: skewX(8deg) scale(1.32);
+  }
+
+  .mural-panel--featured img {
+    transform: skewX(8deg) scale(1.3);
+  }
+
+  .mural-panel--featured:hover img,
+  .mural-panel--featured:focus-visible img {
+    transform: skewX(8deg) scale(1.36);
+  }
+
+  .mural-fallback {
+    display: grid;
+    place-items: center;
+    background: linear-gradient(135deg, var(--bg-raised), color-mix(in srgb, var(--accent-soft) 26%, var(--bg-surface)));
+    color: rgba(255,255,255,0.78);
+    font-size: var(--font-size-2xl);
+    font-weight: var(--font-weight-bold);
+    transform: skewX(8deg) scale(1.08);
+  }
+
+  .mural-panel:focus-visible,
   .hero-title-link:focus-visible {
     outline: 2px solid var(--accent);
     outline-offset: 4px;
     border-radius: 8px;
   }
 
-  .hero-thumb--fallback {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: var(--font-size-4xl);
-    font-weight: var(--font-weight-bold);
-    color: rgba(255,255,255,0.9);
-  }
-
   .hero-meta {
     display: flex;
     flex-direction: column;
     gap: 6px;
+    max-width: min(36rem, 55vw);
+    text-shadow: 0 2px 18px rgba(0,0,0,0.62);
   }
 
   .hero-kind {
     font-size: var(--font-size-2xs);
     font-weight: var(--font-weight-semibold);
-    letter-spacing: 1.5px;
+    letter-spacing: 0;
     color: var(--accent);
     text-transform: uppercase;
     transition: color 300ms ease;
@@ -272,6 +408,7 @@
     gap: 10px;
     align-items: center;
     margin-top: 4px;
+    pointer-events: auto;
   }
 
   .hero-play {
@@ -327,4 +464,20 @@
     transition: background 200ms ease;
   }
   .hero-dot.active { background: rgba(255,255,255,0.85); }
+
+  @media (max-width: 760px) {
+    .hero-bg-mural {
+      grid-template-columns: repeat(5, minmax(0, 1fr));
+      grid-template-rows: repeat(4, minmax(0, 1fr));
+    }
+
+    .hero-content {
+      gap: var(--space-3);
+      padding: var(--space-4);
+    }
+
+    .hero-meta {
+      max-width: 100%;
+    }
+  }
 </style>

--- a/frontend/src/lib/components/dj-cockpit/TransitionLane.svelte
+++ b/frontend/src/lib/components/dj-cockpit/TransitionLane.svelte
@@ -396,32 +396,16 @@
 						<li>
 							<div class="timing-history-title">
 								<span>{formatTimingPair(event)}</span>
-								<span>{formatTimingState(event)}</span>
+								<span class="timing-state-pill">{formatTimingState(event)}</span>
 							</div>
 							<dl class="timing-history-details">
-								<div>
-									<dt>Plan</dt>
-									<dd>{event.planning_reason ?? 'none'}</dd>
-								</div>
-								<div>
-									<dt>Source</dt>
-									<dd>{event.timing_source ?? 'none'}</dd>
-								</div>
 								<div>
 									<dt>Template</dt>
 									<dd>{event.renderer_template ?? event.planned_template}</dd>
 								</div>
 								<div>
-									<dt>Runtime</dt>
-									<dd>{event.runtime_renderer_status ?? 'none'}</dd>
-								</div>
-								<div>
-									<dt>Rendered</dt>
-									<dd>{formatRuntimeRendered(event.runtime_rendered_dj_mixer)}</dd>
-								</div>
-								<div>
-									<dt>Reason</dt>
-									<dd>{event.runtime_renderer_reason ?? 'none'}</dd>
+									<dt>Source</dt>
+									<dd>{event.timing_source ?? 'none'}</dd>
 								</div>
 								<div>
 									<dt>Planned</dt>
@@ -622,13 +606,18 @@
 
 	.timing-history li {
 		display: grid;
-		gap: var(--space-2);
-		padding: var(--space-2);
+		gap: var(--space-1);
+		padding: var(--space-1) var(--space-2);
 		border: 1px solid var(--border-subtle);
 		border-radius: var(--radius-sm);
 		background: color-mix(in srgb, var(--bg-surface) 66%, transparent);
 		color: var(--text-secondary);
 		font-size: var(--font-size-xs);
+	}
+
+	.timing-history li:nth-child(even) {
+		border-color: color-mix(in srgb, var(--accent-line) 24%, var(--border-subtle));
+		background: color-mix(in srgb, var(--bg-elevated) 70%, var(--accent-soft) 30%);
 	}
 
 	.timing-history-title {
@@ -641,23 +630,31 @@
 	.timing-history-title span:first-child {
 		color: var(--text-primary);
 		font-weight: var(--font-weight-semibold);
+		font-size: var(--font-size-2xs);
 	}
 
-	.timing-history-title span:nth-child(2) {
+	.timing-state-pill {
+		display: inline-flex;
+		align-items: center;
+		padding: 0 var(--space-1);
+		border: 1px solid var(--border-subtle);
+		border-radius: 999px;
+		background: color-mix(in srgb, var(--bg-surface) 74%, transparent);
 		color: var(--text-tertiary);
-		text-transform: uppercase;
 		font-size: var(--font-size-2xs);
+		line-height: var(--line-height-tight);
+		text-transform: uppercase;
 	}
 
 	.timing-history-details {
 		display: grid;
 		gap: var(--space-1) var(--space-2);
-		grid-template-columns: repeat(3, minmax(0, 1fr));
+		grid-template-columns: repeat(5, minmax(0, 1fr));
 	}
 
 	.timing-history-details div {
 		display: grid;
-		gap: var(--space-1);
+		gap: 0;
 	}
 
 	.timing-history-details dt {
@@ -670,8 +667,11 @@
 	.timing-history-details dd {
 		margin: 0;
 		color: var(--text-primary);
-		font-size: var(--font-size-xs);
+		font-size: var(--font-size-2xs);
 		text-align: left;
+		white-space: nowrap;
+		text-overflow: ellipsis;
+		overflow: hidden;
 	}
 
 	.empty-history {
@@ -731,7 +731,7 @@
 		}
 
 		.timing-history-details {
-			grid-template-columns: repeat(2, minmax(0, 1fr));
+			grid-template-columns: repeat(3, minmax(0, 1fr));
 		}
 	}
 </style>

--- a/frontend/src/routes/library/+page.svelte
+++ b/frontend/src/routes/library/+page.svelte
@@ -1,3 +1,25 @@
+<script lang="ts" module>
+	import type { Track as CachedTrack } from '$lib/api/client';
+
+	type CachedHomeAlbumCard = {
+		id: number;
+		title: string;
+		artist_id: number | null;
+		artist_name: string | null;
+		artwork_url: string | null;
+	};
+
+	const HOME_PANEL_CACHE_REFRESH_MS = 5 * 60 * 1000;
+	const homePanelCandidateCache = {
+		recentTracks: [] as CachedTrack[],
+		randomTracks: [] as CachedTrack[],
+		randomAlbums: [] as CachedHomeAlbumCard[],
+		randomRequestKey: '',
+		suggestionTracks: [] as CachedTrack[],
+		suggestionRequestKey: '',
+	};
+</script>
+
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { get } from 'svelte/store';
@@ -33,6 +55,7 @@
 	import { buildTrackMenu } from '$lib/player/track_menu';
 	import { buildAlbumMenu } from '$lib/player/album_menu';
 	import { buildArtistMenu } from '$lib/player/artist_menu';
+	import { upscaleTidalArtwork } from '$lib/utils/artwork';
 	import { parseQuery } from '$lib/search/query_parser';
 	import { buildAudioParams, hasAnyFilter } from '$lib/search/audio_params';
 	import { goto } from '$app/navigation';
@@ -71,9 +94,9 @@
 		}), artist.name);
 	}
 
-	function handleHomeAlbumContextMenu(e: MouseEvent, albumId: number) {
-		const card = recentAlbums.find(a => a.id === albumId);
-		const album = card ?? { id: albumId, title: '' };
+	function handleHomeAlbumContextMenu(e: MouseEvent, albumId: number, fallback?: HomeAlbumCard) {
+		const card = recentAlbums.find(a => a.id === albumId) ?? fallback;
+		const album = $albums.find(a => a.id === albumId) ?? (card ? albumFromHomeCard(card) : { id: albumId, title: '' });
 		openContextMenu(e, buildAlbumMenu(album, {
 			isLocal: true,
 			addToPlaylistSubmenu: buildAddToPlaylistSubmenu(async () => {
@@ -85,6 +108,7 @@
 
 	const PAGE_SIZE = 100;
 	const RECENT_TRACK_LIMIT = 10;
+	const HOME_MURAL_ITEM_LIMIT = 12;
 	const ALL_SEARCH_ARTIST_PREVIEW_LIMIT = 12;
 	const ALL_SEARCH_ALBUM_PREVIEW_LIMIT = 12;
 	const ALL_SEARCH_TRACK_PREVIEW_LIMIT = 10;
@@ -110,7 +134,7 @@
 	let artists = $state<Artist[]>([]);
 	let artistsLoading = $state(false);
 	let failedArtistImages = $state(new Set<string>());
-	let recentTracks = $state<Track[]>([]);
+	let recentTracks = $state<Track[]>(homePanelCandidateCache.recentTracks);
 
 	// Keyboard cursor for track list
 	let cursorIndex = $state(-1);
@@ -185,6 +209,13 @@
 			recentTracks = data.tracks
 				.filter((track) => track.last_played_at)
 				.slice(0, RECENT_TRACK_LIMIT);
+			homePanelCandidateCache.recentTracks = recentTracks;
+			if (recentTracks.length === 0) {
+				suggestionCandidateTracks = [];
+				suggestionCandidateRequestKey = '';
+				homePanelCandidateCache.suggestionTracks = [];
+				homePanelCandidateCache.suggestionRequestKey = '';
+			}
 		} catch (error) {
 			console.error('Failed to load recent tracks:', error);
 		}
@@ -846,20 +877,7 @@
 
 		const all = [...countMap.values()];
 		const played = all.filter(a => a.playCount > 0).sort((a, b) => b.playCount - a.playCount);
-		const top: HeroArtist[] = played.slice(0, 5).map(a => ({ ...a, kind: 'top' }));
-
-		// Forgotten favourite: an artist in the local DB (which only contains
-		// Tidal-favourited artists) that the user has barely listened to.
-		const topIds = new Set(top.map(a => a.id));
-		const candidates = all
-			.filter(a => !topIds.has(a.id) && !!(a.photo_url ?? a.fallback_art_url) && a.playCount === 0);
-		const fallback = candidates.length === 0
-			? all.filter(a => !topIds.has(a.id) && !!(a.photo_url ?? a.fallback_art_url) && a.playCount < 2)
-			: candidates;
-		if (fallback.length > 0) {
-			const pick = fallback[Math.floor(Math.random() * fallback.length)];
-			top.push({ ...pick, kind: 'forgotten_favorite' as const });
-		}
+		const top: HeroArtist[] = played.slice(0, 20).map(a => ({ ...a, kind: 'top' }));
 
 		return top;
 	});
@@ -915,6 +933,26 @@
 		artwork_url: string | null;
 	}
 
+	type HomeMuralItemKind = 'track' | 'album';
+
+	interface HomeMuralItem {
+		id: number;
+		kind: HomeMuralItemKind;
+		title: string;
+		subtitle: string;
+		artwork_url: string | null;
+		track?: Track;
+		album?: HomeAlbumCard;
+	}
+
+	interface HomeMuralPanel {
+		id: string;
+		label: string;
+		caption: string;
+		kind: HomeMuralItemKind;
+		items: HomeMuralItem[];
+	}
+
 	let recentAlbums = $derived.by<HomeAlbumCard[]>(() => {
 		const albumDateMap = new Map<number, { card: HomeAlbumCard; date: string }>();
 
@@ -941,11 +979,406 @@
 			.map(({ card }) => card);
 	});
 
+	let randomPanelTracks = $state<Track[]>(homePanelCandidateCache.randomTracks);
+	let randomPanelAlbums = $state<HomeAlbumCard[]>(homePanelCandidateCache.randomAlbums);
+	let randomPanelRequestKey = $state(homePanelCandidateCache.randomRequestKey);
+	let suggestionCandidateTracks = $state<Track[]>(homePanelCandidateCache.suggestionTracks);
+	let suggestionCandidateRequestKey = $state(homePanelCandidateCache.suggestionRequestKey);
+
+	let suggestedTrackItems = $derived.by<HomeMuralItem[]>(() => {
+		const seeds = listenHistorySeeds();
+		const seedTrackIds = new Set(seeds.map(track => track.id));
+		const seedArtistIds = new Set(seeds.map(track => track.artist_id).filter((id): id is number => id != null));
+		const seedAlbumIds = new Set(seeds.map(track => track.album_id).filter((id): id is number => id != null));
+		const scored = suggestionCandidateTracks
+			.map(track => ({ track, score: listenHistoryTrackScore(track, seedTrackIds, seedArtistIds, seedAlbumIds) }))
+			.filter(({ score }) => score > 0)
+			.sort((a, b) => b.score - a.score || stableRank(a.track.id, dailySalt(11)) - stableRank(b.track.id, dailySalt(11)));
+		const selected = scored.slice(0, HOME_MURAL_ITEM_LIMIT).map(({ track }) => track);
+
+		return selected.slice(0, HOME_MURAL_ITEM_LIMIT).map(trackToMuralItem);
+	});
+
+	let suggestedAlbumItems = $derived.by<HomeMuralItem[]>(() => {
+		const seeds = listenHistorySeeds();
+		const seedTrackIds = new Set(seeds.map(track => track.id));
+		const seedArtistIds = new Set(seeds.map(track => track.artist_id).filter((id): id is number => id != null));
+		const seedAlbumIds = new Set(seeds.map(track => track.album_id).filter((id): id is number => id != null));
+		const byAlbum = new Map<number, { card: HomeAlbumCard; score: number }>();
+
+		for (const track of suggestionCandidateTracks) {
+			if (!track.album_id || seedAlbumIds.has(track.album_id)) continue;
+			const score = listenHistoryTrackScore(track, seedTrackIds, seedArtistIds, seedAlbumIds);
+			if (score <= 0) continue;
+			const existing = byAlbum.get(track.album_id);
+			if (existing) {
+				existing.score += score;
+				if (!existing.card.artwork_url && track.artwork_url) existing.card.artwork_url = track.artwork_url;
+			} else {
+				byAlbum.set(track.album_id, { card: homeAlbumCardFromTrack(track), score });
+			}
+		}
+
+		const selected = [...byAlbum.values()]
+			.sort((a, b) => b.score - a.score || stableRank(a.card.id, dailySalt(21)) - stableRank(b.card.id, dailySalt(21)))
+			.slice(0, HOME_MURAL_ITEM_LIMIT)
+			.map(({ card }) => card);
+
+		return selected.slice(0, HOME_MURAL_ITEM_LIMIT).map(albumToMuralItem);
+	});
+
+	let randomTrackItems = $derived.by<HomeMuralItem[]>(() =>
+		randomPanelTracks.map(trackToMuralItem)
+	);
+
+	let randomAlbumItems = $derived.by<HomeMuralItem[]>(() =>
+		randomPanelAlbums.map(albumToMuralItem)
+	);
+
+	let homeMuralPanels = $derived.by<HomeMuralPanel[]>(() => {
+		const panels: HomeMuralPanel[] = [
+			{
+				id: 'suggested-tracks',
+				label: 'Suggested tracks',
+				caption: 'Listen history suggestions',
+				kind: 'track',
+				items: suggestedTrackItems,
+			},
+			{
+				id: 'suggested-albums',
+				label: 'Suggested albums',
+				caption: 'Listen history suggestions',
+				kind: 'album',
+				items: suggestedAlbumItems,
+			},
+			{
+				id: 'random-tracks',
+				label: 'Random tracks',
+				caption: 'Library shuffle picks',
+				kind: 'track',
+				items: randomTrackItems,
+			},
+			{
+				id: 'random-albums',
+				label: 'Random albums',
+				caption: 'Library shuffle picks',
+				kind: 'album',
+				items: randomAlbumItems,
+			},
+		];
+		return panels.filter(panel => panel.items.length > 0);
+	});
+
 	// Per-tile lazy artwork. Keyed by domain-prefixed id so we never collide
 	// (track 5 and album 5 are independent entries). Populated by lazyTidalArt
 	// when a tile without baked artwork scrolls into view.
 	let lazyArt = $state<Record<string, string>>({});
 	let artistLazyArt = $state<Record<number, string>>({});
+	let failedHomePanelArtUrls = $state<Set<string>>(new Set());
+
+	function dailySalt(offset: number): number {
+		const now = new Date();
+		return now.getFullYear() * 10000 + (now.getMonth() + 1) * 100 + now.getDate() + offset;
+	}
+
+	function homePanelRefreshBucket(): number {
+		return Math.floor(Date.now() / HOME_PANEL_CACHE_REFRESH_MS);
+	}
+
+	function stableRank(id: number, salt: number): number {
+		let value = Math.imul(id ^ salt, 0x45d9f3b);
+		value = Math.imul(value ^ (value >>> 16), 0x45d9f3b);
+		return (value ^ (value >>> 16)) >>> 0;
+	}
+
+	function stableRandomOffsets(total: number, saltOffset: number, limit: number, refreshBucket: number): number[] {
+		const count = Math.min(Math.max(total, 0), limit);
+		if (count === 0) return [];
+
+		const salt = dailySalt(saltOffset) ^ total ^ refreshBucket;
+		const offsets: number[] = [];
+		const used = new Set<number>();
+		let attempt = 0;
+
+		while (offsets.length < count && attempt < count * 16 + 64) {
+			const offset = stableRank(attempt + 1, salt) % total;
+			if (!used.has(offset)) {
+				used.add(offset);
+				offsets.push(offset);
+			}
+			attempt++;
+		}
+
+		for (let offset = 0; offsets.length < count && offset < total; offset++) {
+			if (!used.has(offset)) offsets.push(offset);
+		}
+
+		return offsets;
+	}
+
+	async function loadRandomPanelCandidates(trackTotal: number, albumTotal: number, requestKey: string, refreshBucket: number) {
+		const [tracksForPanel, albumsForPanel] = await Promise.all([
+			loadRandomPanelTracks(trackTotal, refreshBucket),
+			loadRandomPanelAlbums(albumTotal, refreshBucket),
+		]);
+		if (randomPanelRequestKey === requestKey) {
+			randomPanelTracks = tracksForPanel;
+			randomPanelAlbums = albumsForPanel;
+			homePanelCandidateCache.randomTracks = tracksForPanel;
+			homePanelCandidateCache.randomAlbums = albumsForPanel;
+			homePanelCandidateCache.randomRequestKey = requestKey;
+		}
+	}
+
+	async function loadRandomPanelTracks(trackTotal: number, refreshBucket: number): Promise<Track[]> {
+		if (trackTotal <= 0) return [];
+		const offsets = stableRandomOffsets(trackTotal, 31, HOME_MURAL_ITEM_LIMIT, refreshBucket);
+		const responses = await Promise.all(
+			offsets.map(offset => api.getTracks('date_added', 'desc', 1, offset, true, false))
+		);
+		return uniqueById(responses.flatMap(response => response.tracks));
+	}
+
+	async function loadRandomPanelAlbums(albumTotal: number, refreshBucket: number): Promise<HomeAlbumCard[]> {
+		if (albumTotal <= 0) return [];
+		const offsets = stableRandomOffsets(albumTotal, 41, HOME_MURAL_ITEM_LIMIT, refreshBucket);
+		const responses = await Promise.all(
+			offsets.map(offset => api.getAlbums('title', 'asc', 1, offset, true))
+		);
+		return uniqueById(responses.flatMap(response => response.albums).map(album => ({
+			id: album.id,
+			title: album.title,
+			artist_id: album.artist_id ?? null,
+			artist_name: album.artist_name,
+			artwork_url: album.artwork_url,
+		})));
+	}
+
+	function uniqueById<T extends { id: number }>(items: T[]): T[] {
+		const seen = new Set<number>();
+		const result: T[] = [];
+		for (const item of items) {
+			if (seen.has(item.id)) continue;
+			seen.add(item.id);
+			result.push(item);
+		}
+		return result;
+	}
+
+	function uniquePositiveIds(ids: Array<number | null | undefined>, limit: number): number[] {
+		const seen = new Set<number>();
+		const result: number[] = [];
+		for (const id of ids) {
+			if (id == null || id <= 0 || seen.has(id)) continue;
+			seen.add(id);
+			result.push(id);
+			if (result.length >= limit) break;
+		}
+		return result;
+	}
+
+	async function loadSuggestionCandidates(seedTracks: Track[], requestKey: string) {
+		const seedArtistIds = uniquePositiveIds(seedTracks.map(track => track.artist_id), 8);
+		const seedAlbumIds = uniquePositiveIds(seedTracks.map(track => track.album_id), 8);
+		const artistResults = await Promise.allSettled(seedArtistIds.map(id => api.getArtistTracks(id)));
+		const albumResults = await Promise.allSettled(seedAlbumIds.map(id => api.getAlbumTracks(id)));
+		const artistTracks = artistResults.flatMap(result =>
+			result.status === 'fulfilled' ? result.value.tracks : []
+		);
+		const albumTracks = albumResults.flatMap(result =>
+			result.status === 'fulfilled' ? result.value.tracks : []
+		);
+		const candidates = uniqueById([...seedTracks, ...albumTracks, ...artistTracks]);
+		if (suggestionCandidateRequestKey === requestKey) {
+			suggestionCandidateTracks = candidates;
+			homePanelCandidateCache.suggestionTracks = candidates;
+			homePanelCandidateCache.suggestionRequestKey = requestKey;
+		}
+	}
+
+	function listenHistorySeeds(): Track[] {
+		const seen = new Set<number>();
+		const seeds: Track[] = [];
+		const playedTracks = [...$tracks]
+			.filter(track => track.last_played_at)
+			.sort((a, b) => (b.last_played_at ?? '').localeCompare(a.last_played_at ?? ''));
+
+		for (const track of [...recentTracks, ...playedTracks]) {
+			if (seen.has(track.id)) continue;
+			seen.add(track.id);
+			seeds.push(track);
+			if (seeds.length >= HOME_MURAL_ITEM_LIMIT) break;
+		}
+
+		return seeds;
+	}
+
+	function listenHistoryTrackScore(
+		track: Track,
+		seedTrackIds: Set<number>,
+		seedArtistIds: Set<number>,
+		seedAlbumIds: Set<number>,
+	): number {
+		if (seedTrackIds.has(track.id)) return 0;
+		let score = 0;
+		if (seedArtistIds.has(track.artist_id)) score += 8;
+		if (track.album_id && seedAlbumIds.has(track.album_id)) score += 3;
+		if (track.is_favorite) score += 1.2;
+		if ((track.play_count ?? 0) === 0) score += 1.4;
+		else score += Math.min(track.play_count ?? 0, 12) * 0.12;
+		if (track.fidelity_score > 0) score += Math.min(track.fidelity_score, 100) / 100;
+		if (track.last_played_at) score -= 0.8;
+		return score;
+	}
+
+	function homeAlbumCardFromTrack(track: Track): HomeAlbumCard {
+		return {
+			id: track.album_id ?? 0,
+			title: track.album_title ?? 'Unknown Album',
+			artist_id: track.artist_id ?? null,
+			artist_name: track.artist_name,
+			artwork_url: track.artwork_url,
+		};
+	}
+
+	function albumFromHomeCard(card: HomeAlbumCard): Album {
+		return {
+			id: card.id,
+			tidal_id: null,
+			title: card.title,
+			artist_id: card.artist_id ?? 0,
+			artist_name: card.artist_name,
+			year: null,
+			artwork_url: card.artwork_url,
+			release_type: null,
+			track_count: null,
+			source: 'tidal',
+		};
+	}
+
+	function trackToMuralItem(track: Track): HomeMuralItem {
+		return {
+			id: track.id,
+			kind: 'track',
+			title: track.title,
+			subtitle: track.artist_name ?? track.album_title ?? 'Unknown artist',
+			artwork_url: track.artwork_url,
+			track,
+		};
+	}
+
+	function albumToMuralItem(album: HomeAlbumCard): HomeMuralItem {
+		return {
+			id: album.id,
+			kind: 'album',
+			title: album.title,
+			subtitle: album.artist_name ?? 'Unknown artist',
+			artwork_url: album.artwork_url,
+			album,
+		};
+	}
+
+	function fallbackLetters(label: string): string {
+		return label.split(/\s+/).map(part => part[0]?.toUpperCase() ?? '').join('').slice(0, 2) || '?';
+	}
+
+	function homePanelArtUrl(item: HomeMuralItem): string | null {
+		const rawUrl = item.artwork_url;
+		if (!rawUrl || failedHomePanelArtUrls.has(rawUrl)) return null;
+		return upscaleTidalArtwork(rawUrl, 320);
+	}
+
+	function markHomePanelArtFailed(item: HomeMuralItem) {
+		const rawUrl = item.artwork_url;
+		if (!rawUrl) return;
+		failedHomePanelArtUrls = new Set([...failedHomePanelArtUrls, rawUrl]);
+	}
+
+	function openHomeAlbumCard(card: HomeAlbumCard) {
+		const found = $albums.find(album => album.id === card.id);
+		void openAlbumDetail(found ?? albumFromHomeCard(card));
+	}
+
+	async function playHomeMuralTrack(item: HomeMuralItem, panel: HomeMuralPanel) {
+		if (!item.track) return;
+		const seen = new Set<number>();
+		const trackIds = panel.items
+			.filter((candidate) => candidate.kind === 'track' && candidate.track)
+			.map((candidate) => candidate.track!.id)
+			.filter((trackId) => {
+				if (seen.has(trackId)) return false;
+				seen.add(trackId);
+				return true;
+			});
+		if (!seen.has(item.track.id)) {
+			trackIds.unshift(item.track.id);
+		}
+
+		try {
+			if (trackIds.length > 0) {
+				await api.replacePlaybackQueue(trackIds, undefined, undefined, get(shuffleMode));
+			}
+			await playTrackNow(item.track.id);
+		} catch (error) {
+			console.error('Failed to play home panel track:', error);
+			await playTrackNow(item.track.id);
+		}
+	}
+
+	function openHomeMuralItem(item: HomeMuralItem, panel: HomeMuralPanel) {
+		if (item.kind === 'track' && item.track) {
+			void playHomeMuralTrack(item, panel);
+			return;
+		}
+		if (item.kind === 'album' && item.album) {
+			openHomeAlbumCard(item.album);
+		}
+	}
+
+	function openHomeMuralItemContextMenu(event: MouseEvent, item: HomeMuralItem) {
+		event.preventDefault();
+		event.stopPropagation();
+		if (item.kind === 'track' && item.track) {
+			openContextMenu(event, buildTrackMenu(item.track), item.title);
+			return;
+		}
+		if (item.kind === 'album' && item.album) {
+			handleHomeAlbumContextMenu(event, item.id, item.album);
+		}
+	}
+
+	$effect(() => {
+		const trackTotal = $totalTracks;
+		const albumTotal = $totalAlbums;
+		if (trackTotal <= 0 && albumTotal <= 0) return;
+
+		const refreshBucket = homePanelRefreshBucket();
+		const requestKey = `${dailySalt(0)}:${refreshBucket}:${trackTotal}:${albumTotal}`;
+		if (randomPanelRequestKey === requestKey) return;
+		randomPanelRequestKey = requestKey;
+
+		void loadRandomPanelCandidates(trackTotal, albumTotal, requestKey, refreshBucket).catch((error) => {
+			console.error('Failed to load random library panels:', error);
+		});
+	});
+
+	$effect(() => {
+		const seeds = listenHistorySeeds();
+		const seedKey = seeds.map(track => `${track.id}:${track.last_played_at ?? ''}`).join('|');
+		const requestKey = seedKey ? `${homePanelRefreshBucket()}:${seedKey}` : '';
+		if (!requestKey) {
+			return;
+		}
+		if (suggestionCandidateRequestKey === requestKey) return;
+		suggestionCandidateRequestKey = requestKey;
+
+		void loadSuggestionCandidates(seeds, requestKey).catch((error) => {
+			if (suggestionCandidateRequestKey === requestKey) {
+				suggestionCandidateTracks = [];
+			}
+			console.error('Failed to load suggestion candidates:', error);
+		});
+	});
 
 	// ── Home view handlers ─────────────────────────────────────────────────
 
@@ -1420,6 +1853,41 @@
 				/>
 			{:else if $isLoading}
 				<div class="home-loading">Loading your library…</div>
+			{/if}
+
+			{#if homeMuralPanels.length > 0}
+				<section class="home-mural-grid" aria-label="Library suggestion panels">
+					{#each homeMuralPanels as panel (panel.id)}
+						<article class="home-mural-panel" aria-label={panel.label}>
+							<div class="home-mural-bg">
+								{#each panel.items as item (`${panel.id}-${item.kind}-${item.id}`)}
+									{@const artUrl = homePanelArtUrl(item)}
+									<button
+										class="home-mural-tile"
+										class:home-mural-tile--album={item.kind === 'album'}
+										type="button"
+										onclick={() => openHomeMuralItem(item, panel)}
+										oncontextmenu={(event) => openHomeMuralItemContextMenu(event, item)}
+										aria-label={`${item.kind === 'track' ? 'Play' : 'Open'} ${item.title}`}
+										title={`${item.title}${item.subtitle ? ` - ${item.subtitle}` : ''}`}
+									>
+										{#if artUrl}
+											<img src={artUrl} alt="" loading="lazy" onerror={() => markHomePanelArtFailed(item)} />
+										{:else}
+											<span class="home-mural-fallback">{fallbackLetters(item.title)}</span>
+										{/if}
+									</button>
+								{/each}
+							</div>
+							<div class="home-mural-shade"></div>
+							<div class="home-mural-copy">
+								<span class="home-mural-caption">{panel.caption}</span>
+								<h3 class="home-mural-title">{panel.label}</h3>
+								<span class="home-mural-count">{panel.items.length} picks</span>
+							</div>
+						</article>
+					{/each}
+				</section>
 			{/if}
 
 			{#if recentArtists.length > 0}
@@ -2085,6 +2553,157 @@
 		display: flex;
 		flex-direction: column;
 		gap: 12px;
+	}
+
+	.home-mural-grid {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: var(--space-4);
+	}
+
+	.home-mural-panel {
+		position: relative;
+		min-height: clamp(140px, 15vw, 210px);
+		border-radius: var(--radius-md);
+		overflow: hidden;
+		border: 1px solid var(--border-subtle);
+		background: var(--panel-bg);
+	}
+
+	.home-mural-bg {
+		position: absolute;
+		inset: -7%;
+		z-index: 0;
+		display: grid;
+		grid-template-columns: repeat(6, minmax(0, 1fr));
+		grid-template-rows: repeat(2, minmax(0, 1fr));
+		background: linear-gradient(120deg, var(--panel-bg), color-mix(in srgb, var(--accent-soft) 24%, transparent));
+	}
+
+	.home-mural-bg::after {
+		content: '';
+		position: absolute;
+		inset: 0;
+		background:
+			radial-gradient(circle at 78% 42%, rgba(255,255,255,0.2), transparent 30%),
+			linear-gradient(90deg, rgba(0,0,0,0.06), transparent 42%, rgba(0,0,0,0.02));
+		pointer-events: none;
+	}
+
+	.home-mural-tile {
+		appearance: none;
+		position: relative;
+		min-width: 0;
+		min-height: 0;
+		padding: 0;
+		border: 0;
+		background: var(--bg-raised);
+		color: var(--text-primary);
+		cursor: pointer;
+		overflow: hidden;
+		opacity: 0.96;
+		filter: saturate(1.18) brightness(1.16);
+		transform: skewX(-7deg) scaleX(1.08);
+		transform-origin: center;
+		transition:
+			filter var(--motion-fast),
+			opacity var(--motion-fast),
+			transform var(--motion-base),
+			box-shadow var(--motion-base);
+	}
+
+	.home-mural-tile::after {
+		content: '';
+		position: absolute;
+		inset: 0;
+		background: linear-gradient(90deg, rgba(0,0,0,0.18), transparent 48%, rgba(0,0,0,0.2));
+		opacity: 0.18;
+		pointer-events: none;
+	}
+
+	.home-mural-tile:hover,
+	.home-mural-tile:focus-visible {
+		z-index: var(--z-raised);
+		opacity: 1;
+		filter: saturate(1.8) brightness(1.42);
+		transform: skewX(-7deg) scaleX(1.08) scale(1.045);
+		box-shadow:
+			0 0 0 1px rgba(255,255,255,0.32),
+			0 14px 30px rgba(0,0,0,0.32),
+			0 0 24px color-mix(in srgb, var(--accent) 38%, transparent);
+		outline: none;
+	}
+
+	.home-mural-tile img,
+	.home-mural-fallback {
+		display: block;
+		width: 100%;
+		height: 100%;
+	}
+
+	.home-mural-tile img {
+		object-fit: cover;
+		transform: skewX(7deg) scale(1.24);
+		transition: transform var(--motion-base);
+	}
+
+	.home-mural-tile:hover img,
+	.home-mural-tile:focus-visible img {
+		transform: skewX(7deg) scale(1.34);
+	}
+
+	.home-mural-fallback {
+		display: grid;
+		place-items: center;
+		background: linear-gradient(135deg, var(--bg-raised), color-mix(in srgb, var(--accent-soft) 28%, var(--bg-surface)));
+		color: rgba(255,255,255,0.78);
+		font-size: var(--font-size-xl);
+		font-weight: var(--font-weight-bold);
+		transform: skewX(7deg) scale(1.08);
+	}
+
+	.home-mural-shade {
+		position: absolute;
+		inset: 0;
+		z-index: var(--z-base);
+		background: linear-gradient(90deg, rgba(0,0,0,0.68) 0%, rgba(0,0,0,0.3) 42%, rgba(0,0,0,0.06) 78%, transparent 100%);
+		pointer-events: none;
+	}
+
+	.home-mural-copy {
+		position: relative;
+		z-index: calc(var(--z-base) + 1);
+		display: flex;
+		flex-direction: column;
+		justify-content: flex-end;
+		gap: var(--space-1);
+		min-height: clamp(140px, 15vw, 210px);
+		max-width: min(22rem, 70%);
+		padding: var(--space-4);
+		text-shadow: 0 2px 18px rgba(0,0,0,0.62);
+		pointer-events: none;
+	}
+
+	.home-mural-caption,
+	.home-mural-count {
+		font-size: var(--font-size-2xs);
+		font-weight: var(--font-weight-semibold);
+		letter-spacing: 0;
+		text-transform: uppercase;
+		color: var(--accent);
+	}
+
+	.home-mural-title {
+		margin: 0;
+		color: var(--text-primary);
+		font-size: var(--font-size-xl);
+		font-weight: var(--font-weight-bold);
+		line-height: var(--line-height-tight);
+	}
+
+	.home-mural-count {
+		color: var(--text-secondary);
+		text-transform: none;
 	}
 
 	.section-label {
@@ -2939,6 +3558,19 @@
 	}
 
 	@media (max-width: 760px) {
+		.home-mural-grid {
+			grid-template-columns: 1fr;
+		}
+
+		.home-mural-bg {
+			grid-template-columns: repeat(4, minmax(0, 1fr));
+			grid-template-rows: repeat(3, minmax(0, 1fr));
+		}
+
+		.home-mural-copy {
+			max-width: 82%;
+		}
+
 		.library-hero {
 			padding: 16px;
 			gap: 12px;

--- a/frontend/src/routes/library/library_home_contract.test.ts
+++ b/frontend/src/routes/library/library_home_contract.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = resolve(here, '../..');
+const libraryPage = readFileSync(join(root, 'routes/library/+page.svelte'), 'utf8');
+const libraryHero = readFileSync(join(root, 'lib/components/LibraryHero.svelte'), 'utf8');
+
+describe('library home hero contract', () => {
+	test('top_artist_hero_uses_a_full_top_20_mural', () => {
+		expect(libraryPage).toContain('played.slice(0, 20)');
+		expect(libraryHero).toContain('YOUR TOP 20 ARTISTS');
+		expect(libraryHero).toContain('hero-bg-mural');
+		expect(libraryHero).toContain('function selectMuralArtist');
+		expect(libraryHero).toContain('onclick={() => selectMuralArtist(artist.id)}');
+		expect(libraryHero).toContain('aria-label={`Select ${artist.name}`}');
+		expect(libraryHero).toContain('grid-template-columns: repeat(10');
+		expect(libraryHero).toContain('grid-template-rows: repeat(2');
+		expect(libraryHero).toContain('mural-panel--featured');
+		expect(libraryHero).toContain('rgba(0,0,0,0.66) 0%');
+		expect(libraryHero).toContain('rgba(0,0,0,0.08) 68%');
+		expect(libraryHero).toContain('opacity: 0.96');
+		expect(libraryHero).toContain('opacity: 0.22');
+		expect(libraryHero).toContain('brightness(1.52)');
+		expect(libraryHero).toContain('saturate(1.95)');
+		expect(libraryHero).toContain('scale(1.045)');
+		expect(libraryHero).toContain('.mural-panel--featured::after');
+		expect(libraryHero).toContain('pointer-events: none');
+		expect(libraryHero).toContain('pointer-events: auto');
+		expect(libraryHero).toContain('upscaleTidalArtwork');
+		expect(libraryHero).toContain('onerror={() => markArtistArtFailed(artist)}');
+		expect(libraryHero).not.toContain('letterColor');
+		expect(libraryHero).not.toContain('played.slice(0, 5)');
+	});
+
+	test('library_home_adds_clickable_recommendation_mural_panels', () => {
+		expect(libraryPage).toContain('homeMuralPanels');
+		expect(libraryPage).toContain('Suggested tracks');
+		expect(libraryPage).toContain('Suggested albums');
+		expect(libraryPage).toContain('Listen history suggestions');
+		expect(libraryPage).toContain('Random tracks');
+		expect(libraryPage).toContain('Random albums');
+		expect(libraryPage).toContain('stableRandomOffsets');
+		expect(libraryPage).toContain("api.getTracks('date_added', 'desc', 1, offset, true, false)");
+		expect(libraryPage).toContain("api.getAlbums('title', 'asc', 1, offset, true)");
+		expect(libraryPage).toContain('const HOME_PANEL_CACHE_REFRESH_MS = 5 * 60 * 1000');
+		expect(libraryPage).toContain('const homePanelCandidateCache = {');
+		expect(libraryPage).toContain('let randomPanelTracks = $state<Track[]>(homePanelCandidateCache.randomTracks)');
+		expect(libraryPage).toContain('let randomPanelAlbums = $state<HomeAlbumCard[]>(homePanelCandidateCache.randomAlbums)');
+		expect(libraryPage).toContain('randomPanelTracks.map(trackToMuralItem)');
+		expect(libraryPage).toContain('randomPanelAlbums.map(albumToMuralItem)');
+		expect(libraryPage).toContain('let suggestionCandidateTracks = $state<Track[]>(homePanelCandidateCache.suggestionTracks)');
+		expect(libraryPage).toContain('async function loadSuggestionCandidates(seedTracks: Track[], requestKey: string)');
+		expect(libraryPage).toContain('api.getArtistTracks(id)');
+		expect(libraryPage).toContain('api.getAlbumTracks(id)');
+		expect(libraryPage).toContain('const scored = suggestionCandidateTracks');
+		expect(libraryPage).toContain('homePanelCandidateCache.randomTracks = tracksForPanel');
+		expect(libraryPage).toContain('homePanelCandidateCache.randomAlbums = albumsForPanel');
+		expect(libraryPage).toContain('homePanelCandidateCache.suggestionTracks = candidates');
+		expect(libraryPage).toContain('homePanelRefreshBucket()');
+		expect(libraryPage).toContain('async function playHomeMuralTrack(item: HomeMuralItem, panel: HomeMuralPanel)');
+		expect(libraryPage).toContain('await api.replacePlaybackQueue(trackIds, undefined, undefined, get(shuffleMode))');
+		expect(libraryPage).toContain('await playTrackNow(item.track.id)');
+		expect(libraryPage).toContain('onclick={() => openHomeMuralItem(item, panel)}');
+		expect(libraryPage).toContain('oncontextmenu={(event) => openHomeMuralItemContextMenu(event, item)}');
+		expect(libraryPage).toContain('void openAlbumDetail(found ?? albumFromHomeCard(card))');
+		expect(libraryPage).toContain('upscaleTidalArtwork(rawUrl, 320)');
+		expect(libraryPage).toContain('onerror={() => markHomePanelArtFailed(item)}');
+		expect(libraryPage).toContain('class="home-mural-grid"');
+		expect(libraryPage).toContain('class="home-mural-panel"');
+		expect(libraryPage).not.toContain('Automix tracks');
+		expect(libraryPage).not.toContain('Automix albums');
+		expect(libraryPage).not.toContain('selected.push(...pickStableRandom($tracks');
+		expect(libraryPage).not.toContain('selected.push(...pickStableRandom(allHomeAlbumCards');
+	});
+});


### PR DESCRIPTION
## What changed

- Reworked the library hero into a brighter, clickable top-artist mural surface.
- Added static cached library home panels for suggested tracks, suggested albums, random tracks, and random albums, with quiet background refresh/rotation.
- Switched random panel candidate loading to backend-wide random offsets instead of the currently loaded page slice.
- Updated automix-style suggestions to use listen-history-derived artist and album candidates rather than the current automix queue.
- Cleaned up the DJ cockpit planner facts debug UI with compact history and clearer alternating rows.
- Added library home contract coverage for panel layout, candidate selection, and cache behavior.

## Why

The library home panels were visually dim, could feel stale or slow when entering the page, and random picks only represented already loaded client data. Clicking suggested songs could also expose queue/player mismatch issues because panel playback was not seeded as an intentional queue context.

## Validation

- `pnpm test -- src/routes/library/library_home_contract.test.ts`
- `pnpm check`
- `pnpm lint`
- `cargo test -p noor-server pause_and_resume_playback_invalidate_inflight_generation`
- `cargo check -p noor-server`
- `cargo fmt --all -- --check`
- `git diff --check`

## Notes

This PR branch contains only `fix(library): stabilize home mural playback panels` cherry-picked onto `master`; unrelated local untracked files were left out.