### PR TITLE
Refresh TIDAL tokens in playback decoder

### DIFF
--- a/noor-server/src/playback/decode/mod.rs
+++ b/noor-server/src/playback/decode/mod.rs
@@ -11,7 +11,6 @@ use crate::playback::runtime::PlaybackRuntimeConfig;
 use crate::playback::runtime::commands::PlaybackRuntimeCommand;
 use crate::playback::runtime::shared::PlaybackSharedState;
 use crate::services::audio_analysis::dj_profile::DjAnalysisJob;
-use crate::services::tidal::stream::resolve_stream;
 use anyhow::{Context, Result, anyhow};
 use futures::StreamExt as _;
 use std::future::Future;
@@ -219,9 +218,7 @@ pub(crate) fn decode_and_buffer_job(
                 return Ok(());
             }
 
-            let stream_info = rt.block_on(async {
-                resolve_stream(&config.http_client, &config.access_token, &request).await
-            })?;
+            let stream_info = rt.block_on(config.resolve_stream(request.clone()))?;
             debug!(
                 "TIDAL runtime stream resolved: track_id={}, quality={}, codec={}, sample_rate={:?}, bit_depth={:?}, dash_segments={}, start_from_segment={}, start_from_offset_ms={}",
                 shared.track_id,

--- a/noor-server/src/playback/runtime/mod.rs
+++ b/noor-server/src/playback/runtime/mod.rs
@@ -7,6 +7,7 @@ use crate::playback::output::wasapi_exclusive::{
 };
 use crate::playback::player::{PreparedPlaybackJob, PreparedTransitionProgram};
 use crate::services::audio_analysis::dj_profile::DjAnalysisJob;
+use crate::services::tidal::stream::{StreamInfo, StreamRequest};
 use anyhow::{Context, Result, anyhow};
 use cpal::traits::{DeviceTrait, HostTrait};
 use cpal::{SampleFormat, StreamConfig};
@@ -29,12 +30,18 @@ pub(crate) use shared::PlaybackSharedState;
 #[cfg(target_os = "windows")]
 pub(crate) use shared::fill_f32_from_shared;
 
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, mpsc};
 use std::thread;
 use tracing::{debug, error, info, warn};
 
 const DJ_MIXER_DEFAULT_MAX_BLOCK_FRAMES: usize = 8192;
+
+pub type RuntimeStreamResolver = Arc<
+    dyn Fn(StreamRequest) -> Pin<Box<dyn Future<Output = Result<StreamInfo>> + Send>> + Send + Sync,
+>;
 
 /// Pure decision helper for the SeekTo handler. Moved out of `server::routes`
 /// (r6 fix A: keep the playback runtime free of HTTP-layer dependencies). The
