### PR TITLE
feat(dj): add autosynced drop previews and repair handoffs

### DIFF
--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -905,6 +905,8 @@ export type DjDeckStatus = {
 	profile_ready: boolean;
 	profile_status: 'ready' | 'missing' | 'analyzing' | 'retrying' | 'decode_failed' | string;
 	profile_error?: string;
+	profile_retry_after_ms?: number;
+	profile_retry_reason?: string;
 	profile_confidence?: number;
 	beat_count?: number;
 	downbeat_count?: number;

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -916,9 +916,20 @@ export type DjDeckStatus = {
 	phrase_markers_ms: number[];
 	mix_in_markers_ms: number[];
 	mix_out_markers_ms: number[];
+	drop_markers_ms: number[];
+	manual_drop_markers_ms: number[];
 	passive_analysis_status?: 'ready' | 'missing' | 'retrying' | 'skipped' | string;
 	passive_analysis_reason?: string;
 	safe_crossfade_only: boolean;
+};
+
+export type DjDropPreviewStatus = {
+	status: 'armed' | 'fired' | 'skipped' | string;
+	planned_fire_ms?: number;
+	actual_fire_ms?: number;
+	incoming_drop_ms?: number;
+	source?: 'manual' | 'profile' | string;
+	reason?: string;
 };
 
 export type DjOverlayDetails = {
@@ -1000,6 +1011,7 @@ export type DjStatusResponse = {
 		media_ref_id: string;
 		bad_feedback_count: number;
 	};
+	drop_preview: DjDropPreviewStatus;
 };
 
 export type DjTimingHistoryEvent = {

--- a/frontend/src/lib/components/dj-cockpit/QueuePairPanel.svelte
+++ b/frontend/src/lib/components/dj-cockpit/QueuePairPanel.svelte
@@ -11,11 +11,33 @@
 
 	function confidenceLabel(deck?: DjDeckStatus) {
 		if (deck?.profile_status === 'decode_failed') return 'Analysis failed';
-		if (deck?.profile_status === 'retrying') return 'Retrying analysis';
+		if (deck?.profile_status === 'retrying') return retryLabel(deck);
 		if (deck?.profile_status === 'analyzing') return 'Analyzing';
 		if (!deck?.profile_ready) return 'Profile missing';
 		if (deck.profile_confidence == null) return 'Profile ready';
 		return `${Math.round(deck.profile_confidence * 100)}% confidence`;
+	}
+
+	function retryLabel(deck: DjDeckStatus) {
+		const wait = formatRetryWait(deck.profile_retry_after_ms);
+		if (!wait) return 'Retrying analysis';
+		return `Retrying analysis in ${wait}`;
+	}
+
+	function formatRetryWait(ms?: number) {
+		if (ms == null || ms <= 0) return null;
+		const seconds = Math.ceil(ms / 1000);
+		if (seconds < 60) return `${seconds}s`;
+		const minutes = Math.ceil(seconds / 60);
+		return `${minutes}m`;
+	}
+
+	function retryReasonLabel(deck?: DjDeckStatus) {
+		if (!deck?.profile_retry_reason) return null;
+		if (deck.profile_retry_reason === 'asset_not_ready') return 'TIDAL asset unavailable';
+		if (deck.profile_retry_reason === 'dash_prebuffer') return 'DASH prebuffer retry';
+		if (deck.profile_retry_reason === 'timeout') return 'Analysis timeout';
+		return 'Transient analysis failure';
 	}
 
 	function passiveAnalysisLabel(deck?: DjDeckStatus) {
@@ -55,6 +77,9 @@
 						{/if}
 						{#if item.deck.profile_error}
 							<span class="error-detail" title={item.deck.profile_error}>{item.deck.profile_error}</span>
+						{/if}
+						{#if retryReasonLabel(item.deck)}
+							<span class="error-detail">{retryReasonLabel(item.deck)}</span>
 						{/if}
 						{#if item.deck.passive_analysis_reason}
 							<span class="error-detail" title={item.deck.passive_analysis_reason}>

--- a/frontend/src/lib/components/dj-cockpit/TransitionLane.svelte
+++ b/frontend/src/lib/components/dj-cockpit/TransitionLane.svelte
@@ -97,6 +97,24 @@
 	let recentTimingHistory = $derived(recentTimingEvents.slice(0, 5));
 	let timingSummary = $derived(status?.timing_history_summary ?? null);
 	let overlayDetails = $derived(status?.overlay_details ?? null);
+	let dropPreview = $derived(status?.drop_preview ?? null);
+	let dropPreviewVisible = $derived(Boolean(dropPreview && dropPreview.status !== 'skipped'));
+	let dropPreviewLabel = $derived(
+		dropPreview?.status === 'fired'
+			? 'Drop preview fired'
+			: dropPreview?.status === 'armed'
+				? 'Drop preview armed'
+				: 'Drop preview skipped',
+	);
+	let dropPreviewCopy = $derived(
+		dropPreview?.status === 'fired'
+			? `Fired at ${formatTimingMs(dropPreview.actual_fire_ms)}. Incoming drop ${formatTimingMs(dropPreview.incoming_drop_ms)}.`
+			: dropPreview?.status === 'armed'
+				? `Armed for ${formatTimingMs(dropPreview.planned_fire_ms)}. Incoming drop ${formatTimingMs(dropPreview.incoming_drop_ms)}.`
+				: dropPreview?.reason
+					? `Skipped: ${formatDropPreviewReason(dropPreview.reason)}.`
+					: 'Skipped.',
+	);
 
 	function formatTimingMs(value: number | null | undefined) {
 		return typeof value === 'number' ? `${value} ms` : 'pending';
@@ -118,6 +136,20 @@
 			return 'unknown';
 		}
 		return value ? 'yes' : 'no';
+	}
+
+	function formatDropPreviewReason(reason: string | null | undefined) {
+		const labels: Record<string, string> = {
+			disabled: 'DJ disabled',
+			pair_missing: 'Pair missing',
+			profiles_missing: 'Profiles missing',
+			safe_crossfade_only: 'Safe crossfade only',
+			profile_low_confidence: 'Profile confidence low',
+			harmonic_incompatible: 'Harmonic mismatch',
+			missing_incoming_drop: 'Incoming drop missing',
+			no_safe_mid_song_marker: 'No safe mid-song marker',
+		};
+		return reason ? (labels[reason] ?? reason) : 'none';
 	}
 
 	function runtimeReasonLabel(reason: string | null | undefined) {
@@ -299,6 +331,12 @@
 	{:else}
 		<p class:pending={!transitionArmed} class:success={transitionArmed} role="status">{laneCopy}</p>
 	{/if}
+	{#if dropPreviewVisible}
+		<p class="drop-preview" class:success={dropPreview?.status === 'fired'} role="status">
+			<strong>{dropPreviewLabel}</strong>
+			<span>{dropPreviewCopy}</span>
+		</p>
+	{/if}
 
 	<TransitionWaveform current={status?.current} next={status?.next} {status} />
 
@@ -417,6 +455,30 @@
 				<div>
 					<dt>Planning status</dt>
 					<dd>{status?.planning_status ?? 'none'}</dd>
+				</div>
+				<div>
+					<dt>Drop preview</dt>
+					<dd>{dropPreview?.status ?? 'none'}</dd>
+				</div>
+				<div>
+					<dt>Preview planned</dt>
+					<dd>{formatTimingMs(dropPreview?.planned_fire_ms)}</dd>
+				</div>
+				<div>
+					<dt>Preview actual</dt>
+					<dd>{formatTimingMs(dropPreview?.actual_fire_ms)}</dd>
+				</div>
+				<div>
+					<dt>Preview drop</dt>
+					<dd>{formatTimingMs(dropPreview?.incoming_drop_ms)}</dd>
+				</div>
+				<div>
+					<dt>Preview source</dt>
+					<dd>{dropPreview?.source ?? 'none'}</dd>
+				</div>
+				<div>
+					<dt>Preview reason</dt>
+					<dd>{formatDropPreviewReason(dropPreview?.reason)}</dd>
 				</div>
 				<div>
 					<dt>Confidence floor</dt>
@@ -579,6 +641,24 @@
 		border: 1px solid color-mix(in srgb, var(--state-success) 28%, transparent);
 		background: color-mix(in srgb, var(--state-success) 9%, transparent);
 		color: var(--text-secondary);
+	}
+
+	.drop-preview {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--space-2);
+		align-items: center;
+		padding: var(--space-3);
+		border: 1px solid color-mix(in srgb, var(--accent-primary) 30%, transparent);
+		border-radius: var(--radius-sm);
+		background: color-mix(in srgb, var(--accent-primary) 8%, transparent);
+		color: var(--text-secondary);
+		font-size: var(--font-size-sm);
+		line-height: var(--line-height-snug);
+	}
+
+	.drop-preview strong {
+		color: var(--accent-primary);
 	}
 
 	.pending {

--- a/frontend/src/routes/dj/dj_page_contract.test.ts
+++ b/frontend/src/routes/dj/dj_page_contract.test.ts
@@ -112,8 +112,12 @@ describe('dj cockpit page contract', () => {
 		expect(transitionLane).toContain('current_profile_decode_failed');
 		expect(queuePair).toContain('Analysis failed');
 		expect(queuePair).toContain('Retrying analysis');
+		expect(queuePair).toContain('Retrying analysis in');
+		expect(queuePair).toContain('TIDAL asset unavailable');
 		expect(queuePair).toContain('Analyzing');
 		expect(queuePair).toContain('profile_error');
+		expect(queuePair).toContain('profile_retry_after_ms');
+		expect(queuePair).toContain('profile_retry_reason');
 		expect(queuePair).toContain('Passive DSP retrying');
 		expect(queuePair).toContain('passive_analysis_status');
 		expect(queuePair).toContain('passive_analysis_reason');

--- a/noor-mix/src/planner/mod.rs
+++ b/noor-mix/src/planner/mod.rs
@@ -439,6 +439,7 @@ pub fn drop_preview_16_program(
     sample_rate: u32,
     channels: u16,
     duration_ms: u32,
+    outgoing: &DjProfile,
     incoming: &DjProfile,
 ) -> Option<TransitionProgram> {
     let sample_rate = sample_rate.max(1);
@@ -447,6 +448,18 @@ pub fn drop_preview_16_program(
         (u64::from(duration_ms).saturating_mul(u64::from(sample_rate)) / 1_000).max(1);
     let swap_start = duration_samples / 2;
     let drop_frame = first_valid_preview_drop_frame(incoming, sample_rate)?;
+    let rate = drop_preview_autosync_rate(outgoing, incoming)?;
+    let mut automation = drop_preview_overlay_automation(duration_samples);
+    if (rate - 1.0).abs() > PLAYBACK_RATE_EPSILON {
+        automation.push(AutomationEvent {
+            param: Param::PlaybackRate(DeckId::B),
+            start_sample: 0,
+            end_sample: duration_samples,
+            from: rate,
+            to: rate,
+            curve: Curve::Linear,
+        });
+    }
     Some(TransitionProgram {
         tier: Tier::FullBlend,
         template: "DropPreview16".to_string(),
@@ -460,8 +473,20 @@ pub fn drop_preview_16_program(
         fade_start: swap_start,
         resolve_at: duration_samples,
         loops: vec![],
-        automation: drop_preview_overlay_automation(duration_samples),
+        automation,
     })
+}
+
+fn drop_preview_autosync_rate(outgoing: &DjProfile, incoming: &DjProfile) -> Option<f32> {
+    let outgoing_bpm = outgoing.bpm?.max(1.0);
+    let incoming_bpm = incoming.bpm?.max(1.0);
+    let comparable_incoming_bpm = scoring::nearest_tempo_family_bpm(outgoing_bpm, incoming_bpm);
+    if scoring::bpm_delta_pct(outgoing_bpm, comparable_incoming_bpm) > 3.0 {
+        return None;
+    }
+    let rate = outgoing_bpm / comparable_incoming_bpm;
+    (rate.is_finite() && (SMALL_TEMPO_NUDGE_MIN..=SMALL_TEMPO_NUDGE_MAX).contains(&rate))
+        .then_some(rate)
 }
 
 fn duration_samples(template: TransitionTemplate, policy: &Policy, bar_samples: u64) -> u64 {
@@ -1539,10 +1564,12 @@ mod tests {
 
     #[test]
     fn drop_preview_16_program_aligns_profile_drop_to_preview_midpoint() {
+        let outgoing = profile(Some(120.0), Some("8A"), 4);
         let mut incoming = profile(Some(120.0), Some("8A"), 4);
         incoming.drop_seconds = vec![32.0];
 
-        let program = drop_preview_16_program(48_000, 2, 16_000, &incoming).expect("drop preview");
+        let program =
+            drop_preview_16_program(48_000, 2, 16_000, &outgoing, &incoming).expect("drop preview");
 
         assert_eq!(program.template, "DropPreview16");
         assert_eq!(program.resolve_at, 768_000);
@@ -1553,28 +1580,33 @@ mod tests {
 
     #[test]
     fn drop_preview_16_program_prefers_manual_drop_marker() {
+        let outgoing = profile(Some(120.0), Some("8A"), 4);
         let mut incoming = profile(Some(120.0), Some("8A"), 4);
         incoming.drop_seconds = vec![32.0];
         incoming.manual_drop_seconds = vec![24.0];
 
-        let program = drop_preview_16_program(48_000, 2, 16_000, &incoming).expect("drop preview");
+        let program =
+            drop_preview_16_program(48_000, 2, 16_000, &outgoing, &incoming).expect("drop preview");
 
         assert_eq!(program.deck_b_start_frame, 768_000);
     }
 
     #[test]
     fn drop_preview_16_program_rejects_missing_drop_marker() {
+        let outgoing = profile(Some(120.0), Some("8A"), 4);
         let incoming = profile(Some(120.0), Some("8A"), 4);
 
-        assert!(drop_preview_16_program(48_000, 2, 16_000, &incoming).is_none());
+        assert!(drop_preview_16_program(48_000, 2, 16_000, &outgoing, &incoming).is_none());
     }
 
     #[test]
     fn drop_preview_16_program_caps_preview_gain() {
+        let outgoing = profile(Some(120.0), Some("8A"), 4);
         let mut incoming = profile(Some(120.0), Some("8A"), 4);
         incoming.drop_seconds = vec![32.0];
 
-        let program = drop_preview_16_program(48_000, 2, 16_000, &incoming).expect("drop preview");
+        let program =
+            drop_preview_16_program(48_000, 2, 16_000, &outgoing, &incoming).expect("drop preview");
 
         assert!(program.automation.iter().any(|event| {
             event.param == Param::DeckGain(DeckId::A) && event.from == 0.0 && event.to == 0.0
@@ -1585,6 +1617,33 @@ mod tests {
         assert!(!program.automation.iter().any(|event| {
             event.param == Param::DeckGain(DeckId::B) && (event.from == 1.0 || event.to == 1.0)
         }));
+    }
+
+    #[test]
+    fn drop_preview_16_program_autosyncs_small_tempo_delta() {
+        let outgoing = profile(Some(120.0), Some("8A"), 4);
+        let mut incoming = profile(Some(122.0), Some("8A"), 4);
+        incoming.drop_seconds = vec![32.0];
+
+        let program =
+            drop_preview_16_program(48_000, 2, 16_000, &outgoing, &incoming).expect("drop preview");
+        let rate = program
+            .automation
+            .iter()
+            .find(|event| event.param == Param::PlaybackRate(DeckId::B))
+            .expect("incoming playback rate automation");
+
+        assert!((rate.from - 120.0 / 122.0).abs() < 0.0001);
+        assert_eq!(rate.from, rate.to);
+    }
+
+    #[test]
+    fn drop_preview_16_program_rejects_unsyncable_tempo_delta() {
+        let outgoing = profile(Some(120.0), Some("8A"), 4);
+        let mut incoming = profile(Some(130.0), Some("8A"), 4);
+        incoming.drop_seconds = vec![32.0];
+
+        assert!(drop_preview_16_program(48_000, 2, 16_000, &outgoing, &incoming).is_none());
     }
 
     #[test]

--- a/noor-mix/src/planner/mod.rs
+++ b/noor-mix/src/planner/mod.rs
@@ -1538,6 +1538,56 @@ mod tests {
     }
 
     #[test]
+    fn drop_preview_16_program_aligns_profile_drop_to_preview_midpoint() {
+        let mut incoming = profile(Some(120.0), Some("8A"), 4);
+        incoming.drop_seconds = vec![32.0];
+
+        let program = drop_preview_16_program(48_000, 2, 16_000, &incoming).expect("drop preview");
+
+        assert_eq!(program.template, "DropPreview16");
+        assert_eq!(program.resolve_at, 768_000);
+        assert_eq!(program.swap_start, 384_000);
+        assert_eq!(program.deck_b_start_frame, 1_152_000);
+        program.validate().expect("drop preview program");
+    }
+
+    #[test]
+    fn drop_preview_16_program_prefers_manual_drop_marker() {
+        let mut incoming = profile(Some(120.0), Some("8A"), 4);
+        incoming.drop_seconds = vec![32.0];
+        incoming.manual_drop_seconds = vec![24.0];
+
+        let program = drop_preview_16_program(48_000, 2, 16_000, &incoming).expect("drop preview");
+
+        assert_eq!(program.deck_b_start_frame, 768_000);
+    }
+
+    #[test]
+    fn drop_preview_16_program_rejects_missing_drop_marker() {
+        let incoming = profile(Some(120.0), Some("8A"), 4);
+
+        assert!(drop_preview_16_program(48_000, 2, 16_000, &incoming).is_none());
+    }
+
+    #[test]
+    fn drop_preview_16_program_caps_preview_gain() {
+        let mut incoming = profile(Some(120.0), Some("8A"), 4);
+        incoming.drop_seconds = vec![32.0];
+
+        let program = drop_preview_16_program(48_000, 2, 16_000, &incoming).expect("drop preview");
+
+        assert!(program.automation.iter().any(|event| {
+            event.param == Param::DeckGain(DeckId::A) && event.from == 0.0 && event.to == 0.0
+        }));
+        assert!(program.automation.iter().any(|event| {
+            event.param == Param::DeckGain(DeckId::B) && event.from == 0.65 && event.to == 0.65
+        }));
+        assert!(!program.automation.iter().any(|event| {
+            event.param == Param::DeckGain(DeckId::B) && (event.from == 1.0 || event.to == 1.0)
+        }));
+    }
+
+    #[test]
     fn filter_sweep_eq_wash_program_uses_requested_duration() {
         let program = filter_sweep_eq_wash_program(48_000, 2, 10_000);
 

--- a/noor-mix/src/planner/mod.rs
+++ b/noor-mix/src/planner/mod.rs
@@ -59,7 +59,11 @@ impl Planner {
         else {
             return TransitionTemplate::SafeCrossfade;
         };
-        if camelot_distance > 7 {
+        let harmonic_fit = matches!(camelot_distance, 0 | 1 | 7);
+        if !harmonic_fit {
+            if bold_filter_candidate {
+                return TransitionTemplate::FilterSweep;
+            }
             return TransitionTemplate::SafeCrossfade;
         }
 
@@ -69,7 +73,7 @@ impl Planner {
                 && incoming.has_full_dj_profile()
                 && outgoing.phrase_bar_indices.len() >= 2
                 && incoming.phrase_bar_indices.len() >= 2
-                && matches!(camelot_distance, 0 | 1 | 7))
+                && harmonic_fit)
         {
             return TransitionTemplate::SafeCrossfade;
         }
@@ -82,7 +86,7 @@ impl Planner {
         if outgoing_phrases >= 2 && incoming_phrases >= 2 && bpm_delta <= 3.0 {
             return TransitionTemplate::BassSwap16;
         }
-        if matches!(camelot_distance, 0 | 1 | 7) && bpm_delta <= 3.0 {
+        if harmonic_fit && bpm_delta <= 3.0 {
             return TransitionTemplate::LongHarmonicBlend;
         }
         if bold_filter_candidate {
@@ -888,6 +892,18 @@ mod tests {
                 &Policy::default()
             ),
             TransitionTemplate::LongHarmonicBlend
+        );
+    }
+
+    #[test]
+    fn choose_template_rejects_distant_same_mode_camelot_for_balanced_intent() {
+        assert_eq!(
+            Planner::choose_template(
+                &profile(Some(120.0), Some("8A"), 4),
+                &profile(Some(121.0), Some("3A"), 4),
+                &Policy::default()
+            ),
+            TransitionTemplate::SafeCrossfade
         );
     }
 

--- a/noor-mix/src/planner/mod.rs
+++ b/noor-mix/src/planner/mod.rs
@@ -40,14 +40,14 @@ impl Planner {
         if drop_tease_candidate_ready(outgoing, incoming, policy) {
             return TransitionTemplate::DropTease16;
         }
-        if matches!(policy.mix_intent, MixIntent::Bold)
+        let bold_filter_candidate = matches!(policy.mix_intent, MixIntent::Bold)
             && !outgoing.phrase_bar_indices.is_empty()
-            && !incoming.phrase_bar_indices.is_empty()
-        {
-            return TransitionTemplate::FilterSweep;
-        }
+            && !incoming.phrase_bar_indices.is_empty();
 
         if bpm_delta > 8.0 {
+            if bold_filter_candidate {
+                return TransitionTemplate::FilterSweep;
+            }
             return TransitionTemplate::SlamCut;
         }
 
@@ -84,6 +84,9 @@ impl Planner {
         }
         if matches!(camelot_distance, 0 | 1 | 7) && bpm_delta <= 3.0 {
             return TransitionTemplate::LongHarmonicBlend;
+        }
+        if bold_filter_candidate {
+            return TransitionTemplate::FilterSweep;
         }
         TransitionTemplate::FilterSweep
     }
@@ -905,7 +908,7 @@ mod tests {
     }
 
     #[test]
-    fn choose_template_bold_prefers_filter_sweep_for_compatible_profiles() {
+    fn choose_template_bold_preserves_bass_swap_32_for_compatible_profiles() {
         let policy = Policy {
             mix_intent: MixIntent::Bold,
             ..Policy::default()
@@ -916,7 +919,39 @@ mod tests {
                 &profile(Some(121.0), Some("8A"), 32),
                 &policy
             ),
-            TransitionTemplate::FilterSweep
+            TransitionTemplate::BassSwap32
+        );
+    }
+
+    #[test]
+    fn choose_template_bold_preserves_bass_swap_16_for_medium_phrases() {
+        let policy = Policy {
+            mix_intent: MixIntent::Bold,
+            ..Policy::default()
+        };
+        assert_eq!(
+            Planner::choose_template(
+                &profile(Some(120.0), Some("8A"), 2),
+                &profile(Some(121.0), Some("8A"), 2),
+                &policy
+            ),
+            TransitionTemplate::BassSwap16
+        );
+    }
+
+    #[test]
+    fn choose_template_bold_preserves_long_harmonic_blend_for_short_compatible_profiles() {
+        let policy = Policy {
+            mix_intent: MixIntent::Bold,
+            ..Policy::default()
+        };
+        assert_eq!(
+            Planner::choose_template(
+                &profile(Some(120.0), Some("8A"), 1),
+                &profile(Some(121.0), Some("9A"), 1),
+                &policy
+            ),
+            TransitionTemplate::LongHarmonicBlend
         );
     }
 
@@ -1366,7 +1401,7 @@ mod tests {
             &profile(Some(121.0), Some("8A"), 4),
             &bold,
         );
-        assert_eq!(selected, TransitionTemplate::FilterSweep);
+        assert_eq!(selected, TransitionTemplate::BassSwap32);
 
         let policy = Policy {
             safety_template_override: Some(TransitionTemplate::DropTease16),

--- a/noor-mix/src/planner/mod.rs
+++ b/noor-mix/src/planner/mod.rs
@@ -13,6 +13,7 @@ const SMALL_TEMPO_NUDGE_MIN: f32 = 0.97;
 const SMALL_TEMPO_NUDGE_MAX: f32 = 1.03;
 const PLAYBACK_RATE_EPSILON: f32 = 0.0001;
 const DROP_TEASE_CONFIDENCE_FLOOR: f32 = 0.65;
+const DROP_PREVIEW_GAIN: f32 = 0.65;
 const PLANNER_SAMPLE_RATE: u32 = 48_000;
 
 pub struct Planner;
@@ -37,9 +38,6 @@ impl Planner {
         };
         let comparable_incoming_bpm = scoring::nearest_tempo_family_bpm(outgoing_bpm, incoming_bpm);
         let bpm_delta = scoring::bpm_delta_pct(outgoing_bpm, comparable_incoming_bpm);
-        if drop_tease_candidate_ready(outgoing, incoming, policy) {
-            return TransitionTemplate::DropTease16;
-        }
         let bold_filter_candidate = matches!(policy.mix_intent, MixIntent::Bold)
             && !outgoing.phrase_bar_indices.is_empty()
             && !incoming.phrase_bar_indices.is_empty();
@@ -181,6 +179,7 @@ fn build_program(
     program
 }
 
+#[allow(dead_code)]
 fn drop_tease_candidate_ready(outgoing: &DjProfile, incoming: &DjProfile, policy: &Policy) -> bool {
     if !matches!(policy.mix_intent, MixIntent::Bold) {
         return false;
@@ -436,6 +435,35 @@ pub fn drop_tease_16_program(
     }
 }
 
+pub fn drop_preview_16_program(
+    sample_rate: u32,
+    channels: u16,
+    duration_ms: u32,
+    incoming: &DjProfile,
+) -> Option<TransitionProgram> {
+    let sample_rate = sample_rate.max(1);
+    let channels = channels.max(1);
+    let duration_samples =
+        (u64::from(duration_ms).saturating_mul(u64::from(sample_rate)) / 1_000).max(1);
+    let swap_start = duration_samples / 2;
+    let drop_frame = first_valid_preview_drop_frame(incoming, sample_rate)?;
+    Some(TransitionProgram {
+        tier: Tier::FullBlend,
+        template: "DropPreview16".to_string(),
+        sample_rate,
+        channels,
+        deck_a_start_frame: 0,
+        deck_b_start_frame: drop_frame.saturating_sub(swap_start),
+        sync_start: 0,
+        intro_start: 0,
+        swap_start,
+        fade_start: swap_start,
+        resolve_at: duration_samples,
+        loops: vec![],
+        automation: drop_preview_overlay_automation(duration_samples),
+    })
+}
+
 fn duration_samples(template: TransitionTemplate, policy: &Policy, bar_samples: u64) -> u64 {
     match template {
         TransitionTemplate::BassSwap32 => bar_samples * 32,
@@ -533,6 +561,56 @@ fn drop_tease_overlay_automation(duration_samples: u64) -> Vec<AutomationEvent> 
             curve: Curve::EqualPowerIn,
         },
     ]
+}
+
+fn drop_preview_overlay_automation(duration_samples: u64) -> Vec<AutomationEvent> {
+    let end_sample = duration_samples.max(1);
+    let fade_in_end = (end_sample / 4).max(1);
+    let fade_out_start = (end_sample * 3 / 4).max(fade_in_end);
+    vec![
+        AutomationEvent {
+            param: Param::DeckGain(DeckId::A),
+            start_sample: 0,
+            end_sample,
+            from: 0.0,
+            to: 0.0,
+            curve: Curve::Linear,
+        },
+        AutomationEvent {
+            param: Param::DeckGain(DeckId::B),
+            start_sample: 0,
+            end_sample: fade_in_end,
+            from: 0.0,
+            to: DROP_PREVIEW_GAIN,
+            curve: Curve::EqualPowerIn,
+        },
+        AutomationEvent {
+            param: Param::DeckGain(DeckId::B),
+            start_sample: fade_in_end,
+            end_sample: fade_out_start.max(fade_in_end + 1),
+            from: DROP_PREVIEW_GAIN,
+            to: DROP_PREVIEW_GAIN,
+            curve: Curve::Linear,
+        },
+        AutomationEvent {
+            param: Param::DeckGain(DeckId::B),
+            start_sample: fade_out_start,
+            end_sample,
+            from: DROP_PREVIEW_GAIN,
+            to: 0.0,
+            curve: Curve::EqualPowerIn,
+        },
+    ]
+}
+
+fn first_valid_preview_drop_frame(incoming: &DjProfile, sample_rate: u32) -> Option<u64> {
+    incoming
+        .manual_drop_seconds
+        .iter()
+        .chain(incoming.drop_seconds.iter())
+        .copied()
+        .find(|seconds| seconds.is_finite() && *seconds >= 0.0)
+        .map(|seconds| (seconds * sample_rate as f32).round() as u64)
 }
 
 fn bass_swap_eq_handoff(duration_samples: u64) -> Vec<AutomationEvent> {
@@ -750,6 +828,7 @@ mod tests {
             outro_start_seconds: Some(180.0),
             breakdown_seconds: vec![],
             drop_seconds: vec![],
+            manual_drop_seconds: vec![],
             safe_transition_windows: vec![TransitionWindow {
                 start_seconds: 0.0,
                 end_seconds: 8.0,
@@ -1318,7 +1397,7 @@ mod tests {
     }
 
     #[test]
-    fn choose_template_bold_selects_drop_tease_for_confident_drop_candidate() {
+    fn choose_template_bold_keeps_drop_tease_out_of_end_transition() {
         let policy = Policy {
             mix_intent: MixIntent::Bold,
             ..Policy::default()
@@ -1329,7 +1408,7 @@ mod tests {
 
         assert_eq!(
             Planner::choose_template(&outgoing, &incoming, &policy),
-            TransitionTemplate::DropTease16
+            TransitionTemplate::BassSwap32
         );
     }
 
@@ -1392,7 +1471,7 @@ mod tests {
     #[test]
     fn drop_tease_plan_aligns_incoming_drop_to_overlay_swap() {
         let policy = Policy {
-            mix_intent: MixIntent::Bold,
+            safety_template_override: Some(TransitionTemplate::DropTease16),
             ..Policy::default()
         };
         let outgoing = profile(Some(120.0), Some("8A"), 4);

--- a/noor-mix/src/planner/policy.rs
+++ b/noor-mix/src/planner/policy.rs
@@ -32,7 +32,7 @@ impl Default for Policy {
         Self {
             max_pitch_shift_pct: 3.0,
             energy_step_max: 0.15,
-            default_crossfade_ms: 8_000,
+            default_crossfade_ms: 12_000,
             transition_speed_bias: TransitionSpeedBias::Neutral,
             mix_intent: MixIntent::Balanced,
             safety_template_override: None,

--- a/noor-mix/src/profile.rs
+++ b/noor-mix/src/profile.rs
@@ -14,6 +14,8 @@ pub struct DjProfile {
     pub outro_start_seconds: Option<f32>,
     pub breakdown_seconds: Vec<f32>,
     pub drop_seconds: Vec<f32>,
+    #[serde(default)]
+    pub manual_drop_seconds: Vec<f32>,
     pub safe_transition_windows: Vec<TransitionWindow>,
     pub vocal_presence_by_bar: Vec<f32>,
     pub vocal_density_by_bar: Vec<f32>,

--- a/noor-server/src/db/queries.rs
+++ b/noor-server/src/db/queries.rs
@@ -4730,6 +4730,14 @@ pub struct ExternalTrackCandidateRow {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResolvedLastfmExternalSightingRow {
+    pub seed_track_id: i64,
+    pub resolved_track_id: i64,
+    pub similarity: f64,
+    pub source_payload_json: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExternalTidalResolutionCandidateRow {
     pub id: i64,
     pub title: String,
@@ -5655,14 +5663,29 @@ pub fn get_external_track_candidates_for_training(
         "SELECT id, tidal_id, mbid, dedupe_key, title, artist_name, genre_tags_json,
                 duration_ms, expires_at, updated_at,
                 (
-                    SELECT json_group_array(source)
+                    SELECT json_group_array(tag)
                     FROM (
-                        SELECT DISTINCT source
+                        SELECT DISTINCT source AS tag
                         FROM external_track_candidate_sightings s
                         WHERE s.candidate_id = c.id
                           AND s.expires_at > ?1
-                        ORDER BY source
+                        UNION
+                        SELECT DISTINCT
+                            CASE
+                                WHEN s.source = 'lastfm_similar'
+                                 AND s.source_payload_json LIKE '%\"branch_from\":%'
+                                 AND s.source_payload_json NOT LIKE '%\"branch_from\":null%'
+                                THEN 'lastfm_branch'
+                                WHEN s.source = 'lastfm_similar'
+                                THEN 'lastfm_direct'
+                            END AS tag
+                        FROM external_track_candidate_sightings s
+                        WHERE s.candidate_id = c.id
+                          AND s.expires_at > ?1
+                          AND s.source = 'lastfm_similar'
+                        ORDER BY tag
                     )
+                    WHERE tag IS NOT NULL
                 ) AS source_tags_json,
                 resolved_track_id
          FROM external_track_candidates c
@@ -5686,6 +5709,41 @@ pub fn get_external_track_candidates_for_training(
                 updated_at: row.get(9)?,
                 source_tags_json: row.get(10)?,
                 resolved_track_id: row.get(11)?,
+            })
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(rows)
+}
+
+pub fn get_resolved_lastfm_external_sightings_for_training(
+    conn: &Connection,
+    now: &str,
+    limit: i64,
+) -> Result<Vec<ResolvedLastfmExternalSightingRow>> {
+    let mut stmt = conn.prepare(
+        "SELECT s.seed_track_id,
+                c.resolved_track_id,
+                COALESCE(s.similarity, 0.0),
+                s.source_payload_json
+         FROM external_track_candidate_sightings s
+         JOIN external_track_candidates c ON c.id = s.candidate_id
+         WHERE s.source = 'lastfm_similar'
+           AND s.expires_at > ?1
+           AND c.expires_at > ?1
+           AND c.resolved_track_id IS NOT NULL
+           AND c.resolved_track_id <> s.seed_track_id
+         ORDER BY COALESCE(s.similarity, 0.0) DESC,
+                  s.expires_at DESC,
+                  s.candidate_id DESC
+         LIMIT ?2",
+    )?;
+    let rows = stmt
+        .query_map(params![now, limit.max(1)], |row| {
+            Ok(ResolvedLastfmExternalSightingRow {
+                seed_track_id: row.get(0)?,
+                resolved_track_id: row.get(1)?,
+                similarity: row.get(2)?,
+                source_payload_json: row.get(3)?,
             })
         })?
         .collect::<rusqlite::Result<Vec<_>>>()?;
@@ -9654,7 +9712,112 @@ mod tests {
         assert_eq!(rows[0].dedupe_key, "fresh");
         assert_eq!(
             rows[0].source_tags_json.as_deref(),
-            Some(r#"["lastfm_similar"]"#)
+            Some(r#"["lastfm_direct","lastfm_similar"]"#)
+        );
+    }
+
+    #[test]
+    fn external_training_tags_derive_lastfm_branch_from_cached_payload() {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        schema::run_migrations(&conn).expect("migrations");
+        conn.execute("INSERT INTO artists (id, name) VALUES (1, 'Artist')", [])
+            .expect("seed artist");
+        conn.execute(
+            "INSERT INTO tracks (id, title, artist_id) VALUES (1, 'Seed', 1)",
+            [],
+        )
+        .expect("seed track");
+        let candidate = upsert_external_track_candidate(
+            &conn,
+            &ExternalTrackCandidateUpsert {
+                tidal_id: None,
+                mbid: None,
+                dedupe_key: "branch-candidate".to_string(),
+                title: "Branch".to_string(),
+                artist_name: "Outside".to_string(),
+                genre_tags_json: None,
+                duration_ms: Some(180_000),
+                expires_at: "2026-03-01 00:00:00".to_string(),
+            },
+        )
+        .expect("candidate");
+        upsert_external_candidate_sighting(
+            &conn,
+            &ExternalCandidateSightingUpsert {
+                candidate_id: candidate.id,
+                seed_track_id: 1,
+                source: "lastfm_similar".to_string(),
+                source_payload_json: Some(
+                    r#"{"match":0.42,"branch_from":"Parent Artist - Parent Track"}"#.to_string(),
+                ),
+                similarity: Some(0.42),
+                expires_at: "2026-03-01 00:00:00".to_string(),
+            },
+        )
+        .expect("sighting");
+
+        let rows = get_external_track_candidates_for_training(&conn, "2026-02-01 00:00:00", 10)
+            .expect("training candidates");
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0].source_tags_json.as_deref(),
+            Some(r#"["lastfm_branch","lastfm_similar"]"#)
+        );
+    }
+
+    #[test]
+    fn resolved_lastfm_sightings_for_training_include_cached_payload() {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        schema::run_migrations(&conn).expect("migrations");
+        conn.execute("INSERT INTO artists (id, name) VALUES (1, 'Artist')", [])
+            .expect("seed artist");
+        conn.execute(
+            "INSERT INTO tracks (id, title, artist_id)
+             VALUES (1, 'Seed', 1), (2, 'Resolved', 1)",
+            [],
+        )
+        .expect("seed tracks");
+        let candidate = upsert_external_track_candidate(
+            &conn,
+            &ExternalTrackCandidateUpsert {
+                tidal_id: Some(9002),
+                mbid: None,
+                dedupe_key: "resolved-lastfm".to_string(),
+                title: "Resolved".to_string(),
+                artist_name: "Artist".to_string(),
+                genre_tags_json: None,
+                duration_ms: Some(180_000),
+                expires_at: "2026-03-01 00:00:00".to_string(),
+            },
+        )
+        .expect("candidate");
+        mark_external_candidate_resolved(&conn, Some(9002), "Resolved", "Artist", 2)
+            .expect("mark resolved");
+        upsert_external_candidate_sighting(
+            &conn,
+            &ExternalCandidateSightingUpsert {
+                candidate_id: candidate.id,
+                seed_track_id: 1,
+                source: "lastfm_similar".to_string(),
+                source_payload_json: Some(r#"{"match":0.77}"#.to_string()),
+                similarity: Some(0.77),
+                expires_at: "2026-03-01 00:00:00".to_string(),
+            },
+        )
+        .expect("sighting");
+
+        let rows =
+            get_resolved_lastfm_external_sightings_for_training(&conn, "2026-02-01 00:00:00", 10)
+                .expect("resolved sightings");
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].seed_track_id, 1);
+        assert_eq!(rows[0].resolved_track_id, 2);
+        assert_eq!(rows[0].similarity, 0.77);
+        assert_eq!(
+            rows[0].source_payload_json.as_deref(),
+            Some(r#"{"match":0.77}"#)
         );
     }
 

--- a/noor-server/src/main.rs
+++ b/noor-server/src/main.rs
@@ -71,6 +71,13 @@ pub struct NextPrebufferKey {
     pub generation: u64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DropPreviewRuntimeState {
+    pub track_id: i64,
+    pub generation: u64,
+    pub actual_fire_ms: i64,
+}
+
 /// Shared application state accessible by all modules
 pub struct AppState {
     pub db: db::Database,
@@ -123,6 +130,7 @@ pub struct AppState {
     pub current_stream_display: Option<StreamDisplayInfo>,
     pub pending_stream_display: Option<StreamDisplayInfo>,
     pub next_prebuffer_inflight: Option<NextPrebufferKey>,
+    pub last_drop_preview: Option<DropPreviewRuntimeState>,
     pub active_listen_session: Option<playback::player::ActiveListenSession>,
     pub live_listen_session: Option<playback::player::LiveListenSession>,
     pub external_playback_track: Option<db::models::Track>,
@@ -751,6 +759,7 @@ async fn main() -> Result<()> {
         current_stream_display: None,
         pending_stream_display: None,
         next_prebuffer_inflight: None,
+        last_drop_preview: None,
         active_listen_session: None,
         live_listen_session: None,
         external_playback_track: None,

--- a/noor-server/src/playback/automix.rs
+++ b/noor-server/src/playback/automix.rs
@@ -13,12 +13,15 @@
 //! `normalize_genre_key`) and `pub` / `pub(crate)` for items player.rs already
 //! exposed (`load_state`, `load_snapshot`, `build_session_taste_profile`).
 
+#[cfg(test)]
+use crate::db::models::AudioDjProfileKey;
 use crate::db::{
     models::{AudioDspFeatures, QueueItem, Track},
     queries,
 };
 use crate::playback::dj_queue_ranker::{
-    GeneratedCandidate, append_dj_reason, rank_generated_candidates,
+    GeneratedCandidate, GeneratedCandidatePolicy, append_dj_reason, rank_generated_candidates,
+    rank_generated_candidates_chain,
 };
 use crate::playback::player::{
     PlaybackSnapshot, build_session_taste_profile, load_snapshot, load_state, normalize_genre_key,
@@ -36,6 +39,8 @@ use crate::smart::taste_vector::adapters::from_session_profile;
 use crate::smart::taste_vector::{SeedContext, TasteVector};
 use anyhow::Result;
 use rusqlite::{Connection, params};
+#[cfg(test)]
+use serde::Serialize;
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 
@@ -53,6 +58,7 @@ struct ScoredTrack {
 pub(crate) struct AutomixSelection {
     pub(crate) track: Track,
     reason: Option<String>,
+    ranking_policy: GeneratedCandidatePolicy,
 }
 
 impl AutomixSelection {
@@ -60,7 +66,13 @@ impl AutomixSelection {
         Self {
             track,
             reason: Some(reason.into()),
+            ranking_policy: GeneratedCandidatePolicy::default(),
         }
+    }
+
+    fn with_ranking_policy(mut self, ranking_policy: GeneratedCandidatePolicy) -> Self {
+        self.ranking_policy = ranking_policy;
+        self
     }
 
     fn into_queue_pair(self) -> (Track, Option<String>) {
@@ -264,6 +276,7 @@ fn append_automix_external_candidates(
         .map(|row| GeneratedCandidate {
             track_id: None,
             tidal_id: row.tidal_id,
+            policy: Default::default(),
             item: row,
         })
         .collect::<Vec<_>>();
@@ -326,6 +339,7 @@ fn rank_automix_selections(
         .map(|selection| GeneratedCandidate {
             track_id: Some(selection.track.id),
             tidal_id: selection.track.tidal_id,
+            policy: selection.ranking_policy.clone(),
             item: selection,
         })
         .collect::<Vec<_>>();
@@ -333,7 +347,7 @@ fn rank_automix_selections(
         .iter()
         .map(|candidate| candidate.item.clone())
         .collect::<Vec<_>>();
-    rank_generated_candidates(conn, seed_track_id, generated)
+    rank_generated_candidates_chain(conn, seed_track_id, generated)
         .map(|ranked| {
             ranked
                 .into_iter()
@@ -419,6 +433,10 @@ pub(crate) fn build_automix_extension_with_reasons(
                 .iter()
                 .map(|row| (row.track_id, automix_neighbor_reason(row)))
                 .collect::<HashMap<_, _>>();
+            let neighbor_policies = neighbors
+                .iter()
+                .map(|row| (row.track_id, automix_neighbor_policy(row)))
+                .collect::<HashMap<_, _>>();
             let neighbor_ids = neighbors.iter().map(|row| row.track_id).collect::<Vec<_>>();
             let tracks = queue::get_tracks_by_ids(conn, &neighbor_ids)?;
             let track_map = tracks
@@ -429,6 +447,10 @@ pub(crate) fn build_automix_extension_with_reasons(
                 .into_iter()
                 .filter_map(|track_id| {
                     track_map.get(&track_id).cloned().map(|track| {
+                        let policy = neighbor_policies
+                            .get(&track_id)
+                            .cloned()
+                            .unwrap_or_default();
                         AutomixSelection::new(
                             track,
                             neighbor_reasons
@@ -436,6 +458,7 @@ pub(crate) fn build_automix_extension_with_reasons(
                                 .cloned()
                                 .unwrap_or_else(|| "automix: learned similarity".to_string()),
                         )
+                        .with_ranking_policy(policy)
                     })
                 })
                 .collect::<Vec<_>>();
@@ -584,6 +607,196 @@ pub(crate) fn build_automix_extension_with_reasons(
         .collect())
 }
 
+#[cfg(test)]
+#[derive(Debug, Serialize)]
+pub(crate) struct AutomixEvaluationReport {
+    pub(crate) seed_track_id: i64,
+    pub(crate) queue_len_before: i64,
+    pub(crate) queue_len_after: i64,
+    pub(crate) before: Vec<AutomixEvaluationRow>,
+    pub(crate) after: Vec<AutomixEvaluationRow>,
+}
+
+#[cfg(test)]
+#[derive(Debug, Serialize)]
+pub(crate) struct AutomixEvaluationRow {
+    pub(crate) order: usize,
+    pub(crate) track_id: i64,
+    pub(crate) title: String,
+    pub(crate) artist_name: Option<String>,
+    pub(crate) bpm: Option<f64>,
+    pub(crate) camelot_key: Option<String>,
+    pub(crate) profile_confidence: Option<f64>,
+    pub(crate) safe_crossfade_only: bool,
+    pub(crate) learned_score: Option<f64>,
+    pub(crate) primary_reason: Option<String>,
+    pub(crate) reason_tags: Vec<String>,
+    pub(crate) chain_score: Option<f64>,
+    pub(crate) dj_reasons: Vec<String>,
+    pub(crate) final_score: Option<f64>,
+    pub(crate) final_reason: Option<String>,
+}
+
+#[cfg(test)]
+pub(crate) fn evaluate_automix_for_seed(
+    conn: &Connection,
+    seed_track_id: i64,
+    limit: usize,
+) -> Result<AutomixEvaluationReport> {
+    let queue_len_before = queue_len(conn)?;
+    let seed = queue::get_track_by_id(conn, seed_track_id)?
+        .ok_or_else(|| anyhow::anyhow!("seed track {seed_track_id} not found"))?;
+    let model = queries::get_selected_discovery_embedding_model(conn)
+        .ok()
+        .flatten();
+    let learned_rows = if let Some(model) = model {
+        queries::get_track_neighbors(
+            conn,
+            model.id,
+            seed_track_id,
+            (limit * 4).max(24) as i64,
+            &[],
+        )
+        .unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+    let learned_by_track = learned_rows
+        .iter()
+        .map(|row| (row.track_id, row.clone()))
+        .collect::<HashMap<_, _>>();
+    let before_ids = learned_rows
+        .iter()
+        .take(limit)
+        .map(|row| row.track_id)
+        .collect::<Vec<_>>();
+    let before_tracks = queue::get_tracks_by_ids(conn, &before_ids)?;
+    let before_track_map = before_tracks
+        .into_iter()
+        .map(|track| (track.id, track))
+        .collect::<HashMap<_, _>>();
+    let before = before_ids
+        .into_iter()
+        .enumerate()
+        .filter_map(|(idx, track_id)| {
+            before_track_map.get(&track_id).map(|track| {
+                evaluation_row(conn, idx + 1, track, learned_by_track.get(&track.id), None)
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let selected = build_automix_extension_with_reasons(
+        conn,
+        &seed,
+        &[],
+        ShuffleMode::Off,
+        None,
+        limit,
+        true,
+    )?;
+    let after = selected
+        .iter()
+        .enumerate()
+        .map(|(idx, selection)| {
+            evaluation_row(
+                conn,
+                idx + 1,
+                &selection.track,
+                learned_by_track.get(&selection.track.id),
+                selection.reason.as_deref(),
+            )
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let queue_len_after = queue_len(conn)?;
+
+    Ok(AutomixEvaluationReport {
+        seed_track_id,
+        queue_len_before,
+        queue_len_after,
+        before,
+        after,
+    })
+}
+
+#[cfg(test)]
+fn evaluation_row(
+    conn: &Connection,
+    order: usize,
+    track: &Track,
+    learned: Option<&queries::EmbeddingNeighborRow>,
+    final_reason: Option<&str>,
+) -> Result<AutomixEvaluationRow> {
+    let dsp = queries::get_audio_dsp_features(conn, track.id)
+        .ok()
+        .flatten();
+    let profile = queries::get_audio_dj_profile_for_track(conn, track.id)
+        .ok()
+        .flatten();
+    let safe_crossfade_only = queries::get_audio_dj_profile_correction(
+        conn,
+        &AudioDjProfileKey {
+            media_ref_kind: "library_track".to_string(),
+            media_ref_id: track.id.to_string(),
+        },
+    )
+    .ok()
+    .flatten()
+    .is_some_and(|correction| correction.safe_crossfade_only);
+    let tags = learned
+        .and_then(|row| row.reason_json.as_deref())
+        .map(|reason_json| automix_reason_tags(Some(reason_json)))
+        .unwrap_or_default();
+    let dj_reasons = final_reason
+        .and_then(|reason| reason.split(" | dj: ").nth(1))
+        .map(|suffix| suffix.split(" | {").next().unwrap_or(suffix))
+        .map(|reasons| {
+            reasons
+                .split(',')
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default();
+    let chain_score = final_reason.and_then(|reason| reason_json_number(reason, "dj_score"));
+    let final_score = chain_score.or_else(|| learned.map(|row| row.score));
+
+    Ok(AutomixEvaluationRow {
+        order,
+        track_id: track.id,
+        title: track.title.clone(),
+        artist_name: track.artist_name.clone(),
+        bpm: dsp.as_ref().and_then(|features| features.bpm),
+        camelot_key: dsp
+            .as_ref()
+            .and_then(|features| features.camelot_key.clone()),
+        profile_confidence: profile.as_ref().map(|profile| profile.profile_confidence),
+        safe_crossfade_only,
+        learned_score: learned.map(|row| row.score),
+        primary_reason: learned.and_then(|row| row.primary_reason.clone()),
+        reason_tags: tags,
+        chain_score,
+        dj_reasons,
+        final_score,
+        final_reason: final_reason.map(str::to_string),
+    })
+}
+
+#[cfg(test)]
+fn reason_json_number(reason: &str, key: &str) -> Option<f64> {
+    let start = reason.rfind('{')?;
+    serde_json::from_str::<serde_json::Value>(&reason[start..])
+        .ok()?
+        .get(key)?
+        .as_f64()
+}
+
+#[cfg(test)]
+fn queue_len(conn: &Connection) -> Result<i64> {
+    conn.query_row("SELECT COUNT(*) FROM queue", [], |row| row.get(0))
+        .map_err(Into::into)
+}
+
 fn automix_neighbor_reason(row: &queries::EmbeddingNeighborRow) -> String {
     let reason = row
         .primary_reason
@@ -596,6 +809,73 @@ fn automix_neighbor_reason(row: &queries::EmbeddingNeighborRow) -> String {
         "{prefix} | {{\"score\":{:.4},\"behavioral_score\":{:.4},\"audio_score\":{:.4},\"metadata_score\":{:.4},\"confidence\":{:.4}}}",
         row.score, row.behavioral_score, row.audio_score, row.metadata_score, row.confidence
     )
+}
+
+fn automix_neighbor_policy(row: &queries::EmbeddingNeighborRow) -> GeneratedCandidatePolicy {
+    let mut multiplier = 1.0;
+    let mut policy_reasons = Vec::new();
+    let reason_tags = automix_reason_tags(row.reason_json.as_deref());
+    let has_tag = |tag: &str| reason_tags.iter().any(|value| value == tag);
+
+    let has_lastfm_direct = has_tag("lastfm_direct");
+    let has_lastfm_branch = has_tag("lastfm_branch");
+    if has_lastfm_direct {
+        multiplier *= 1.06;
+        policy_reasons.push("lastfm direct");
+    }
+    if has_lastfm_branch {
+        multiplier *= 0.90;
+        policy_reasons.push("lastfm branch");
+    }
+
+    let primary_is_texture = row.primary_reason.as_deref() == Some("audio_texture");
+    let has_texture = primary_is_texture || has_tag("audio_texture");
+    let has_supporting_reason = reason_tags.iter().any(|tag| {
+        matches!(
+            tag.as_str(),
+            "artist_affinity"
+                | "genre_branch"
+                | "album_context"
+                | "bpm_match"
+                | "harmonic_match"
+                | "energy_match"
+                | "behavioral"
+                | "direct_transition"
+                | "lastfm_direct"
+                | "lastfm_branch"
+        )
+    }) || row.behavioral_score > 0.35
+        || row.metadata_score > 0.0
+        || row.support_transition > 0.0
+        || row.support_structure > 0.0
+        || row.support_colisten > 0.0;
+
+    if has_texture && !has_supporting_reason {
+        multiplier *= 0.82;
+        policy_reasons.push("texture-only learned signal");
+    }
+
+    GeneratedCandidatePolicy {
+        score_multiplier: multiplier,
+        reasons: policy_reasons,
+    }
+}
+
+fn automix_reason_tags(reason_json: Option<&str>) -> Vec<String> {
+    reason_json
+        .and_then(|raw| serde_json::from_str::<Vec<serde_json::Value>>(raw).ok())
+        .map(|values| {
+            values
+                .into_iter()
+                .filter_map(|value| {
+                    value
+                        .get("key")
+                        .and_then(|key| key.as_str())
+                        .map(str::to_string)
+                })
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 fn automix_metadata_reason(seed: &Track, track: &Track) -> String {
@@ -932,6 +1212,168 @@ mod tests {
             date_added: None,
             source: "tidal".to_string(),
             artwork_url: None,
+        }
+    }
+
+    fn create_dsp_schema(conn: &Connection) {
+        conn.execute_batch(
+            "
+            CREATE TABLE audio_dsp_features (
+                track_id INTEGER PRIMARY KEY,
+                bpm REAL,
+                key_signature TEXT,
+                camelot_key TEXT,
+                loudness_lufs REAL,
+                energy REAL,
+                danceability REAL,
+                beat_strength REAL,
+                spectral_centroid REAL,
+                stereo_width REAL,
+                is_instrumental INTEGER NOT NULL DEFAULT 0,
+                analysis_source TEXT NOT NULL DEFAULT 'test',
+                analysis_offset_ms INTEGER NOT NULL DEFAULT 0,
+                samples_analyzed INTEGER,
+                analyzed_at TEXT NOT NULL DEFAULT '2026-01-01T00:00:00Z',
+                analysis_version TEXT NOT NULL DEFAULT 'test'
+            );
+            ",
+        )
+        .expect("dsp schema");
+    }
+
+    fn insert_dsp(conn: &Connection, track_id: i64, bpm: f64, camelot_key: &str) {
+        conn.execute(
+            "INSERT INTO audio_dsp_features (track_id, bpm, camelot_key) VALUES (?1, ?2, ?3)",
+            params![track_id, bpm, camelot_key],
+        )
+        .expect("insert dsp");
+    }
+
+    fn policy(multiplier: f64, reason: &'static str) -> GeneratedCandidatePolicy {
+        GeneratedCandidatePolicy {
+            score_multiplier: multiplier,
+            reasons: vec![reason],
+        }
+    }
+
+    #[test]
+    fn learned_policy_penalizes_texture_only_when_dj_fit_disagrees() {
+        let conn = Connection::open_in_memory().expect("db");
+        create_dsp_schema(&conn);
+        insert_dsp(&conn, 1, 120.0, "1A");
+        insert_dsp(&conn, 2, 145.0, "6B");
+        insert_dsp(&conn, 3, 121.0, "2A");
+
+        let ranked = rank_automix_selections(
+            &conn,
+            1,
+            vec![
+                AutomixSelection::new(track_with_album(2, None), "automix: audio texture")
+                    .with_ranking_policy(policy(0.82, "texture-only learned signal")),
+                AutomixSelection::new(track_with_album(3, None), "automix: learned similarity"),
+            ],
+        );
+
+        assert_eq!(ranked[0].track.id, 3);
+        assert_eq!(ranked[1].track.id, 2);
+        assert!(
+            ranked[1]
+                .reason
+                .as_deref()
+                .unwrap_or_default()
+                .contains("texture-only learned signal")
+        );
+    }
+
+    #[test]
+    fn lastfm_direct_is_confidence_not_override() {
+        let conn = Connection::open_in_memory().expect("db");
+        create_dsp_schema(&conn);
+        insert_dsp(&conn, 1, 120.0, "1A");
+        insert_dsp(&conn, 2, 120.5, "1A");
+        insert_dsp(&conn, 3, 120.5, "1A");
+
+        let tied_facts = rank_automix_selections(
+            &conn,
+            1,
+            vec![
+                AutomixSelection::new(track_with_album(3, None), "automix: lastfm branch")
+                    .with_ranking_policy(policy(0.90, "lastfm branch")),
+                AutomixSelection::new(track_with_album(2, None), "automix: lastfm direct")
+                    .with_ranking_policy(policy(1.06, "lastfm direct")),
+            ],
+        );
+        assert_eq!(tied_facts[0].track.id, 2);
+
+        let conn = Connection::open_in_memory().expect("db");
+        create_dsp_schema(&conn);
+        insert_dsp(&conn, 1, 120.0, "1A");
+        insert_dsp(&conn, 2, 145.0, "6B");
+        insert_dsp(&conn, 3, 120.5, "1A");
+
+        let better_fit_branch = rank_automix_selections(
+            &conn,
+            1,
+            vec![
+                AutomixSelection::new(track_with_album(2, None), "automix: lastfm direct")
+                    .with_ranking_policy(policy(1.06, "lastfm direct")),
+                AutomixSelection::new(track_with_album(3, None), "automix: lastfm branch")
+                    .with_ranking_policy(policy(0.90, "lastfm branch")),
+            ],
+        );
+        assert_eq!(better_fit_branch[0].track.id, 3);
+    }
+
+    #[test]
+    #[ignore]
+    fn automix_diagnostic_for_seed() {
+        let db_path = crate::paths::resolve_db_path_from_env();
+        let limit = std::env::var("NOOR_AUTOMIX_LIMIT")
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .unwrap_or(8);
+        let seeds = std::env::var("NOOR_AUTOMIX_SEEDS")
+            .ok()
+            .or_else(|| std::env::var("NOOR_SEED").ok())
+            .unwrap_or_else(|| "1".to_string())
+            .split(',')
+            .filter_map(|value| value.trim().parse::<i64>().ok())
+            .collect::<Vec<_>>();
+        let db = crate::db::Database::open(&db_path).expect("open db");
+
+        for seed in seeds {
+            let report = db
+                .with_conn(|conn| evaluate_automix_for_seed(conn, seed, limit))
+                .expect("evaluate automix");
+            println!("{}", serde_json::to_string_pretty(&report).expect("json"));
+            println!("seed {}", report.seed_track_id);
+            println!("before:");
+            for row in &report.before {
+                println!(
+                    "#{:<2} {:<6} {:<32} bpm={:?} key={:?} learned={:?} primary={:?}",
+                    row.order,
+                    row.track_id,
+                    row.title.chars().take(32).collect::<String>(),
+                    row.bpm,
+                    row.camelot_key,
+                    row.learned_score,
+                    row.primary_reason
+                );
+            }
+            println!("after:");
+            for row in &report.after {
+                println!(
+                    "#{:<2} {:<6} {:<32} bpm={:?} key={:?} final={:?} reason={:?}",
+                    row.order,
+                    row.track_id,
+                    row.title.chars().take(32).collect::<String>(),
+                    row.bpm,
+                    row.camelot_key,
+                    row.final_score,
+                    row.final_reason
+                );
+            }
+            assert_eq!(report.queue_len_before, report.queue_len_after);
         }
     }
 

--- a/noor-server/src/playback/dj_engine.rs
+++ b/noor-server/src/playback/dj_engine.rs
@@ -1,10 +1,10 @@
 use anyhow::Result;
 use noor_mix::planner::{DJ_PLANNER_VERSION, MixIntent, TransitionSpeedBias, TransitionTemplate};
 use noor_mix::{DjProfile, Planner, Policy, TransitionProgram};
-use rusqlite::Connection;
+use rusqlite::{Connection, OptionalExtension};
 use serde::Serialize;
 
-use crate::db::models::{AudioDjProfileCorrectionRow, AudioDjProfileRow};
+use crate::db::models::{AudioDjProfileCorrectionRow, AudioDjProfileRow, AudioDspFeatures};
 use crate::db::{Database, queries};
 use crate::playback::dj_lookahead::DjMediaRef;
 use crate::services::audio_analysis::dj_profile::{decode_f32_blob, decode_u32_blob};
@@ -92,8 +92,8 @@ impl DjEngine {
                 )));
             }
 
-            let mut outgoing = profile_from_row(from_profile.as_ref().expect("checked"));
-            let mut incoming = profile_from_row(to_profile.as_ref().expect("checked"));
+            let mut outgoing = profile_from_row(conn, from_profile.as_ref().expect("checked"))?;
+            let mut incoming = profile_from_row(conn, to_profile.as_ref().expect("checked"))?;
             apply_correction(&mut outgoing, from_correction.as_ref());
             apply_correction(&mut incoming, to_correction.as_ref());
 
@@ -312,7 +312,7 @@ fn apply_correction(profile: &mut DjProfile, correction: Option<&AudioDjProfileC
     }
 }
 
-fn profile_from_row(row: &AudioDjProfileRow) -> DjProfile {
+fn profile_from_row(conn: &Connection, row: &AudioDjProfileRow) -> Result<DjProfile> {
     let beat_grid_seconds = decode_f32_blob(&row.beat_grid_blob).unwrap_or_default();
     let downbeat_seconds = decode_f32_blob(&row.downbeats_blob).unwrap_or_default();
     let phrase_bar_indices = decode_u32_blob(&row.phrase_boundaries_blob).unwrap_or_default();
@@ -320,10 +320,16 @@ fn profile_from_row(row: &AudioDjProfileRow) -> DjProfile {
     let mix_out_seconds = decode_f32_blob(&row.mix_out_blob).unwrap_or_default();
     let safe_transition_windows =
         decode_f32_blob(&row.safe_transition_windows_blob).unwrap_or_default();
-    DjProfile {
+    let dsp = dsp_features_for_profile(conn, row)?;
+    let energy = dsp
+        .as_ref()
+        .and_then(|features| features.energy)
+        .map(|value| value as f32)
+        .or_else(|| average_energy_contour(&row.energy_contour_blob));
+    Ok(DjProfile {
         bpm: estimate_bpm(&beat_grid_seconds),
-        camelot_key: Some("8A".to_string()),
-        energy: None,
+        camelot_key: dsp.and_then(|features| features.camelot_key),
+        energy,
         beat_grid_seconds,
         downbeat_seconds,
         phrase_bar_indices,
@@ -348,7 +354,40 @@ fn profile_from_row(row: &AudioDjProfileRow) -> DjProfile {
         profile_confidence: row.profile_confidence as f32,
         safe_crossfade_only: false,
         profile_version: row.profile_version.clone(),
+    })
+}
+
+fn dsp_features_for_profile(
+    conn: &Connection,
+    row: &AudioDjProfileRow,
+) -> Result<Option<AudioDspFeatures>> {
+    if let Some(track_id) = row.track_id {
+        return queries::get_audio_dsp_features(conn, track_id);
     }
+    let Some(tidal_id) = row.tidal_id else {
+        return Ok(None);
+    };
+    let track_id = conn
+        .query_row(
+            "SELECT id FROM tracks WHERE tidal_id = ?1 LIMIT 1",
+            rusqlite::params![tidal_id],
+            |row| row.get::<_, i64>(0),
+        )
+        .optional()?;
+    track_id
+        .map(|track_id| queries::get_audio_dsp_features(conn, track_id))
+        .unwrap_or(Ok(None))
+}
+
+fn average_energy_contour(blob: &[u8]) -> Option<f32> {
+    let contour = decode_f32_blob(blob)?;
+    let mut sum = 0.0_f32;
+    let mut count = 0_u32;
+    for value in contour.into_iter().filter(|value| value.is_finite()) {
+        sum += value.clamp(0.0, 1.0);
+        count += 1;
+    }
+    (count > 0).then_some(sum / count as f32)
 }
 
 fn estimate_bpm(beats: &[f32]) -> Option<f32> {
@@ -416,6 +455,19 @@ mod tests {
                     "INSERT OR IGNORE INTO tracks (id, title, artist_id) VALUES (?1, ?2, 1)",
                     rusqlite::params![id, format!("Track {id}")],
                 )?;
+                seed_dsp(conn, id, "8A", 0.5)?;
+            }
+            if kind == "tidal_track" {
+                let track_id = 100_000 + id;
+                conn.execute(
+                    "INSERT OR IGNORE INTO artists (id, name) VALUES (1, 'Artist')",
+                    [],
+                )?;
+                conn.execute(
+                    "INSERT OR IGNORE INTO tracks (id, title, artist_id, tidal_id) VALUES (?1, ?2, 1, ?3)",
+                    rusqlite::params![track_id, format!("Tidal Track {id}"), id],
+                )?;
+                seed_dsp(conn, track_id, "8A", 0.5)?;
             }
             if kind == "queue_item" {
                 conn.execute(
@@ -457,6 +509,30 @@ mod tests {
             queries::upsert_audio_dj_profile(conn, &row)
         })
         .expect("seed profile");
+    }
+
+    fn seed_dsp(conn: &Connection, track_id: i64, camelot_key: &str, energy: f64) -> Result<()> {
+        queries::upsert_audio_dsp_features(
+            conn,
+            &AudioDspFeatures {
+                track_id,
+                bpm: Some(120.0),
+                key_signature: None,
+                camelot_key: Some(camelot_key.to_string()),
+                loudness_lufs: Some(-12.0),
+                energy: Some(energy),
+                danceability: None,
+                beat_strength: None,
+                spectral_centroid: None,
+                stereo_width: None,
+                is_instrumental: false,
+                analysis_source: "test".to_string(),
+                analysis_offset_ms: 0,
+                samples_analyzed: None,
+                analyzed_at: "now".to_string(),
+                analysis_version: "test".to_string(),
+            },
+        )
     }
 
     fn seed_correction(db: &Database, key: AudioDjProfileKey, safe: bool, speed: Option<&str>) {
@@ -672,6 +748,54 @@ mod tests {
         .expect("program");
 
         assert_eq!(program.template, "FilterSweep");
+    }
+
+    #[test]
+    fn missing_dsp_camelot_uses_safe_crossfade_not_fake_harmonic_match() {
+        let db = db();
+        enable(&db);
+        seed_profile(&db, "library_track", 1, 0.9);
+        seed_profile(&db, "library_track", 2, 0.9);
+        db.with_conn(|conn| {
+            conn.execute(
+                "DELETE FROM audio_dsp_features WHERE track_id IN (1, 2)",
+                [],
+            )?;
+            Ok(())
+        })
+        .expect("remove dsp features");
+
+        let program = plan(
+            &db,
+            ref_for("library_track", 1),
+            ref_for("library_track", 2),
+        )
+        .expect("program");
+
+        assert_eq!(program.template, "SafeCrossfade");
+    }
+
+    #[test]
+    fn distant_camelot_keys_use_safe_crossfade() {
+        let db = db();
+        enable(&db);
+        seed_profile(&db, "library_track", 1, 0.9);
+        seed_profile(&db, "library_track", 2, 0.9);
+        db.with_conn(|conn| {
+            seed_dsp(conn, 1, "8A", 0.5)?;
+            seed_dsp(conn, 2, "3A", 0.5)?;
+            Ok(())
+        })
+        .expect("seed clashing dsp features");
+
+        let program = plan(
+            &db,
+            ref_for("library_track", 1),
+            ref_for("library_track", 2),
+        )
+        .expect("program");
+
+        assert_eq!(program.template, "SafeCrossfade");
     }
 
     #[test]

--- a/noor-server/src/playback/dj_engine.rs
+++ b/noor-server/src/playback/dj_engine.rs
@@ -112,6 +112,48 @@ impl DjEngine {
         })
     }
 
+    pub fn plan_drop_preview(
+        &self,
+        from: &DjMediaRef,
+        to: &DjMediaRef,
+        sample_rate: u32,
+        channels: u16,
+        duration_ms: u32,
+    ) -> Result<Option<TransitionProgram>> {
+        self.db.with_conn(|conn| {
+            if !queries::is_dj_engine_enabled(conn)? {
+                return Ok(None);
+            }
+
+            let from_key = from.profile_key();
+            let to_key = to.profile_key();
+            let Some(from_profile) = queries::get_audio_dj_profile(conn, &from_key)? else {
+                return Ok(None);
+            };
+            let Some(to_profile) = queries::get_audio_dj_profile(conn, &to_key)? else {
+                return Ok(None);
+            };
+            let from_correction = queries::get_audio_dj_profile_correction(conn, &from_key)?;
+            let to_correction = queries::get_audio_dj_profile_correction(conn, &to_key)?;
+
+            let mut outgoing = profile_from_row(conn, &from_profile)?;
+            let mut incoming = profile_from_row(conn, &to_profile)?;
+            apply_correction(&mut outgoing, from_correction.as_ref());
+            apply_correction(&mut incoming, to_correction.as_ref());
+            if runtime_safety_decision(&outgoing, &incoming).force_safe_crossfade {
+                return Ok(None);
+            }
+
+            Ok(noor_mix::planner::drop_preview_16_program(
+                sample_rate,
+                channels,
+                duration_ms,
+                &outgoing,
+                &incoming,
+            ))
+        })
+    }
+
     fn recent_bad_feedback_count(&self, media_ref: &DjMediaRef) -> Result<i64> {
         let key = media_ref.profile_key();
         self.db

--- a/noor-server/src/playback/dj_engine.rs
+++ b/noor-server/src/playback/dj_engine.rs
@@ -570,7 +570,7 @@ mod tests {
     }
 
     #[test]
-    fn bold_policy_prefers_filter_sweep_for_compatible_profiles() {
+    fn bold_policy_preserves_bass_swap_for_compatible_profiles() {
         let db = db();
         enable(&db);
         db.with_conn(|conn| queries::set_dj_global_policy(conn, "bold", "neutral"))
@@ -585,7 +585,7 @@ mod tests {
         )
         .expect("program");
 
-        assert_eq!(program.template, "FilterSweep");
+        assert_eq!(program.template, "BassSwap16");
         program.validate().expect("valid");
     }
 
@@ -597,6 +597,24 @@ mod tests {
             .expect("set bold policy");
         seed_profile(&db, "library_track", 1, 0.9);
         seed_profile(&db, "library_track", 2, 0.9);
+        db.with_conn(|conn| {
+            queries::upsert_audio_dj_profile_correction(
+                conn,
+                &AudioDjProfileCorrectionRow {
+                    media_ref_kind: "library_track".to_string(),
+                    media_ref_id: "2".to_string(),
+                    bpm_multiplier: Some(1.05),
+                    downbeat_offset_beats: None,
+                    phrase_offset_bars: None,
+                    safe_crossfade_only: false,
+                    transition_speed_bias: None,
+                    notes: None,
+                    created_at: "now".to_string(),
+                    updated_at: "now".to_string(),
+                },
+            )
+        })
+        .expect("tempo correction");
         let engine = DjEngine::new(db);
 
         let plan = engine

--- a/noor-server/src/playback/dj_engine.rs
+++ b/noor-server/src/playback/dj_engine.rs
@@ -240,6 +240,7 @@ fn fallback_profile() -> DjProfile {
         outro_start_seconds: Some(120.0),
         breakdown_seconds: vec![],
         drop_seconds: vec![],
+        manual_drop_seconds: vec![],
         safe_transition_windows: vec![noor_mix::profile::TransitionWindow {
             start_seconds: 0.0,
             end_seconds: 8.0,
@@ -339,6 +340,7 @@ fn profile_from_row(conn: &Connection, row: &AudioDjProfileRow) -> Result<DjProf
         outro_start_seconds: row.outro_start_seconds.map(|value| value as f32),
         breakdown_seconds: decode_f32_blob(&row.breakdown_blob).unwrap_or_default(),
         drop_seconds: decode_f32_blob(&row.drop_blob).unwrap_or_default(),
+        manual_drop_seconds: vec![],
         safe_transition_windows: safe_transition_windows
             .chunks_exact(3)
             .map(|chunk| noor_mix::profile::TransitionWindow {

--- a/noor-server/src/playback/dj_queue_ranker.rs
+++ b/noor-server/src/playback/dj_queue_ranker.rs
@@ -13,6 +13,22 @@ pub(crate) struct GeneratedCandidate<T> {
     pub(crate) item: T,
     pub(crate) track_id: Option<i64>,
     pub(crate) tidal_id: Option<i64>,
+    pub(crate) policy: GeneratedCandidatePolicy,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct GeneratedCandidatePolicy {
+    pub(crate) score_multiplier: f64,
+    pub(crate) reasons: Vec<&'static str>,
+}
+
+impl Default for GeneratedCandidatePolicy {
+    fn default() -> Self {
+        Self {
+            score_multiplier: 1.0,
+            reasons: Vec::new(),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -47,8 +63,8 @@ pub(crate) fn rank_generated_candidates<T>(
             .into_iter()
             .map(|candidate| RankedGeneratedCandidate {
                 item: candidate.item,
-                score: 1.0,
-                reasons: Vec::new(),
+                score: candidate.policy.score_multiplier,
+                reasons: candidate.policy.reasons,
             })
             .collect());
     }
@@ -59,7 +75,9 @@ pub(crate) fn rank_generated_candidates<T>(
         .enumerate()
         .map(|(ordinal, candidate)| {
             let facts = load_facts(conn, candidate.track_id, candidate.tidal_id)?;
-            let (score, reasons) = score_facts(&seed, &facts);
+            let (score, mut reasons) = score_facts(&seed, &facts);
+            let score = score * candidate.policy.score_multiplier;
+            reasons.extend(candidate.policy.reasons);
             Ok(ScoredCandidate {
                 ordinal,
                 ranked: RankedGeneratedCandidate {
@@ -81,6 +99,63 @@ pub(crate) fn rank_generated_candidates<T>(
     });
 
     Ok(scored.into_iter().map(|entry| entry.ranked).collect())
+}
+
+pub(crate) fn rank_generated_candidates_chain<T>(
+    conn: &Connection,
+    seed_track_id: i64,
+    candidates: Vec<GeneratedCandidate<T>>,
+) -> Result<Vec<RankedGeneratedCandidate<T>>> {
+    if candidates.len() <= 1 {
+        return Ok(candidates
+            .into_iter()
+            .map(|candidate| RankedGeneratedCandidate {
+                item: candidate.item,
+                score: candidate.policy.score_multiplier,
+                reasons: candidate.policy.reasons,
+            })
+            .collect());
+    }
+
+    let mut previous = load_facts_for_track(conn, seed_track_id)?;
+    let mut remaining = candidates
+        .into_iter()
+        .enumerate()
+        .map(|(ordinal, candidate)| {
+            let facts = load_facts(conn, candidate.track_id, candidate.tidal_id)?;
+            Ok((ordinal, candidate.item, facts, candidate.policy))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let mut ranked = Vec::with_capacity(remaining.len());
+
+    while !remaining.is_empty() {
+        let mut best_index = 0usize;
+        let mut best_score = f64::NEG_INFINITY;
+        for (idx, (ordinal, _, facts, policy)) in remaining.iter().enumerate() {
+            let (score, _) = score_facts(&previous, facts);
+            let score = score * policy.score_multiplier;
+            let score_order = score.partial_cmp(&best_score).unwrap_or(Ordering::Equal);
+            let is_better = score_order == Ordering::Greater
+                || (score_order == Ordering::Equal && *ordinal < remaining[best_index].0);
+            if is_better {
+                best_index = idx;
+                best_score = score;
+            }
+        }
+
+        let (_ordinal, item, facts, policy) = remaining.remove(best_index);
+        let (score, mut reasons) = score_facts(&previous, &facts);
+        let score = score * policy.score_multiplier;
+        reasons.extend(policy.reasons);
+        previous = facts;
+        ranked.push(RankedGeneratedCandidate {
+            item,
+            score,
+            reasons,
+        });
+    }
+
+    Ok(ranked)
 }
 
 pub(crate) fn append_dj_reason(existing: &str, score: f64, reasons: &[&'static str]) -> String {
@@ -409,11 +484,13 @@ mod tests {
                     item: "first",
                     track_id: None,
                     tidal_id: None,
+                    policy: Default::default(),
                 },
                 GeneratedCandidate {
                     item: "second",
                     track_id: None,
                     tidal_id: None,
+                    policy: Default::default(),
                 },
             ],
         )
@@ -471,11 +548,13 @@ mod tests {
                     item: "clash",
                     track_id: Some(3),
                     tidal_id: Some(9003),
+                    policy: Default::default(),
                 },
                 GeneratedCandidate {
                     item: "tidal-fit",
                     track_id: None,
                     tidal_id: Some(9002),
+                    policy: Default::default(),
                 },
             ],
         )
@@ -484,5 +563,112 @@ mod tests {
         assert_eq!(ranked[0].item, "tidal-fit");
         assert!(ranked[0].reasons.contains(&"tempo inside 3 percent"));
         assert!(ranked[0].reasons.contains(&"harmonic match"));
+    }
+
+    #[test]
+    fn rank_generated_candidates_chain_scores_each_pick_against_previous_pick() {
+        let conn = Connection::open_in_memory().expect("db");
+        conn.execute_batch(
+            "
+            CREATE TABLE tracks (id INTEGER PRIMARY KEY, tidal_id INTEGER);
+            CREATE TABLE audio_dsp_features (
+                track_id INTEGER PRIMARY KEY,
+                bpm REAL,
+                key_signature TEXT,
+                camelot_key TEXT,
+                loudness_lufs REAL,
+                energy REAL,
+                danceability REAL,
+                beat_strength REAL,
+                spectral_centroid REAL,
+                stereo_width REAL,
+                is_instrumental INTEGER NOT NULL DEFAULT 0,
+                analysis_source TEXT NOT NULL DEFAULT 'test',
+                analysis_offset_ms INTEGER NOT NULL DEFAULT 0,
+                samples_analyzed INTEGER,
+                analyzed_at TEXT NOT NULL DEFAULT '2026-01-01T00:00:00Z',
+                analysis_version TEXT NOT NULL DEFAULT 'test'
+            );
+            ",
+        )
+        .expect("schema");
+        for (track_id, bpm, key) in [
+            (1, 120.0, "1A"),
+            (2, 121.0, "2A"),
+            (3, 122.0, "6A"),
+            (4, 122.0, "3A"),
+        ] {
+            conn.execute(
+                "INSERT INTO audio_dsp_features (track_id, bpm, camelot_key) VALUES (?1, ?2, ?3)",
+                params![track_id, bpm, key],
+            )
+            .expect("features");
+        }
+
+        let ranked = rank_generated_candidates_chain(
+            &conn,
+            1,
+            vec![
+                GeneratedCandidate {
+                    item: "first-fit",
+                    track_id: Some(2),
+                    tidal_id: None,
+                    policy: Default::default(),
+                },
+                GeneratedCandidate {
+                    item: "seed-favored-clash-after-first",
+                    track_id: Some(3),
+                    tidal_id: None,
+                    policy: Default::default(),
+                },
+                GeneratedCandidate {
+                    item: "chain-fit",
+                    track_id: Some(4),
+                    tidal_id: None,
+                    policy: Default::default(),
+                },
+            ],
+        )
+        .expect("rank");
+
+        assert_eq!(
+            ranked.into_iter().map(|row| row.item).collect::<Vec<_>>(),
+            vec!["first-fit", "chain-fit", "seed-favored-clash-after-first"]
+        );
+    }
+
+    #[test]
+    fn rank_generated_candidates_chain_keeps_equal_scores_stable() {
+        let conn = Connection::open_in_memory().expect("db");
+        let ranked = rank_generated_candidates_chain(
+            &conn,
+            1,
+            vec![
+                GeneratedCandidate {
+                    item: "first",
+                    track_id: None,
+                    tidal_id: None,
+                    policy: Default::default(),
+                },
+                GeneratedCandidate {
+                    item: "second",
+                    track_id: None,
+                    tidal_id: None,
+                    policy: Default::default(),
+                },
+                GeneratedCandidate {
+                    item: "third",
+                    track_id: None,
+                    tidal_id: None,
+                    policy: Default::default(),
+                },
+            ],
+        )
+        .expect("rank");
+
+        assert_eq!(
+            ranked.into_iter().map(|row| row.item).collect::<Vec<_>>(),
+            vec!["first", "second", "third"]
+        );
     }
 }

--- a/noor-server/src/playback/player.rs
+++ b/noor-server/src/playback/player.rs
@@ -1865,6 +1865,7 @@ mod tests {
     use super::*;
     use crate::playback::automix::{
         automix_score, automix_scored_reason, build_automix_extension_with_reasons,
+        evaluate_automix_for_seed,
     };
 
     fn conn() -> Connection {
@@ -4504,6 +4505,248 @@ mod tests {
             !extension.is_empty(),
             "expected non-empty extension once a similarity row exists"
         );
+    }
+
+    #[test]
+    fn learned_automix_builds_chain_aware_order_from_overfetched_neighbors() {
+        let conn = conn();
+        conn.execute_batch(
+            "
+            CREATE TABLE track_neighbors (
+                track_id INTEGER NOT NULL,
+                neighbor_track_id INTEGER NOT NULL,
+                model_id INTEGER NOT NULL,
+                rank INTEGER NOT NULL,
+                score REAL NOT NULL DEFAULT 0,
+                behavioral_score REAL DEFAULT 0,
+                audio_score REAL DEFAULT 0,
+                metadata_score REAL DEFAULT 0,
+                reason_json TEXT,
+                computed_at TEXT DEFAULT (datetime('now')),
+                primary_reason TEXT,
+                confidence REAL NOT NULL DEFAULT 0,
+                support_count INTEGER NOT NULL DEFAULT 0,
+                candidate_in_degree INTEGER NOT NULL DEFAULT 0,
+                candidate_in_degree_percentile REAL NOT NULL DEFAULT 0,
+                play_count_seed INTEGER NOT NULL DEFAULT 0,
+                play_count_candidate INTEGER NOT NULL DEFAULT 0,
+                support_transition REAL NOT NULL DEFAULT 0,
+                support_colisten REAL NOT NULL DEFAULT 0,
+                support_structure REAL NOT NULL DEFAULT 0,
+                support_metadata REAL NOT NULL DEFAULT 0,
+                PRIMARY KEY (track_id, neighbor_track_id, model_id)
+            );
+            CREATE TABLE audio_dsp_features (
+                track_id INTEGER PRIMARY KEY,
+                bpm REAL,
+                key_signature TEXT,
+                camelot_key TEXT,
+                loudness_lufs REAL,
+                energy REAL,
+                danceability REAL,
+                beat_strength REAL,
+                spectral_centroid REAL,
+                stereo_width REAL,
+                is_instrumental INTEGER NOT NULL DEFAULT 0,
+                analysis_source TEXT NOT NULL DEFAULT 'test',
+                analysis_offset_ms INTEGER NOT NULL DEFAULT 0,
+                samples_analyzed INTEGER,
+                analyzed_at TEXT NOT NULL DEFAULT '2026-01-01T00:00:00Z',
+                analysis_version TEXT NOT NULL DEFAULT 'test'
+            );
+            INSERT INTO server_config (key, value) VALUES ('discovery_engine', 'v2');
+            INSERT INTO embedding_models (
+                id, model_key, family, dimension, status, is_active, trained_at, created_at
+            ) VALUES (
+                1, 'test-chain', 'discovery-fusion-v2', 3, 'ready', 1,
+                '2026-01-01 00:00:00', '2026-01-01 00:00:00'
+            );
+            INSERT INTO track_neighbors (
+                track_id, neighbor_track_id, model_id, rank, score, audio_score, primary_reason
+            ) VALUES
+                (1, 2, 1, 1, 0.90, 0.90, 'audio_texture'),
+                (1, 3, 1, 2, 0.89, 0.89, 'audio_texture'),
+                (1, 4, 1, 3, 0.88, 0.88, 'audio_texture');
+            INSERT INTO audio_dsp_features (track_id, bpm, camelot_key) VALUES
+                (1, 120.0, '1A'),
+                (2, 120.0, '2A'),
+                (3, 120.0, '12A'),
+                (4, 120.0, '3A');
+            ",
+        )
+        .expect("schema");
+        let seed = queue::get_track_by_id(&conn, 1).unwrap().unwrap();
+
+        let extension =
+            extension_tracks(&conn, &seed, &[], ShuffleMode::Off, 3, true).expect("extension call");
+
+        assert_eq!(
+            extension.iter().map(|track| track.id).collect::<Vec<_>>(),
+            vec![2, 4, 3]
+        );
+    }
+
+    #[test]
+    fn learned_automix_smoke_prefers_next_track_fit_over_vague_similarity() {
+        let conn = conn();
+        conn.execute_batch(
+            "
+            CREATE TABLE track_neighbors (
+                track_id INTEGER NOT NULL,
+                neighbor_track_id INTEGER NOT NULL,
+                model_id INTEGER NOT NULL,
+                rank INTEGER NOT NULL,
+                score REAL NOT NULL DEFAULT 0,
+                behavioral_score REAL DEFAULT 0,
+                audio_score REAL DEFAULT 0,
+                metadata_score REAL DEFAULT 0,
+                reason_json TEXT,
+                computed_at TEXT DEFAULT (datetime('now')),
+                primary_reason TEXT,
+                confidence REAL NOT NULL DEFAULT 0,
+                support_count INTEGER NOT NULL DEFAULT 0,
+                candidate_in_degree INTEGER NOT NULL DEFAULT 0,
+                candidate_in_degree_percentile REAL NOT NULL DEFAULT 0,
+                play_count_seed INTEGER NOT NULL DEFAULT 0,
+                play_count_candidate INTEGER NOT NULL DEFAULT 0,
+                support_transition REAL NOT NULL DEFAULT 0,
+                support_colisten REAL NOT NULL DEFAULT 0,
+                support_structure REAL NOT NULL DEFAULT 0,
+                support_metadata REAL NOT NULL DEFAULT 0,
+                PRIMARY KEY (track_id, neighbor_track_id, model_id)
+            );
+            CREATE TABLE audio_dsp_features (
+                track_id INTEGER PRIMARY KEY,
+                bpm REAL,
+                key_signature TEXT,
+                camelot_key TEXT,
+                loudness_lufs REAL,
+                energy REAL,
+                danceability REAL,
+                beat_strength REAL,
+                spectral_centroid REAL,
+                stereo_width REAL,
+                is_instrumental INTEGER NOT NULL DEFAULT 0,
+                analysis_source TEXT NOT NULL DEFAULT 'test',
+                analysis_offset_ms INTEGER NOT NULL DEFAULT 0,
+                samples_analyzed INTEGER,
+                analyzed_at TEXT NOT NULL DEFAULT '2026-01-01T00:00:00Z',
+                analysis_version TEXT NOT NULL DEFAULT 'test'
+            );
+            INSERT INTO server_config (key, value) VALUES ('discovery_engine', 'v2');
+            INSERT INTO embedding_models (
+                id, model_key, family, dimension, status, is_active, trained_at, created_at
+            ) VALUES (
+                1, 'test-smoke', 'discovery-fusion-v2', 3, 'ready', 1,
+                '2026-01-01 00:00:00', '2026-01-01 00:00:00'
+            );
+            INSERT INTO track_neighbors (
+                track_id, neighbor_track_id, model_id, rank, score, behavioral_score,
+                audio_score, metadata_score, reason_json, primary_reason, support_colisten
+            ) VALUES
+                (1, 2, 1, 1, 0.99, 0.80, 0.10, 0.10, '[{\"key\":\"behavioral\"}]', 'behavioral', 1.0),
+                (1, 3, 1, 2, 0.98, 0.00, 0.98, 0.00, '[{\"key\":\"audio_texture\"}]', 'audio_texture', 0.0),
+                (1, 4, 1, 3, 0.97, 0.00, 0.10, 0.00, '[{\"key\":\"lastfm_direct\"}]', 'lastfm_direct', 0.0),
+                (1, 5, 1, 4, 0.96, 0.00, 0.10, 0.00, '[{\"key\":\"lastfm_branch\"}]', 'lastfm_branch', 0.0),
+                (1, 6, 1, 5, 0.70, 0.00, 0.20, 0.30, '[{\"key\":\"bpm_match\"},{\"key\":\"harmonic_match\"}]', 'bpm_match', 0.0);
+            INSERT INTO audio_dsp_features (track_id, bpm, camelot_key) VALUES
+                (1, 120.0, '1A'),
+                (2, 150.0, '6B'),
+                (3, 120.0, '1A'),
+                (4, 145.0, '6B'),
+                (5, 120.0, '1A'),
+                (6, 120.0, '1A');
+            ",
+        )
+        .expect("schema");
+        let seed = queue::get_track_by_id(&conn, 1).unwrap().unwrap();
+
+        let extension =
+            extension_tracks(&conn, &seed, &[], ShuffleMode::Off, 5, true).expect("extension call");
+
+        assert_eq!(extension.first().map(|track| track.id), Some(6));
+        assert_eq!(
+            extension.iter().map(|track| track.id).collect::<Vec<_>>(),
+            vec![6, 5, 3, 4, 2]
+        );
+    }
+
+    #[test]
+    fn automix_evaluator_reports_before_after_without_queue_insert() {
+        let conn = conn();
+        conn.execute_batch(
+            "
+            CREATE TABLE track_neighbors (
+                track_id INTEGER NOT NULL,
+                neighbor_track_id INTEGER NOT NULL,
+                model_id INTEGER NOT NULL,
+                rank INTEGER NOT NULL,
+                score REAL NOT NULL DEFAULT 0,
+                behavioral_score REAL DEFAULT 0,
+                audio_score REAL DEFAULT 0,
+                metadata_score REAL DEFAULT 0,
+                reason_json TEXT,
+                computed_at TEXT DEFAULT (datetime('now')),
+                primary_reason TEXT,
+                confidence REAL NOT NULL DEFAULT 0,
+                support_count INTEGER NOT NULL DEFAULT 0,
+                candidate_in_degree INTEGER NOT NULL DEFAULT 0,
+                candidate_in_degree_percentile REAL NOT NULL DEFAULT 0,
+                play_count_seed INTEGER NOT NULL DEFAULT 0,
+                play_count_candidate INTEGER NOT NULL DEFAULT 0,
+                support_transition REAL NOT NULL DEFAULT 0,
+                support_colisten REAL NOT NULL DEFAULT 0,
+                support_structure REAL NOT NULL DEFAULT 0,
+                support_metadata REAL NOT NULL DEFAULT 0,
+                PRIMARY KEY (track_id, neighbor_track_id, model_id)
+            );
+            CREATE TABLE audio_dsp_features (
+                track_id INTEGER PRIMARY KEY,
+                bpm REAL,
+                key_signature TEXT,
+                camelot_key TEXT,
+                loudness_lufs REAL,
+                energy REAL,
+                danceability REAL,
+                beat_strength REAL,
+                spectral_centroid REAL,
+                stereo_width REAL,
+                is_instrumental INTEGER NOT NULL DEFAULT 0,
+                analysis_source TEXT NOT NULL DEFAULT 'test',
+                analysis_offset_ms INTEGER NOT NULL DEFAULT 0,
+                samples_analyzed INTEGER,
+                analyzed_at TEXT NOT NULL DEFAULT '2026-01-01T00:00:00Z',
+                analysis_version TEXT NOT NULL DEFAULT 'test'
+            );
+            INSERT INTO server_config (key, value) VALUES ('discovery_engine', 'v2');
+            INSERT INTO embedding_models (
+                id, model_key, family, dimension, status, is_active, trained_at, created_at
+            ) VALUES (
+                1, 'test-evaluator', 'discovery-fusion-v2', 3, 'ready', 1,
+                '2026-01-01 00:00:00', '2026-01-01 00:00:00'
+            );
+            INSERT INTO track_neighbors (
+                track_id, neighbor_track_id, model_id, rank, score, audio_score,
+                metadata_score, reason_json, primary_reason
+            ) VALUES
+                (1, 2, 1, 1, 0.90, 0.40, 0.20, '[{\"key\":\"bpm_match\"}]', 'bpm_match');
+            INSERT INTO audio_dsp_features (track_id, bpm, camelot_key) VALUES
+                (1, 120.0, '1A'),
+                (2, 120.5, '1A');
+            ",
+        )
+        .expect("schema");
+
+        let report = evaluate_automix_for_seed(&conn, 1, 1).expect("evaluate");
+
+        assert_eq!(report.queue_len_before, report.queue_len_after);
+        assert_eq!(report.before.len(), 1);
+        assert_eq!(report.after.len(), 1);
+        assert_eq!(report.before[0].track_id, 2);
+        assert_eq!(report.after[0].track_id, 2);
+        assert_eq!(report.after[0].bpm, Some(120.5));
+        assert_eq!(report.after[0].camelot_key.as_deref(), Some("1A"));
+        assert!(report.after[0].final_score.is_some());
     }
 
     /// Metadata fallback: seed has no embedding/similarity signal but the

--- a/noor-server/src/playback/player.rs
+++ b/noor-server/src/playback/player.rs
@@ -2780,12 +2780,12 @@ mod tests {
         }
 
         #[test]
-        fn v1_planner_logs_and_prepares_drop_tease_overlay_when_candidate_matches() {
+        fn v1_planner_keeps_drop_tease_overlay_out_of_end_transition() {
             let db = db_with_pair();
             make_pair_drop_tease_ready(&db);
             let transition = plan(&db);
 
-            assert_eq!(transition.program.template, "DropTease16");
+            assert_eq!(transition.program.template, "BassSwap32");
             let row: (String, String, Option<String>) = db
                 .with_conn(|conn| {
                     conn.query_row(
@@ -2800,9 +2800,8 @@ mod tests {
             let renderer_program: noor_mix::TransitionProgram =
                 serde_json::from_str(&row.1).expect("program");
 
-            assert_eq!(row.0, "DropTease16");
-            assert_eq!(renderer_program.template, "DropTease16");
-            assert_eq!(renderer_program.deck_b_start_frame, 768_000);
+            assert_eq!(row.0, "BassSwap32");
+            assert_eq!(renderer_program.template, "BassSwap32");
             assert_eq!(row.2, None);
         }
 

--- a/noor-server/src/playback/player.rs
+++ b/noor-server/src/playback/player.rs
@@ -505,11 +505,11 @@ const DJ_FILTER_SWEEP_TIMING_WINDOW: i64 = 20;
 const DJ_FILTER_SWEEP_TIMING_MIN_ROWS: usize = 4;
 const DJ_FILTER_SWEEP_MEDIAN_ABS_MAX_MS: i64 = 300;
 const DJ_FILTER_SWEEP_WORST_ABS_MAX_MS: i64 = 750;
-const DJ_FILTER_SWEEP_RENDER_MS: u32 = 12_000;
-const DJ_BASS_SWAP_16_RENDER_MS: u32 = 16_000;
-const DJ_BASS_SWAP_32_RENDER_MS: u32 = 32_000;
+const DJ_FILTER_SWEEP_RENDER_MS: u32 = 18_000;
+const DJ_BASS_SWAP_16_RENDER_MS: u32 = 24_000;
+const DJ_BASS_SWAP_32_RENDER_MS: u32 = 28_000;
 const DJ_SLAM_CUT_RENDER_MS: u32 = 200;
-const DJ_LONG_HARMONIC_BLEND_RENDER_MS: u32 = 16_000;
+const DJ_LONG_HARMONIC_BLEND_RENDER_MS: u32 = 24_000;
 
 fn dj_transition_fire_ahead_ms(conn: &Connection) -> Result<u32> {
     let deltas = dj_timing_calibration_deltas(conn, DJ_FIRE_AHEAD_WINDOW)?;
@@ -732,7 +732,7 @@ fn synced_overlap_from_grid_ms(
     sample_rate: u32,
 ) -> Option<i32> {
     const MIN_SYNC_OVERLAP_MS: i64 = 8_000;
-    const MAX_SYNC_OVERLAP_MS: i64 = 16_000;
+    const MAX_SYNC_OVERLAP_MS: i64 = 28_000;
     let preferred_ms = preferred_overlap_ms.max(250) as i64;
     let program_ms = program_samples
         .map(|samples| {
@@ -2398,7 +2398,7 @@ mod tests {
     mod dj_transition_logging {
         use super::*;
         use crate::db::models::{
-            AudioDjProfileCorrectionRow, AudioDjProfileKey, AudioDjProfileRow,
+            AudioDjProfileCorrectionRow, AudioDjProfileKey, AudioDjProfileRow, AudioDspFeatures,
         };
         use crate::db::schema;
         use crate::services::audio_analysis::dj_profile::{
@@ -2430,6 +2430,8 @@ mod tests {
                     [],
                 )?;
                 queries::set_dj_engine_enabled(conn, true)?;
+                seed_dsp(conn, 1, "8A")?;
+                seed_dsp(conn, 2, "8A")?;
                 seed_profile(conn, "tidal_track", "1", Some(1))?;
                 seed_profile(conn, "tidal_track", "2", Some(2))?;
                 Ok(())
@@ -2479,6 +2481,30 @@ mod tests {
                 computed_at: "now".to_string(),
             };
             queries::upsert_audio_dj_profile(conn, &row)
+        }
+
+        fn seed_dsp(conn: &Connection, track_id: i64, camelot_key: &str) -> Result<()> {
+            queries::upsert_audio_dsp_features(
+                conn,
+                &AudioDspFeatures {
+                    track_id,
+                    bpm: Some(120.0),
+                    key_signature: None,
+                    camelot_key: Some(camelot_key.to_string()),
+                    loudness_lufs: Some(-12.0),
+                    energy: Some(0.5),
+                    danceability: None,
+                    beat_strength: None,
+                    spectral_centroid: None,
+                    stereo_width: None,
+                    is_instrumental: false,
+                    analysis_source: "test".to_string(),
+                    analysis_offset_ms: 0,
+                    samples_analyzed: None,
+                    analyzed_at: "now".to_string(),
+                    analysis_version: "test".to_string(),
+                },
+            )
         }
 
         fn next_job(db: &Database) -> PlaybackPreparation {
@@ -2749,7 +2775,7 @@ mod tests {
 
             assert_eq!(row.0, "BassSwap16");
             assert_eq!(renderer_program.template, "BassSwap16");
-            assert_eq!(renderer_program.resolve_at, 768_000);
+            assert_eq!(renderer_program.resolve_at, 1_152_000);
             assert_eq!(row.2, None);
         }
 
@@ -2820,7 +2846,7 @@ mod tests {
 
             assert_eq!(row.0, "FilterSweep");
             assert_eq!(renderer_program.template, "FilterSweep");
-            assert_eq!(renderer_program.resolve_at, 576_000);
+            assert_eq!(renderer_program.resolve_at, 864_000);
             assert_eq!(row.2, None);
         }
 
@@ -2831,7 +2857,7 @@ mod tests {
             let (program, reason) = v1_renderable_program(&input, 48_000, 2, false);
 
             assert_eq!(program.template, "FilterSweep");
-            assert_eq!(program.resolve_at, 576_000);
+            assert_eq!(program.resolve_at, 864_000);
             assert_eq!(reason, None);
             assert!(
                 program
@@ -2857,7 +2883,7 @@ mod tests {
             let (program, reason) = v1_renderable_program(&input, 48_000, 2, false);
 
             assert_eq!(program.template, "BassSwap16");
-            assert_eq!(program.resolve_at, 768_000);
+            assert_eq!(program.resolve_at, 1_152_000);
             assert_eq!(program.deck_b_start_frame, 384_000);
             assert_eq!(reason, None);
             let rate = program
@@ -2880,7 +2906,7 @@ mod tests {
             let (program, reason) = v1_renderable_program(&input, 48_000, 2, false);
 
             assert_eq!(program.template, "BassSwap32");
-            assert_eq!(program.resolve_at, 1_536_000);
+            assert_eq!(program.resolve_at, 1_344_000);
             assert_eq!(reason, None);
             assert!(program.automation.iter().any(|event| event.param
                 == noor_mix::Param::LowGain(noor_mix::DeckId::B)
@@ -2913,7 +2939,7 @@ mod tests {
             let (program, reason) = v1_renderable_program(&input, 48_000, 2, false);
 
             assert_eq!(program.template, "LongHarmonicBlend");
-            assert_eq!(program.resolve_at, 768_000);
+            assert_eq!(program.resolve_at, 1_152_000);
             assert_eq!(reason, None);
             let rate = program
                 .automation
@@ -3006,12 +3032,12 @@ mod tests {
             let bass_swap_32 =
                 noor_mix::planner::bass_swap_32_program(48_000, 2, DJ_BASS_SWAP_32_RENDER_MS);
 
-            assert_eq!(dj_gapless_plan_from_program(&safe).overlap_ms, 8_000);
-            assert_eq!(dj_gapless_plan_from_program(&filter).overlap_ms, 12_000);
-            assert_eq!(dj_gapless_plan_from_program(&bass_swap).overlap_ms, 16_000);
+            assert_eq!(dj_gapless_plan_from_program(&safe).overlap_ms, 12_000);
+            assert_eq!(dj_gapless_plan_from_program(&filter).overlap_ms, 18_000);
+            assert_eq!(dj_gapless_plan_from_program(&bass_swap).overlap_ms, 24_000);
             assert_eq!(
                 dj_gapless_plan_from_program(&bass_swap_32).overlap_ms,
-                32_000
+                28_000
             );
         }
 
@@ -3653,6 +3679,20 @@ mod tests {
                 .expect("overlap");
 
         assert_eq!(overlap_ms, 9_000);
+    }
+
+    #[test]
+    fn synced_overlap_allows_longer_dj_handoff_windows() {
+        let overlap_ms = synced_overlap_from_grid_ms(
+            180_000,
+            &[0.0, 2.0, 4.0],
+            24_000,
+            Some(24_000 * 48),
+            48_000,
+        )
+        .expect("overlap");
+
+        assert_eq!(overlap_ms, 24_000);
     }
 
     #[test]

--- a/noor-server/src/playback/runtime/commands.rs
+++ b/noor-server/src/playback/runtime/commands.rs
@@ -23,6 +23,15 @@ pub enum PlaybackRuntimeCommand {
     },
     /// Pre-decode the next track in background so it can start gaplessly.
     PrepareNext(PreparedPlaybackJob),
+    /// Pre-decode an incoming deck for a mid-song drop preview overlay.
+    PrepareDropPreview(PreparedPlaybackJob),
+    /// Arm the active deck to start the prepared drop preview at an absolute
+    /// active-track sample position.
+    ArmDropPreview {
+        track_id: i64,
+        generation: u64,
+        trigger_position_samples: u64,
+    },
     /// Update the runtime's in-memory DJ gate after the persisted feature flag changes.
     SetDjEngineEnabled {
         enabled: bool,
@@ -45,6 +54,11 @@ pub enum PlaybackRuntimeCommand {
     /// Sent by the CPAL callback when the current track is within `crossfade_ms` of its end.
     /// If a pre-decoded next engine is ready, its stream is unpaused so both mix via the OS.
     CrossfadeStart {
+        track_id: i64,
+        generation: u64,
+        trigger_position_samples: u64,
+    },
+    DropPreviewStart {
         track_id: i64,
         generation: u64,
         trigger_position_samples: u64,
@@ -150,6 +164,11 @@ pub enum PlaybackRuntimeEvent {
         runtime_rendered_dj_mixer: bool,
         runtime_renderer_status: String,
         runtime_renderer_reason: String,
+    },
+    DropPreviewStarted {
+        track_id: i64,
+        generation: u64,
+        actual_start_ms: i64,
     },
     /// Fired when the current track is within `NEAR_END_THRESHOLD_MS` of its end.
     /// The listener should peek the next track and send `PrepareNext` to pre-buffer it.

--- a/noor-server/src/playback/runtime/commands.rs
+++ b/noor-server/src/playback/runtime/commands.rs
@@ -47,6 +47,7 @@ pub enum PlaybackRuntimeCommand {
     CrossfadeStart {
         track_id: i64,
         generation: u64,
+        trigger_position_samples: u64,
     },
     TrackTerminal {
         track_id: i64,

--- a/noor-server/src/playback/runtime/mod.rs
+++ b/noor-server/src/playback/runtime/mod.rs
@@ -1298,6 +1298,7 @@ fn start_prepared_overlay(
     event_tx: &tokio::sync::broadcast::Sender<PlaybackRuntimeEvent>,
     timing_status: &'static str,
     runtime_renderer_reason: DjRuntimeRendererReason,
+    actual_start_ms_override: Option<i64>,
     device_sample_rate: u32,
     device_channels: u16,
 ) -> Result<(), DjRuntimeRendererReason> {
@@ -1311,7 +1312,8 @@ fn start_prepared_overlay(
     };
     let outgoing_track_id = active.track_id;
     let outgoing_generation = active.generation;
-    let actual_start_ms = track_position_ms(&active.shared, device_sample_rate, device_channels);
+    let actual_start_ms = actual_start_ms_override
+        .unwrap_or_else(|| track_position_ms(&active.shared, device_sample_rate, device_channels));
     active.shared.crossfade_samples.store(0, Ordering::Relaxed);
 
     install_prepared_overlay_mixer_buffer(state)?;
@@ -1776,6 +1778,7 @@ fn run_runtime_loop(
                 PlaybackRuntimeCommand::CrossfadeStart {
                     track_id,
                     generation,
+                    trigger_position_samples,
                 } => {
                     // The OUTGOING engine just entered its fade-out window and is asking
                     // us to start the pre-decoded next engine, if one is ready.
@@ -1788,6 +1791,11 @@ fn run_runtime_loop(
                             .and_then(|e| e.shared.buffer.lock().ok().map(|g| g.is_ready()))
                             .unwrap_or(false);
                         if next_ready && !active_engine_suppresses_crossfade_after_seek(&state) {
+                            let trigger_actual_start_ms = samples_to_ms(
+                                trigger_position_samples,
+                                state.device_sample_rate,
+                                state.device_channels,
+                            );
                             let _ = prepare_dj_mixer_for_pair(
                                 &mut state,
                                 dj_mixer_max_block_samples(&output_config),
@@ -1800,6 +1808,7 @@ fn run_runtime_loop(
                                     &event_tx,
                                     "fired",
                                     DjRuntimeRendererReason::None,
+                                    Some(trigger_actual_start_ms),
                                     device_sample_rate,
                                     device_channels,
                                 ) {
@@ -1825,6 +1834,7 @@ fn run_runtime_loop(
                                     &buffered_source,
                                     &offset_source,
                                     "fired",
+                                    Some(trigger_actual_start_ms),
                                     runtime_renderer,
                                 );
                             }
@@ -1873,6 +1883,7 @@ fn run_runtime_loop(
                                     &event_tx,
                                     "late",
                                     late_fire_reason,
+                                    None,
                                     device_sample_rate,
                                     device_channels,
                                 ) {
@@ -1902,6 +1913,7 @@ fn run_runtime_loop(
                                     &buffered_source,
                                     &offset_source,
                                     "late",
+                                    None,
                                     runtime_renderer,
                                 );
                             }
@@ -2785,6 +2797,7 @@ fn promote_next_to_active(
     buffered_source: &Arc<Mutex<Arc<AtomicU64>>>,
     offset_source: &Arc<Mutex<Arc<AtomicU64>>>,
     timing_status: &'static str,
+    actual_start_ms_override: Option<i64>,
     runtime_renderer: DjRuntimeRendererOutcome,
 ) {
     state.prepared_dj_mixer = None;
@@ -2833,11 +2846,13 @@ fn promote_next_to_active(
     if let Some(mut outgoing) = outgoing {
         let outgoing_id = outgoing.track_id;
         let outgoing_generation = outgoing.generation;
-        let actual_start_ms = track_position_ms(
-            &outgoing.shared,
-            state.device_sample_rate,
-            state.device_channels,
-        );
+        let actual_start_ms = actual_start_ms_override.unwrap_or_else(|| {
+            track_position_ms(
+                &outgoing.shared,
+                state.device_sample_rate,
+                state.device_channels,
+            )
+        });
         if runtime_renderer.rendered {
             outgoing.stop();
         } else {
@@ -2880,10 +2895,14 @@ fn promote_next_to_active(
 }
 
 fn track_position_ms(shared: &PlaybackSharedState, sample_rate: u32, channels: u16) -> i64 {
+    let samples = shared.position_samples.load(Ordering::Relaxed);
+    samples_to_ms(samples, sample_rate, channels)
+}
+
+fn samples_to_ms(samples: u64, sample_rate: u32, channels: u16) -> i64 {
     if sample_rate == 0 || channels == 0 {
         return 0;
     }
-    let samples = shared.position_samples.load(Ordering::Relaxed);
     (samples.saturating_mul(1000) / (u64::from(sample_rate) * u64::from(channels))) as i64
 }
 
@@ -3922,6 +3941,7 @@ mod tests {
                 &event_tx,
                 "fired",
                 DjRuntimeRendererReason::None,
+                None,
                 48_000,
                 2
             )
@@ -3954,6 +3974,80 @@ mod tests {
                 assert!(runtime_rendered_dj_mixer);
                 assert_eq!(runtime_renderer_status, "rendered_overlay");
                 assert_eq!(runtime_renderer_reason, "none");
+            }
+            other => panic!("expected overlay event, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn prepared_overlay_reports_captured_fire_position() {
+        let mut state = test_runtime_loop_state();
+        start_dj_lookahead_in_state(
+            &mut state,
+            Some(DjMediaRef::LibraryTrack { track_id: 1 }),
+            Some(DjMediaRef::LibraryTrack { track_id: 2 }),
+            Some(11),
+            Some(12),
+            20,
+            48_000,
+        );
+
+        let active = test_engine_with_shared(1, 20);
+        active
+            .shared
+            .position_samples
+            .store(96_000, Ordering::Relaxed);
+        finish_engine_buffer(&active, &[0.1, 0.1, 0.2, 0.2]);
+
+        let mut transition = test_prepared_transition_program(20, Some(11), Some(12));
+        transition.transition_event_id = Some(100);
+        transition.program.template = "DropTease16".to_string();
+        transition.program.automation = vec![
+            noor_mix::AutomationEvent {
+                param: noor_mix::Param::DeckGain(noor_mix::DeckId::A),
+                start_sample: 0,
+                end_sample: transition.program.resolve_at,
+                from: 0.0,
+                to: 0.0,
+                curve: noor_mix::Curve::Linear,
+            },
+            noor_mix::AutomationEvent {
+                param: noor_mix::Param::DeckGain(noor_mix::DeckId::B),
+                start_sample: 0,
+                end_sample: transition.program.resolve_at,
+                from: 1.0,
+                to: 1.0,
+                curve: noor_mix::Curve::Linear,
+            },
+        ];
+
+        let mut next = test_engine_with_shared(2, 21);
+        next.job = PreparedPlaybackJob::test_fixture(2, 21).with_prepared_transition(transition);
+        finish_engine_buffer(&next, &[0.0, 0.0, 0.4, 0.4]);
+
+        state.engine = Some(active);
+        state.next_engine = Some(next);
+        assert!(prepare_dj_mixer_for_pair(&mut state, 64).is_ok());
+
+        let (event_tx, mut event_rx) = tokio::sync::broadcast::channel(8);
+        assert!(
+            start_prepared_overlay(
+                &mut state,
+                &event_tx,
+                "fired",
+                DjRuntimeRendererReason::None,
+                Some(2_500),
+                48_000,
+                2
+            )
+            .is_ok()
+        );
+
+        match event_rx.try_recv().expect("overlay event") {
+            PlaybackRuntimeEvent::DjTransitionPromoted {
+                actual_start_ms, ..
+            } => {
+                assert_eq!(actual_start_ms, 2_500);
             }
             other => panic!("expected overlay event, got {other:?}"),
         }
@@ -4003,6 +4097,7 @@ mod tests {
             &buffered_source,
             &offset_source,
             "fired",
+            None,
             DjRuntimeRendererOutcome::rendered_handoff(),
         );
 
@@ -4025,6 +4120,58 @@ mod tests {
                 assert!(runtime_rendered_dj_mixer);
                 assert_eq!(runtime_renderer_status, "rendered_handoff");
                 assert_eq!(runtime_renderer_reason, "none");
+            }
+            other => panic!("expected timing event, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mixer_promotion_reports_captured_fire_position() {
+        let mut state = test_runtime_loop_state();
+        start_dj_lookahead_in_state(
+            &mut state,
+            Some(DjMediaRef::LibraryTrack { track_id: 1 }),
+            Some(DjMediaRef::LibraryTrack { track_id: 2 }),
+            Some(11),
+            Some(12),
+            20,
+            48_000,
+        );
+
+        let active = test_engine_with_shared(1, 20);
+        active
+            .shared
+            .position_samples
+            .store(96_000, Ordering::Relaxed);
+        let mut transition = test_prepared_transition_program(20, Some(11), Some(12));
+        transition.transition_event_id = Some(101);
+        let mut next = test_engine_with_shared(2, 21);
+        next.job = PreparedPlaybackJob::test_fixture(2, 21).with_prepared_transition(transition);
+
+        state.engine = Some(active);
+        state.next_engine = Some(next);
+
+        let (event_tx, mut event_rx) = tokio::sync::broadcast::channel(8);
+        let position_source = Arc::new(Mutex::new(Arc::new(AtomicU64::new(0))));
+        let buffered_source = Arc::new(Mutex::new(Arc::new(AtomicU64::new(0))));
+        let offset_source = Arc::new(Mutex::new(Arc::new(AtomicU64::new(0))));
+
+        promote_next_to_active(
+            &mut state,
+            &event_tx,
+            &position_source,
+            &buffered_source,
+            &offset_source,
+            "fired",
+            Some(2_750),
+            DjRuntimeRendererOutcome::legacy_overlap(DjRuntimeRendererReason::PreparedMixerMissing),
+        );
+
+        match event_rx.try_recv().expect("timing event") {
+            PlaybackRuntimeEvent::DjTransitionPromoted {
+                actual_start_ms, ..
+            } => {
+                assert_eq!(actual_start_ms, 2_750);
             }
             other => panic!("expected timing event, got {other:?}"),
         }
@@ -4158,6 +4305,7 @@ mod tests {
             &buffered_source,
             &offset_source,
             "fired",
+            None,
             DjRuntimeRendererOutcome::legacy_overlap(DjRuntimeRendererReason::PreparedMixerMissing),
         );
 

--- a/noor-server/src/playback/runtime/mod.rs
+++ b/noor-server/src/playback/runtime/mod.rs
@@ -511,6 +511,11 @@ struct PreparedDjMixer {
     next_track_id: i64,
 }
 
+struct RuntimeDeckSnapshot {
+    deck: noor_mix::deck::DeckBuffer,
+    start_frame: u64,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct RuntimeDjLookahead {
     current: Option<DjMediaRef>,
@@ -905,24 +910,68 @@ fn dj_mixer_max_block_samples(output_config: &StreamConfig) -> usize {
     }
 }
 
-fn decoded_deck_buffer(
+fn decoded_deck_snapshot(
     engine: &PlaybackEngine,
     channels: u16,
-) -> Result<(noor_mix::deck::DeckBuffer, u64), DjRuntimeRendererReason> {
+    start_frame: u64,
+    required_frames: u64,
+    late_tolerance_frames: u64,
+    reason: DjRuntimeRendererReason,
+) -> Result<RuntimeDeckSnapshot, DjRuntimeRendererReason> {
     let guard = engine
         .shared
         .buffer
         .lock()
         .map_err(|_| DjRuntimeRendererReason::BufferLockFailed)?;
-    if !guard.finished || guard.samples.is_empty() {
-        return Err(DjRuntimeRendererReason::ActiveDeckNotDecoded);
+    if guard.samples.is_empty() {
+        return Err(reason);
     }
     let channels = usize::from(channels.max(1));
     let frames = (guard.samples.len() / channels) as u64;
-    Ok((
-        noor_mix::deck::DeckBuffer::new(guard.samples.clone(), channels as u16),
-        frames,
-    ))
+    if start_frame >= frames {
+        return Err(reason);
+    }
+    let available_frames = frames.saturating_sub(start_frame);
+    if available_frames.saturating_add(late_tolerance_frames) < required_frames.max(1) {
+        return Err(reason);
+    }
+    Ok(RuntimeDeckSnapshot {
+        deck: noor_mix::deck::DeckBuffer::new(guard.samples.clone(), channels as u16),
+        start_frame,
+    })
+}
+
+fn active_deck_snapshot(
+    engine: &PlaybackEngine,
+    channels: u16,
+    program_start_frame: u64,
+    required_frames: u64,
+    late_tolerance_frames: u64,
+) -> Result<RuntimeDeckSnapshot, DjRuntimeRendererReason> {
+    let guard = engine
+        .shared
+        .buffer
+        .lock()
+        .map_err(|_| DjRuntimeRendererReason::BufferLockFailed)?;
+    let channels = usize::from(channels.max(1));
+    let start_frame = if program_start_frame == 0 {
+        (guard.read_pos / channels) as u64
+    } else {
+        program_start_frame
+    };
+    drop(guard);
+    decoded_deck_snapshot(
+        engine,
+        channels as u16,
+        start_frame,
+        required_frames,
+        late_tolerance_frames,
+        DjRuntimeRendererReason::ActiveDeckNotDecoded,
+    )
+}
+
+fn dj_renderer_late_tolerance_frames(sample_rate: u32) -> u64 {
+    u64::from(sample_rate.max(1)) / 2
 }
 
 fn build_prepared_dj_mixer(
@@ -949,19 +998,33 @@ fn build_prepared_dj_mixer(
     if !handoff_mixer_program(&transition.program) && !overlay_mixer_program(&transition.program) {
         return Err(DjRuntimeRendererReason::ProgramNotMixerRenderable);
     }
-    let (deck_a, active_frames) =
-        decoded_deck_buffer(active, state.device_channels).map_err(|reason| match reason {
-            DjRuntimeRendererReason::BufferLockFailed => DjRuntimeRendererReason::BufferLockFailed,
-            _ => DjRuntimeRendererReason::ActiveDeckNotDecoded,
-        })?;
-    let (deck_b, _) =
-        decoded_deck_buffer(next, state.device_channels).map_err(|reason| match reason {
-            DjRuntimeRendererReason::BufferLockFailed => DjRuntimeRendererReason::BufferLockFailed,
-            _ => DjRuntimeRendererReason::NextDeckNotDecoded,
-        })?;
     let mut program = transition.program.clone();
-    align_runtime_program_source_frames(&mut program, active_frames);
-    let mixer = match noor_mix::Mixer::new(program.clone(), deck_a, deck_b, max_block_samples) {
+    let deck_b_consumed_frames = deck_b_consumed_frames(&program)
+        .ok_or(DjRuntimeRendererReason::ProgramNotMixerRenderable)?;
+    let tolerance_frames = dj_renderer_late_tolerance_frames(state.device_sample_rate);
+    let active_snapshot = active_deck_snapshot(
+        active,
+        state.device_channels,
+        program.deck_a_start_frame,
+        program.resolve_at,
+        tolerance_frames,
+    )?;
+    let next_snapshot = decoded_deck_snapshot(
+        next,
+        state.device_channels,
+        program.deck_b_start_frame,
+        deck_b_consumed_frames.saturating_add(1),
+        tolerance_frames,
+        DjRuntimeRendererReason::NextDeckNotDecoded,
+    )?;
+    program.deck_a_start_frame = active_snapshot.start_frame;
+    program.deck_b_start_frame = next_snapshot.start_frame;
+    let mixer = match noor_mix::Mixer::new(
+        program.clone(),
+        active_snapshot.deck,
+        next_snapshot.deck,
+        max_block_samples,
+    ) {
         Ok(mixer) => mixer,
         Err(error) => {
             warn!("Prepared DJ mixer rejected transition program: {error:?}");
@@ -980,19 +1043,15 @@ fn build_prepared_dj_mixer(
     })
 }
 
-fn align_runtime_program_source_frames(
-    program: &mut noor_mix::TransitionProgram,
-    active_frames: u64,
-) {
-    if program.deck_a_start_frame == 0 && program.resolve_at > 0 {
-        program.deck_a_start_frame = active_frames.saturating_sub(program.resolve_at);
-    }
-}
-
 fn handoff_mixer_program(program: &noor_mix::TransitionProgram) -> bool {
     matches!(
         program.template.as_str(),
-        "SafeCrossfade" | "BassSwap16" | "BassSwap32" | "LongHarmonicBlend" | "FilterSweep"
+        "SafeCrossfade"
+            | "SlamCut"
+            | "BassSwap16"
+            | "BassSwap32"
+            | "LongHarmonicBlend"
+            | "FilterSweep"
     ) && deck_b_consumed_frames(program).is_some()
 }
 
@@ -1095,6 +1154,8 @@ fn install_prepared_handoff_mixer_buffer(
         Ok(guard) => guard,
         Err(_) => return Err(DjRuntimeRendererReason::BufferLockFailed),
     };
+    let was_finished = guard.finished;
+    let previous_total_samples = next.shared.total_samples.load(Ordering::Relaxed);
     let remainder_start = deck_b_resume_sample.min(guard.samples.len());
     let remainder = guard.samples[remainder_start..].to_vec();
     rendered.extend_from_slice(&remainder);
@@ -1104,10 +1165,20 @@ fn install_prepared_handoff_mixer_buffer(
     guard.started_notified = false;
     guard.starved_notified = false;
     guard.finished_notified = false;
-    guard.finished = true;
+    guard.finished = was_finished;
+    let rendered_total_samples = next
+        .shared
+        .position_offset_samples
+        .load(Ordering::Relaxed)
+        .saturating_add(guard.samples.len() as u64);
+    let total_samples = if was_finished || previous_total_samples == 0 {
+        rendered_total_samples
+    } else {
+        previous_total_samples.max(rendered_total_samples)
+    };
     next.shared
         .total_samples
-        .store(guard.samples.len() as u64, Ordering::Relaxed);
+        .store(total_samples, Ordering::Relaxed);
     next.shared.publish_buffered_samples(guard.samples.len());
     next.shared.crossfade_samples.store(0, Ordering::Relaxed);
     next.shared
@@ -1717,6 +1788,10 @@ fn run_runtime_loop(
                             .and_then(|e| e.shared.buffer.lock().ok().map(|g| g.is_ready()))
                             .unwrap_or(false);
                         if next_ready && !active_engine_suppresses_crossfade_after_seek(&state) {
+                            let _ = prepare_dj_mixer_for_pair(
+                                &mut state,
+                                dj_mixer_max_block_samples(&output_config),
+                            );
                             if prepared_overlay_program(&state) {
                                 let device_sample_rate = state.device_sample_rate;
                                 let device_channels = state.device_channels;
@@ -3514,6 +3589,113 @@ mod tests {
     }
 
     #[test]
+    fn runtime_constructs_mixer_from_decoded_transition_windows() {
+        let mut state = test_runtime_loop_state();
+        start_dj_lookahead_in_state(
+            &mut state,
+            Some(DjMediaRef::LibraryTrack { track_id: 1 }),
+            Some(DjMediaRef::LibraryTrack { track_id: 2 }),
+            Some(11),
+            Some(12),
+            20,
+            48_000,
+        );
+
+        let active = test_engine_with_shared(1, 20);
+        {
+            let mut buffer = active.shared.buffer.lock().expect("active buffer");
+            buffer
+                .samples
+                .extend_from_slice(&[0.1, 0.1, 0.2, 0.2, 0.3, 0.3]);
+            buffer.read_pos = 2;
+        }
+
+        let mut next = test_engine_with_shared(2, 21);
+        next.job = PreparedPlaybackJob::test_fixture(2, 21)
+            .with_prepared_transition(test_prepared_transition_program(20, Some(11), Some(12)));
+        {
+            let mut buffer = next.shared.buffer.lock().expect("next buffer");
+            buffer
+                .samples
+                .extend_from_slice(&[0.0, 0.0, 0.4, 0.4, 0.5, 0.5]);
+        }
+
+        state.engine = Some(active);
+        state.next_engine = Some(next);
+
+        assert!(prepare_dj_mixer_for_pair(&mut state, 64).is_ok());
+        let prepared = state.prepared_dj_mixer.as_ref().expect("prepared mixer");
+        assert_eq!(prepared.program.deck_a_start_frame, 1);
+    }
+
+    #[test]
+    fn runtime_rebuilds_mixer_from_latest_active_read_position() {
+        let mut state = test_runtime_loop_state();
+        start_dj_lookahead_in_state(
+            &mut state,
+            Some(DjMediaRef::LibraryTrack { track_id: 1 }),
+            Some(DjMediaRef::LibraryTrack { track_id: 2 }),
+            Some(11),
+            Some(12),
+            20,
+            48_000,
+        );
+
+        let active = test_engine_with_shared(1, 20);
+        {
+            let mut buffer = active.shared.buffer.lock().expect("active buffer");
+            buffer
+                .samples
+                .extend_from_slice(&[0.1, 0.1, 0.2, 0.2, 0.3, 0.3, 0.4, 0.4]);
+        }
+
+        let mut next = test_engine_with_shared(2, 21);
+        next.job = PreparedPlaybackJob::test_fixture(2, 21)
+            .with_prepared_transition(test_prepared_transition_program(20, Some(11), Some(12)));
+        {
+            let mut buffer = next.shared.buffer.lock().expect("next buffer");
+            buffer
+                .samples
+                .extend_from_slice(&[0.0, 0.0, 0.4, 0.4, 0.5, 0.5]);
+        }
+
+        state.engine = Some(active);
+        state.next_engine = Some(next);
+
+        assert!(prepare_dj_mixer_for_pair(&mut state, 64).is_ok());
+        assert_eq!(
+            state
+                .prepared_dj_mixer
+                .as_ref()
+                .expect("early mixer")
+                .program
+                .deck_a_start_frame,
+            0
+        );
+
+        state
+            .engine
+            .as_ref()
+            .expect("active engine")
+            .shared
+            .buffer
+            .lock()
+            .expect("active buffer")
+            .read_pos = 4;
+
+        assert!(prepare_dj_mixer_for_pair(&mut state, 64).is_ok());
+        assert_eq!(
+            state
+                .prepared_dj_mixer
+                .as_ref()
+                .expect("rebuilt mixer")
+                .program
+                .deck_a_start_frame,
+            2
+        );
+    }
+
+    #[test]
     fn runtime_prepared_mixer_honors_program_start_frames() {
         let mut state = test_runtime_loop_state();
         start_dj_lookahead_in_state(
@@ -3564,6 +3746,7 @@ mod tests {
 
         let active = test_engine_with_shared(1, 20);
         finish_engine_buffer(&active, &[0.1, 0.1, 0.2, 0.2, 0.3, 0.3]);
+        active.shared.buffer.lock().expect("active buffer").read_pos = 2;
 
         let mut next = test_engine_with_shared(2, 21);
         next.job = PreparedPlaybackJob::test_fixture(2, 21)
@@ -3630,6 +3813,52 @@ mod tests {
         assert_eq!(buffer.samples.len(), 10);
         assert_samples_close(&buffer.samples[4..], &[0.4, 0.4, 0.5, 0.5, 0.6, 0.6]);
         assert_eq!(next.shared.total_samples.load(Ordering::Relaxed), 10);
+    }
+
+    #[test]
+    fn handoff_mixer_preserves_unfinished_next_buffer() {
+        let mut state = test_runtime_loop_state();
+        start_dj_lookahead_in_state(
+            &mut state,
+            Some(DjMediaRef::LibraryTrack { track_id: 1 }),
+            Some(DjMediaRef::LibraryTrack { track_id: 2 }),
+            Some(11),
+            Some(12),
+            20,
+            48_000,
+        );
+
+        let active = test_engine_with_shared(1, 20);
+        finish_engine_buffer(&active, &[0.1, 0.1, 0.2, 0.2, 0.3, 0.3]);
+
+        let mut next = test_engine_with_shared(2, 21);
+        next.job = PreparedPlaybackJob::test_fixture(2, 21)
+            .with_prepared_transition(test_prepared_transition_program(20, Some(11), Some(12)));
+        let estimated_total_samples =
+            estimate_total_samples_from_duration_ms(180_000, 48_000, 2).expect("estimated total");
+        next.shared
+            .total_samples
+            .store(estimated_total_samples, Ordering::Relaxed);
+        {
+            let mut buffer = next.shared.buffer.lock().expect("next buffer");
+            buffer
+                .samples
+                .extend_from_slice(&[0.0, 0.0, 0.4, 0.4, 0.5, 0.5, 0.6, 0.6]);
+        }
+
+        state.engine = Some(active);
+        state.next_engine = Some(next);
+
+        assert!(prepare_dj_mixer_for_pair(&mut state, 64).is_ok());
+        assert!(install_prepared_handoff_mixer_buffer(&mut state).is_ok());
+
+        let next = state.next_engine.as_ref().expect("next engine");
+        let buffer = next.shared.buffer.lock().expect("buffer lock");
+        assert!(!buffer.finished);
+        assert_eq!(
+            next.shared.total_samples.load(Ordering::Relaxed),
+            estimated_total_samples
+        );
     }
 
     #[test]

--- a/noor-server/src/playback/runtime/mod.rs
+++ b/noor-server/src/playback/runtime/mod.rs
@@ -287,6 +287,23 @@ impl PlaybackRuntimeHandle {
         self.send(PlaybackRuntimeCommand::PrepareNext(job))
     }
 
+    pub fn prepare_drop_preview(&self, job: PreparedPlaybackJob) -> Result<()> {
+        self.send(PlaybackRuntimeCommand::PrepareDropPreview(job))
+    }
+
+    pub fn arm_drop_preview(
+        &self,
+        track_id: i64,
+        generation: u64,
+        trigger_position_samples: u64,
+    ) -> Result<()> {
+        self.send(PlaybackRuntimeCommand::ArmDropPreview {
+            track_id,
+            generation,
+            trigger_position_samples,
+        })
+    }
+
     pub fn set_dj_engine_enabled(&self, enabled: bool) -> Result<()> {
         self.send(PlaybackRuntimeCommand::SetDjEngineEnabled { enabled })
     }
@@ -472,6 +489,9 @@ struct PlaybackRuntimeLoopState {
     /// window opens. Once unpaused it gets promoted to `engine` and the old
     /// `engine` slides into `fading_out_engine`.
     next_engine: Option<PlaybackEngine>,
+    /// Temporary incoming deck for a mid-song drop preview. It is never
+    /// promoted and is discarded after the preview overlay finishes.
+    drop_preview_engine: Option<PlaybackEngine>,
     /// Engine that's still audible during the crossfade fade-out window. It
     /// keeps producing audio (with a fade-out gain ramp) until its buffer
     /// drains, at which point it self-terminates and we drop it silently -
@@ -497,6 +517,7 @@ struct PlaybackRuntimeLoopState {
     dj_lookahead: Option<RuntimeDjLookahead>,
     dj_lookahead_failure: Option<DjLookaheadFailure>,
     prepared_dj_mixer: Option<PreparedDjMixer>,
+    prepared_drop_preview_mixer: Option<PreparedDjMixer>,
     last_dj_renderer_failure: Option<DjRuntimeRendererFailure>,
 }
 
@@ -979,10 +1000,6 @@ fn build_prepared_dj_mixer(
     transition: &PreparedTransitionProgram,
     max_block_samples: usize,
 ) -> Result<PreparedDjMixer, DjRuntimeRendererReason> {
-    let active = state
-        .engine
-        .as_ref()
-        .ok_or(DjRuntimeRendererReason::ActiveDeckNotDecoded)?;
     let next = state
         .next_engine
         .as_ref()
@@ -995,6 +1012,19 @@ fn build_prepared_dj_mixer(
     ) {
         return Err(DjRuntimeRendererReason::LookaheadPairMismatch);
     }
+    build_prepared_dj_mixer_for_engine(state, transition, next, max_block_samples)
+}
+
+fn build_prepared_dj_mixer_for_engine(
+    state: &PlaybackRuntimeLoopState,
+    transition: &PreparedTransitionProgram,
+    incoming: &PlaybackEngine,
+    max_block_samples: usize,
+) -> Result<PreparedDjMixer, DjRuntimeRendererReason> {
+    let active = state
+        .engine
+        .as_ref()
+        .ok_or(DjRuntimeRendererReason::ActiveDeckNotDecoded)?;
     if !handoff_mixer_program(&transition.program) && !overlay_mixer_program(&transition.program) {
         return Err(DjRuntimeRendererReason::ProgramNotMixerRenderable);
     }
@@ -1010,7 +1040,7 @@ fn build_prepared_dj_mixer(
         tolerance_frames,
     )?;
     let next_snapshot = decoded_deck_snapshot(
-        next,
+        incoming,
         state.device_channels,
         program.deck_b_start_frame,
         deck_b_consumed_frames.saturating_add(1),
@@ -1039,7 +1069,7 @@ fn build_prepared_dj_mixer(
         current_queue_item_id: transition.current_queue_item_id,
         next_queue_item_id: transition.next_queue_item_id,
         current_track_id: active.track_id,
-        next_track_id: next.track_id,
+        next_track_id: incoming.track_id,
     })
 }
 
@@ -1056,7 +1086,8 @@ fn handoff_mixer_program(program: &noor_mix::TransitionProgram) -> bool {
 }
 
 fn overlay_mixer_program(program: &noor_mix::TransitionProgram) -> bool {
-    program.template == "DropTease16" && deck_b_consumed_frames(program).is_some()
+    matches!(program.template.as_str(), "DropTease16" | "DropPreview16")
+        && deck_b_consumed_frames(program).is_some()
 }
 
 fn render_prepared_mixer_to_buffer(
@@ -1253,6 +1284,72 @@ fn install_prepared_overlay_mixer_buffer(
     Ok(())
 }
 
+fn install_prepared_drop_preview_mixer_buffer(
+    state: &mut PlaybackRuntimeLoopState,
+) -> Result<(), DjRuntimeRendererReason> {
+    let prepared = state
+        .prepared_drop_preview_mixer
+        .as_ref()
+        .ok_or(DjRuntimeRendererReason::PreparedMixerMissing)?;
+    if prepared.program.template != "DropPreview16" || !overlay_mixer_program(&prepared.program) {
+        return Err(DjRuntimeRendererReason::ProgramNotMixerRenderable);
+    }
+    if state
+        .engine
+        .as_ref()
+        .map(|engine| engine.track_id != prepared.current_track_id)
+        .unwrap_or(true)
+    {
+        return Err(DjRuntimeRendererReason::ActiveTrackChanged);
+    }
+    if state
+        .drop_preview_engine
+        .as_ref()
+        .map(|engine| engine.track_id != prepared.next_track_id)
+        .unwrap_or(true)
+    {
+        return Err(DjRuntimeRendererReason::NextTrackChanged);
+    }
+
+    let mut prepared = state
+        .prepared_drop_preview_mixer
+        .take()
+        .ok_or(DjRuntimeRendererReason::PreparedMixerMissing)?;
+    let channels = usize::from(state.device_channels.max(1));
+    let rendered = render_prepared_mixer_to_buffer(&mut prepared, channels)
+        .ok_or(DjRuntimeRendererReason::RenderBufferFailed)?;
+    let preview = state
+        .drop_preview_engine
+        .as_ref()
+        .ok_or(DjRuntimeRendererReason::NextDeckNotDecoded)?;
+    let mut guard = match preview.shared.buffer.lock() {
+        Ok(guard) => guard,
+        Err(_) => return Err(DjRuntimeRendererReason::BufferLockFailed),
+    };
+    guard.samples = rendered;
+    guard.read_pos = 0;
+    guard.started = false;
+    guard.started_notified = false;
+    guard.starved_notified = false;
+    guard.finished_notified = false;
+    guard.finished = true;
+    preview
+        .shared
+        .total_samples
+        .store(guard.samples.len() as u64, Ordering::Relaxed);
+    preview.shared.publish_buffered_samples(guard.samples.len());
+    preview.shared.crossfade_samples.store(0, Ordering::Relaxed);
+    preview
+        .shared
+        .crossfade_start_signaled
+        .store(true, Ordering::Relaxed);
+    preview
+        .shared
+        .fadein_start_samples
+        .store(u64::MAX, Ordering::Relaxed);
+    Ok(())
+}
+
 fn prepare_dj_mixer_for_pair(
     state: &mut PlaybackRuntimeLoopState,
     max_block_samples: usize,
@@ -1281,6 +1378,40 @@ fn prepare_dj_mixer_for_pair(
         Err(reason) => {
             state.prepared_dj_mixer = None;
             record_runtime_renderer_failure(state, &transition, reason);
+            Err(reason)
+        }
+    }
+}
+
+fn prepare_drop_preview_mixer(
+    state: &mut PlaybackRuntimeLoopState,
+    max_block_samples: usize,
+) -> Result<(), DjRuntimeRendererReason> {
+    if !state.dj_engine_enabled {
+        state.prepared_drop_preview_mixer = None;
+        return Err(DjRuntimeRendererReason::DjDisabled);
+    }
+    let Some((transition, incoming)) = state.drop_preview_engine.as_ref().and_then(|engine| {
+        engine
+            .job
+            .prepared_transition
+            .as_ref()
+            .map(|transition| (transition.clone(), engine))
+    }) else {
+        state.prepared_drop_preview_mixer = None;
+        return Err(DjRuntimeRendererReason::PreparedMixerMissing);
+    };
+    if transition.program.template != "DropPreview16" {
+        state.prepared_drop_preview_mixer = None;
+        return Err(DjRuntimeRendererReason::ProgramNotMixerRenderable);
+    }
+    match build_prepared_dj_mixer_for_engine(state, &transition, incoming, max_block_samples) {
+        Ok(prepared) => {
+            state.prepared_drop_preview_mixer = Some(prepared);
+            Ok(())
+        }
+        Err(reason) => {
+            state.prepared_drop_preview_mixer = None;
             Err(reason)
         }
     }
@@ -1339,6 +1470,30 @@ fn start_prepared_overlay(
     Ok(())
 }
 
+fn start_prepared_drop_preview_overlay(
+    state: &mut PlaybackRuntimeLoopState,
+    event_tx: &tokio::sync::broadcast::Sender<PlaybackRuntimeEvent>,
+    actual_start_ms: i64,
+) -> Result<(), DjRuntimeRendererReason> {
+    let Some(active) = state.engine.as_ref() else {
+        return Err(DjRuntimeRendererReason::ActiveDeckNotDecoded);
+    };
+    let active_track_id = active.track_id;
+    let active_generation = active.generation;
+
+    install_prepared_drop_preview_mixer_buffer(state)?;
+    let Some(preview) = state.drop_preview_engine.as_ref() else {
+        return Err(DjRuntimeRendererReason::NextDeckNotDecoded);
+    };
+    preview.shared.paused.store(false, Ordering::SeqCst);
+    let _ = event_tx.send(PlaybackRuntimeEvent::DropPreviewStarted {
+        track_id: active_track_id,
+        generation: active_generation,
+        actual_start_ms,
+    });
+    Ok(())
+}
+
 fn arm_active_transition_window(
     state: &mut PlaybackRuntimeLoopState,
     job: &PreparedPlaybackJob,
@@ -1380,6 +1535,30 @@ fn arm_active_transition_window(
     true
 }
 
+fn arm_drop_preview_in_state(
+    state: &PlaybackRuntimeLoopState,
+    track_id: i64,
+    generation: u64,
+    trigger_position_samples: u64,
+) -> bool {
+    let Some(active) = state
+        .engine
+        .as_ref()
+        .filter(|engine| engine.track_id == track_id && engine.generation == generation)
+    else {
+        return false;
+    };
+    active
+        .shared
+        .drop_preview_trigger_samples
+        .store(trigger_position_samples, Ordering::Relaxed);
+    active
+        .shared
+        .drop_preview_start_signaled
+        .store(false, Ordering::Relaxed);
+    true
+}
+
 fn gate_prepare_next_for_dj(
     state: &mut PlaybackRuntimeLoopState,
     job: &mut PreparedPlaybackJob,
@@ -1403,9 +1582,13 @@ fn set_dj_engine_enabled_in_state(state: &mut PlaybackRuntimeLoopState, enabled:
     state.dj_lookahead = None;
     state.dj_lookahead_failure = None;
     state.prepared_dj_mixer = None;
+    state.prepared_drop_preview_mixer = None;
     state.last_dj_renderer_failure = None;
     if let Some(engine) = state.next_engine.as_mut() {
         engine.job.prepared_transition = None;
+    }
+    if let Some(mut engine) = state.drop_preview_engine.take() {
+        engine.stop();
     }
 }
 
@@ -1455,6 +1638,7 @@ fn run_runtime_loop(
         exclusive_sink: ExclusiveRuntimeSink::new(),
         engine: None,
         next_engine: None,
+        drop_preview_engine: None,
         fading_out_engine: None,
         current_exclusive: false,
         current_sample_rate_follow: false,
@@ -1466,6 +1650,7 @@ fn run_runtime_loop(
         dj_lookahead: None,
         dj_lookahead_failure: None,
         prepared_dj_mixer: None,
+        prepared_drop_preview_mixer: None,
         last_dj_renderer_failure: None,
     };
 
@@ -1743,6 +1928,82 @@ fn run_runtime_loop(
                         }
                     }
                 }
+                PlaybackRuntimeCommand::PrepareDropPreview(job) => {
+                    if !state.dj_engine_enabled {
+                        state.prepared_drop_preview_mixer = None;
+                        if let Some(mut stale) = state.drop_preview_engine.take() {
+                            stale.stop();
+                        }
+                        return std::ops::ControlFlow::Continue(());
+                    }
+                    let has_drop_preview_program = job
+                        .prepared_transition
+                        .as_ref()
+                        .is_some_and(|transition| transition.program.template == "DropPreview16");
+                    if !has_drop_preview_program {
+                        state.prepared_drop_preview_mixer = None;
+                        if let Some(mut stale) = state.drop_preview_engine.take() {
+                            stale.stop();
+                        }
+                        return std::ops::ControlFlow::Continue(());
+                    }
+                    let already_pending = state
+                        .drop_preview_engine
+                        .as_ref()
+                        .map(|engine| {
+                            engine.track_id == job.track.id && engine.generation == job.generation
+                        })
+                        .unwrap_or(false);
+                    if !already_pending {
+                        if let Some(mut stale) = state.drop_preview_engine.take() {
+                            state.prepared_drop_preview_mixer = None;
+                            stale.stop();
+                        }
+                        let pending_position = Arc::new(AtomicU64::new(0));
+                        let engine_result = if state.current_exclusive {
+                            PlaybackEngine::start_decoder_only(
+                                &config,
+                                &command_tx,
+                                job,
+                                state.device_sample_rate,
+                                state.device_channels,
+                                Arc::clone(&volume_ctl),
+                                pending_position,
+                            )
+                        } else {
+                            PlaybackEngine::start(
+                                &config,
+                                &command_tx,
+                                &device,
+                                &output_config,
+                                output_sample_format,
+                                job,
+                                event_tx.clone(),
+                                state.device_sample_rate,
+                                state.device_channels,
+                                Arc::clone(&volume_ctl),
+                                pending_position,
+                            )
+                        };
+                        match engine_result {
+                            Ok(engine) => {
+                                engine.shared.paused.store(true, Ordering::SeqCst);
+                                state.drop_preview_engine = Some(engine);
+                                let _ = prepare_drop_preview_mixer(
+                                    &mut state,
+                                    dj_mixer_max_block_samples(&output_config),
+                                );
+                                #[cfg(target_os = "windows")]
+                                if state.current_exclusive {
+                                    refresh_exclusive_sources(&state);
+                                }
+                            }
+                            Err(err) => {
+                                warn!("Failed to pre-buffer drop preview: {err:?}");
+                            }
+                        }
+                    }
+                }
                 PlaybackRuntimeCommand::SetDjEngineEnabled { enabled } => {
                     config.dj_engine_enabled = enabled;
                     set_dj_engine_enabled_in_state(&mut state, enabled);
@@ -1845,6 +2106,51 @@ fn run_runtime_loop(
                         // If not ready yet, NextDecodeComplete handles the late path.
                     }
                 }
+                PlaybackRuntimeCommand::ArmDropPreview {
+                    track_id,
+                    generation,
+                    trigger_position_samples,
+                } => {
+                    arm_drop_preview_in_state(
+                        &state,
+                        track_id,
+                        generation,
+                        trigger_position_samples,
+                    );
+                }
+                PlaybackRuntimeCommand::DropPreviewStart {
+                    track_id,
+                    generation,
+                    trigger_position_samples,
+                } => {
+                    if state
+                        .engine
+                        .as_ref()
+                        .map(|engine| (engine.track_id, engine.generation))
+                        == Some((track_id, generation))
+                    {
+                        let _ = prepare_drop_preview_mixer(
+                            &mut state,
+                            dj_mixer_max_block_samples(&output_config),
+                        );
+                        let actual_start_ms = samples_to_ms(
+                            trigger_position_samples,
+                            state.device_sample_rate,
+                            state.device_channels,
+                        );
+                        if let Err(reason) = start_prepared_drop_preview_overlay(
+                            &mut state,
+                            &event_tx,
+                            actual_start_ms,
+                        ) {
+                            debug!("Drop preview start skipped: {}", reason.as_str());
+                            state.prepared_drop_preview_mixer = None;
+                            if let Some(mut engine) = state.drop_preview_engine.take() {
+                                engine.stop();
+                            }
+                        }
+                    }
+                }
                 PlaybackRuntimeCommand::NextDecodeComplete {
                     track_id,
                     generation,
@@ -1937,6 +2243,11 @@ fn run_runtime_loop(
                         }
                     }
                     if let Some(engine) = state.fading_out_engine.as_mut() {
+                        if let Err(error) = engine.pause() {
+                            report_runtime_command_error(&event_tx, "Pause", error);
+                        }
+                    }
+                    if let Some(engine) = state.drop_preview_engine.as_mut() {
                         if let Err(error) = engine.pause() {
                             report_runtime_command_error(&event_tx, "Pause", error);
                         }
@@ -2038,6 +2349,15 @@ fn run_runtime_loop(
                             report_runtime_command_error(&event_tx, "Resume", error);
                         }
                     }
+                    if let Some(engine) = state
+                        .drop_preview_engine
+                        .as_mut()
+                        .filter(|engine| !engine.shared.paused.load(Ordering::SeqCst))
+                    {
+                        if let Err(error) = engine.resume() {
+                            report_runtime_command_error(&event_tx, "Resume", error);
+                        }
+                    }
                 }
                 PlaybackRuntimeCommand::Stop => {
                     stop_all_engines(&mut state);
@@ -2057,6 +2377,10 @@ fn run_runtime_loop(
                         .fading_out_engine
                         .as_ref()
                         .map(|e| (e.track_id, e.generation));
+                    let drop_preview = state
+                        .drop_preview_engine
+                        .as_ref()
+                        .map(|engine| (engine.track_id, engine.generation));
                     let next = state
                         .next_engine
                         .as_ref()
@@ -2066,7 +2390,14 @@ fn run_runtime_loop(
                         .as_ref()
                         .map(|engine| (engine.track_id, engine.generation));
 
-                    match terminal_engine_slot(active, next, fading, track_id, generation) {
+                    match terminal_engine_slot(
+                        active,
+                        next,
+                        fading,
+                        drop_preview,
+                        track_id,
+                        generation,
+                    ) {
                         Some(TerminalEngineSlot::FadingOut) => {
                             debug!(
                                 "Playback terminal ignored for fading engine: track_id={}, generation={}, outcome={:?}",
@@ -2085,6 +2416,16 @@ fn run_runtime_loop(
                                 emit_prepared_track_failure(&event_tx, track_id, message);
                             }
                             if let Some(mut engine) = state.next_engine.take() {
+                                engine.stop();
+                            }
+                        }
+                        Some(TerminalEngineSlot::DropPreview) => {
+                            debug!(
+                                "Playback terminal ignored for drop preview engine: track_id={}, generation={}, outcome={:?}",
+                                track_id, generation, outcome
+                            );
+                            state.prepared_drop_preview_mixer = None;
+                            if let Some(mut engine) = state.drop_preview_engine.take() {
                                 engine.stop();
                             }
                         }
@@ -2197,7 +2538,8 @@ fn run_runtime_loop(
 
                     let has_live_engines = state.engine.is_some()
                         || state.next_engine.is_some()
-                        || state.fading_out_engine.is_some();
+                        || state.fading_out_engine.is_some()
+                        || state.drop_preview_engine.is_some();
                     let desired_rate = device_swap_target_sample_rate(
                         desired_sample_rate,
                         sample_rate_follow,
@@ -2232,6 +2574,7 @@ fn run_runtime_loop(
                                 state.engine.as_mut(),
                                 state.next_engine.as_mut(),
                                 state.fading_out_engine.as_mut(),
+                                state.drop_preview_engine.as_mut(),
                             ]
                             .into_iter()
                             .flatten()
@@ -2268,6 +2611,7 @@ fn run_runtime_loop(
                                         state.engine.as_mut(),
                                         state.next_engine.as_mut(),
                                         state.fading_out_engine.as_mut(),
+                                        state.drop_preview_engine.as_mut(),
                                     ]
                                     .into_iter()
                                     .flatten()
@@ -2304,6 +2648,7 @@ fn run_runtime_loop(
                             state.engine.as_mut(),
                             state.next_engine.as_mut(),
                             state.fading_out_engine.as_mut(),
+                            state.drop_preview_engine.as_mut(),
                         ]
                         .into_iter()
                         .flatten()
@@ -2596,6 +2941,7 @@ fn switch_is_noop_for_active_job(
 
 fn stop_current_engine(state: &mut PlaybackRuntimeLoopState) {
     state.prepared_dj_mixer = None;
+    state.prepared_drop_preview_mixer = None;
     if let Some(mut engine) = state.engine.take() {
         engine.stop();
     }
@@ -2607,6 +2953,9 @@ fn stop_all_engines(state: &mut PlaybackRuntimeLoopState) {
         engine.stop();
     }
     if let Some(mut engine) = state.fading_out_engine.take() {
+        engine.stop();
+    }
+    if let Some(mut engine) = state.drop_preview_engine.take() {
         engine.stop();
     }
 }
@@ -2691,6 +3040,7 @@ fn exclusive_render_sources(
     active: Option<&PlaybackEngine>,
     prepared: Option<&PlaybackEngine>,
     fading: Option<&PlaybackEngine>,
+    drop_preview: Option<&PlaybackEngine>,
 ) -> Vec<ExclusiveRenderSource> {
     let mut sources = Vec::new();
     if let Some(engine) = active {
@@ -2711,6 +3061,12 @@ fn exclusive_render_sources(
             shared: Arc::clone(&engine.shared),
         });
     }
+    if let Some(engine) = drop_preview {
+        sources.push(ExclusiveRenderSource {
+            role: ExclusiveRenderRole::Prepared,
+            shared: Arc::clone(&engine.shared),
+        });
+    }
     sources
 }
 
@@ -2723,6 +3079,7 @@ fn refresh_exclusive_sources(state: &PlaybackRuntimeLoopState) {
             state.engine.as_ref(),
             state.next_engine.as_ref(),
             state.fading_out_engine.as_ref(),
+            state.drop_preview_engine.as_ref(),
         ));
 }
 
@@ -3049,18 +3406,22 @@ enum TerminalEngineSlot {
     Active,
     Next,
     FadingOut,
+    DropPreview,
 }
 
 fn terminal_engine_slot(
     active: Option<(i64, u64)>,
     next: Option<(i64, u64)>,
     fading: Option<(i64, u64)>,
+    drop_preview: Option<(i64, u64)>,
     track_id: i64,
     generation: u64,
 ) -> Option<TerminalEngineSlot> {
     let target = Some((track_id, generation));
     if fading == target {
         Some(TerminalEngineSlot::FadingOut)
+    } else if drop_preview == target {
+        Some(TerminalEngineSlot::DropPreview)
     } else if next == target {
         Some(TerminalEngineSlot::Next)
     } else if active == target {
@@ -4054,6 +4415,128 @@ mod tests {
     }
 
     #[test]
+    fn drop_preview_overlay_starts_without_promotion_or_crossfade_window() {
+        let mut state = test_runtime_loop_state();
+        start_dj_lookahead_in_state(
+            &mut state,
+            Some(DjMediaRef::LibraryTrack { track_id: 1 }),
+            Some(DjMediaRef::LibraryTrack { track_id: 2 }),
+            Some(11),
+            Some(12),
+            20,
+            48_000,
+        );
+
+        let active = test_engine_with_shared(1, 20);
+        active
+            .shared
+            .position_samples
+            .store(96_000, Ordering::Relaxed);
+        finish_engine_buffer(&active, &[0.1, 0.1, 0.2, 0.2]);
+
+        let mut real_next = test_engine_with_shared(2, 21);
+        real_next.shared.paused.store(true, Ordering::SeqCst);
+        real_next.job = PreparedPlaybackJob::test_fixture(2, 21)
+            .with_prepared_transition(test_prepared_transition_program(20, Some(11), Some(12)));
+        finish_engine_buffer(&real_next, &[0.3, 0.3, 0.4, 0.4]);
+
+        let mut transition = test_prepared_transition_program(20, Some(11), Some(12));
+        transition.program.template = "DropPreview16".to_string();
+        transition.program.automation = vec![
+            noor_mix::AutomationEvent {
+                param: noor_mix::Param::DeckGain(noor_mix::DeckId::A),
+                start_sample: 0,
+                end_sample: transition.program.resolve_at,
+                from: 0.0,
+                to: 0.0,
+                curve: noor_mix::Curve::Linear,
+            },
+            noor_mix::AutomationEvent {
+                param: noor_mix::Param::DeckGain(noor_mix::DeckId::B),
+                start_sample: 0,
+                end_sample: transition.program.resolve_at,
+                from: 0.65,
+                to: 0.65,
+                curve: noor_mix::Curve::Linear,
+            },
+        ];
+        let mut preview = test_engine_with_shared(2, 21);
+        preview.shared.paused.store(true, Ordering::SeqCst);
+        preview.job = PreparedPlaybackJob::test_fixture(2, 21).with_prepared_transition(transition);
+        finish_engine_buffer(&preview, &[0.0, 0.0, 0.4, 0.4]);
+
+        state.engine = Some(active);
+        state.next_engine = Some(real_next);
+        state.drop_preview_engine = Some(preview);
+
+        assert!(prepare_drop_preview_mixer(&mut state, 64).is_ok());
+        let (event_tx, mut event_rx) = tokio::sync::broadcast::channel(8);
+        assert!(start_prepared_drop_preview_overlay(&mut state, &event_tx, 120_000).is_ok());
+
+        assert!(state.prepared_drop_preview_mixer.is_none());
+        assert_eq!(state.engine.as_ref().map(|engine| engine.track_id), Some(1));
+        assert_eq!(
+            state.next_engine.as_ref().map(|engine| engine.track_id),
+            Some(2)
+        );
+        assert!(
+            state
+                .next_engine
+                .as_ref()
+                .expect("real next engine")
+                .shared
+                .paused
+                .load(Ordering::SeqCst)
+        );
+        let active = state.engine.as_ref().expect("active engine");
+        assert_eq!(active.shared.crossfade_samples.load(Ordering::Relaxed), 0);
+        let preview = state.drop_preview_engine.as_ref().expect("preview engine");
+        assert!(!preview.shared.paused.load(Ordering::SeqCst));
+        let buffer = preview.shared.buffer.lock().expect("preview buffer");
+        assert_samples_close(&buffer.samples, &[0.0, 0.0, 0.26, 0.26]);
+        match event_rx.try_recv().expect("preview event") {
+            PlaybackRuntimeEvent::DropPreviewStarted {
+                track_id,
+                generation,
+                actual_start_ms,
+            } => {
+                assert_eq!(track_id, 1);
+                assert_eq!(generation, 20);
+                assert_eq!(actual_start_ms, 120_000);
+            }
+            other => panic!("expected preview event, got {other:?}"),
+        }
+        assert!(
+            event_rx.try_recv().is_err(),
+            "preview must not finish outgoing"
+        );
+    }
+
+    #[test]
+    fn arming_drop_preview_sets_absolute_trigger_without_crossfade_samples() {
+        let mut state = test_runtime_loop_state();
+        let active = test_engine_with_shared(1, 20);
+        active.shared.crossfade_samples.store(0, Ordering::Relaxed);
+        state.engine = Some(active);
+
+        assert!(arm_drop_preview_in_state(&state, 1, 20, 144_000));
+
+        assert_eq!(
+            state.next_engine.as_ref().map(|engine| engine.track_id),
+            None
+        );
+        let active = state.engine.as_ref().expect("active engine");
+        assert_eq!(active.shared.crossfade_samples.load(Ordering::Relaxed), 0);
+        assert_eq!(
+            active
+                .shared
+                .drop_preview_trigger_samples
+                .load(Ordering::Relaxed),
+            144_000
+        );
+    }
+
+    #[test]
     fn mixer_promotion_stops_outgoing_without_legacy_fade() {
         let mut state = test_runtime_loop_state();
         start_dj_lookahead_in_state(
@@ -4832,15 +5315,19 @@ mod tests {
     #[test]
     fn terminal_engine_slot_identifies_prebuffered_track() {
         assert_eq!(
-            terminal_engine_slot(Some((1, 1)), Some((2, 1)), None, 2, 1),
+            terminal_engine_slot(Some((1, 1)), Some((2, 1)), None, None, 2, 1),
             Some(TerminalEngineSlot::Next)
         );
         assert_eq!(
-            terminal_engine_slot(Some((1, 1)), Some((2, 1)), Some((3, 1)), 3, 1),
+            terminal_engine_slot(Some((1, 1)), Some((2, 1)), Some((3, 1)), None, 3, 1),
             Some(TerminalEngineSlot::FadingOut)
         );
         assert_eq!(
-            terminal_engine_slot(Some((1, 1)), Some((2, 1)), Some((3, 1)), 4, 1),
+            terminal_engine_slot(Some((1, 1)), Some((2, 1)), Some((3, 1)), Some((4, 1)), 4, 1),
+            Some(TerminalEngineSlot::DropPreview)
+        );
+        assert_eq!(
+            terminal_engine_slot(Some((1, 1)), Some((2, 1)), Some((3, 1)), None, 4, 1),
             None
         );
     }
@@ -4971,13 +5458,20 @@ mod tests {
         let active = test_engine_with_shared(10, 1);
         let prepared = test_engine_with_shared(11, 1);
         let fading = test_engine_with_shared(9, 1);
+        let drop_preview = test_engine_with_shared(12, 1);
 
-        let sources = exclusive_render_sources(Some(&active), Some(&prepared), Some(&fading));
+        let sources = exclusive_render_sources(
+            Some(&active),
+            Some(&prepared),
+            Some(&fading),
+            Some(&drop_preview),
+        );
 
-        assert_eq!(sources.len(), 3);
+        assert_eq!(sources.len(), 4);
         assert_eq!(sources[0].role, ExclusiveRenderRole::Active);
         assert_eq!(sources[1].role, ExclusiveRenderRole::Prepared);
         assert_eq!(sources[2].role, ExclusiveRenderRole::Fading);
+        assert_eq!(sources[3].role, ExclusiveRenderRole::Prepared);
     }
 
     #[test]
@@ -5133,6 +5627,7 @@ mod tests {
             exclusive_sink: ExclusiveRuntimeSink::new(),
             engine: None,
             next_engine: None,
+            drop_preview_engine: None,
             fading_out_engine: None,
             current_exclusive: false,
             current_sample_rate_follow: false,
@@ -5144,6 +5639,7 @@ mod tests {
             dj_lookahead: None,
             dj_lookahead_failure: None,
             prepared_dj_mixer: None,
+            prepared_drop_preview_mixer: None,
             last_dj_renderer_failure: None,
         }
     }

--- a/noor-server/src/playback/runtime/shared.rs
+++ b/noor-server/src/playback/runtime/shared.rs
@@ -279,6 +279,23 @@ fn write_output_buffer<T>(
             }
         }
     }
+
+    if !shared.drop_preview_start_signaled.load(Ordering::Relaxed) {
+        let trigger = shared.drop_preview_trigger_samples.load(Ordering::Relaxed);
+        if trigger != u64::MAX {
+            let pos = shared.position_samples.load(Ordering::Relaxed);
+            if pos >= trigger {
+                shared
+                    .drop_preview_start_signaled
+                    .store(true, Ordering::Relaxed);
+                let _ = command_tx.send(PlaybackRuntimeCommand::DropPreviewStart {
+                    track_id: shared.track_id,
+                    generation: shared.generation,
+                    trigger_position_samples: pos,
+                });
+            }
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -326,6 +343,8 @@ pub(crate) struct PlaybackSharedState {
     pub(crate) crossfade_samples: AtomicU64,
     pub(crate) crossfade_start_signaled: AtomicBool,
     pub(crate) suppress_crossfade_after_seek: AtomicBool,
+    pub(crate) drop_preview_trigger_samples: AtomicU64,
+    pub(crate) drop_preview_start_signaled: AtomicBool,
     pub(crate) fadein_start_samples: AtomicU64,
     pub(crate) device_sample_rate: u32,
     pub(crate) device_channels: u16,
@@ -378,6 +397,8 @@ impl PlaybackSharedState {
             crossfade_samples: AtomicU64::new(crossfade_samples),
             crossfade_start_signaled: AtomicBool::new(false),
             suppress_crossfade_after_seek: AtomicBool::new(false),
+            drop_preview_trigger_samples: AtomicU64::new(u64::MAX),
+            drop_preview_start_signaled: AtomicBool::new(false),
             fadein_start_samples: AtomicU64::new(u64::MAX),
             device_sample_rate,
             device_channels,
@@ -872,6 +893,42 @@ mod tests {
                 assert_eq!(trigger_position_samples, 9_604);
             }
             other => panic!("expected CrossfadeStart, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn drop_preview_start_command_uses_absolute_trigger_without_crossfade() {
+        let shared = test_shared_state();
+        shared.total_samples.store(100_000, Ordering::Relaxed);
+        shared.position_samples.store(48_000, Ordering::Relaxed);
+        shared
+            .drop_preview_trigger_samples
+            .store(48_000, Ordering::Relaxed);
+        shared
+            .drop_preview_start_signaled
+            .store(false, Ordering::Relaxed);
+        {
+            let mut buffer = shared.buffer.lock().expect("buffer lock");
+            buffer.samples.extend_from_slice(&[0.5, 0.5, 0.5, 0.5]);
+        }
+
+        let (command_tx, command_rx) = mpsc::channel();
+        let (event_tx, _) = tokio::sync::broadcast::channel(8);
+        let mut out = [0.0_f32; 4];
+        write_output_f32(&mut out, &shared, &command_tx, &event_tx);
+
+        assert_eq!(shared.crossfade_samples.load(Ordering::Relaxed), 0);
+        match command_rx.try_recv().expect("drop preview command") {
+            PlaybackRuntimeCommand::DropPreviewStart {
+                track_id,
+                generation,
+                trigger_position_samples,
+            } => {
+                assert_eq!(track_id, shared.track_id);
+                assert_eq!(generation, shared.generation);
+                assert_eq!(trigger_position_samples, 48_004);
+            }
+            other => panic!("expected DropPreviewStart, got {other:?}"),
         }
     }
 

--- a/noor-server/src/playback/runtime/shared.rs
+++ b/noor-server/src/playback/runtime/shared.rs
@@ -273,6 +273,7 @@ fn write_output_buffer<T>(
                     let _ = command_tx.send(PlaybackRuntimeCommand::CrossfadeStart {
                         track_id: shared.track_id,
                         generation: shared.generation,
+                        trigger_position_samples: pos,
                     });
                 }
             }
@@ -842,6 +843,36 @@ mod tests {
             command_rx.try_recv().is_err(),
             "no CrossfadeStart command should be queued yet"
         );
+    }
+
+    #[test]
+    fn crossfade_start_command_captures_callback_position() {
+        let shared = test_shared_state();
+        shared.total_samples.store(10_000, Ordering::Relaxed);
+        shared.position_samples.store(9_600, Ordering::Relaxed);
+        shared.crossfade_samples.store(500, Ordering::Relaxed);
+        {
+            let mut buffer = shared.buffer.lock().expect("buffer lock");
+            buffer.samples.extend_from_slice(&[0.5, 0.5, 0.5, 0.5]);
+        }
+
+        let (command_tx, command_rx) = mpsc::channel();
+        let (event_tx, _) = tokio::sync::broadcast::channel(8);
+        let mut out = [0.0_f32; 4];
+        write_output_f32(&mut out, &shared, &command_tx, &event_tx);
+
+        match command_rx.try_recv().expect("crossfade command") {
+            PlaybackRuntimeCommand::CrossfadeStart {
+                track_id,
+                generation,
+                trigger_position_samples,
+            } => {
+                assert_eq!(track_id, shared.track_id);
+                assert_eq!(generation, shared.generation);
+                assert_eq!(trigger_position_samples, 9_604);
+            }
+            other => panic!("expected CrossfadeStart, got {other:?}"),
+        }
     }
 
     #[test]

--- a/noor-server/src/server/radio_pipeline.rs
+++ b/noor-server/src/server/radio_pipeline.rs
@@ -167,6 +167,7 @@ fn rank_radio_candidates(
             track_id: (candidate.is_in_library && candidate.track_id > 0)
                 .then_some(candidate.track_id),
             tidal_id: candidate.tidal_track_id,
+            policy: Default::default(),
             item: candidate,
         })
         .collect::<Vec<_>>();

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -11658,8 +11658,20 @@ fn spawn_playback_runtime_listener(
                 }
                 Ok(playback_runtime::PlaybackRuntimeEvent::Paused { .. })
                 | Ok(playback_runtime::PlaybackRuntimeEvent::Resumed { .. })
-                | Ok(playback_runtime::PlaybackRuntimeEvent::Preparing { .. })
-                | Ok(playback_runtime::PlaybackRuntimeEvent::DropPreviewStarted { .. }) => {}
+                | Ok(playback_runtime::PlaybackRuntimeEvent::Preparing { .. }) => {}
+                Ok(playback_runtime::PlaybackRuntimeEvent::DropPreviewStarted {
+                    track_id,
+                    generation,
+                    actual_start_ms,
+                }) => {
+                    let mut state_guard = state.write().await;
+                    state_guard.last_drop_preview = Some(crate::DropPreviewRuntimeState {
+                        track_id,
+                        generation,
+                        actual_fire_ms: actual_start_ms,
+                    });
+                    let _ = state_guard.event_tx.send(AppEvent::PlaybackStateChanged);
+                }
                 Ok(playback_runtime::PlaybackRuntimeEvent::Stopped) => {
                     let mut state_guard = state.write().await;
                     state_guard
@@ -11674,6 +11686,7 @@ fn spawn_playback_runtime_listener(
                     state_guard.current_stream_display = None;
                     state_guard.pending_stream_display = None;
                     state_guard.next_prebuffer_inflight = None;
+                    state_guard.last_drop_preview = None;
                 }
                 Ok(playback_runtime::PlaybackRuntimeEvent::NearEnd {
                     track_id,
@@ -14401,6 +14414,7 @@ mod tests {
             current_stream_display: None,
             pending_stream_display: None,
             next_prebuffer_inflight: None,
+            last_drop_preview: None,
             active_listen_session: None,
             live_listen_session: None,
             external_playback_track: None,

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -11437,7 +11437,8 @@ fn spawn_playback_runtime_listener(
                 }
                 Ok(playback_runtime::PlaybackRuntimeEvent::Paused { .. })
                 | Ok(playback_runtime::PlaybackRuntimeEvent::Resumed { .. })
-                | Ok(playback_runtime::PlaybackRuntimeEvent::Preparing { .. }) => {}
+                | Ok(playback_runtime::PlaybackRuntimeEvent::Preparing { .. })
+                | Ok(playback_runtime::PlaybackRuntimeEvent::DropPreviewStarted { .. }) => {}
                 Ok(playback_runtime::PlaybackRuntimeEvent::Stopped) => {
                     let mut state_guard = state.write().await;
                     state_guard

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -31,7 +31,7 @@ use rusqlite::{OptionalExtension, params};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 use tracing::{error, info, warn};
 
@@ -51,11 +51,17 @@ mod tidal_sync_routes;
 pub use tidal_sync_routes::trigger_auto_sync;
 
 type TidalPlaylistTracksCache = Arc<Mutex<HashMap<String, (Instant, Vec<TidalTrack>)>>>;
+type DropPreviewArmKey = (i64, i64, u64);
 
 const TIDAL_PLAYLIST_TRACKS_CACHE_TTL: Duration = Duration::from_secs(60 * 60);
 const EPHEMERAL_DJ_LOOKAHEAD_DEADLINE_SAMPLES: u64 = 48_000 * 30;
+const DROP_PREVIEW_DURATION_MS: u32 = 16_000;
+const DROP_PREVIEW_ARM_RETRY_SECS: u64 = 60 * 60;
 const PLAYBACK_FINISH_DB_LOCK_RETRY_LIMIT: usize = 60;
 const PLAYBACK_FINISH_DB_LOCK_RETRY_DELAY_SECS: u64 = 2;
+
+static DROP_PREVIEW_ARM_ATTEMPTS: OnceLock<Mutex<HashMap<DropPreviewArmKey, Instant>>> =
+    OnceLock::new();
 
 async fn queue_missing_dj_profiles_after_pair_change(state: SharedState, context: &'static str) {
     if let Err(status) = dj_routes::queue_missing_dj_profiles_for_current_pair(state).await {
@@ -95,8 +101,223 @@ async fn start_dj_lookahead_and_queue_profiles_after_pair_change(
     };
     if let Some(lookahead) = lookahead {
         let _ = lookahead.dispatch(&handle);
+        spawn_drop_preview_scheduler(state.clone(), handle, lookahead);
     }
     queue_missing_dj_profiles_after_pair_change(state, context).await;
+}
+
+fn spawn_drop_preview_scheduler(
+    state: SharedState,
+    handle: playback_runtime::PlaybackRuntimeHandle,
+    lookahead: player::DjLookaheadStart,
+) {
+    tokio::spawn(async move {
+        if let Err(error) = schedule_drop_preview_for_pair(state, handle, lookahead).await {
+            warn!("Drop preview scheduling skipped: {error:?}");
+        }
+    });
+}
+
+async fn schedule_drop_preview_for_pair(
+    state: SharedState,
+    handle: playback_runtime::PlaybackRuntimeHandle,
+    lookahead: player::DjLookaheadStart,
+) -> anyhow::Result<()> {
+    let Some(current_ref) = lookahead.current.clone() else {
+        return Ok(());
+    };
+    let Some(next_ref) = lookahead.next.clone() else {
+        return Ok(());
+    };
+    let (Some(current_track_id), Some(next_track_id)) =
+        (current_ref.track_id(), next_ref.track_id())
+    else {
+        return Ok(());
+    };
+    if !claim_drop_preview_arm(current_track_id, next_track_id, lookahead.queue_generation) {
+        return Ok(());
+    }
+
+    let (next, runtime_info, user_quality) = {
+        let state_guard = state.read().await;
+        let active_id = state_guard
+            .playback_runtime_info
+            .as_ref()
+            .and_then(|info| info.active_track_id);
+        if active_id != Some(current_track_id)
+            || current_playback_generation(&state_guard) != lookahead.queue_generation
+        {
+            return Ok(());
+        }
+        let current = state_guard
+            .db
+            .with_conn(|conn| queue::get_track_by_id(conn, current_track_id))?
+            .context("drop preview current track missing")?;
+        let next = state_guard
+            .db
+            .with_conn(|conn| queue::get_track_by_id(conn, next_track_id))?
+            .context("drop preview next track missing")?;
+        let plan = state_guard.db.with_conn(|conn| {
+            dj_routes::drop_preview_plan_for_pair(
+                conn,
+                &current_ref,
+                &next_ref,
+                current.duration_ms,
+            )
+        })?;
+        let Some(plan) = plan else {
+            return Ok(());
+        };
+        let info = state_guard
+            .playback_runtime_info
+            .clone()
+            .context("playback runtime info missing")?;
+        let position_ms = handle.get_position_ms(info.sample_rate, info.channels);
+        if position_ms >= plan.planned_fire_ms {
+            return Ok(());
+        }
+        (
+            next,
+            (info.sample_rate, info.channels, plan),
+            current_user_audio_quality_locked(&state_guard),
+        )
+    };
+
+    let stream_request = match player::build_tidal_stream_request(&next, user_quality.clone()) {
+        Some(request) => request,
+        None => return Ok(()),
+    };
+    let stream_info = match resolve_tidal_playback_stream(&state, &next, &stream_request).await {
+        Ok(info) => Some(info),
+        Err(error) => {
+            warn!(
+                "Skipping drop preview for next track {}: {}",
+                next.id,
+                describe_tidal_playback_error(&error)
+            );
+            return Ok(());
+        }
+    };
+
+    let (sample_rate, channels, plan) = runtime_info;
+    let engine = {
+        let state_guard = state.read().await;
+        crate::playback::dj_engine::DjEngine::new(state_guard.db.clone())
+    };
+    let Some(program) = engine.plan_drop_preview(
+        &current_ref,
+        &next_ref,
+        stream_info
+            .as_ref()
+            .and_then(|info| info.sample_rate_hz())
+            .unwrap_or(sample_rate),
+        channels,
+        DROP_PREVIEW_DURATION_MS,
+    )?
+    else {
+        return Ok(());
+    };
+
+    let mut job = player::build_playback_preparation(&next, stream_info.as_ref(), 0, user_quality)
+        .with_generation(lookahead.queue_generation)
+        .with_dj_media_ref(next_ref.clone())
+        .with_prepared_transition(player::PreparedTransitionProgram {
+            program,
+            transition_event_id: None,
+            fire_ahead_ms: 0,
+            queue_generation: lookahead.queue_generation,
+            current_queue_item_id: lookahead.current_queue_item_id,
+            next_queue_item_id: lookahead.next_queue_item_id,
+        });
+    job.gapless = crate::playback::gapless::GaplessPlan::disabled();
+
+    {
+        let state_guard = state.read().await;
+        let active_id = state_guard
+            .playback_runtime_info
+            .as_ref()
+            .and_then(|info| info.active_track_id);
+        if active_id != Some(current_track_id)
+            || current_playback_generation(&state_guard) != lookahead.queue_generation
+        {
+            return Ok(());
+        }
+        let info = state_guard
+            .playback_runtime_info
+            .as_ref()
+            .context("playback runtime info missing")?;
+        let position_ms = handle.get_position_ms(info.sample_rate, info.channels);
+        if position_ms >= plan.planned_fire_ms {
+            return Ok(());
+        }
+    }
+
+    let trigger_position_samples =
+        samples_from_ms_for_runtime(plan.planned_fire_ms, sample_rate, channels);
+    handle.prepare_drop_preview(job)?;
+    handle.arm_drop_preview(
+        current_track_id,
+        lookahead.queue_generation,
+        trigger_position_samples,
+    )?;
+    info!(
+        current_track_id,
+        next_track_id = next.id,
+        planned_fire_ms = plan.planned_fire_ms,
+        incoming_drop_ms = plan.incoming_drop_ms,
+        source = %plan.source,
+        "Drop preview armed"
+    );
+    Ok(())
+}
+
+fn current_user_audio_quality_locked(
+    state: &crate::AppState,
+) -> Option<crate::db::audio_settings::AudioQuality> {
+    state
+        .db
+        .with_conn(|conn| crate::db::audio_settings::load(conn).map_err(anyhow::Error::from))
+        .ok()
+        .map(|settings| settings.quality)
+}
+
+fn samples_from_ms_for_runtime(ms: i64, sample_rate: u32, channels: u16) -> u64 {
+    let ms = ms.max(0) as u64;
+    ms.saturating_mul(sample_rate.max(1) as u64)
+        .saturating_mul(channels.max(1) as u64)
+        / 1000
+}
+
+fn claim_drop_preview_arm(current_track_id: i64, next_track_id: i64, generation: u64) -> bool {
+    let attempts = DROP_PREVIEW_ARM_ATTEMPTS.get_or_init(|| Mutex::new(HashMap::new()));
+    let now = Instant::now();
+    let mut attempts = attempts.lock().unwrap_or_else(|error| error.into_inner());
+    claim_drop_preview_arm_at(
+        &mut attempts,
+        current_track_id,
+        next_track_id,
+        generation,
+        now,
+    )
+}
+
+fn claim_drop_preview_arm_at(
+    attempts: &mut HashMap<DropPreviewArmKey, Instant>,
+    current_track_id: i64,
+    next_track_id: i64,
+    generation: u64,
+    now: Instant,
+) -> bool {
+    let retry_after = Duration::from_secs(DROP_PREVIEW_ARM_RETRY_SECS);
+    attempts.retain(|_, last_attempt| now.duration_since(*last_attempt) < retry_after);
+    let key = (current_track_id, next_track_id, generation);
+    if let Some(last_attempt) = attempts.get(&key)
+        && now.duration_since(*last_attempt) < retry_after
+    {
+        return false;
+    }
+    attempts.insert(key, now);
+    true
 }
 
 async fn refresh_dj_after_queue_change(state: SharedState, context: &'static str) {

--- a/noor-server/src/server/routes/dj_routes.rs
+++ b/noor-server/src/server/routes/dj_routes.rs
@@ -217,6 +217,13 @@ struct DjDropPreviewStatus {
     reason: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DropPreviewPlan {
+    pub(crate) planned_fire_ms: i64,
+    pub(crate) incoming_drop_ms: i64,
+    pub(crate) source: String,
+}
+
 #[derive(Debug, Serialize)]
 struct DjSafeSuggestion {
     media_ref_kind: String,
@@ -1697,6 +1704,43 @@ fn drop_preview_status(
         source: Some(source.to_string()),
         reason: None,
     })
+}
+
+pub(crate) fn drop_preview_plan_for_pair(
+    conn: &rusqlite::Connection,
+    current_ref: &DjMediaRef,
+    next_ref: &DjMediaRef,
+    current_duration_ms: Option<i64>,
+) -> anyhow::Result<Option<DropPreviewPlan>> {
+    let enabled = queries::is_dj_engine_enabled(conn)?;
+    let current = deck_status(conn, current_ref, None, false)?;
+    let next = deck_status(conn, next_ref, None, false)?;
+    let status = drop_preview_status(
+        conn,
+        enabled,
+        Some(current_ref),
+        Some(next_ref),
+        Some(&current),
+        Some(&next),
+        current_duration_ms,
+    )?;
+    Ok(
+        match (
+            status.status.as_str(),
+            status.planned_fire_ms,
+            status.incoming_drop_ms,
+            status.source,
+        ) {
+            ("armed", Some(planned_fire_ms), Some(incoming_drop_ms), Some(source)) => {
+                Some(DropPreviewPlan {
+                    planned_fire_ms,
+                    incoming_drop_ms,
+                    source,
+                })
+            }
+            _ => None,
+        },
+    )
 }
 
 fn incoming_drop_marker(next: Option<&DjDeckStatus>) -> Option<(i64, &'static str)> {

--- a/noor-server/src/server/routes/dj_routes.rs
+++ b/noor-server/src/server/routes/dj_routes.rs
@@ -26,7 +26,7 @@ use crate::playback::runtime::PlaybackRuntimeConfig;
 use crate::playback::runtime::commands::PlaybackRuntimeCommand;
 use crate::playback::runtime::shared::PlaybackSharedState;
 use crate::services::audio_analysis::dj_profile::{
-    DJ_PROFILE_VERSION, DJ_WAVEFORM_PEAK_COUNT, decode_f32_blob, decode_u32_blob,
+    DJ_WAVEFORM_PEAK_COUNT, decode_f32_blob, decode_u32_blob, dj_profile_row_is_current,
 };
 use crate::services::tidal::stream as tidal_stream;
 
@@ -571,6 +571,10 @@ pub(super) async fn queue_missing_dj_profiles_for_current_pair(
                 if !queries::is_dj_engine_enabled(conn)? {
                     return Ok(Vec::new());
                 }
+                if foreground_playback_is_buffering(conn, &state_guard)? {
+                    tracing::debug!("Deferring DJ profile rebuilds while playback is buffering");
+                    return Ok(Vec::new());
+                }
                 let pair = match ephemeral_pair {
                     Some(pair) => pair,
                     None => crate::playback::dj_lookahead::load_dj_lookahead_pair(conn)?,
@@ -946,7 +950,6 @@ async fn queue_tidal_profile_rebuild(
             }
             tracing::warn!(tidal_id, error = %message, "DJ profile rebuild decode failed");
         } else {
-            clear_dj_profile_inflight(&inflight_for_decode, &inflight_key_for_decode);
             clear_dj_profile_rebuild_failure(&failure_key);
             tracing::info!(tidal_id, "DJ profile rebuild decode queued analysis");
         }
@@ -998,8 +1001,23 @@ fn dj_profile_inflight_key(key: &AudioDjProfileKey) -> String {
     format!("{}:{}", key.media_ref_kind, key.media_ref_id)
 }
 
+fn foreground_playback_is_buffering(
+    conn: &rusqlite::Connection,
+    state: &crate::AppState,
+) -> anyhow::Result<bool> {
+    if state
+        .audio_active
+        .load(std::sync::atomic::Ordering::Relaxed)
+        || state.playback_runtime.is_none()
+    {
+        return Ok(false);
+    }
+    Ok(player::load_state(conn)?.is_playing)
+}
+
 fn deck_needs_profile_rebuild(deck: &DjDeckStatus) -> bool {
-    !deck.profile_ready && matches!(deck.profile_status.as_str(), "missing" | "retrying")
+    (!deck.profile_ready && matches!(deck.profile_status.as_str(), "missing" | "retrying"))
+        || (deck.profile_ready && deck.waveform_status == "missing")
 }
 
 #[cfg(test)]
@@ -1415,8 +1433,10 @@ fn dj_profile_is_current_version(
     conn: &rusqlite::Connection,
     key: &AudioDjProfileKey,
 ) -> anyhow::Result<bool> {
-    Ok(queries::get_audio_dj_profile(conn, key)?
-        .is_some_and(|row| row.profile_version == DJ_PROFILE_VERSION))
+    Ok(
+        queries::get_audio_dj_profile(conn, key)?
+            .is_some_and(|row| dj_profile_row_is_current(&row)),
+    )
 }
 
 fn correction_response(row: AudioDjProfileCorrectionRow) -> DjProfileCorrectionResponse {
@@ -2175,7 +2195,7 @@ fn feedback_rating(value: &str) -> Option<i64> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::services::audio_analysis::dj_profile::encode_f32_blob;
+    use crate::services::audio_analysis::dj_profile::{DJ_PROFILE_VERSION, encode_f32_blob};
 
     fn test_profile_row(key: &AudioDjProfileKey, version: &str) -> AudioDjProfileRow {
         AudioDjProfileRow {
@@ -2257,6 +2277,11 @@ mod tests {
             .expect("current profile");
 
         assert!(dj_profile_is_current_version(&conn, &key).expect("current"));
+        let mut current_without_waveform = test_profile_row(&key, DJ_PROFILE_VERSION);
+        current_without_waveform.waveform_peaks_blob = encode_f32_blob(&[]);
+        queries::upsert_audio_dj_profile(&conn, &current_without_waveform)
+            .expect("profile missing waveform");
+        assert!(!dj_profile_is_current_version(&conn, &key).expect("missing waveform"));
     }
 
     #[test]
@@ -2312,6 +2337,7 @@ mod tests {
 
         assert_eq!(deck.waveform_status, "missing");
         assert!(deck.waveform_peaks.is_empty());
+        assert!(deck_needs_profile_rebuild(&deck));
     }
 
     #[test]

--- a/noor-server/src/server/routes/dj_routes.rs
+++ b/noor-server/src/server/routes/dj_routes.rs
@@ -189,6 +189,8 @@ struct DjDeckStatus {
     profile_ready: bool,
     profile_status: String,
     profile_error: Option<String>,
+    profile_retry_after_ms: Option<i64>,
+    profile_retry_reason: Option<String>,
     profile_confidence: Option<f64>,
     beat_count: Option<usize>,
     downbeat_count: Option<usize>,
@@ -358,6 +360,8 @@ enum ProfileRebuildInflightDecision {
 struct DjProfileRebuildFailure {
     status: String,
     message: String,
+    retry_reason: Option<String>,
+    next_retry_at: Option<Instant>,
     recorded_at: Instant,
 }
 
@@ -981,13 +985,29 @@ async fn queue_tidal_profile_rebuild(
     let inflight_for_decode = inflight.clone();
     let inflight_key_for_decode = inflight_key.clone();
     let failure_key = inflight_key.clone();
+    let retry_state = state.clone();
+    let event_tx = {
+        let state_guard = state.read().await;
+        state_guard.event_tx.clone()
+    };
+    let runtime_handle = tokio::runtime::Handle::current();
     tokio::task::spawn_blocking(move || {
         if let Err(error) = decode_and_buffer_job(config, job, shared, 48_000, 2) {
             let status = profile_rebuild_failure_status(&error);
             let message = profile_rebuild_error_message(&error, status);
-            record_dj_profile_rebuild_failure(&failure_key, status, message.clone());
-            if status != "retrying" {
-                clear_dj_profile_inflight(&inflight_for_decode, &inflight_key_for_decode);
+            finish_dj_profile_rebuild_failure(
+                &inflight_for_decode,
+                &inflight_key_for_decode,
+                status,
+                message.clone(),
+            );
+            let _ = event_tx.send(crate::AppEvent::PlaybackStateChanged);
+            if status == "retrying" {
+                schedule_dj_profile_retry(
+                    &runtime_handle,
+                    retry_state,
+                    Duration::from_secs(DJ_PROFILE_AUTO_REBUILD_RETRY_SECS),
+                );
             }
             tracing::warn!(tidal_id, error = %message, "DJ profile rebuild decode failed");
         } else {
@@ -1057,7 +1077,10 @@ fn foreground_playback_is_buffering(
 }
 
 fn deck_needs_profile_rebuild(deck: &DjDeckStatus) -> bool {
-    (!deck.profile_ready && matches!(deck.profile_status.as_str(), "missing" | "retrying"))
+    (!deck.profile_ready
+        && (deck.profile_status == "missing"
+            || (deck.profile_status == "retrying"
+                && deck.profile_retry_after_ms.unwrap_or(0) <= 0)))
         || (deck.profile_ready && deck.waveform_status == "missing")
 }
 
@@ -1094,17 +1117,49 @@ fn clear_dj_profile_inflight(
     }
 }
 
+fn finish_dj_profile_rebuild_failure(
+    inflight: &Arc<std::sync::Mutex<std::collections::HashMap<String, std::time::Instant>>>,
+    key: &str,
+    status: &str,
+    message: String,
+) {
+    record_dj_profile_rebuild_failure(key, status, message);
+    clear_dj_profile_inflight(inflight, key);
+}
+
+fn schedule_dj_profile_retry(
+    runtime: &tokio::runtime::Handle,
+    state: SharedState,
+    delay: Duration,
+) {
+    runtime.spawn(async move {
+        tokio::time::sleep(delay).await;
+        if let Err(status) = queue_missing_dj_profiles_for_current_pair(state).await {
+            tracing::warn!(
+                ?status,
+                "Scheduled DJ profile retry failed to queue current pair"
+            );
+        }
+    });
+}
+
 fn profile_rebuild_failures() -> &'static Mutex<HashMap<String, DjProfileRebuildFailure>> {
     DJ_PROFILE_REBUILD_FAILURES.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
 fn record_dj_profile_rebuild_failure(key: &str, status: &str, message: String) {
     if let Ok(mut guard) = profile_rebuild_failures().lock() {
+        let retry_reason = profile_rebuild_retry_reason(status, &message);
+        let next_retry_at = retry_reason
+            .as_ref()
+            .map(|_| Instant::now() + Duration::from_secs(DJ_PROFILE_AUTO_REBUILD_RETRY_SECS));
         guard.insert(
             key.to_string(),
             DjProfileRebuildFailure {
                 status: status.to_string(),
                 message,
+                retry_reason,
+                next_retry_at,
                 recorded_at: Instant::now(),
             },
         );
@@ -1153,6 +1208,37 @@ fn profile_rebuild_error_is_retryable(message: &str) -> bool {
         || lower.contains("request failed")
         || lower.contains("chunk error")
         || lower.contains("returned error status")
+}
+
+fn profile_rebuild_retry_reason(status: &str, message: &str) -> Option<String> {
+    if status != "retrying" {
+        return None;
+    }
+    let lower = message.to_ascii_lowercase();
+    let reason = if lower.contains("asset") || lower.contains("substatus") {
+        "asset_not_ready"
+    } else if lower.contains("dash") || lower.contains("prebuffer") {
+        "dash_prebuffer"
+    } else if lower.contains("timed out") || lower.contains("timeout") {
+        "timeout"
+    } else {
+        "transient_decode"
+    };
+    Some(reason.to_string())
+}
+
+fn profile_rebuild_retry_after_ms(failure: &DjProfileRebuildFailure) -> Option<i64> {
+    let next_retry_at = failure.next_retry_at?;
+    let now = Instant::now();
+    if next_retry_at <= now {
+        return Some(0);
+    }
+    Some(
+        next_retry_at
+            .duration_since(now)
+            .as_millis()
+            .min(i64::MAX as u128) as i64,
+    )
 }
 
 fn profile_rebuild_error_message(error: &anyhow::Error, status: &str) -> String {
@@ -1519,6 +1605,12 @@ fn deck_status(
     } else {
         "missing".to_string()
     };
+    let profile_retry_after_ms = rebuild_failure
+        .as_ref()
+        .and_then(profile_rebuild_retry_after_ms);
+    let profile_retry_reason = rebuild_failure
+        .as_ref()
+        .and_then(|failure| failure.retry_reason.clone());
     let profile_error = rebuild_failure.map(|failure| failure.message);
     let (title, artist) = match label_override {
         Some((title, artist)) => (title.clone(), artist.clone()),
@@ -1586,6 +1678,8 @@ fn deck_status(
         profile_ready: profile.is_some(),
         profile_status,
         profile_error,
+        profile_retry_after_ms,
+        profile_retry_reason,
         profile_confidence,
         beat_count,
         downbeat_count,
@@ -1655,7 +1749,7 @@ fn drop_preview_status(
     current_duration_ms: Option<i64>,
     actual_fire_ms: Option<i64>,
 ) -> anyhow::Result<DjDropPreviewStatus> {
-    let skipped = |reason: &'static str| DjDropPreviewStatus {
+    let skipped = |reason: &str| DjDropPreviewStatus {
         status: "skipped".to_string(),
         planned_fire_ms: None,
         actual_fire_ms: None,
@@ -1672,8 +1766,13 @@ fn drop_preview_status(
     else {
         return Ok(skipped("pair_missing"));
     };
-    if !current.profile_ready || !next.profile_ready {
-        return Ok(skipped("profiles_missing"));
+    if !current.profile_ready {
+        return Ok(skipped(&deck_profile_unavailable_reason(
+            "current", current,
+        )));
+    }
+    if !next.profile_ready {
+        return Ok(skipped(&deck_profile_unavailable_reason("next", next)));
     }
     if current.safe_crossfade_only || next.safe_crossfade_only {
         return Ok(skipped("safe_crossfade_only"));
@@ -1715,6 +1814,16 @@ fn drop_preview_status(
         source: Some(source.to_string()),
         reason: None,
     })
+}
+
+fn deck_profile_unavailable_reason(prefix: &str, deck: &DjDeckStatus) -> String {
+    if deck.profile_status == "retrying" {
+        if let Some(reason) = deck.profile_retry_reason.as_deref() {
+            return format!("{prefix}_profile_retrying_{reason}");
+        }
+        return format!("{prefix}_profile_retrying");
+    }
+    format!("{prefix}_profile_missing")
 }
 
 pub(crate) fn drop_preview_plan_for_pair(
@@ -2491,6 +2600,8 @@ mod tests {
             profile_ready,
             profile_status: profile_status.to_string(),
             profile_error: None,
+            profile_retry_after_ms: None,
+            profile_retry_reason: None,
             profile_confidence: profile_ready.then_some(0.85),
             beat_count: profile_ready.then_some(128),
             downbeat_count: profile_ready.then_some(32),
@@ -3640,6 +3751,42 @@ mod tests {
     }
 
     #[test]
+    fn drop_preview_status_reports_retrying_asset_unavailable() {
+        let conn = rusqlite::Connection::open_in_memory().expect("db");
+        crate::db::schema::run_migrations(&conn).expect("migrations");
+        let current_ref = DjMediaRef::TidalTrack {
+            tidal_id: 111,
+            track_id: Some(1),
+        };
+        let next_ref = DjMediaRef::TidalTrack {
+            tidal_id: 222,
+            track_id: Some(2),
+        };
+        let mut current = test_deck_status(true, "ready");
+        current.phrase_markers_ms = vec![128_000];
+        let mut next = test_deck_status(false, "retrying");
+        next.profile_retry_reason = Some("asset_not_ready".to_string());
+
+        let status = drop_preview_status(
+            &conn,
+            true,
+            Some(&current_ref),
+            Some(&next_ref),
+            Some(&current),
+            Some(&next),
+            Some(240_000),
+            None,
+        )
+        .expect("preview status");
+
+        assert_eq!(status.status, "skipped");
+        assert_eq!(
+            status.reason.as_deref(),
+            Some("next_profile_retrying_asset_not_ready")
+        );
+    }
+
+    #[test]
     fn ready_pair_transition_planning_cooldown_suppresses_same_generation() {
         let mut attempts = HashMap::new();
         let now = Instant::now();
@@ -3863,9 +4010,78 @@ mod tests {
             deck.profile_error.as_deref(),
             Some("DASH stream prebuffer failed. Retrying analysis.")
         );
-        assert!(deck_needs_profile_rebuild(&deck));
+        assert!(deck.profile_retry_after_ms.is_some_and(|ms| ms > 0));
+        assert_eq!(deck.profile_retry_reason.as_deref(), Some("dash_prebuffer"));
+        assert!(!deck_needs_profile_rebuild(&deck));
 
         clear_dj_profile_rebuild_failure(&rebuild_key);
+    }
+
+    #[test]
+    fn due_retrying_profile_failure_needs_rebuild() {
+        let mut deck = test_deck_status(false, "retrying");
+        deck.profile_retry_after_ms = Some(0);
+
+        assert!(deck_needs_profile_rebuild(&deck));
+    }
+
+    #[test]
+    fn asset_not_ready_retrying_profile_reports_retry_reason() {
+        let conn = rusqlite::Connection::open_in_memory().expect("db");
+        crate::db::schema::run_migrations(&conn).expect("migrations");
+        let media_ref = DjMediaRef::TidalTrack {
+            tidal_id: 12198476,
+            track_id: None,
+        };
+        let key = media_ref.profile_key();
+        let rebuild_key = dj_profile_inflight_key(&key);
+        clear_dj_profile_rebuild_failure(&rebuild_key);
+        record_dj_profile_rebuild_failure(
+            &rebuild_key,
+            "retrying",
+            "TIDAL asset is not ready. Retrying analysis.".to_string(),
+        );
+
+        let deck = deck_status(&conn, &media_ref, None, false).expect("deck status");
+
+        assert_eq!(deck.profile_status, "retrying");
+        assert_eq!(
+            deck.profile_retry_reason.as_deref(),
+            Some("asset_not_ready")
+        );
+        assert!(deck.profile_retry_after_ms.is_some_and(|ms| ms > 0));
+
+        clear_dj_profile_rebuild_failure(&rebuild_key);
+    }
+
+    #[test]
+    fn retryable_profile_rebuild_failure_clears_inflight() {
+        let inflight = Arc::new(std::sync::Mutex::new(std::collections::HashMap::new()));
+        let key = "tidal_track:250295729";
+        let first = mark_dj_profile_rebuild_inflight(
+            &inflight,
+            key,
+            std::time::Duration::from_secs(DJ_PROFILE_AUTO_REBUILD_RETRY_SECS),
+        )
+        .expect("first mark");
+
+        finish_dj_profile_rebuild_failure(
+            &inflight,
+            key,
+            "retrying",
+            "TIDAL asset is not ready. Retrying analysis.".to_string(),
+        );
+
+        let second = mark_dj_profile_rebuild_inflight(
+            &inflight,
+            key,
+            std::time::Duration::from_secs(DJ_PROFILE_AUTO_REBUILD_RETRY_SECS),
+        )
+        .expect("second mark");
+
+        assert_eq!(first, ProfileRebuildInflightDecision::Start);
+        assert_eq!(second, ProfileRebuildInflightDecision::Start);
+        clear_dj_profile_rebuild_failure(key);
     }
 
     #[test]

--- a/noor-server/src/server/routes/dj_routes.rs
+++ b/noor-server/src/server/routes/dj_routes.rs
@@ -36,6 +36,7 @@ const SAFE_SUGGESTION_BAD_COUNT: i64 = 3;
 const DJ_PROFILE_AUTO_REBUILD_RETRY_SECS: u64 = 300;
 const DJ_TIMING_HISTORY_LIMIT: i64 = 5;
 const DJ_READY_PAIR_TRANSITION_WINDOW_MS: i64 = 30_000;
+const DJ_TIMING_SANITY_MAX_DELTA_MS: i64 = 30_000;
 #[cfg(test)]
 const DJ_READY_PAIR_PLANNING_RETRY_SECS: u64 = 15;
 const DJ_PROFILE_REBUILD_FAILURE_TTL_SECS: u64 = 300;
@@ -1796,10 +1797,15 @@ fn latest_fired_dj_timing_deltas(
          FROM dj_transition_events
          WHERE timing_status = 'fired'
            AND timing_delta_ms IS NOT NULL
+           AND ABS(timing_delta_ms) <= ?2
+           AND template != 'DropPreview16'
          ORDER BY started_at DESC, id DESC
          LIMIT ?1",
     )?;
-    let rows = stmt.query_map([limit.max(0)], |row| row.get::<_, i64>(0))?;
+    let rows = stmt.query_map(
+        params![limit.max(0), DJ_TIMING_SANITY_MAX_DELTA_MS],
+        |row| row.get::<_, i64>(0),
+    )?;
     let mut deltas = Vec::new();
     for row in rows {
         deltas.push(row?);
@@ -1834,7 +1840,10 @@ fn summarize_timing_history(
         if event.timing_status.as_deref() == Some("missed") {
             missed_count += 1;
         }
-        if let Some(delta_ms) = event.timing_delta_ms {
+        if let Some(delta_ms) = event
+            .timing_delta_ms
+            .filter(|delta| timing_delta_is_sane(*delta))
+        {
             delta_sum += delta_ms;
             abs_delta_sum += delta_ms.abs();
             delta_count += 1;
@@ -1862,6 +1871,10 @@ fn summarize_timing_history(
         late_count,
         missed_count,
     }
+}
+
+fn timing_delta_is_sane(delta_ms: i64) -> bool {
+    delta_ms.abs() <= DJ_TIMING_SANITY_MAX_DELTA_MS
 }
 
 fn median_abs_delta(deltas: &[i64]) -> Option<i64> {
@@ -2894,6 +2907,40 @@ mod tests {
     }
 
     #[test]
+    fn latest_fired_timing_deltas_exclude_impossible_and_preview_rows() {
+        let conn = rusqlite::Connection::open_in_memory().expect("db");
+        crate::db::schema::run_migrations(&conn).expect("migrations");
+        conn.execute(
+            "INSERT INTO dj_transition_events (
+                from_media_ref_kind, from_media_ref_id, to_media_ref_kind, to_media_ref_id,
+                template, program_json, planner_version, planned_start_ms,
+                actual_start_ms, timing_delta_ms, timing_source, timing_status
+             ) VALUES
+             (
+                'tidal_track', '1', 'tidal_track', '2',
+                'SafeCrossfade', '{\"template\":\"SafeCrossfade\"}', 'dj-v1',
+                100000, 100120, 120, 'downbeat_sync', 'fired'
+             ),
+             (
+                'tidal_track', '2', 'tidal_track', '3',
+                'SafeCrossfade', '{\"template\":\"SafeCrossfade\"}', 'dj-v1',
+                100000, 140001, 40001, 'downbeat_sync', 'fired'
+             ),
+             (
+                'tidal_track', '3', 'tidal_track', '4',
+                'DropPreview16', '{\"template\":\"DropPreview16\"}', 'dj-v1',
+                100000, 100240, 240, 'drop_preview', 'fired'
+             )",
+            [],
+        )
+        .expect("insert timing rows");
+
+        let deltas = latest_fired_dj_timing_deltas(&conn, 20).expect("deltas");
+
+        assert_eq!(deltas, vec![120]);
+    }
+
+    #[test]
     fn timing_history_includes_track_pair_labels() {
         let conn = rusqlite::Connection::open_in_memory().expect("db");
         crate::db::schema::run_migrations(&conn).expect("migrations");
@@ -3081,6 +3128,64 @@ mod tests {
         assert_eq!(summary.bad_count, 1);
         assert_eq!(summary.late_count, 1);
         assert_eq!(summary.missed_count, 1);
+    }
+
+    #[test]
+    fn timing_history_summary_excludes_impossible_deltas_from_averages() {
+        let events = vec![
+            DjTimingHistoryEvent {
+                event_id: 1,
+                from_title: None,
+                from_artist: None,
+                to_title: None,
+                to_artist: None,
+                planned_template: "SafeCrossfade".to_string(),
+                renderer_template: Some("SafeCrossfade".to_string()),
+                planning_reason: None,
+                planned_start_ms: Some(10_000),
+                actual_start_ms: Some(10_100),
+                timing_delta_ms: Some(100),
+                timing_source: Some("downbeat_sync".to_string()),
+                timing_status: Some("fired".to_string()),
+                timing_quality: "tight".to_string(),
+                timing_direction: "on_time".to_string(),
+                runtime_rendered_dj_mixer: Some(true),
+                runtime_renderer_status: Some("rendered_handoff".to_string()),
+                runtime_renderer_reason: Some("none".to_string()),
+                started_at: "now".to_string(),
+                rejected_alternatives: Vec::new(),
+            },
+            DjTimingHistoryEvent {
+                event_id: 2,
+                from_title: None,
+                from_artist: None,
+                to_title: None,
+                to_artist: None,
+                planned_template: "SafeCrossfade".to_string(),
+                renderer_template: Some("SafeCrossfade".to_string()),
+                planning_reason: None,
+                planned_start_ms: Some(10_000),
+                actual_start_ms: Some(50_001),
+                timing_delta_ms: Some(40_001),
+                timing_source: Some("downbeat_sync".to_string()),
+                timing_status: Some("fired".to_string()),
+                timing_quality: "bad".to_string(),
+                timing_direction: "late".to_string(),
+                runtime_rendered_dj_mixer: Some(true),
+                runtime_renderer_status: Some("rendered_handoff".to_string()),
+                runtime_renderer_reason: Some("none".to_string()),
+                started_at: "now".to_string(),
+                rejected_alternatives: Vec::new(),
+            },
+        ];
+
+        let summary = summarize_timing_history(&events, &[100]);
+
+        assert_eq!(summary.event_count, 2);
+        assert_eq!(summary.average_delta_ms, Some(100));
+        assert_eq!(summary.average_abs_delta_ms, Some(100));
+        assert_eq!(summary.tight_count, 1);
+        assert_eq!(summary.bad_count, 1);
     }
 
     #[test]

--- a/noor-server/src/server/routes/dj_routes.rs
+++ b/noor-server/src/server/routes/dj_routes.rs
@@ -443,6 +443,11 @@ async fn get_status(
             .playback_runtime_info
             .as_ref()
             .and_then(|info| info.active_track_id);
+        let active_generation = super::current_playback_generation(&state);
+        let drop_preview_actual_fire_ms = state.last_drop_preview.and_then(|preview| {
+            (Some(preview.track_id) == active_track_id && preview.generation == active_generation)
+                .then_some(preview.actual_fire_ms)
+        });
         state
             .db
             .with_conn(|conn| {
@@ -550,6 +555,7 @@ async fn get_status(
                     active_track_id.and_then(|track_id| {
                         current_track_duration_ms(conn, track_id).ok().flatten()
                     }),
+                    drop_preview_actual_fire_ms,
                 )?;
                 Ok(DjStatusResponse {
                     enabled,
@@ -1647,6 +1653,7 @@ fn drop_preview_status(
     current: Option<&DjDeckStatus>,
     next: Option<&DjDeckStatus>,
     current_duration_ms: Option<i64>,
+    actual_fire_ms: Option<i64>,
 ) -> anyhow::Result<DjDropPreviewStatus> {
     let skipped = |reason: &'static str| DjDropPreviewStatus {
         status: "skipped".to_string(),
@@ -1697,9 +1704,13 @@ fn drop_preview_status(
         });
     };
     Ok(DjDropPreviewStatus {
-        status: "armed".to_string(),
+        status: if actual_fire_ms.is_some() {
+            "fired".to_string()
+        } else {
+            "armed".to_string()
+        },
         planned_fire_ms: Some(planned_fire_ms),
-        actual_fire_ms: None,
+        actual_fire_ms,
         incoming_drop_ms: Some(incoming_drop_ms),
         source: Some(source.to_string()),
         reason: None,
@@ -1723,6 +1734,7 @@ pub(crate) fn drop_preview_plan_for_pair(
         Some(&current),
         Some(&next),
         current_duration_ms,
+        None,
     )?;
     Ok(
         match (
@@ -3539,6 +3551,7 @@ mod tests {
             Some(&current),
             Some(&next),
             Some(240_000),
+            None,
         )
         .expect("preview status");
 
@@ -3553,6 +3566,42 @@ mod tests {
                 reason: None,
             }
         );
+    }
+
+    #[test]
+    fn drop_preview_status_reports_actual_fire() {
+        let conn = rusqlite::Connection::open_in_memory().expect("db");
+        crate::db::schema::run_migrations(&conn).expect("migrations");
+        seed_dsp_key(&conn, 1, "8A");
+        seed_dsp_key(&conn, 2, "8B");
+        let current_ref = DjMediaRef::TidalTrack {
+            tidal_id: 111,
+            track_id: Some(1),
+        };
+        let next_ref = DjMediaRef::TidalTrack {
+            tidal_id: 222,
+            track_id: Some(2),
+        };
+        let mut current = test_deck_status(true, "ready");
+        current.phrase_markers_ms = vec![128_000];
+        let mut next = test_deck_status(true, "ready");
+        next.drop_markers_ms = vec![32_000];
+
+        let status = drop_preview_status(
+            &conn,
+            true,
+            Some(&current_ref),
+            Some(&next_ref),
+            Some(&current),
+            Some(&next),
+            Some(240_000),
+            Some(128_008),
+        )
+        .expect("preview status");
+
+        assert_eq!(status.status, "fired");
+        assert_eq!(status.planned_fire_ms, Some(128_000));
+        assert_eq!(status.actual_fire_ms, Some(128_008));
     }
 
     #[test]
@@ -3582,6 +3631,7 @@ mod tests {
             Some(&current),
             Some(&next),
             Some(240_000),
+            None,
         )
         .expect("preview status");
 

--- a/noor-server/src/server/routes/dj_routes.rs
+++ b/noor-server/src/server/routes/dj_routes.rs
@@ -34,6 +34,7 @@ const DEFAULT_DJ_LOOKAHEAD_DEADLINE_SAMPLES: u64 = 48_000 * 30;
 const DJ_PROFILE_CONFIDENCE_FLOOR: f64 = 0.65;
 const SAFE_SUGGESTION_BAD_COUNT: i64 = 3;
 const DJ_PROFILE_AUTO_REBUILD_RETRY_SECS: u64 = 300;
+const DJ_PROFILE_TRANSIENT_RETRY_SECS: u64 = 25;
 const DJ_TIMING_HISTORY_LIMIT: i64 = 5;
 const DJ_READY_PAIR_TRANSITION_WINDOW_MS: i64 = 30_000;
 const DJ_TIMING_SANITY_MAX_DELTA_MS: i64 = 30_000;
@@ -1006,7 +1007,7 @@ async fn queue_tidal_profile_rebuild(
                 schedule_dj_profile_retry(
                     &runtime_handle,
                     retry_state,
-                    Duration::from_secs(DJ_PROFILE_AUTO_REBUILD_RETRY_SECS),
+                    Duration::from_secs(DJ_PROFILE_TRANSIENT_RETRY_SECS),
                 );
             }
             tracing::warn!(tidal_id, error = %message, "DJ profile rebuild decode failed");
@@ -1152,7 +1153,7 @@ fn record_dj_profile_rebuild_failure(key: &str, status: &str, message: String) {
         let retry_reason = profile_rebuild_retry_reason(status, &message);
         let next_retry_at = retry_reason
             .as_ref()
-            .map(|_| Instant::now() + Duration::from_secs(DJ_PROFILE_AUTO_REBUILD_RETRY_SECS));
+            .map(|_| Instant::now() + Duration::from_secs(DJ_PROFILE_TRANSIENT_RETRY_SECS));
         guard.insert(
             key.to_string(),
             DjProfileRebuildFailure {
@@ -4011,6 +4012,7 @@ mod tests {
             Some("DASH stream prebuffer failed. Retrying analysis.")
         );
         assert!(deck.profile_retry_after_ms.is_some_and(|ms| ms > 0));
+        assert!(deck.profile_retry_after_ms.is_some_and(|ms| ms <= 25_000));
         assert_eq!(deck.profile_retry_reason.as_deref(), Some("dash_prebuffer"));
         assert!(!deck_needs_profile_rebuild(&deck));
 
@@ -4050,6 +4052,7 @@ mod tests {
             Some("asset_not_ready")
         );
         assert!(deck.profile_retry_after_ms.is_some_and(|ms| ms > 0));
+        assert!(deck.profile_retry_after_ms.is_some_and(|ms| ms <= 25_000));
 
         clear_dj_profile_rebuild_failure(&rebuild_key);
     }

--- a/noor-server/src/server/routes/dj_routes.rs
+++ b/noor-server/src/server/routes/dj_routes.rs
@@ -37,6 +37,8 @@ const DJ_PROFILE_AUTO_REBUILD_RETRY_SECS: u64 = 300;
 const DJ_TIMING_HISTORY_LIMIT: i64 = 5;
 const DJ_READY_PAIR_TRANSITION_WINDOW_MS: i64 = 30_000;
 const DJ_TIMING_SANITY_MAX_DELTA_MS: i64 = 30_000;
+const DROP_PREVIEW_MIN_POSITION_MS: i64 = 60_000;
+const DROP_PREVIEW_FINAL_WINDOW_GUARD_MS: i64 = 45_000;
 #[cfg(test)]
 const DJ_READY_PAIR_PLANNING_RETRY_SECS: u64 = 15;
 const DJ_PROFILE_REBUILD_FAILURE_TTL_SECS: u64 = 300;
@@ -175,6 +177,7 @@ struct DjStatusResponse {
     recent_timing_events: Vec<DjTimingHistoryEvent>,
     timing_history_summary: DjTimingHistorySummary,
     safe_crossfade_suggestion: Option<DjSafeSuggestion>,
+    drop_preview: DjDropPreviewStatus,
 }
 
 #[derive(Debug, Serialize)]
@@ -197,9 +200,21 @@ struct DjDeckStatus {
     phrase_markers_ms: Vec<i64>,
     mix_in_markers_ms: Vec<i64>,
     mix_out_markers_ms: Vec<i64>,
+    drop_markers_ms: Vec<i64>,
+    manual_drop_markers_ms: Vec<i64>,
     passive_analysis_status: Option<String>,
     passive_analysis_reason: Option<String>,
     safe_crossfade_only: bool,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct DjDropPreviewStatus {
+    status: String,
+    planned_fire_ms: Option<i64>,
+    actual_fire_ms: Option<i64>,
+    incoming_drop_ms: Option<i64>,
+    source: Option<String>,
+    reason: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -518,6 +533,17 @@ async fn get_status(
                 let timing_history_summary =
                     summarize_timing_history(&recent_timing_events, &tuning_deltas);
                 let renderer_status = renderer_status_for_transition(latest_transition.as_ref());
+                let drop_preview = drop_preview_status(
+                    conn,
+                    enabled,
+                    current_ref.as_ref(),
+                    next_ref.as_ref(),
+                    current.as_ref(),
+                    next.as_ref(),
+                    active_track_id.and_then(|track_id| {
+                        current_track_duration_ms(conn, track_id).ok().flatten()
+                    }),
+                )?;
                 Ok(DjStatusResponse {
                     enabled,
                     current,
@@ -552,6 +578,7 @@ async fn get_status(
                     recent_timing_events,
                     timing_history_summary,
                     safe_crossfade_suggestion,
+                    drop_preview,
                 })
             })
             .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
@@ -1498,6 +1525,8 @@ fn deck_status(
         phrase_markers_ms,
         mix_in_markers_ms,
         mix_out_markers_ms,
+        drop_markers_ms,
+        manual_drop_markers_ms,
     ) = if let Some(profile) = profile.as_ref() {
         let beat_markers = decode_f32_blob(&profile.beat_grid_blob).unwrap_or_default();
         let downbeat_markers = decode_f32_blob(&profile.downbeats_blob).unwrap_or_default();
@@ -1516,6 +1545,8 @@ fn deck_status(
             phrase_markers,
             seconds_markers_ms(&decode_f32_blob(&profile.mix_in_blob).unwrap_or_default()),
             seconds_markers_ms(&decode_f32_blob(&profile.mix_out_blob).unwrap_or_default()),
+            seconds_markers_ms(&decode_f32_blob(&profile.drop_blob).unwrap_or_default()),
+            Vec::new(),
         )
     } else {
         (
@@ -1523,6 +1554,8 @@ fn deck_status(
             None,
             None,
             None,
+            Vec::new(),
+            Vec::new(),
             Vec::new(),
             Vec::new(),
             Vec::new(),
@@ -1551,6 +1584,8 @@ fn deck_status(
         phrase_markers_ms,
         mix_in_markers_ms,
         mix_out_markers_ms,
+        drop_markers_ms,
+        manual_drop_markers_ms,
         passive_analysis_status: passive_analysis
             .as_ref()
             .map(|snapshot| snapshot.status.to_string()),
@@ -1595,6 +1630,154 @@ fn phrase_markers_ms(phrases: &[u32], downbeats: &[f32]) -> Vec<i64> {
         .filter(|value| value.is_finite() && **value >= 0.0)
         .map(|value| (*value as f64 * 1000.0).round() as i64)
         .collect()
+}
+
+fn drop_preview_status(
+    conn: &rusqlite::Connection,
+    enabled: bool,
+    current_ref: Option<&DjMediaRef>,
+    next_ref: Option<&DjMediaRef>,
+    current: Option<&DjDeckStatus>,
+    next: Option<&DjDeckStatus>,
+    current_duration_ms: Option<i64>,
+) -> anyhow::Result<DjDropPreviewStatus> {
+    let skipped = |reason: &'static str| DjDropPreviewStatus {
+        status: "skipped".to_string(),
+        planned_fire_ms: None,
+        actual_fire_ms: None,
+        incoming_drop_ms: incoming_drop_marker(next).map(|marker| marker.0),
+        source: incoming_drop_marker(next).map(|marker| marker.1.to_string()),
+        reason: Some(reason.to_string()),
+    };
+
+    if !enabled {
+        return Ok(skipped("disabled"));
+    }
+    let (Some(current_ref), Some(next_ref), Some(current), Some(next)) =
+        (current_ref, next_ref, current, next)
+    else {
+        return Ok(skipped("pair_missing"));
+    };
+    if !current.profile_ready || !next.profile_ready {
+        return Ok(skipped("profiles_missing"));
+    }
+    if current.safe_crossfade_only || next.safe_crossfade_only {
+        return Ok(skipped("safe_crossfade_only"));
+    }
+    if current
+        .profile_confidence
+        .is_some_and(|value| value < DJ_PROFILE_CONFIDENCE_FLOOR)
+        || next
+            .profile_confidence
+            .is_some_and(|value| value < DJ_PROFILE_CONFIDENCE_FLOOR)
+    {
+        return Ok(skipped("profile_low_confidence"));
+    }
+    if !drop_preview_pair_harmonic_compatible(conn, current_ref, next_ref)? {
+        return Ok(skipped("harmonic_incompatible"));
+    }
+    let Some((incoming_drop_ms, source)) = incoming_drop_marker(Some(next)) else {
+        return Ok(skipped("missing_incoming_drop"));
+    };
+    let Some(planned_fire_ms) = select_drop_preview_fire_ms(current, current_duration_ms) else {
+        return Ok(DjDropPreviewStatus {
+            status: "skipped".to_string(),
+            planned_fire_ms: None,
+            actual_fire_ms: None,
+            incoming_drop_ms: Some(incoming_drop_ms),
+            source: Some(source.to_string()),
+            reason: Some("no_safe_mid_song_marker".to_string()),
+        });
+    };
+    Ok(DjDropPreviewStatus {
+        status: "armed".to_string(),
+        planned_fire_ms: Some(planned_fire_ms),
+        actual_fire_ms: None,
+        incoming_drop_ms: Some(incoming_drop_ms),
+        source: Some(source.to_string()),
+        reason: None,
+    })
+}
+
+fn incoming_drop_marker(next: Option<&DjDeckStatus>) -> Option<(i64, &'static str)> {
+    let next = next?;
+    next.manual_drop_markers_ms
+        .iter()
+        .copied()
+        .find(|marker| *marker >= 0)
+        .map(|marker| (marker, "manual"))
+        .or_else(|| {
+            next.drop_markers_ms
+                .iter()
+                .copied()
+                .find(|marker| *marker >= 0)
+                .map(|marker| (marker, "profile"))
+        })
+}
+
+fn select_drop_preview_fire_ms(current: &DjDeckStatus, duration_ms: Option<i64>) -> Option<i64> {
+    let duration_ms = duration_ms.filter(|duration| *duration > 0)?;
+    let min_ms = DROP_PREVIEW_MIN_POSITION_MS.max(duration_ms * 45 / 100);
+    let max_ms = (duration_ms * 65 / 100)
+        .min(duration_ms - DJ_READY_PAIR_TRANSITION_WINDOW_MS - DROP_PREVIEW_FINAL_WINDOW_GUARD_MS);
+    if max_ms < min_ms {
+        return None;
+    }
+    let target_ms = duration_ms * 55 / 100;
+    current
+        .phrase_markers_ms
+        .iter()
+        .chain(current.downbeat_markers_ms.iter())
+        .copied()
+        .filter(|marker| (min_ms..=max_ms).contains(marker))
+        .min_by_key(|marker| (*marker - target_ms).abs())
+}
+
+fn drop_preview_pair_harmonic_compatible(
+    conn: &rusqlite::Connection,
+    current_ref: &DjMediaRef,
+    next_ref: &DjMediaRef,
+) -> anyhow::Result<bool> {
+    let current_key = media_ref_camelot_key(conn, current_ref)?;
+    let next_key = media_ref_camelot_key(conn, next_ref)?;
+    Ok(match (current_key.as_deref(), next_key.as_deref()) {
+        (Some(current), Some(next)) => noor_mix::planner::scoring::camelot_distance(current, next)
+            .is_some_and(|distance| matches!(distance, 0 | 1 | 7)),
+        _ => false,
+    })
+}
+
+fn media_ref_camelot_key(
+    conn: &rusqlite::Connection,
+    media_ref: &DjMediaRef,
+) -> anyhow::Result<Option<String>> {
+    let key = media_ref.profile_key();
+    let profile = queries::get_audio_dj_profile(conn, &key)?;
+    let track_id = media_ref
+        .track_id()
+        .or_else(|| profile.as_ref().and_then(|profile| profile.track_id))
+        .or_else(|| {
+            media_ref
+                .tidal_id()
+                .and_then(|tidal_id| track_id_for_tidal_id(conn, tidal_id).ok().flatten())
+        });
+    let Some(track_id) = track_id else {
+        return Ok(None);
+    };
+    Ok(queries::get_audio_dsp_features(conn, track_id)?.and_then(|features| features.camelot_key))
+}
+
+fn track_id_for_tidal_id(
+    conn: &rusqlite::Connection,
+    tidal_id: i64,
+) -> anyhow::Result<Option<i64>> {
+    conn.query_row(
+        "SELECT id FROM tracks WHERE tidal_id = ?1 LIMIT 1",
+        [tidal_id],
+        |row| row.get::<_, i64>(0),
+    )
+    .optional()
+    .map_err(anyhow::Error::from)
 }
 
 fn latest_open_transition_for_pair(
@@ -2267,10 +2450,48 @@ mod tests {
             phrase_markers_ms: Vec::new(),
             mix_in_markers_ms: Vec::new(),
             mix_out_markers_ms: Vec::new(),
+            drop_markers_ms: Vec::new(),
+            manual_drop_markers_ms: Vec::new(),
             passive_analysis_status: None,
             passive_analysis_reason: None,
             safe_crossfade_only: false,
         }
+    }
+
+    fn seed_dsp_key(conn: &rusqlite::Connection, track_id: i64, camelot_key: &str) {
+        conn.execute(
+            "INSERT OR IGNORE INTO artists (id, name) VALUES (1, 'Test Artist')",
+            [],
+        )
+        .expect("artist");
+        conn.execute(
+            "INSERT OR IGNORE INTO tracks (id, title, artist_id, source)
+             VALUES (?1, ?2, 1, 'tidal')",
+            params![track_id, format!("Track {track_id}")],
+        )
+        .expect("track");
+        queries::upsert_audio_dsp_features(
+            conn,
+            &crate::db::models::AudioDspFeatures {
+                track_id,
+                bpm: Some(120.0),
+                key_signature: None,
+                camelot_key: Some(camelot_key.to_string()),
+                loudness_lufs: Some(-12.0),
+                energy: Some(0.7),
+                danceability: Some(0.7),
+                beat_strength: Some(0.7),
+                spectral_centroid: None,
+                stereo_width: None,
+                is_instrumental: false,
+                analysis_source: "test".to_string(),
+                analysis_offset_ms: 0,
+                samples_analyzed: None,
+                analyzed_at: "now".to_string(),
+                analysis_version: "test".to_string(),
+            },
+        )
+        .expect("dsp features");
     }
 
     #[test]
@@ -3215,6 +3436,113 @@ mod tests {
         assert!(ready_pair_transition_due(151_000, Some(180_000)));
         assert!(ready_pair_transition_due(180_000, Some(180_000)));
         assert!(!ready_pair_transition_due(151_000, None));
+    }
+
+    #[test]
+    fn drop_preview_selects_nearest_safe_mid_song_marker() {
+        let mut current = test_deck_status(true, "ready");
+        current.phrase_markers_ms = vec![40_000, 120_000];
+        current.downbeat_markers_ms = vec![132_000, 190_000];
+
+        assert_eq!(
+            select_drop_preview_fire_ms(&current, Some(240_000)),
+            Some(132_000)
+        );
+    }
+
+    #[test]
+    fn drop_preview_rejects_unsafe_mid_song_window() {
+        let mut current = test_deck_status(true, "ready");
+        current.phrase_markers_ms = vec![40_000, 190_000];
+        current.downbeat_markers_ms = vec![59_000];
+
+        assert_eq!(select_drop_preview_fire_ms(&current, Some(240_000)), None);
+    }
+
+    #[test]
+    fn drop_preview_prefers_manual_drop_marker() {
+        let mut next = test_deck_status(true, "ready");
+        next.drop_markers_ms = vec![32_000];
+        next.manual_drop_markers_ms = vec![24_000];
+
+        assert_eq!(incoming_drop_marker(Some(&next)), Some((24_000, "manual")));
+    }
+
+    #[test]
+    fn drop_preview_status_arms_compatible_ready_pair() {
+        let conn = rusqlite::Connection::open_in_memory().expect("db");
+        crate::db::schema::run_migrations(&conn).expect("migrations");
+        seed_dsp_key(&conn, 1, "8A");
+        seed_dsp_key(&conn, 2, "8B");
+        let current_ref = DjMediaRef::TidalTrack {
+            tidal_id: 111,
+            track_id: Some(1),
+        };
+        let next_ref = DjMediaRef::TidalTrack {
+            tidal_id: 222,
+            track_id: Some(2),
+        };
+        let mut current = test_deck_status(true, "ready");
+        current.phrase_markers_ms = vec![128_000];
+        let mut next = test_deck_status(true, "ready");
+        next.drop_markers_ms = vec![32_000];
+
+        let status = drop_preview_status(
+            &conn,
+            true,
+            Some(&current_ref),
+            Some(&next_ref),
+            Some(&current),
+            Some(&next),
+            Some(240_000),
+        )
+        .expect("preview status");
+
+        assert_eq!(
+            status,
+            DjDropPreviewStatus {
+                status: "armed".to_string(),
+                planned_fire_ms: Some(128_000),
+                actual_fire_ms: None,
+                incoming_drop_ms: Some(32_000),
+                source: Some("profile".to_string()),
+                reason: None,
+            }
+        );
+    }
+
+    #[test]
+    fn drop_preview_status_skips_harmonic_mismatch() {
+        let conn = rusqlite::Connection::open_in_memory().expect("db");
+        crate::db::schema::run_migrations(&conn).expect("migrations");
+        seed_dsp_key(&conn, 1, "8A");
+        seed_dsp_key(&conn, 2, "2B");
+        let current_ref = DjMediaRef::TidalTrack {
+            tidal_id: 111,
+            track_id: Some(1),
+        };
+        let next_ref = DjMediaRef::TidalTrack {
+            tidal_id: 222,
+            track_id: Some(2),
+        };
+        let mut current = test_deck_status(true, "ready");
+        current.phrase_markers_ms = vec![128_000];
+        let mut next = test_deck_status(true, "ready");
+        next.drop_markers_ms = vec![32_000];
+
+        let status = drop_preview_status(
+            &conn,
+            true,
+            Some(&current_ref),
+            Some(&next_ref),
+            Some(&current),
+            Some(&next),
+            Some(240_000),
+        )
+        .expect("preview status");
+
+        assert_eq!(status.status, "skipped");
+        assert_eq!(status.reason.as_deref(), Some("harmonic_incompatible"));
     }
 
     #[test]

--- a/noor-server/src/services/audio_analysis/dj_profile.rs
+++ b/noor-server/src/services/audio_analysis/dj_profile.rs
@@ -5,6 +5,7 @@ use anyhow::Result;
 use rusqlite::Connection;
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
 
@@ -13,6 +14,8 @@ use super::{onset, tempo};
 
 pub const DJ_PROFILE_VERSION: &str = "dj_profile_v2";
 pub const DJ_WAVEFORM_PEAK_COUNT: usize = 512;
+const DJ_PROFILE_DB_LOCK_RETRY_LIMIT: usize = 6;
+const DJ_PROFILE_DB_LOCK_RETRY_DELAY: Duration = Duration::from_secs(1);
 
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
@@ -102,7 +105,9 @@ fn persist_dj_analysis_job(
     analyzer: fn(&[f32], u32) -> Option<BeatGridAnalysis>,
 ) -> Result<()> {
     let key = job.media_ref.profile_key();
-    if db.with_conn(|conn| dj_analysis_skips_existing_profile_version(conn, &key))? {
+    if with_dj_profile_db_retry("check current DJ profile version", || {
+        db.with_conn(|conn| dj_analysis_skips_existing_profile_version(conn, &key))
+    })? {
         debug!(
             media_ref_kind = %key.media_ref_kind,
             media_ref_id = %key.media_ref_id,
@@ -133,8 +138,10 @@ fn persist_dj_analysis_job(
         return Ok(());
     };
 
-    db.with_conn(|conn| {
-        persist_dj_analysis_job_from_analysis(conn, &job, "dj_playback", &analysis)
+    with_dj_profile_db_retry("persist DJ profile", || {
+        db.with_conn(|conn| {
+            persist_dj_analysis_job_from_analysis(conn, &job, "dj_playback", &analysis)
+        })
     })?;
     info!(
         media_ref_kind = %key.media_ref_kind,
@@ -144,6 +151,59 @@ fn persist_dj_analysis_job(
         "DJ profile persisted"
     );
     Ok(())
+}
+
+fn with_dj_profile_db_retry<T, F>(operation: &'static str, f: F) -> Result<T>
+where
+    F: FnMut() -> Result<T>,
+{
+    with_dj_profile_db_retry_config(
+        operation,
+        DJ_PROFILE_DB_LOCK_RETRY_LIMIT,
+        DJ_PROFILE_DB_LOCK_RETRY_DELAY,
+        f,
+    )
+}
+
+fn with_dj_profile_db_retry_config<T, F>(
+    operation: &'static str,
+    retry_limit: usize,
+    retry_delay: Duration,
+    mut f: F,
+) -> Result<T>
+where
+    F: FnMut() -> Result<T>,
+{
+    for attempt in 0..=retry_limit {
+        match f() {
+            Ok(value) => return Ok(value),
+            Err(error) if sqlite_database_locked(&error) && attempt < retry_limit => {
+                let next_attempt = attempt + 1;
+                warn!(
+                    operation,
+                    next_attempt, retry_limit, "DJ profile database locked; retrying"
+                );
+                std::thread::sleep(retry_delay);
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    unreachable!("DJ profile retry loop always returns before exhausting attempts")
+}
+
+fn sqlite_database_locked(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        if let Some(rusqlite::Error::SqliteFailure(sqlite_error, _)) =
+            cause.downcast_ref::<rusqlite::Error>()
+        {
+            return matches!(
+                sqlite_error.code,
+                rusqlite::ErrorCode::DatabaseBusy | rusqlite::ErrorCode::DatabaseLocked
+            );
+        }
+        let message = cause.to_string();
+        message.contains("database is locked") || message.contains("database table is locked")
+    })
 }
 
 fn fallback_beat_grid_analysis(samples: &[f32], sample_rate: u32) -> Option<BeatGridAnalysis> {
@@ -266,9 +326,12 @@ pub fn dj_analysis_skips_existing_profile_version(
     key: &AudioDjProfileKey,
 ) -> Result<bool> {
     let existing = queries::get_audio_dj_profile(conn, key)?;
-    Ok(existing
-        .as_ref()
-        .is_some_and(|row| row.profile_version == DJ_PROFILE_VERSION))
+    Ok(existing.as_ref().is_some_and(dj_profile_row_is_current))
+}
+
+pub fn dj_profile_row_is_current(row: &AudioDjProfileRow) -> bool {
+    row.profile_version == DJ_PROFILE_VERSION
+        && decode_f32_blob(&row.waveform_peaks_blob).is_some_and(|peaks| !peaks.is_empty())
 }
 
 pub fn persist_dj_analysis_job_from_analysis(
@@ -837,6 +900,12 @@ mod tests {
                 conn,
                 &key("tidal_track", "1")
             )?);
+            row.waveform_peaks_blob = encode_f32_blob(&[]);
+            queries::upsert_audio_dj_profile(conn, &row)?;
+            assert!(!super::dj_analysis_skips_existing_profile_version(
+                conn,
+                &key("tidal_track", "1")
+            )?);
             Ok(())
         })
         .expect("check");
@@ -1255,6 +1324,34 @@ mod tests {
             .expect("get")
             .expect("profile");
         assert_eq!(loaded.tidal_id, Some(7));
+    }
+
+    #[test]
+    fn dj_profile_db_retry_retries_locked_database_errors() {
+        let attempts = std::cell::Cell::new(0);
+        let result = with_dj_profile_db_retry_config(
+            "test retry",
+            2,
+            Duration::ZERO,
+            || -> Result<&'static str> {
+                let attempt = attempts.get();
+                attempts.set(attempt + 1);
+                if attempt == 0 {
+                    return Err(rusqlite::Error::SqliteFailure(
+                        rusqlite::ffi::Error {
+                            code: rusqlite::ErrorCode::DatabaseBusy,
+                            extended_code: rusqlite::ffi::SQLITE_BUSY,
+                        },
+                        None,
+                    )
+                    .into());
+                }
+                Ok("ok")
+            },
+        );
+
+        assert_eq!(result.expect("retry result"), "ok");
+        assert_eq!(attempts.get(), 2);
     }
 
     #[test]

--- a/noor-server/src/services/audio_analysis/queue_prescanner.rs
+++ b/noor-server/src/services/audio_analysis/queue_prescanner.rs
@@ -555,13 +555,23 @@ async fn load_candidates(state: &SharedState) -> Result<(Vec<PrescanCandidate>, 
 
 async fn run_batch(state: &SharedState, event_rx: &mut broadcast::Receiver<AppEvent>) {
     // Respect the global passive-DSP toggle.
-    let passive_on = state
-        .read()
-        .await
-        .db
-        .with_conn(|conn| Ok::<_, anyhow::Error>(super::is_passive_enabled(conn)))
-        .unwrap_or(true);
+    let (passive_on, playback_buffering) = {
+        let state_guard = state.read().await;
+        state_guard
+            .db
+            .with_conn(|conn| {
+                Ok::<_, anyhow::Error>((
+                    super::is_passive_enabled(conn),
+                    foreground_playback_is_buffering(conn, &state_guard)?,
+                ))
+            })
+            .unwrap_or((true, false))
+    };
     if !passive_on {
+        return;
+    }
+    if playback_buffering {
+        tracing::debug!("queue prescanner deferred while playback is buffering");
         return;
     }
 
@@ -632,6 +642,20 @@ async fn run_batch(state: &SharedState, event_rx: &mut broadcast::Receiver<AppEv
         }
         tokio::time::sleep(INTER_TRACK_DELAY).await;
     }
+}
+
+fn foreground_playback_is_buffering(
+    conn: &rusqlite::Connection,
+    state: &crate::AppState,
+) -> anyhow::Result<bool> {
+    if state
+        .audio_active
+        .load(std::sync::atomic::Ordering::Relaxed)
+        || state.playback_runtime.is_none()
+    {
+        return Ok(false);
+    }
+    Ok(crate::playback::player::load_state(conn)?.is_playing)
 }
 
 /// Spawn the long-lived queue-lookahead actor. Subscribes to queue/track

--- a/noor-server/src/services/discovery_trainer.rs
+++ b/noor-server/src/services/discovery_trainer.rs
@@ -62,6 +62,8 @@ pub enum EvidenceKind {
     ArtistAffinity,
     GenreAffinity,
     FavoriteAffinity,
+    LastfmDirectSimilarity,
+    LastfmBranchSimilarity,
 }
 
 #[derive(Debug, Clone, Copy, Default, Serialize)]
@@ -70,6 +72,8 @@ pub struct SupportBreakdown {
     pub colisten: f64,
     pub structure: f64,
     pub metadata: f64,
+    pub lastfm_direct: f64,
+    pub lastfm_branch: f64,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -531,7 +535,12 @@ fn build_behavioral_embeddings(
                 edge.evidence_kind,
                 weighted,
             );
-            if edge.evidence_kind != EvidenceKind::DirectTransition {
+            if !matches!(
+                edge.evidence_kind,
+                EvidenceKind::DirectTransition
+                    | EvidenceKind::LastfmDirectSimilarity
+                    | EvidenceKind::LastfmBranchSimilarity
+            ) {
                 *co.entry(edge.to_track_id)
                     .or_default()
                     .entry(edge.from_track_id)
@@ -630,6 +639,8 @@ fn add_support_bucket(
         | EvidenceKind::ArtistAffinity
         | EvidenceKind::GenreAffinity
         | EvidenceKind::FavoriteAffinity => bucket.structure += weight,
+        EvidenceKind::LastfmDirectSimilarity => bucket.lastfm_direct += weight,
+        EvidenceKind::LastfmBranchSimilarity => bucket.lastfm_branch += weight,
     }
 }
 
@@ -1031,6 +1042,18 @@ fn similarity_neighbors(
                     reason_tags.push("direct_transition".to_string());
                     contributions.push(("direct_transition", directional_behavior_bonus));
                 }
+                let lastfm_direct_bonus = (support_breakdown.lastfm_direct * 0.06).clamp(0.0, 0.12);
+                if lastfm_direct_bonus > 0.0 {
+                    metadata_score += lastfm_direct_bonus;
+                    reason_tags.push("lastfm_direct".to_string());
+                    contributions.push(("lastfm_direct", lastfm_direct_bonus));
+                }
+                let lastfm_branch_bonus = (support_breakdown.lastfm_branch * 0.04).clamp(0.0, 0.08);
+                if lastfm_branch_bonus > 0.0 {
+                    metadata_score += lastfm_branch_bonus;
+                    reason_tags.push("lastfm_branch".to_string());
+                    contributions.push(("lastfm_branch", lastfm_branch_bonus));
+                }
 
                 let total_score = score + metadata_score + directional_behavior_bonus;
                 reason_tags.sort();
@@ -1276,6 +1299,8 @@ fn heldout_metric_label(kind: EvidenceKind) -> &'static str {
         EvidenceKind::ArtistAffinity => "artist",
         EvidenceKind::GenreAffinity => "genre",
         EvidenceKind::FavoriteAffinity => "favorite",
+        EvidenceKind::LastfmDirectSimilarity => "lastfm_direct",
+        EvidenceKind::LastfmBranchSimilarity => "lastfm_branch",
     }
 }
 
@@ -1825,6 +1850,47 @@ mod tests {
         assert!(tokens.iter().any(|token| token == "dance_8"));
         assert!(tokens.iter().any(|token| token == "beat_4"));
         assert!(tokens.iter().any(|token| token == "lufs_-12"));
+    }
+
+    #[test]
+    fn lastfm_evidence_tags_are_directional() {
+        let (tracks, behavioral, audio, fusion) = make_test_input(2, 32);
+        let co_score = HashMap::new();
+        let co_count = HashMap::new();
+        let mut support_buckets: HashMap<i64, HashMap<i64, SupportBreakdown>> = HashMap::new();
+        support_buckets.entry(0).or_default().insert(
+            1,
+            SupportBreakdown {
+                lastfm_direct: 0.44,
+                ..Default::default()
+            },
+        );
+        let play_counts = HashMap::new();
+
+        let result = similarity_neighbors(
+            &tracks,
+            &behavioral,
+            &audio,
+            &fusion,
+            &co_score,
+            &co_count,
+            &support_buckets,
+            &play_counts,
+            1,
+            None,
+            None,
+        );
+
+        let forward = result
+            .iter()
+            .find(|row| row.track_id == 0 && row.neighbor_track_id == 1)
+            .expect("forward neighbor");
+        let reverse = result
+            .iter()
+            .find(|row| row.track_id == 1 && row.neighbor_track_id == 0)
+            .expect("reverse neighbor");
+        assert!(forward.reason_tags.iter().any(|tag| tag == "lastfm_direct"));
+        assert!(!reverse.reason_tags.iter().any(|tag| tag == "lastfm_direct"));
     }
 
     #[test]

--- a/noor-server/src/services/learning.rs
+++ b/noor-server/src/services/learning.rs
@@ -27,8 +27,16 @@ use tokio::sync::mpsc;
 
 const MODEL_FAMILY: &str = queries::DISCOVERY_ENGINE_V2_FAMILY;
 const EXTERNAL_TRAINING_CANDIDATE_LIMIT: i64 = 1_000;
+const EXTERNAL_TRAINING_RESOLVED_LASTFM_LIMIT: i64 = 5_000;
+const LASTFM_DIRECT_EDGE_WEIGHT: f64 = 0.55;
+const LASTFM_BRANCH_EDGE_WEIGHT: f64 = 0.35;
 const EXTERNAL_REFRESH_MAX_SEED_TRACKS: usize = 100;
 const EXTERNAL_REFRESH_LASTFM_ROWS_PER_SEED: usize = 20;
+const EXTERNAL_REFRESH_LASTFM_BRANCH_SEED_TRACKS: usize = 25;
+const EXTERNAL_REFRESH_LASTFM_BRANCHES_PER_SEED: usize = 2;
+const EXTERNAL_REFRESH_LASTFM_BRANCH_ROWS: usize = 5;
+const EXTERNAL_REFRESH_LASTFM_BRANCH_ATTENUATION: f64 = 0.65;
+const EXTERNAL_REFRESH_LASTFM_BRANCH_MIN_PARENT_MATCH: f64 = 0.50;
 const EXTERNAL_REFRESH_TIDAL_NEW_RELEASE_ROWS: usize = 500;
 const EXTERNAL_REFRESH_TIDAL_SIMILAR_SEED_TRACKS: usize = 10;
 const EXTERNAL_REFRESH_TIDAL_SIMILAR_ARTISTS_PER_SEED: i32 = 2;
@@ -67,6 +75,7 @@ pub struct ExternalLastfmCandidate {
     pub title: String,
     pub mbid: Option<String>,
     pub match_score: f64,
+    pub branch_from: Option<String>,
 }
 
 impl From<LastFmSimilarTrack> for ExternalLastfmCandidate {
@@ -76,6 +85,22 @@ impl From<LastFmSimilarTrack> for ExternalLastfmCandidate {
             title: value.title,
             mbid: value.mbid,
             match_score: value.match_score,
+            branch_from: None,
+        }
+    }
+}
+
+impl ExternalLastfmCandidate {
+    fn branch_from(value: LastFmSimilarTrack, parent: &ExternalLastfmCandidate) -> Self {
+        Self {
+            artist: value.artist,
+            title: value.title,
+            mbid: value.mbid,
+            match_score: (parent.match_score
+                * value.match_score
+                * EXTERNAL_REFRESH_LASTFM_BRANCH_ATTENUATION)
+                .clamp(0.0, 1.0),
+            branch_from: Some(format!("{} - {}", parent.artist, parent.title)),
         }
     }
 }
@@ -294,13 +319,19 @@ pub async fn refresh_external_provider_candidates(
                 .await
             {
                 Ok(rows) => {
-                    lastfm_rows.insert(
-                        seed.track_id,
-                        rows.into_iter()
-                            .take(budget.lastfm_rows_per_seed)
-                            .map(ExternalLastfmCandidate::from)
-                            .collect(),
-                    );
+                    let direct_rows = rows
+                        .into_iter()
+                        .take(budget.lastfm_rows_per_seed)
+                        .map(ExternalLastfmCandidate::from)
+                        .collect::<Vec<_>>();
+                    let branch_rows = if index < EXTERNAL_REFRESH_LASTFM_BRANCH_SEED_TRACKS {
+                        refresh_lastfm_branch_rows(lastfm, seed.track_id, &direct_rows).await
+                    } else {
+                        Vec::new()
+                    };
+                    let mut rows = direct_rows;
+                    rows.extend(branch_rows);
+                    lastfm_rows.insert(seed.track_id, rows);
                 }
                 Err(error) => {
                     if is_provider_rate_limit_error(&error) {
@@ -455,6 +486,64 @@ pub async fn refresh_external_provider_candidates(
     })?;
     report.tidal_similar_provider_errors = tidal_similar_provider_errors;
     Ok(report)
+}
+
+async fn refresh_lastfm_branch_rows(
+    lastfm: &LastFmClient,
+    seed_track_id: i64,
+    direct_rows: &[ExternalLastfmCandidate],
+) -> Vec<ExternalLastfmCandidate> {
+    let mut branch_rows = Vec::new();
+    let mut branch_seen = direct_rows
+        .iter()
+        .map(|row| lastfm_candidate_key(&row.artist, &row.title))
+        .collect::<HashSet<_>>();
+    for parent in direct_rows
+        .iter()
+        .filter(|row| row.match_score >= EXTERNAL_REFRESH_LASTFM_BRANCH_MIN_PARENT_MATCH)
+        .take(EXTERNAL_REFRESH_LASTFM_BRANCHES_PER_SEED)
+    {
+        tokio::time::sleep(std::time::Duration::from_millis(
+            EXTERNAL_REFRESH_LASTFM_DELAY_MS,
+        ))
+        .await;
+        let rows = match lastfm
+            .track_get_similar(
+                &parent.artist,
+                &parent.title,
+                EXTERNAL_REFRESH_LASTFM_BRANCH_ROWS,
+            )
+            .await
+        {
+            Ok(rows) => rows,
+            Err(error) => {
+                tracing::warn!(
+                    target: "noor.discovery.external",
+                    seed_track_id,
+                    parent_artist = %parent.artist,
+                    parent_title = %parent.title,
+                    error = %error,
+                    "Last.fm branch refresh failed"
+                );
+                continue;
+            }
+        };
+        for row in rows.into_iter().take(EXTERNAL_REFRESH_LASTFM_BRANCH_ROWS) {
+            let key = lastfm_candidate_key(&row.artist, &row.title);
+            if branch_seen.insert(key) {
+                branch_rows.push(ExternalLastfmCandidate::branch_from(row, parent));
+            }
+        }
+    }
+    branch_rows
+}
+
+fn lastfm_candidate_key(artist: &str, title: &str) -> String {
+    format!(
+        "{}\u{1f}{}",
+        artist.trim().to_ascii_lowercase(),
+        title.trim().to_ascii_lowercase()
+    )
 }
 
 pub async fn resolve_external_tidal_candidates(
@@ -675,6 +764,7 @@ pub fn persist_external_provider_refresh(
                         serde_json::json!({
                             "match_score": row.match_score,
                             "mbid": row.mbid,
+                            "branch_from": row.branch_from,
                         })
                         .to_string(),
                     ),
@@ -2063,6 +2153,76 @@ fn trainer_external_candidates_from_rows(
         .collect()
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum LastfmRecallKind {
+    Direct,
+    Branch,
+}
+
+fn lastfm_recall_kind(source_payload_json: Option<&str>) -> LastfmRecallKind {
+    let has_branch_parent = source_payload_json
+        .and_then(|raw| serde_json::from_str::<serde_json::Value>(raw).ok())
+        .and_then(|value| {
+            value
+                .get("branch_from")
+                .and_then(|branch| branch.as_str())
+                .map(str::trim)
+                .map(str::is_empty)
+        })
+        .is_some_and(|empty| !empty);
+    if has_branch_parent {
+        LastfmRecallKind::Branch
+    } else {
+        LastfmRecallKind::Direct
+    }
+}
+
+fn lastfm_resolved_edges_from_rows(
+    rows: Vec<queries::ResolvedLastfmExternalSightingRow>,
+) -> Vec<TrainerEdge> {
+    let mut grouped: HashMap<(i64, i64, LastfmRecallKind), f64> = HashMap::new();
+    for row in rows {
+        let kind = lastfm_recall_kind(row.source_payload_json.as_deref());
+        let weight = row.similarity.clamp(0.0, 1.0)
+            * match kind {
+                LastfmRecallKind::Direct => LASTFM_DIRECT_EDGE_WEIGHT,
+                LastfmRecallKind::Branch => LASTFM_BRANCH_EDGE_WEIGHT,
+            };
+        grouped
+            .entry((row.seed_track_id, row.resolved_track_id, kind))
+            .and_modify(|existing| {
+                if weight > *existing {
+                    *existing = weight;
+                }
+            })
+            .or_insert(weight);
+    }
+
+    grouped
+        .into_iter()
+        .map(
+            |((seed_track_id, resolved_track_id, kind), weight)| TrainerEdge {
+                event_id: format!(
+                    "lastfm-resolved:{}:{}:{}",
+                    seed_track_id,
+                    resolved_track_id,
+                    match kind {
+                        LastfmRecallKind::Direct => "direct",
+                        LastfmRecallKind::Branch => "branch",
+                    }
+                ),
+                from_track_id: seed_track_id,
+                to_track_id: resolved_track_id,
+                weight,
+                evidence_kind: match kind {
+                    LastfmRecallKind::Direct => EvidenceKind::LastfmDirectSimilarity,
+                    LastfmRecallKind::Branch => EvidenceKind::LastfmBranchSimilarity,
+                },
+            },
+        )
+        .collect()
+}
+
 fn external_freshness_bucket(updated_at: &str) -> Option<String> {
     let updated = chrono::NaiveDateTime::parse_from_str(updated_at, "%Y-%m-%d %H:%M:%S").ok()?;
     let now = chrono::Utc::now().naive_utc();
@@ -2131,6 +2291,13 @@ fn build_trainer_input(
     let playback_transition_rows = queries::get_playback_transition_edges(conn)?;
     let listen_transition_rows = queries::get_listen_history_transition_edges(conn)?;
     let listen_colisten_rows = queries::get_completion_weighted_listen_edges(conn, 45)?;
+    let lastfm_resolved_edges = lastfm_resolved_edges_from_rows(
+        queries::get_resolved_lastfm_external_sightings_for_training(
+            conn,
+            &chrono::Utc::now().format("%Y-%m-%d %H:%M:%S").to_string(),
+            EXTERNAL_TRAINING_RESOLVED_LASTFM_LIMIT,
+        )?,
+    );
     let playlist_sequences = queries::get_playlist_sequences(conn)?;
     let album_sequences = queries::get_album_sequences(conn)?;
     let artist_sequences = queries::get_artist_sequences(conn)?;
@@ -2273,6 +2440,11 @@ fn build_trainer_input(
                 label: "listen_history".to_string(),
                 base_weight: 1.3,
                 edges: listen_colisten_edges,
+            },
+            TrainerEvidenceGroup {
+                label: "lastfm_resolved".to_string(),
+                base_weight: 1.0,
+                edges: lastfm_resolved_edges,
             },
         ],
         heldout_pairs,
@@ -2964,6 +3136,7 @@ mod tests {
                 title: "Similar Track".to_string(),
                 mbid: Some("mbid-1".to_string()),
                 match_score: 0.91,
+                branch_from: Some("Branch Artist - Branch Track".to_string()),
             }],
         );
         let tidal = vec![ExternalTidalCandidate {
@@ -3024,6 +3197,88 @@ mod tests {
             )
             .unwrap();
         assert_eq!(refresh_at, "2026-02-02 12:00:00");
+    }
+
+    #[test]
+    fn lastfm_branch_candidate_attenuates_parent_and_child_match() {
+        let parent = ExternalLastfmCandidate {
+            artist: "Parent Artist".to_string(),
+            title: "Parent Track".to_string(),
+            mbid: None,
+            match_score: 0.8,
+            branch_from: None,
+        };
+        let child = LastFmSimilarTrack {
+            artist: "Child Artist".to_string(),
+            title: "Child Track".to_string(),
+            mbid: Some("child-mbid".to_string()),
+            match_score: 0.5,
+        };
+
+        let branched = ExternalLastfmCandidate::branch_from(child, &parent);
+
+        assert_eq!(branched.artist, "Child Artist");
+        assert_eq!(branched.title, "Child Track");
+        assert_eq!(branched.mbid.as_deref(), Some("child-mbid"));
+        assert_eq!(
+            branched.branch_from.as_deref(),
+            Some("Parent Artist - Parent Track")
+        );
+        assert!((branched.match_score - 0.26).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn lastfm_resolved_edges_weight_direct_above_branch() {
+        let edges = lastfm_resolved_edges_from_rows(vec![
+            queries::ResolvedLastfmExternalSightingRow {
+                seed_track_id: 1,
+                resolved_track_id: 2,
+                similarity: 0.8,
+                source_payload_json: Some(r#"{"match":0.8}"#.to_string()),
+            },
+            queries::ResolvedLastfmExternalSightingRow {
+                seed_track_id: 1,
+                resolved_track_id: 3,
+                similarity: 0.8,
+                source_payload_json: Some(
+                    r#"{"match":0.8,"branch_from":"Parent - Track"}"#.to_string(),
+                ),
+            },
+        ]);
+
+        let direct = edges
+            .iter()
+            .find(|edge| edge.evidence_kind == EvidenceKind::LastfmDirectSimilarity)
+            .expect("direct edge");
+        let branch = edges
+            .iter()
+            .find(|edge| edge.evidence_kind == EvidenceKind::LastfmBranchSimilarity)
+            .expect("branch edge");
+        assert_eq!(edges.len(), 2);
+        assert!(direct.weight > branch.weight);
+        assert_eq!(direct.from_track_id, 1);
+        assert_eq!(direct.to_track_id, 2);
+    }
+
+    #[test]
+    fn lastfm_resolved_edges_dedupe_same_seed_and_track_by_kind() {
+        let edges = lastfm_resolved_edges_from_rows(vec![
+            queries::ResolvedLastfmExternalSightingRow {
+                seed_track_id: 1,
+                resolved_track_id: 2,
+                similarity: 0.4,
+                source_payload_json: Some(r#"{"match":0.4}"#.to_string()),
+            },
+            queries::ResolvedLastfmExternalSightingRow {
+                seed_track_id: 1,
+                resolved_track_id: 2,
+                similarity: 0.9,
+                source_payload_json: Some(r#"{"match":0.9}"#.to_string()),
+            },
+        ]);
+
+        assert_eq!(edges.len(), 1);
+        assert!((edges[0].weight - (0.9 * LASTFM_DIRECT_EDGE_WEIGHT)).abs() < f64::EPSILON);
     }
 
     fn tidal_search_track(
@@ -3189,6 +3444,8 @@ fn reason_label(key: &str) -> &'static str {
         "album_context" => "album-adjacent",
         "artist_affinity" => "session neighbor",
         "genre_branch" => "genre branch",
+        "lastfm_direct" => "Last.fm direct",
+        "lastfm_branch" => "Last.fm branch",
         _ => "learned signal",
     }
 }


### PR DESCRIPTION
## Summary
- add autosynced DropPreview16 as an isolated mid-song overlay path
- repair DJ transition fire timing by using the captured audio callback trigger position
- keep preview programs out of normal end-of-track handoffs
- add drop preview status fields and cockpit labels for armed and fired previews
- retry missing DJ profiles after transient TIDAL and DASH failures with short retry windows
- improve automix and DJ handoff planning so renderable programs are prepared and tracked more reliably

## Scope notes
- Chart work is intentionally excluded from this branch.
- This PR is limited to DJ, automix, playback runtime, planner, profile retry, and cockpit status surfaces.

## Verification
- cargo test -p noor-mix planner
- cargo test -p noor-server server::routes::dj_routes::tests
- cargo test -p noor-server playback::runtime::tests
- cargo test -p noor-server playback::player
- cargo check -p noor-server
- cargo fmt --all -- --check
- pnpm check
- pnpm test -- dj_page_contract

## Not verified
- Live audible TIDAL playback audition for a real mid-song preview followed by a later handoff transition.