### PR TITLE
[codex] update library recent tracks contract

### DIFF
--- a/frontend/scripts/library-recent-tracks-contract.test.mjs
+++ b/frontend/scripts/library-recent-tracks-contract.test.mjs
@@ -6,12 +6,14 @@ describe('library recent tracks contract', () => {
 		const source = readFileSync('src/routes/library/+page.svelte', 'utf8');
 
 		expect(source).toContain("const RECENT_TRACK_LIMIT = 10;");
-		expect(source).toContain('let recentTracks = $state<Track[]>([]);');
+		expect(source).toContain('recentTracks: [] as CachedTrack[],');
+		expect(source).toContain('let recentTracks = $state<Track[]>(homePanelCandidateCache.recentTracks);');
 		expect(source).toContain('async function loadRecentTracks()');
 		expect(source).toContain(
 			"api.getTracks('last_played_at', 'desc', RECENT_TRACK_LIMIT, 0, true, false)",
 		);
 		expect(source).toContain('filter((track) => track.last_played_at)');
+		expect(source).toContain('homePanelCandidateCache.recentTracks = recentTracks;');
 		expect(source).not.toContain('let recentTracks = $derived.by(() =>');
 	});
 


### PR DESCRIPTION
## What changed

- Updated the library recent tracks contract test to expect module-level home panel caching.
- Kept the dedicated last-played query assertions and added coverage that refreshed recent tracks write back to the cache.

## Why

PR #75 changed `recentTracks` from an empty local state initializer to cached state seeded from `homePanelCandidateCache`. The old contract still expected the pre-cache string, causing the frontend CI test job to fail even though the behavior was intentional.

## Validation

- `pnpm test -- scripts/library-recent-tracks-contract.test.mjs`
- `pnpm test -- scripts/library-recent-tracks-contract.test.mjs src/routes/library/library_home_contract.test.ts`
- `pnpm check`
- `pnpm lint`

## Notes

A full local `pnpm test` is currently blocked by an unrelated untracked local test file: `frontend/src/lib/components/remote/remote_mini_search_contract.test.ts`. That file is not in this branch or on `master`, so it should not affect CI.