@@ -76,10 +83,11 @@ pub(crate) fn evaluate_seek_decision(
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct PlaybackRuntimeConfig {
     pub http_client: reqwest::Client,
     pub access_token: String,
+    pub stream_resolver: Option<RuntimeStreamResolver>,
     /// Channel to send mono audio samples for passive DSP analysis.
     /// (track_id, mono_samples, sample_rate)
     pub analysis_tx: Option<tokio::sync::mpsc::UnboundedSender<(i64, Vec<f32>, u32)>>,
@@ -97,11 +105,30 @@ impl PlaybackRuntimeConfig {
         Self {
             http_client,
             access_token: access_token.into(),
+            stream_resolver: None,
             analysis_tx,
             dj_analysis_tx: None,
             dj_engine_enabled: false,
             dj_analysis_only: false,
         }
+    }
+
+    pub fn with_stream_resolver(mut self, resolver: RuntimeStreamResolver) -> Self {
+        self.stream_resolver = Some(resolver);
+        self
+    }
+
+    pub(crate) async fn resolve_stream(&self, request: StreamRequest) -> Result<StreamInfo> {
+        if let Some(resolver) = self.stream_resolver.as_ref() {
+            return resolver(request).await;
+        }
+        crate::services::tidal::stream::resolve_stream(
+            &self.http_client,
+            &self.access_token,
+            &request,
+        )
+        .await
+        .map_err(anyhow::Error::from)
     }
 
     pub fn with_dj_analysis(
@@ -2887,6 +2914,37 @@ mod tests {
         Arc,
         atomic::{AtomicU32, AtomicU64},
     };
+
+    #[test]
+    fn runtime_stream_resolver_overrides_static_access_token() {
+        let resolver: RuntimeStreamResolver = Arc::new(|request| {
+            Box::pin(async move {
+                Ok(StreamInfo {
+                    url: "https://audio.example.test/init.mp4".to_string(),
+                    segment_urls: vec![],
+                    segment_offsets_ms: vec![],
+                    track_id: request.track_id,
+                    audio_quality: request.audio_quality,
+                    codec: "flac".to_string(),
+                    sample_rate: Some(44_100),
+                    bit_depth: Some(16),
+                })
+            })
+        });
+        let config = PlaybackRuntimeConfig::new(reqwest::Client::new(), "expired-token", None)
+            .with_stream_resolver(resolver);
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+
+        let info = rt
+            .block_on(config.resolve_stream(StreamRequest::new(42, "LOW")))
+            .expect("stream info");
+
+        assert_eq!(info.track_id, 42);
+        assert_eq!(info.audio_quality, "LOW");
+    }
 
     mod dj_lookahead {
         use super::*;

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -7407,6 +7407,60 @@ enum TidalPlaybackError {
     StreamResolve(tidal_stream::StreamResolveError),
 }
 
+fn runtime_stream_resolver(state: SharedState) -> playback_runtime::RuntimeStreamResolver {
+    let state = Arc::downgrade(&state);
+    Arc::new(move |request| {
+        let state = state.clone();
+        Box::pin(async move {
+            let state = state
+                .upgrade()
+                .ok_or_else(|| anyhow::anyhow!("server state is no longer available"))?;
+            resolve_tidal_runtime_stream(&state, request).await
+        })
+    })
+}
+
+async fn resolve_tidal_runtime_stream(
+    state: &SharedState,
+    request: tidal_stream::StreamRequest,
+) -> anyhow::Result<tidal_stream::StreamInfo> {
+    let tokens = {
+        let state_guard = state.read().await;
+        state_guard.tidal_tokens.clone()
+    }
+    .ok_or_else(|| anyhow::anyhow!("TIDAL is not connected."))?;
+
+    let http = {
+        let state_guard = state.read().await;
+        state_guard.http_client.clone()
+    };
+
+    match tidal_stream::resolve_stream(&http, &tokens.access_token, &request).await {
+        Ok(info) => Ok(info),
+        Err(error) if error.is_session_expired() => {
+            tracing::warn!(
+                target: "noor.playback.tidal",
+                event = "runtime_stream_session_expired",
+                track_id = request.track_id,
+                error = %error,
+                "TIDAL session expired in playback decoder; refreshing session"
+            );
+            let refreshed = recover_tidal_session(state, &http, &tokens).await?;
+            match tidal_stream::resolve_stream(&http, &refreshed.access_token, &request).await {
+                Ok(info) => Ok(info),
+                Err(retry_error) if retry_error.is_session_expired() => {
+                    let _ = clear_tidal_session(state).await;
+                    Err(anyhow::anyhow!(
+                        "TIDAL session expired after refresh while resolving runtime stream: {retry_error}"
+                    ))
+                }
+                Err(retry_error) => Err(anyhow::Error::from(retry_error)),
+            }
+        }
+        Err(error) => Err(anyhow::Error::from(error)),
+    }
+}
+
 async fn resolve_tidal_playback_stream(
     state: &SharedState,
     track: &crate::db::models::Track,
@@ -11067,6 +11121,7 @@ async fn ensure_playback_runtime_for_track(
             access_token.clone(),
             state_guard.analysis_tx.clone(),
         )
+        .with_stream_resolver(runtime_stream_resolver(state.clone()))
         .with_dj_analysis(dj_engine_enabled, state_guard.dj_analysis_tx.clone());
         let handle = playback_runtime::spawn_runtime(config).map_err(|error| {
             let message = format!("Failed to start host audio runtime: {error}");


### PR DESCRIPTION
## Summary
- route runtime decoder stream resolution through the server-side TIDAL session recovery path
- refresh expired TIDAL access tokens before retrying runtime stream resolution
- avoid a runtime/state ownership cycle by storing a weak state reference in the resolver

## Verification
- cargo test -p noor-server playback::runtime::tests::runtime_stream_resolver_overrides_static_access_token
- cargo test -p noor-server playback::runtime::tests
- cargo test -p noor-server playback::decode::tests
- cargo fmt --all -- --check
- cargo check -p noor-server

## Adversarial review
- found and fixed a strong SharedState capture in the runtime resolver before opening this PR