### PR TITLE
fix(playback): ignore seek-suppressed DJ timing

### DIFF
--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -954,6 +954,7 @@ export type DjRuntimeRendererReason =
 	| 'next_deck_missing_at_fire'
 	| 'transition_plan_missing_at_fire'
 	| 'sync_window_not_signaled'
+	| 'manual_seek_suppressed'
 	| string;
 
 export type DjStatusResponse = {

--- a/noor-server/src/db/queries.rs
+++ b/noor-server/src/db/queries.rs
@@ -7534,6 +7534,7 @@ fn validate_dj_runtime_renderer_reason(reason: Option<&str>) -> Result<()> {
                 | "next_deck_missing_at_fire"
                 | "transition_plan_missing_at_fire"
                 | "sync_window_not_signaled"
+                | "manual_seek_suppressed"
         )
     {
         bail!("unknown DJ runtime renderer reason: {reason}");
@@ -7747,6 +7748,46 @@ pub fn mark_dj_transition_timing_status_for_pair(
             to_media_ref_kind,
             to_media_ref_id,
             timing_status,
+        ],
+    )
+    .map_err(Into::into)
+}
+
+pub fn mark_dj_transition_manual_seek_suppressed_for_pair(
+    conn: &Connection,
+    from_media_ref_kind: &str,
+    from_media_ref_id: &str,
+    to_media_ref_kind: &str,
+    to_media_ref_id: &str,
+) -> Result<usize> {
+    validate_dj_timing_status(Some("missed"))?;
+    validate_dj_runtime_renderer_status(Some("boundary_fallback"))?;
+    validate_dj_runtime_renderer_reason(Some("manual_seek_suppressed"))?;
+    conn.execute(
+        "UPDATE dj_transition_events
+         SET timing_status = 'missed',
+             outcome = COALESCE(outcome, 'manual_seek_suppressed'),
+             outcome_at = COALESCE(outcome_at, datetime('now')),
+             runtime_rendered_dj_mixer = 0,
+             runtime_renderer_status = 'boundary_fallback',
+             runtime_renderer_reason = 'manual_seek_suppressed'
+         WHERE id = (
+             SELECT id
+             FROM dj_transition_events
+             WHERE from_media_ref_kind = ?1
+               AND from_media_ref_id = ?2
+               AND to_media_ref_kind = ?3
+               AND to_media_ref_id = ?4
+               AND outcome IS NULL
+               AND timing_status = 'armed'
+              ORDER BY started_at DESC, id DESC
+              LIMIT 1
+         )",
+        params![
+            from_media_ref_kind,
+            from_media_ref_id,
+            to_media_ref_kind,
+            to_media_ref_id,
         ],
     )
     .map_err(Into::into)
@@ -8202,6 +8243,32 @@ mod tests {
         }
 
         #[test]
+        fn update_dj_transition_fire_timing_accepts_manual_seek_reason() {
+            let conn = setup_conn();
+            let id = insert_event(&conn);
+
+            update_dj_transition_fire_timing(
+                &conn,
+                id,
+                180_000,
+                "late",
+                false,
+                "boundary_fallback",
+                "manual_seek_suppressed",
+            )
+            .expect("manual seek timing");
+
+            let reason: Option<String> = conn
+                .query_row(
+                    "SELECT runtime_renderer_reason FROM dj_transition_events WHERE id = ?1",
+                    params![id],
+                    |row| row.get(0),
+                )
+                .expect("reason");
+            assert_eq!(reason.as_deref(), Some("manual_seek_suppressed"));
+        }
+
+        #[test]
         fn update_dj_transition_fire_timing_closes_duplicate_armed_pair_rows() {
             let conn = setup_conn();
             let older_id = insert_event(&conn);
@@ -8273,6 +8340,56 @@ mod tests {
                 )
                 .expect("status");
             assert_eq!(status.as_deref(), Some("missed"));
+        }
+
+        #[test]
+        fn mark_dj_transition_manual_seek_suppressed_closes_armed_pair() {
+            let conn = setup_conn();
+            let id = insert_event(&conn);
+
+            let updated = mark_dj_transition_manual_seek_suppressed_for_pair(
+                &conn,
+                "library_track",
+                "1",
+                "tidal_track",
+                "200",
+            )
+            .expect("mark manual seek suppressed");
+            assert_eq!(updated, 1);
+
+            let row = conn
+                .query_row(
+                    "SELECT timing_status, outcome, runtime_rendered_dj_mixer,
+                            runtime_renderer_status, runtime_renderer_reason
+                     FROM dj_transition_events WHERE id = ?1",
+                    params![id],
+                    |row| {
+                        Ok((
+                            row.get::<_, Option<String>>(0)?,
+                            row.get::<_, Option<String>>(1)?,
+                            row.get::<_, Option<i64>>(2)?,
+                            row.get::<_, Option<String>>(3)?,
+                            row.get::<_, Option<String>>(4)?,
+                        ))
+                    },
+                )
+                .expect("manual seek row");
+
+            assert_eq!(row.0.as_deref(), Some("missed"));
+            assert_eq!(row.1.as_deref(), Some("manual_seek_suppressed"));
+            assert_eq!(row.2, Some(0));
+            assert_eq!(row.3.as_deref(), Some("boundary_fallback"));
+            assert_eq!(row.4.as_deref(), Some("manual_seek_suppressed"));
+
+            let second = mark_dj_transition_manual_seek_suppressed_for_pair(
+                &conn,
+                "library_track",
+                "1",
+                "tidal_track",
+                "200",
+            )
+            .expect("mark manual seek suppressed again");
+            assert_eq!(second, 0);
         }
 
         #[test]

--- a/noor-server/src/playback/player.rs
+++ b/noor-server/src/playback/player.rs
@@ -512,37 +512,33 @@ const DJ_SLAM_CUT_RENDER_MS: u32 = 200;
 const DJ_LONG_HARMONIC_BLEND_RENDER_MS: u32 = 16_000;
 
 fn dj_transition_fire_ahead_ms(conn: &Connection) -> Result<u32> {
-    let mut stmt = conn.prepare(
-        "SELECT timing_delta_ms
-         FROM dj_transition_events
-         WHERE timing_status = 'fired'
-           AND timing_delta_ms IS NOT NULL
-         ORDER BY started_at DESC, id DESC
-         LIMIT ?1",
-    )?;
-    let rows = stmt.query_map([DJ_FIRE_AHEAD_WINDOW], |row| row.get::<_, i64>(0))?;
-    let mut deltas = Vec::new();
-    for row in rows {
-        deltas.push(row?);
-    }
+    let deltas = dj_timing_calibration_deltas(conn, DJ_FIRE_AHEAD_WINDOW)?;
     Ok(fire_ahead_ms_from_deltas(&deltas))
 }
 
 fn render_timing_unstable(conn: &Connection) -> Result<bool> {
+    let deltas = dj_timing_calibration_deltas(conn, DJ_FILTER_SWEEP_TIMING_WINDOW)?;
+    Ok(render_timing_unstable_from_deltas(&deltas))
+}
+
+fn dj_timing_calibration_deltas(conn: &Connection, limit: i64) -> Result<Vec<i64>> {
     let mut stmt = conn.prepare(
         "SELECT timing_delta_ms
          FROM dj_transition_events
          WHERE timing_status = 'fired'
            AND timing_delta_ms IS NOT NULL
+           AND runtime_rendered_dj_mixer = 1
+           AND runtime_renderer_status IN ('rendered_handoff', 'rendered_overlay')
+           AND COALESCE(runtime_renderer_reason, 'none') = 'none'
          ORDER BY started_at DESC, id DESC
          LIMIT ?1",
     )?;
-    let rows = stmt.query_map([DJ_FILTER_SWEEP_TIMING_WINDOW], |row| row.get::<_, i64>(0))?;
+    let rows = stmt.query_map([limit], |row| row.get::<_, i64>(0))?;
     let mut deltas = Vec::new();
     for row in rows {
         deltas.push(row?);
     }
-    Ok(render_timing_unstable_from_deltas(&deltas))
+    Ok(deltas)
 }
 
 fn render_timing_unstable_from_deltas(deltas: &[i64]) -> bool {
@@ -2509,6 +2505,33 @@ mod tests {
             .expect("count")
         }
 
+        fn insert_timing_sample(
+            conn: &Connection,
+            delta_ms: i64,
+            runtime_rendered_dj_mixer: bool,
+            runtime_renderer_status: &str,
+            runtime_renderer_reason: &str,
+        ) -> Result<()> {
+            conn.execute(
+                "INSERT INTO dj_transition_events (
+                    from_media_ref_kind, from_media_ref_id, to_media_ref_kind, to_media_ref_id,
+                    template, program_json, planner_version, timing_delta_ms, timing_status,
+                    runtime_rendered_dj_mixer, runtime_renderer_status, runtime_renderer_reason
+                 ) VALUES (
+                    'tidal_track', '1', 'tidal_track', '2',
+                    'SafeCrossfade', '{\"template\":\"SafeCrossfade\"}', 'dj-v1',
+                    ?1, 'fired', ?2, ?3, ?4
+                 )",
+                params![
+                    delta_ms,
+                    if runtime_rendered_dj_mixer { 1 } else { 0 },
+                    runtime_renderer_status,
+                    runtime_renderer_reason,
+                ],
+            )?;
+            Ok(())
+        }
+
         fn make_pair_drop_tease_ready(db: &Database) {
             db.with_conn(|conn| {
                 queries::set_dj_global_policy(conn, "bold", "neutral")?;
@@ -3017,6 +3040,71 @@ mod tests {
             assert!(render_timing_unstable_from_deltas(&[549, -399, 303, -375]));
             assert!(!render_timing_unstable_from_deltas(&[140, -130, 75, -90]));
             assert!(!render_timing_unstable_from_deltas(&[549, -399, 303]));
+        }
+
+        #[test]
+        fn timing_calibration_ignores_decode_fallback_rows() {
+            let db = db_with_pair();
+            db.with_conn(|conn| {
+                conn.execute("DELETE FROM dj_transition_events", [])?;
+                for delta_ms in [549, -399, 303, -375] {
+                    insert_timing_sample(
+                        conn,
+                        delta_ms,
+                        false,
+                        "legacy_overlap",
+                        "active_deck_not_decoded",
+                    )?;
+                }
+                Ok(())
+            })
+            .expect("seed fallback timing");
+
+            let unstable = db.with_conn(render_timing_unstable).expect("gate");
+
+            assert!(!unstable);
+        }
+
+        #[test]
+        fn timing_calibration_uses_successful_dj_mixer_rows() {
+            let db = db_with_pair();
+            db.with_conn(|conn| {
+                conn.execute("DELETE FROM dj_transition_events", [])?;
+                for delta_ms in [549, -399, 303, -375] {
+                    insert_timing_sample(conn, delta_ms, true, "rendered_handoff", "none")?;
+                }
+                Ok(())
+            })
+            .expect("seed rendered timing");
+
+            let unstable = db.with_conn(render_timing_unstable).expect("gate");
+
+            assert!(unstable);
+        }
+
+        #[test]
+        fn fire_ahead_ignores_fallback_timing_rows() {
+            let db = db_with_pair();
+            db.with_conn(|conn| {
+                conn.execute("DELETE FROM dj_transition_events", [])?;
+                for _ in 0..20 {
+                    insert_timing_sample(
+                        conn,
+                        500,
+                        false,
+                        "legacy_overlap",
+                        "next_deck_not_decoded",
+                    )?;
+                }
+                Ok(())
+            })
+            .expect("seed fallback timing");
+
+            let fire_ahead_ms = db
+                .with_conn(dj_transition_fire_ahead_ms)
+                .expect("fire ahead");
+
+            assert_eq!(fire_ahead_ms, 0);
         }
 
         #[test]

--- a/noor-server/src/playback/runtime/commands.rs
+++ b/noor-server/src/playback/runtime/commands.rs
@@ -95,6 +95,10 @@ pub enum SeekToOutcome {
     /// transition. The audible playhead may take up to ~1s to converge as the
     /// new engine primes samples; the frontend's 1 Hz refresher closes the gap.
     Dispatched,
+    /// Seek accepted and it intentionally invalidated the active crossfade
+    /// window. The HTTP layer treats this as success but should not score the
+    /// previously armed DJ timing row as a miss.
+    DispatchedCrossfadeSuppressed,
     /// Target outside `[offset, buffered]` and the caller opted out of the
     /// segment-restart path (`allow_segment_seek=false`). HTTP 409.
     RejectedOutOfBuffer,

--- a/noor-server/src/playback/runtime/mod.rs
+++ b/noor-server/src/playback/runtime/mod.rs
@@ -276,7 +276,7 @@ impl PlaybackRuntimeHandle {
     /// or failed transitions surface as `Err`.
     pub fn seek(&self, position_ms: i64) -> Result<()> {
         match self.seek_to_segment_aware(position_ms, false) {
-            SeekToOutcome::Dispatched => Ok(()),
+            SeekToOutcome::Dispatched | SeekToOutcome::DispatchedCrossfadeSuppressed => Ok(()),
             SeekToOutcome::RejectedOutOfBuffer => Err(anyhow!("seek target is out of buffer")),
             SeekToOutcome::Failed => Err(anyhow!("seek dispatch failed")),
         }
@@ -577,6 +577,7 @@ enum DjRuntimeRendererReason {
     NextDeckMissingAtFire,
     TransitionPlanMissingAtFire,
     SyncWindowNotSignaled,
+    ManualSeekSuppressed,
 }
 
 impl DjRuntimeRendererReason {
@@ -598,6 +599,7 @@ impl DjRuntimeRendererReason {
             Self::NextDeckMissingAtFire => "next_deck_missing_at_fire",
             Self::TransitionPlanMissingAtFire => "transition_plan_missing_at_fire",
             Self::SyncWindowNotSignaled => "sync_window_not_signaled",
+            Self::ManualSeekSuppressed => "manual_seek_suppressed",
         }
     }
 }
@@ -717,6 +719,9 @@ fn runtime_renderer_fire_block_reason(
 fn runtime_renderer_boundary_fallback_reason(
     state: &PlaybackRuntimeLoopState,
 ) -> DjRuntimeRendererReason {
+    if active_engine_suppresses_crossfade_after_seek(state) {
+        return DjRuntimeRendererReason::ManualSeekSuppressed;
+    }
     let reason =
         runtime_renderer_failure_reason(state, DjRuntimeRendererReason::PreparedMixerMissing);
     if reason != DjRuntimeRendererReason::PreparedMixerMissing {
@@ -1527,12 +1532,13 @@ fn run_runtime_loop(
                     // Phase 2: act on the decision under a mutable borrow.
                     match decision {
                         SeekHandling::InBuffer { target_samples } => {
+                            let mut suppressed = false;
                             if let Some(engine) = state.engine.as_ref() {
                                 engine
                                     .shared
                                     .seek_target_samples
                                     .store(target_samples, Ordering::Relaxed);
-                                engine
+                                suppressed = engine
                                     .shared
                                     .set_manual_seek_crossfade_suppression(target_samples);
                                 // Reset fire-once guards so NearEnd /
@@ -1546,7 +1552,12 @@ fn run_runtime_loop(
                                     .crossfade_start_signaled
                                     .store(false, Ordering::Relaxed);
                             }
-                            let _ = respond_to.send(SeekToOutcome::Dispatched);
+                            let outcome = if suppressed {
+                                SeekToOutcome::DispatchedCrossfadeSuppressed
+                            } else {
+                                SeekToOutcome::Dispatched
+                            };
+                            let _ = respond_to.send(outcome);
                         }
                         SeekHandling::Reject => {
                             let _ = respond_to.send(SeekToOutcome::RejectedOutOfBuffer);
@@ -1569,16 +1580,22 @@ fn run_runtime_loop(
                                 true, // force_restart - bypass switch_is_noop
                             ) {
                                 Ok(()) => {
+                                    let mut suppressed = false;
                                     if let Some(engine) = state.engine.as_ref() {
                                         let target_samples = (target_ms.max(0) as u64)
                                             .saturating_mul(rate)
                                             .saturating_mul(channels)
                                             / 1000;
-                                        engine
+                                        suppressed = engine
                                             .shared
                                             .set_manual_seek_crossfade_suppression(target_samples);
                                     }
-                                    let _ = respond_to.send(SeekToOutcome::Dispatched);
+                                    let outcome = if suppressed {
+                                        SeekToOutcome::DispatchedCrossfadeSuppressed
+                                    } else {
+                                        SeekToOutcome::Dispatched
+                                    };
+                                    let _ = respond_to.send(outcome);
                                 }
                                 Err(error) => {
                                     warn!(
@@ -4109,6 +4126,51 @@ mod tests {
                 assert_eq!(generation, 20);
             }
             other => panic!("expected finished event, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn boundary_fallback_after_manual_seek_reports_seek_suppression() {
+        let mut state = test_runtime_loop_state();
+        let active = test_engine_with_shared(1, 20);
+        active
+            .shared
+            .position_samples
+            .store(480_000, Ordering::Relaxed);
+        active
+            .shared
+            .suppress_crossfade_after_seek
+            .store(true, Ordering::Relaxed);
+        let mut next = test_engine_with_shared(2, 20);
+        let mut transition = test_prepared_transition_program(20, Some(11), Some(12));
+        transition.transition_event_id = Some(79);
+        next.job = PreparedPlaybackJob::test_fixture(2, 20).with_prepared_transition(transition);
+        state.engine = Some(active);
+        state.next_engine = Some(next);
+
+        let (event_tx, mut event_rx) = tokio::sync::broadcast::channel(8);
+        let position_source = Arc::new(Mutex::new(Arc::new(AtomicU64::new(0))));
+        let buffered_source = Arc::new(Mutex::new(Arc::new(AtomicU64::new(0))));
+        let offset_source = Arc::new(Mutex::new(Arc::new(AtomicU64::new(0))));
+
+        promote_prepared_at_boundary(
+            &mut state,
+            &event_tx,
+            &position_source,
+            &buffered_source,
+            &offset_source,
+        );
+
+        match event_rx.try_recv().expect("timing event") {
+            PlaybackRuntimeEvent::DjTransitionPromoted {
+                runtime_renderer_status,
+                runtime_renderer_reason,
+                ..
+            } => {
+                assert_eq!(runtime_renderer_status, "boundary_fallback");
+                assert_eq!(runtime_renderer_reason, "manual_seek_suppressed");
+            }
+            other => panic!("expected timing event, got {other:?}"),
         }
     }
 

--- a/noor-server/src/playback/runtime/shared.rs
+++ b/noor-server/src/playback/runtime/shared.rs
@@ -403,7 +403,7 @@ impl PlaybackSharedState {
         Arc::clone(&self.stopped)
     }
 
-    pub(crate) fn set_manual_seek_crossfade_suppression(&self, target_samples: u64) {
+    pub(crate) fn set_manual_seek_crossfade_suppression(&self, target_samples: u64) -> bool {
         let total = self.total_samples.load(Ordering::Relaxed);
         let threshold_samples = (NEAR_END_THRESHOLD_MS as u64)
             .saturating_mul(u64::from(self.device_sample_rate))
@@ -416,6 +416,7 @@ impl PlaybackSharedState {
                 || total.saturating_sub(target_samples) <= threshold_samples.max(1));
         self.suppress_crossfade_after_seek
             .store(suppress, Ordering::Relaxed);
+        suppress
     }
 
     /// Audio-thread-safe: publish the current decoded-sample count for

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -99,6 +99,21 @@ async fn start_dj_lookahead_and_queue_profiles_after_pair_change(
     queue_missing_dj_profiles_after_pair_change(state, context).await;
 }
 
+async fn refresh_dj_after_queue_change(state: SharedState, context: &'static str) {
+    let runtime = {
+        let state_guard = state.read().await;
+        state_guard
+            .playback_runtime
+            .as_ref()
+            .map(|runtime| runtime.handle.clone())
+    };
+    if let Some(runtime) = runtime {
+        start_dj_lookahead_and_queue_profiles_after_pair_change(state, runtime, context).await;
+    } else {
+        queue_missing_dj_profiles_after_pair_change(state, context).await;
+    }
+}
+
 #[derive(Debug, Deserialize)]
 pub struct ListParams {
     sort_by: Option<String>,
@@ -5461,9 +5476,12 @@ async fn spawn_pending_resolvers_for_queue_items(
             let tok = tokens.clone();
             let tx = event_tx.clone();
             let http = tidal_http_client.clone();
+            let state_bg = state.clone();
             tokio::spawn(async move {
                 let _permit = sem.acquire_owned().await.ok();
-                resolve_pending_row(db_bg, tok, item_id, tx, http).await;
+                if resolve_pending_row(db_bg, tok, item_id, tx, http).await {
+                    refresh_dj_after_queue_change(state_bg, context).await;
+                }
             });
         }
     } else {
@@ -5734,9 +5752,13 @@ async fn radio_start(
                 let tok = tokens.clone();
                 let tx = event_tx.clone();
                 let http = tidal_http_client.clone();
+                let state_bg = state.clone();
                 tokio::spawn(async move {
                     let _permit = sem.acquire_owned().await.ok();
-                    resolve_pending_row(db_bg, tok, item_id, tx, http).await;
+                    if resolve_pending_row(db_bg, tok, item_id, tx, http).await {
+                        refresh_dj_after_queue_change(state_bg, "radio_start_pending_resolved")
+                            .await;
+                    }
                 });
             }
         } else {
@@ -7859,21 +7881,21 @@ async fn resolve_pending_row(
     queue_item_id: i64,
     event_tx: tokio::sync::broadcast::Sender<AppEvent>,
     http: reqwest::Client,
-) {
+) -> bool {
     let row = db
         .with_conn(move |conn| pending::read_identity(conn, queue_item_id))
         .unwrap_or(None);
 
     let (pending_artist, pending_title, tidal_id_hint) = match row {
         Some(r) => r,
-        None => return,
+        None => return false,
     };
 
     let claimed = db
         .with_conn(move |conn| pending::try_claim(conn, queue_item_id))
         .unwrap_or(false);
     if !claimed {
-        return;
+        return false;
     }
 
     let release = |db: &crate::db::Database, qid: i64| {
@@ -7900,7 +7922,7 @@ async fn resolve_pending_row(
         Err(e) => {
             tracing::warn!(queue_item_id, error = %e, "background resolver: Tidal resolve failed");
             release(&db, queue_item_id);
-            return;
+            return false;
         }
     };
 
@@ -7914,7 +7936,7 @@ async fn resolve_pending_row(
                 "background resolver: no match above threshold"
             );
             release(&db, queue_item_id);
-            return;
+            return false;
         }
     };
 
@@ -7926,7 +7948,7 @@ async fn resolve_pending_row(
         Err(e) => {
             tracing::warn!(queue_item_id, error = %e, "background resolver: import failed");
             release(&db, queue_item_id);
-            return;
+            return false;
         }
     };
 
@@ -7962,6 +7984,7 @@ async fn resolve_pending_row(
             "background resolver: promoted pending row"
         );
     }
+    promoted
 }
 
 /// Attempts to resolve the current pending queue item to a Tidal track.
@@ -8558,6 +8581,17 @@ async fn set_playback_position(
     };
 
     match outcome {
+        playback_runtime::SeekToOutcome::DispatchedCrossfadeSuppressed => {
+            if let Err(error) =
+                mark_armed_dj_transition_manual_seek_suppressed_if_needed(&state).await
+            {
+                warn!("Failed to suppress armed DJ transition after seek: {error}");
+            }
+            Ok((
+                StatusCode::ACCEPTED,
+                Json(json!({ "state": snapshot.state })),
+            ))
+        }
         playback_runtime::SeekToOutcome::Dispatched => Ok((
             StatusCode::ACCEPTED,
             Json(json!({ "state": snapshot.state })),
@@ -8681,19 +8715,23 @@ async fn add_queue_track(
     State(state): State<SharedState>,
     Json(payload): Json<PlaybackTrackRequest>,
 ) -> Result<Json<Value>, StatusCode> {
-    let state = state.read().await;
-    // User-driven enqueue; clear the post-clear suppression window.
-    state
-        .user_cleared_at
-        .store(0, std::sync::atomic::Ordering::Relaxed);
-    state
-        .db
-        .with_conn(|conn| {
-            let queue = player::enqueue_track(conn, payload.track_id, "user")?;
-            let _ = state.event_tx.send(AppEvent::QueueUpdated);
-            Ok(Json(json!({ "queue": queue })))
-        })
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+    let response = {
+        let state_guard = state.read().await;
+        // User-driven enqueue; clear the post-clear suppression window.
+        state_guard
+            .user_cleared_at
+            .store(0, std::sync::atomic::Ordering::Relaxed);
+        state_guard
+            .db
+            .with_conn(|conn| {
+                let queue = player::enqueue_track(conn, payload.track_id, "user")?;
+                let _ = state_guard.event_tx.send(AppEvent::QueueUpdated);
+                Ok(Json(json!({ "queue": queue })))
+            })
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+    };
+    refresh_dj_after_queue_change(state, "add_queue_track").await;
+    Ok(response)
 }
 
 fn queue_external_insert<'a>(
@@ -8793,8 +8831,11 @@ async fn spawn_pending_queue_resolver(state: &SharedState, queue_item_id: i64) {
             s.tidal_http_client.clone(),
         )
     };
+    let state = state.clone();
     tokio::spawn(async move {
-        resolve_pending_row(db, tokens, queue_item_id, event_tx, tidal_http_client).await;
+        if resolve_pending_row(db, tokens, queue_item_id, event_tx, tidal_http_client).await {
+            refresh_dj_after_queue_change(state, "pending_queue_resolved").await;
+        }
     });
 }
 
@@ -8830,6 +8871,7 @@ async fn queue_append(
     if let queue::InsertResult::Pending { queue_id } = inserted {
         spawn_pending_queue_resolver(&state, queue_id).await;
     }
+    refresh_dj_after_queue_change(state, "queue_append").await;
 
     Ok(Json(json!({ "queue": queue })))
 }
@@ -8875,6 +8917,7 @@ async fn queue_append_many(
             spawn_pending_queue_resolver(&state, queue_id).await;
         }
     }
+    refresh_dj_after_queue_change(state, "queue_append_many").await;
 
     Ok(Json(json!({ "queue": queue })))
 }
@@ -8914,6 +8957,7 @@ async fn queue_play_next(
     if let queue::InsertResult::Pending { queue_id } = inserted {
         spawn_pending_queue_resolver(&state, queue_id).await;
     }
+    refresh_dj_after_queue_change(state, "queue_play_next").await;
 
     Ok(Json(json!({ "queue": queue })))
 }
@@ -8971,6 +9015,7 @@ async fn queue_play_next_many(
             spawn_pending_queue_resolver(&state, queue_id).await;
         }
     }
+    refresh_dj_after_queue_change(state, "queue_play_next_many").await;
 
     Ok(Json(json!({ "queue": queue })))
 }
@@ -8979,99 +9024,115 @@ async fn replace_playback_queue(
     State(state): State<SharedState>,
     Json(payload): Json<QueueReplaceRequest>,
 ) -> Result<Json<Value>, StatusCode> {
-    let state = state.read().await;
-    state
-        .db
-        .with_conn(|conn| {
-            // Replace with library tracks first.
-            match payload.reasons.as_ref() {
-                Some(reasons) => {
-                    player::replace_queue_with_reasons(conn, &payload.track_ids, reasons, "user")?
+    let response = {
+        let state_guard = state.read().await;
+        state_guard
+            .db
+            .with_conn(|conn| {
+                // Replace with library tracks first.
+                match payload.reasons.as_ref() {
+                    Some(reasons) => player::replace_queue_with_reasons(
+                        conn,
+                        &payload.track_ids,
+                        reasons,
+                        "user",
+                    )?,
+                    None => player::replace_queue_with_tracks(conn, &payload.track_ids, "user")?,
+                };
+                // Phase 2c-ii-a: append pending (last.fm) candidates after library tracks.
+                if let Some(pending) = &payload.pending_candidates
+                    && !pending.is_empty()
+                {
+                    use crate::playback::queue::{PendingCandidate, append_pending_tracks};
+                    let candidates: Vec<PendingCandidate> = pending
+                        .iter()
+                        .map(|p| PendingCandidate {
+                            artist: p.artist.clone(),
+                            title: p.title.clone(),
+                            reason: p.reason.clone(),
+                        })
+                        .collect();
+                    append_pending_tracks(conn, &candidates)?;
                 }
-                None => player::replace_queue_with_tracks(conn, &payload.track_ids, "user")?,
-            };
-            // Phase 2c-ii-a: append pending (last.fm) candidates after library tracks.
-            if let Some(pending) = &payload.pending_candidates
-                && !pending.is_empty()
-            {
-                use crate::playback::queue::{PendingCandidate, append_pending_tracks};
-                let candidates: Vec<PendingCandidate> = pending
-                    .iter()
-                    .map(|p| PendingCandidate {
-                        artist: p.artist.clone(),
-                        title: p.title.clone(),
-                        reason: p.reason.clone(),
-                    })
-                    .collect();
-                append_pending_tracks(conn, &candidates)?;
-            }
-            let mut shuffle_debug = None;
-            let final_queue = match payload.shuffle_mode.as_deref() {
-                Some(raw_mode) => {
-                    let mode = queue::ShuffleMode::parse(raw_mode);
-                    if mode == queue::ShuffleMode::Off {
-                        crate::playback::queue::load_queue(conn)?
-                    } else {
-                        let seed = crate::playback::shuffle::generate_shuffle_seed();
-                        let result = crate::playback::queue::apply_shuffle_with_seed(
-                            conn,
-                            mode,
-                            None,
-                            seed,
-                            "queue_replace",
-                        )?;
-                        shuffle_debug = result.debug;
-                        result.queue
+                let mut shuffle_debug = None;
+                let final_queue = match payload.shuffle_mode.as_deref() {
+                    Some(raw_mode) => {
+                        let mode = queue::ShuffleMode::parse(raw_mode);
+                        if mode == queue::ShuffleMode::Off {
+                            crate::playback::queue::load_queue(conn)?
+                        } else {
+                            let seed = crate::playback::shuffle::generate_shuffle_seed();
+                            let result = crate::playback::queue::apply_shuffle_with_seed(
+                                conn,
+                                mode,
+                                None,
+                                seed,
+                                "queue_replace",
+                            )?;
+                            shuffle_debug = result.debug;
+                            result.queue
+                        }
                     }
-                }
-                None => crate::playback::queue::load_queue(conn)?,
-            };
-            let _ = state.event_tx.send(AppEvent::QueueUpdated);
-            Ok(Json(json!({
-                "queue": final_queue,
-                "shuffle_debug": shuffle_debug
-            })))
-        })
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+                    None => crate::playback::queue::load_queue(conn)?,
+                };
+                let _ = state_guard.event_tx.send(AppEvent::QueueUpdated);
+                Ok(Json(json!({
+                    "queue": final_queue,
+                    "shuffle_debug": shuffle_debug
+                })))
+            })
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+    };
+    refresh_dj_after_queue_change(state, "replace_playback_queue").await;
+    Ok(response)
 }
 
 async fn remove_queue_track(
     State(state): State<SharedState>,
     Json(payload): Json<QueueRemoveRequest>,
 ) -> Result<Json<Value>, StatusCode> {
-    let state = state.read().await;
-    state
-        .db
-        .with_conn(|conn| {
-            queue::remove_queue_item(conn, payload.queue_item_id)?;
-            let queue = queue::load_queue(conn)?;
-            let _ = state.event_tx.send(AppEvent::QueueUpdated);
-            Ok(Json(json!({ "queue": queue })))
-        })
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+    let response = {
+        let state_guard = state.read().await;
+        state_guard
+            .db
+            .with_conn(|conn| {
+                queue::remove_queue_item(conn, payload.queue_item_id)?;
+                let queue = queue::load_queue(conn)?;
+                let _ = state_guard.event_tx.send(AppEvent::QueueUpdated);
+                Ok(Json(json!({ "queue": queue })))
+            })
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+    };
+    refresh_dj_after_queue_change(state, "remove_queue_track").await;
+    Ok(response)
 }
 
 async fn move_queue_track(
     State(state): State<SharedState>,
     Json(payload): Json<QueueMoveRequest>,
 ) -> Result<Json<Value>, StatusCode> {
-    let state = state.read().await;
-    state
-        .db
-        .with_conn(|conn| {
-            queue::move_queue_item(conn, payload.item_id, payload.new_pos)?;
-            let queue = queue::load_queue(conn)?;
-            let _ = state.event_tx.send(AppEvent::QueueUpdated);
-            Ok(Json(json!({ "queue": queue })))
-        })
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+    let response = {
+        let state_guard = state.read().await;
+        state_guard
+            .db
+            .with_conn(|conn| {
+                queue::move_queue_item(conn, payload.item_id, payload.new_pos)?;
+                let queue = queue::load_queue(conn)?;
+                let _ = state_guard.event_tx.send(AppEvent::QueueUpdated);
+                Ok(Json(json!({ "queue": queue })))
+            })
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+    };
+    refresh_dj_after_queue_change(state, "move_queue_track").await;
+    Ok(response)
 }
 
 async fn clear_queue_route(State(state): State<SharedState>) -> Result<Json<Value>, StatusCode> {
-    let state = state.read().await;
-    state
-        .db
-        .with_conn(|conn| {
+    let response = {
+        let state_guard = state.read().await;
+        state_guard
+            .db
+            .with_conn(|conn| {
             let (current_track_id, current_queue_item_id): (Option<i64>, Option<i64>) =
                 conn.query_row(
                     "SELECT current_track_id, current_queue_item_id FROM playback_state WHERE id = 1",
@@ -9091,7 +9152,7 @@ async fn clear_queue_route(State(state): State<SharedState>) -> Result<Json<Valu
                     queue::clear_queue(conn)?;
                 }
             }
-            state.pending_tidal_mix_queue.lock().unwrap().clear();
+                state_guard.pending_tidal_mix_queue.lock().unwrap().clear();
             // Return the full PlaybackSnapshot ({state, queue}) so the UI can
             // refresh both at once - additive over the prior `{queue}` shape:
             // existing consumers keep reading `queue`, new ones read
@@ -9105,16 +9166,19 @@ async fn clear_queue_route(State(state): State<SharedState>) -> Result<Json<Valu
                 .duration_since(std::time::UNIX_EPOCH)
                 .map(|d| d.as_secs() as i64)
                 .unwrap_or(0);
-            state
+                state_guard
                 .user_cleared_at
                 .store(now_secs, std::sync::atomic::Ordering::Relaxed);
-            let _ = state.event_tx.send(AppEvent::QueueUpdated);
+                let _ = state_guard.event_tx.send(AppEvent::QueueUpdated);
             Ok(Json(json!({
                 "queue": snapshot.queue,
                 "playback_state": snapshot.state,
             })))
         })
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+    };
+    refresh_dj_after_queue_change(state, "clear_queue_route").await;
+    Ok(response)
 }
 
 fn non_empty_or_default(value: Option<String>, fallback: &str) -> String {
@@ -12443,6 +12507,43 @@ async fn mark_armed_dj_transition_missed_if_needed(state: &SharedState) -> anyho
                 next_key.media_ref_kind.as_str(),
                 next_key.media_ref_id.as_str(),
                 "missed",
+            )
+        })?
+    };
+    if updated > 0 {
+        let state_guard = state.read().await;
+        let _ = state_guard.event_tx.send(AppEvent::PlaybackStateChanged);
+    }
+    Ok(())
+}
+
+async fn mark_armed_dj_transition_manual_seek_suppressed_if_needed(
+    state: &SharedState,
+) -> anyhow::Result<()> {
+    let pair = {
+        let state_guard = state.read().await;
+        if let Some(pair) = active_ephemeral_tidal_mix_dj_pair(&state_guard) {
+            pair
+        } else {
+            state_guard
+                .db
+                .with_conn(crate::playback::dj_lookahead::load_dj_lookahead_pair)?
+        }
+    };
+    let (Some(current), Some(next)) = (pair.current.as_ref(), pair.next.as_ref()) else {
+        return Ok(());
+    };
+    let current_key = current.profile_key();
+    let next_key = next.profile_key();
+    let updated = {
+        let state_guard = state.read().await;
+        state_guard.db.with_conn(|conn| {
+            queries::mark_dj_transition_manual_seek_suppressed_for_pair(
+                conn,
+                current_key.media_ref_kind.as_str(),
+                current_key.media_ref_id.as_str(),
+                next_key.media_ref_kind.as_str(),
+                next_key.media_ref_id.as_str(),
             )
         })?
     };

--- a/noor-server/src/server/routes/dj_routes.rs
+++ b/noor-server/src/server/routes/dj_routes.rs
@@ -1673,6 +1673,7 @@ fn latest_dj_transition_timing_history(
          LEFT JOIN tracks to_queue_track ON to_queue_track.id = to_queue.track_id
          LEFT JOIN artists to_queue_artist ON to_queue_artist.id = to_queue_track.artist_id
          WHERE e.timing_status IN ('fired', 'late', 'missed')
+           AND COALESCE(e.runtime_renderer_reason, '') <> 'manual_seek_suppressed'
            AND NOT (
              e.timing_status = 'missed'
              AND EXISTS (
@@ -2822,6 +2823,48 @@ mod tests {
         assert_eq!(history.len(), 2);
         assert_eq!(history[0].timing_status.as_deref(), Some("missed"));
         assert_eq!(history[1].timing_status.as_deref(), Some("fired"));
+    }
+
+    #[test]
+    fn timing_history_filters_manual_seek_suppressed_boundary_rows() {
+        let conn = rusqlite::Connection::open_in_memory().expect("db");
+        crate::db::schema::run_migrations(&conn).expect("migrations");
+        conn.execute(
+            "INSERT INTO dj_transition_events (
+                from_media_ref_kind, from_media_ref_id, to_media_ref_kind, to_media_ref_id,
+                template, program_json, planner_version, planned_start_ms,
+                actual_start_ms, timing_delta_ms, timing_source, timing_status,
+                runtime_rendered_dj_mixer, runtime_renderer_status, runtime_renderer_reason
+             ) VALUES (
+                'tidal_track', '1', 'tidal_track', '2',
+                'SafeCrossfade', '{\"template\":\"SafeCrossfade\"}', 'dj-v1',
+                222000, 240000, 18000, 'downbeat_sync', 'late',
+                0, 'boundary_fallback', 'manual_seek_suppressed'
+             )",
+            [],
+        )
+        .expect("insert manual seek row");
+        conn.execute(
+            "INSERT INTO dj_transition_events (
+                from_media_ref_kind, from_media_ref_id, to_media_ref_kind, to_media_ref_id,
+                template, program_json, planner_version, planned_start_ms,
+                actual_start_ms, timing_delta_ms, timing_source, timing_status,
+                runtime_rendered_dj_mixer, runtime_renderer_status, runtime_renderer_reason
+             ) VALUES (
+                'tidal_track', '2', 'tidal_track', '3',
+                'SafeCrossfade', '{\"template\":\"SafeCrossfade\"}', 'dj-v1',
+                222000, 222040, 40, 'downbeat_sync', 'fired',
+                1, 'rendered_handoff', 'none'
+             )",
+            [],
+        )
+        .expect("insert rendered row");
+
+        let history = latest_dj_transition_timing_history(&conn, 5).expect("history");
+
+        assert_eq!(history.len(), 1);
+        assert_eq!(history[0].timing_delta_ms, Some(40));
+        assert_eq!(history[0].runtime_renderer_reason.as_deref(), Some("none"));
     }
 
     #[test]


### PR DESCRIPTION
Summary:
- close DJ timing rows invalidated by manual seeks as manual_seek_suppressed
- exclude fallback and seek-suppressed rows from timing calibration/history
- preserve upstream precise DJ miss reasons after rebase

Tests:
- cargo test -p noor-server playback::runtime
- cargo test -p noor-server db::queries::tests::dj_transition_event
- cargo test -p noor-server server::routes::dj_routes::tests
- cargo test -p noor-server playback::player::tests::dj_transition_logging
- cargo fmt --all -- --check
- git diff --check