### PR TITLE
fix(discovery): speed up moods and spotify hydration

### DIFF
--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -3173,7 +3173,7 @@ export const api = {
 	// Workout, Focus, etc). Each entry has a slug that can be fed to
 	// getTidalMoodPage for the drill-down content.
 	getTidalMoods() {
-		return fetchApi<{ categories: TidalMoodCategory[]; source: string }>(
+		return fetchApi<{ categories: TidalMoodCategory[]; source: string; fallback?: boolean }>(
 			'/api/tidal/moods',
 		);
 	},

--- a/frontend/src/lib/components/home/HomeMoodsRail.svelte
+++ b/frontend/src/lib/components/home/HomeMoodsRail.svelte
@@ -2,16 +2,20 @@
 	import { onMount } from 'svelte';
 	import { api, type TidalMoodCategory } from '$lib/api/client';
 	import { wheelToHorizontal } from '$lib/actions/wheel-to-horizontal';
+	import ArtworkImage from '$lib/components/ui/ArtworkImage.svelte';
 	import { openContextMenu } from '$lib/stores/context_menu';
 	import { goto } from '$app/navigation';
 	import {
 		getCachedMoodCategories,
-		putCachedMoodCategories,
+		moodCategoriesNeedThumbnails,
+		putCompleteMoodCategories,
 	} from '$lib/stores/tidal-moods-cache';
 
 	const PREVIEW_LIMIT = 8;
 	const LOAD_ARM_DELAY_MS = 0;
 	const FALLBACK_LOAD_DELAY_MS = 3000;
+	const THUMBNAIL_REFRESH_DELAY_MS = 1800;
+	const MAX_THUMBNAIL_REFRESH_ATTEMPTS = 3;
 
 	// Sync-read the shared moods cache on script init so a second visit
 	// within the 6h TTL renders instantly without a network round-trip.
@@ -24,24 +28,32 @@
 	let loading = $state(!cachedOnMount);
 	let errored = $state(false);
 	let sectionEl = $state<HTMLElement | null>(null);
-	let loadStarted = false;
+	let inFlight = false;
+	let thumbnailRefreshAttempts = 0;
+	let thumbnailRefreshTimer: ReturnType<typeof setTimeout> | null = null;
 
 	async function loadMoods() {
-		if (loadStarted) return;
-		loadStarted = true;
+		if (inFlight) return;
+		inFlight = true;
 		try {
 			const data = await api.getTidalMoods();
 			const all = data.categories ?? [];
-			if (all.length > 0) putCachedMoodCategories(all);
+			if (all.length > 0) putCompleteMoodCategories(all);
 			categories = all.slice(0, PREVIEW_LIMIT);
+			scheduleThumbnailRefresh(all);
 		} catch {
 			errored = true;
 		} finally {
 			loading = false;
+			inFlight = false;
 		}
 	}
 
 	onMount(() => {
+		if (cachedOnMount && moodCategoriesNeedThumbnails(cachedOnMount)) {
+			scheduleThumbnailRefresh(cachedOnMount);
+			return () => clearThumbnailRefresh();
+		}
 		if (cachedOnMount) return;
 
 		let observer: IntersectionObserver | null = null;
@@ -68,9 +80,27 @@
 		return () => {
 			clearTimeout(armTimer);
 			if (fallbackTimer) clearTimeout(fallbackTimer);
+			clearThumbnailRefresh();
 			observer?.disconnect();
 		};
 	});
+
+	function clearThumbnailRefresh() {
+		if (!thumbnailRefreshTimer) return;
+		clearTimeout(thumbnailRefreshTimer);
+		thumbnailRefreshTimer = null;
+	}
+
+	function scheduleThumbnailRefresh(nextCategories: TidalMoodCategory[]) {
+		clearThumbnailRefresh();
+		if (!moodCategoriesNeedThumbnails(nextCategories)) {
+			thumbnailRefreshAttempts = 0;
+			return;
+		}
+		if (thumbnailRefreshAttempts >= MAX_THUMBNAIL_REFRESH_ATTEMPTS) return;
+		thumbnailRefreshAttempts += 1;
+		thumbnailRefreshTimer = setTimeout(() => void loadMoods(), THUMBNAIL_REFRESH_DELAY_MS);
+	}
 
 	function menu(slug: string, title: string) {
 		return [{ label: `Open ${title}`, onSelect: () => void goto(`/moods/${slug}`) }];
@@ -95,11 +125,13 @@
 						oncontextmenu={(e) => { e.preventDefault(); openContextMenu(e, menu(c.slug, c.title), c.title); }}
 					>
 						<div class="art-wrap">
-							{#if c.thumbnail}
-								<div class="art" style="background-image:url('{c.thumbnail}')"></div>
-							{:else}
-								<div class="art fallback">~</div>
-							{/if}
+							<ArtworkImage
+								className="mood-art"
+								src={c.thumbnail}
+								alt={c.title}
+								size={320}
+								fallbackText="~"
+							/>
 						</div>
 						<p class="card-title">{c.title}</p>
 					</a>
@@ -164,9 +196,10 @@
 	.card:hover, .card:focus-visible { background: var(--bg-hover); border-color: var(--panel-border); outline: none; }
 	.card:focus-visible { border-color: var(--accent-line); }
 	.art-wrap { position: relative; aspect-ratio: 1 / 1; width: 100%; border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-hover); }
-	.art { width: 100%; height: 100%; background-size: cover; background-position: center; transition: transform var(--motion-base); }
-	.card:hover .art { transform: scale(1.05); }
-	.art.fallback { display: flex; align-items: center; justify-content: center; font-size: var(--font-size-4xl); color: var(--text-muted); }
+	:global(.mood-art) { width: 100%; height: 100%; object-fit: cover; display: block; transition: transform var(--motion-base); }
+	:global(.mood-art.fallback) { display: flex; align-items: center; justify-content: center; background: var(--bg-hover); }
+	:global(.mood-art.fallback span) { font-size: var(--font-size-4xl); color: var(--text-muted); }
+	.card:hover :global(.mood-art) { transform: scale(1.05); }
 	.card-title { margin: 0; font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; line-height: var(--line-height-snug); }
 
 	.card.skeleton { cursor: default; pointer-events: none; }

--- a/frontend/src/lib/components/home/HomeMoodsRail.svelte
+++ b/frontend/src/lib/components/home/HomeMoodsRail.svelte
@@ -10,8 +10,8 @@
 	} from '$lib/stores/tidal-moods-cache';
 
 	const PREVIEW_LIMIT = 8;
-	const LOAD_ARM_DELAY_MS = 2500;
-	const FALLBACK_LOAD_DELAY_MS = 10000;
+	const LOAD_ARM_DELAY_MS = 0;
+	const FALLBACK_LOAD_DELAY_MS = 3000;
 
 	// Sync-read the shared moods cache on script init so a second visit
 	// within the 6h TTL renders instantly without a network round-trip.

--- a/frontend/src/lib/stores/tidal-moods-cache.test.ts
+++ b/frontend/src/lib/stores/tidal-moods-cache.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test, beforeEach } from 'vitest';
+import {
+	clearCachedMoods,
+	getCachedMoodCategories,
+	moodCategoriesNeedThumbnails,
+	putCompleteMoodCategories,
+} from './tidal-moods-cache';
+import type { TidalMoodCategory } from '$lib/api/client';
+
+const completeCategories: TidalMoodCategory[] = [
+	{
+		slug: 'mood_party',
+		title: 'Party',
+		icon: null,
+		imageId: null,
+		thumbnail: 'https://resources.tidal.com/images/party/320x320.jpg',
+	},
+];
+
+const incompleteCategories: TidalMoodCategory[] = [
+	{
+		slug: 'mood_party',
+		title: 'Party',
+		icon: null,
+		imageId: null,
+		thumbnail: null,
+	},
+];
+
+describe('TIDAL moods cache', () => {
+	beforeEach(() => {
+		clearCachedMoods();
+	});
+
+	test('treats mood lists without thumbnails as provisional', () => {
+		expect(moodCategoriesNeedThumbnails(incompleteCategories)).toBe(true);
+		expect(moodCategoriesNeedThumbnails(completeCategories)).toBe(false);
+	});
+
+	test('does not cache incomplete mood thumbnail probes for six hours', () => {
+		putCompleteMoodCategories(incompleteCategories);
+
+		expect(getCachedMoodCategories()).toBeNull();
+
+		putCompleteMoodCategories(completeCategories);
+
+		expect(getCachedMoodCategories()).toEqual(completeCategories);
+	});
+});

--- a/frontend/src/lib/stores/tidal-moods-cache.ts
+++ b/frontend/src/lib/stores/tidal-moods-cache.ts
@@ -33,6 +33,14 @@ export function putCachedMoodCategories(categories: TidalMoodCategory[]): void {
 	landing = { categories, insertedAt: Date.now() };
 }
 
+export function moodCategoriesNeedThumbnails(categories: TidalMoodCategory[]): boolean {
+	return categories.length > 0 && categories.some((category) => !category.thumbnail);
+}
+
+export function putCompleteMoodCategories(categories: TidalMoodCategory[]): void {
+	if (!moodCategoriesNeedThumbnails(categories)) putCachedMoodCategories(categories);
+}
+
 export function getCachedMoodPage(slug: string): TidalHomeModule[] | null {
 	const e = drilldown.get(slug);
 	if (!e) return null;

--- a/frontend/src/routes/moods/+page.svelte
+++ b/frontend/src/routes/moods/+page.svelte
@@ -1,16 +1,20 @@
 <script lang="ts">
   import { onMount, untrack } from 'svelte';
   import { ApiError, api, type TidalMoodCategory } from '$lib/api/client';
+  import ArtworkImage from '$lib/components/ui/ArtworkImage.svelte';
   import { tidalStatus } from '$lib/stores/tidal';
   import { openContextMenu } from '$lib/stores/context_menu';
   import { goto } from '$app/navigation';
   import {
     getCachedMoodCategories,
-    putCachedMoodCategories,
+    moodCategoriesNeedThumbnails,
+    putCompleteMoodCategories,
     clearCachedMoods,
   } from '$lib/stores/tidal-moods-cache';
 
   type State = 'loading' | 'ready' | 'empty' | 'disconnected' | 'error';
+  const THUMBNAIL_REFRESH_DELAY_MS = 1800;
+  const MAX_THUMBNAIL_REFRESH_ATTEMPTS = 3;
 
   // Sync-read the cache on script init so revisiting /moods within the
   // 6h TTL renders instantly without a skeleton flash. Mirrors the
@@ -20,10 +24,17 @@
   let viewState = $state<State>(
     cachedOnMount && cachedOnMount.length > 0 ? 'ready' : 'loading'
   );
+  let inFlight = false;
+  let thumbnailRefreshAttempts = 0;
+  let thumbnailRefreshTimer: ReturnType<typeof setTimeout> | null = null;
 
   onMount(() => {
-    if (cachedOnMount && cachedOnMount.length > 0) return;
+    if (cachedOnMount && cachedOnMount.length > 0) {
+      if (moodCategoriesNeedThumbnails(cachedOnMount)) scheduleThumbnailRefresh(cachedOnMount);
+      return () => clearThumbnailRefresh();
+    }
     void load();
+    return () => clearThumbnailRefresh();
   });
 
   $effect(() => {
@@ -33,12 +44,15 @@
   });
 
   async function load() {
-    viewState = 'loading';
+    if (inFlight) return;
+    inFlight = true;
+    if (categories.length === 0) viewState = 'loading';
     try {
       const data = await api.getTidalMoods();
       categories = data.categories ?? [];
-      if (categories.length > 0) putCachedMoodCategories(categories);
+      if (categories.length > 0) putCompleteMoodCategories(categories);
       viewState = categories.length > 0 ? 'ready' : 'empty';
+      scheduleThumbnailRefresh(categories);
     } catch (e) {
       if (e instanceof ApiError && e.status === 503) {
         clearCachedMoods();
@@ -46,7 +60,26 @@
       } else {
         viewState = 'error';
       }
+    } finally {
+      inFlight = false;
     }
+  }
+
+  function clearThumbnailRefresh() {
+    if (!thumbnailRefreshTimer) return;
+    clearTimeout(thumbnailRefreshTimer);
+    thumbnailRefreshTimer = null;
+  }
+
+  function scheduleThumbnailRefresh(nextCategories: TidalMoodCategory[]) {
+    clearThumbnailRefresh();
+    if (!moodCategoriesNeedThumbnails(nextCategories)) {
+      thumbnailRefreshAttempts = 0;
+      return;
+    }
+    if (thumbnailRefreshAttempts >= MAX_THUMBNAIL_REFRESH_ATTEMPTS) return;
+    thumbnailRefreshAttempts += 1;
+    thumbnailRefreshTimer = setTimeout(() => void load(), THUMBNAIL_REFRESH_DELAY_MS);
   }
 
   function buildMenu(slug: string, title: string) {
@@ -74,11 +107,13 @@
           oncontextmenu={(e) => { e.preventDefault(); openContextMenu(e, buildMenu(c.slug, c.title), c.title); }}
         >
           <div class="art-wrap">
-            {#if c.thumbnail}
-              <div class="art" style="background-image:url('{c.thumbnail}')"></div>
-            {:else}
-              <div class="art fallback">~</div>
-            {/if}
+            <ArtworkImage
+              className="mood-art"
+              src={c.thumbnail}
+              alt={c.title}
+              size={320}
+              fallbackText="~"
+            />
           </div>
           <p class="card-title">{c.title}</p>
         </a>
@@ -120,8 +155,9 @@
   .card:hover, .card:focus-visible { background: var(--bg-hover); border-color: var(--panel-border); outline: none; }
   .card:focus-visible { border-color: var(--accent-line); }
   .art-wrap { position: relative; aspect-ratio: 1 / 1; width: 100%; border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-hover); }
-  .art { width: 100%; height: 100%; background-size: cover; background-position: center; transition: transform var(--motion-base); }
-  .card:hover .art { transform: scale(1.05); }
-  .art.fallback { display: flex; align-items: center; justify-content: center; font-size: var(--font-size-4xl); color: var(--text-muted); }
+  :global(.mood-art) { width: 100%; height: 100%; object-fit: cover; display: block; transition: transform var(--motion-base); }
+  :global(.mood-art.fallback) { display: flex; align-items: center; justify-content: center; background: var(--bg-hover); }
+  :global(.mood-art.fallback span) { font-size: var(--font-size-4xl); color: var(--text-muted); }
+  .card:hover :global(.mood-art) { transform: scale(1.05); }
   .card-title { margin: 0; font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; line-height: var(--line-height-snug); }
 </style>

--- a/noor-server/src/db/queries.rs
+++ b/noor-server/src/db/queries.rs
@@ -4353,27 +4353,44 @@ pub struct TrackSimilarityResult {
 /// Fixes: Stage 1 now enumerates ALL pairs per album/artist (not just MIN/MAX).
 ///        Stage 2 uses indexed temp tables so scores merge correctly.
 pub fn compute_track_similarity(conn: &Connection) -> Result<usize> {
-    // Run all stages inside a single transaction so a kill or error mid-way
-    // can't leave the table in a half-populated state (rows inserted but
-    // component scores never updated). Dropping `tx` without commit rolls back.
-    let tx = conn.unchecked_transaction()?;
-
-    tx.execute("DELETE FROM track_similarity", [])?;
+    // Do the expensive work in temporary tables so the background rebuild does
+    // not hold SQLite's single writer slot while playback is trying to update
+    // playback_state. The real table is swapped in one short transaction at
+    // the end.
+    conn.execute_batch(
+        "
+        DROP TABLE IF EXISTS _track_similarity_build;
+        CREATE TEMP TABLE _track_similarity_build (
+            track_a INTEGER NOT NULL,
+            track_b INTEGER NOT NULL,
+            similarity_score REAL NOT NULL DEFAULT 0,
+            co_listen_score REAL DEFAULT 0,
+            co_album_score REAL DEFAULT 0,
+            co_artist_score REAL DEFAULT 0,
+            genre_proximity REAL DEFAULT 0,
+            duration_proximity REAL DEFAULT 0,
+            era_proximity REAL DEFAULT 0,
+            computed_at TEXT DEFAULT (datetime('now')),
+            PRIMARY KEY (track_a, track_b),
+            CHECK (track_a < track_b)
+        );
+    ",
+    )?;
 
     // ── Stage 1: candidate pairs ─────────────────────────────────────────────
     // Each INSERT must satisfy CHECK (track_a < track_b), ensured by `b.id > a.id`.
 
-    tx.execute_batch(
+    conn.execute_batch(
         "
         -- 1a: Same-album pairs (all combinations, not just min/max)
-        INSERT OR IGNORE INTO track_similarity (track_a, track_b)
+        INSERT OR IGNORE INTO _track_similarity_build (track_a, track_b)
         SELECT a.id, b.id
         FROM tracks a
         JOIN tracks b ON b.album_id = a.album_id AND b.id > a.id
         WHERE a.album_id IS NOT NULL;
 
         -- 1b: Same-artist pairs (cap at artists with <=100 tracks)
-        INSERT OR IGNORE INTO track_similarity (track_a, track_b)
+        INSERT OR IGNORE INTO _track_similarity_build (track_a, track_b)
         SELECT a.id, b.id
         FROM tracks a
         JOIN tracks b ON b.artist_id = a.artist_id AND b.id > a.id
@@ -4382,7 +4399,7 @@ pub fn compute_track_similarity(conn: &Connection) -> Result<usize> {
         );
 
         -- 1c: Shared-genre pairs (deduplicated by GROUP BY, limited to avoid explosion)
-        INSERT OR IGNORE INTO track_similarity (track_a, track_b)
+        INSERT OR IGNORE INTO _track_similarity_build (track_a, track_b)
         SELECT a.track_id, b.track_id
         FROM track_genres a
         JOIN track_genres b ON b.genre_id = a.genre_id AND b.track_id > a.track_id
@@ -4393,7 +4410,7 @@ pub fn compute_track_similarity(conn: &Connection) -> Result<usize> {
 
     // ── Stage 2: aggregate signals into indexed temp tables ──────────────────
 
-    tx.execute_batch(
+    conn.execute_batch(
         "
         DROP TABLE IF EXISTS _co_listen;
         CREATE TEMP TABLE _co_listen AS
@@ -4432,13 +4449,13 @@ pub fn compute_track_similarity(conn: &Connection) -> Result<usize> {
     // ── Stage 3: score each component ────────────────────────────────────────
 
     // co_album: 1.0 if same album
-    tx.execute(
+    conn.execute(
         "
-        UPDATE track_similarity SET co_album_score = 1.0
+        UPDATE _track_similarity_build SET co_album_score = 1.0
         WHERE EXISTS (
             SELECT 1 FROM tracks a, tracks b
-            WHERE a.id = track_similarity.track_a
-              AND b.id = track_similarity.track_b
+            WHERE a.id = _track_similarity_build.track_a
+              AND b.id = _track_similarity_build.track_b
               AND a.album_id IS NOT NULL
               AND a.album_id = b.album_id
         )
@@ -4447,13 +4464,13 @@ pub fn compute_track_similarity(conn: &Connection) -> Result<usize> {
     )?;
 
     // co_artist: 1.0 if same artist
-    tx.execute(
+    conn.execute(
         "
-        UPDATE track_similarity SET co_artist_score = 1.0
+        UPDATE _track_similarity_build SET co_artist_score = 1.0
         WHERE EXISTS (
             SELECT 1 FROM tracks a, tracks b
-            WHERE a.id = track_similarity.track_a
-              AND b.id = track_similarity.track_b
+            WHERE a.id = _track_similarity_build.track_a
+              AND b.id = _track_similarity_build.track_b
               AND a.artist_id IS NOT NULL
               AND a.artist_id = b.artist_id
         )
@@ -4462,23 +4479,23 @@ pub fn compute_track_similarity(conn: &Connection) -> Result<usize> {
     )?;
 
     // genre_proximity: shared genres / max genres on any single track
-    tx.execute("
-        UPDATE track_similarity SET genre_proximity = COALESCE((
+    conn.execute("
+        UPDATE _track_similarity_build SET genre_proximity = COALESCE((
             SELECT CAST(gs.shared AS REAL) / NULLIF(
                 (SELECT MAX(c) FROM (SELECT COUNT(DISTINCT genre_id) AS c FROM track_genres GROUP BY track_id)),
                 0)
             FROM _genre_shared gs
-            WHERE gs.ta = track_similarity.track_a AND gs.tb = track_similarity.track_b
+            WHERE gs.ta = _track_similarity_build.track_a AND gs.tb = _track_similarity_build.track_b
         ), 0)
     ", [])?;
 
     // duration_proximity: 1 - |dur_a - dur_b| / 180s, clamped 0-1
-    tx.execute(
+    conn.execute(
         "
-        UPDATE track_similarity SET duration_proximity = COALESCE((
+        UPDATE _track_similarity_build SET duration_proximity = COALESCE((
             SELECT 1.0 - MIN(CAST(ABS(a.duration_ms - b.duration_ms) AS REAL) / 180000.0, 1.0)
             FROM tracks a, tracks b
-            WHERE a.id = track_similarity.track_a AND b.id = track_similarity.track_b
+            WHERE a.id = _track_similarity_build.track_a AND b.id = _track_similarity_build.track_b
               AND a.duration_ms IS NOT NULL AND b.duration_ms IS NOT NULL
         ), 0)
     ",
@@ -4486,25 +4503,25 @@ pub fn compute_track_similarity(conn: &Connection) -> Result<usize> {
     )?;
 
     // co_listen: normalized co-occurrence count
-    tx.execute(
+    conn.execute(
         "
-        UPDATE track_similarity SET co_listen_score = COALESCE((
+        UPDATE _track_similarity_build SET co_listen_score = COALESCE((
             SELECT cl.n / NULLIF((SELECT MAX(n) FROM _co_listen), 0)
             FROM _co_listen cl
-            WHERE cl.ta = track_similarity.track_a AND cl.tb = track_similarity.track_b
+            WHERE cl.ta = _track_similarity_build.track_a AND cl.tb = _track_similarity_build.track_b
         ), 0)
     ",
         [],
     )?;
 
     // era_proximity: 1 - |year_a - year_b| / 25, clamped 0-1. Zero when either year is unknown.
-    tx.execute(
+    conn.execute(
         "
-        UPDATE track_similarity SET era_proximity = COALESCE((
+        UPDATE _track_similarity_build SET era_proximity = COALESCE((
             SELECT 1.0 - MIN(CAST(ABS(ya.year - yb.year) AS REAL) / 25.0, 1.0)
             FROM _track_year ya, _track_year yb
-            WHERE ya.track_id = track_similarity.track_a
-              AND yb.track_id = track_similarity.track_b
+            WHERE ya.track_id = _track_similarity_build.track_a
+              AND yb.track_id = _track_similarity_build.track_b
         ), 0)
     ",
         [],
@@ -4512,9 +4529,9 @@ pub fn compute_track_similarity(conn: &Connection) -> Result<usize> {
 
     // Final weighted score. era_proximity replaces some duration_proximity weight
     // because era is a stronger taste signal than song length.
-    tx.execute(
+    conn.execute(
         "
-        UPDATE track_similarity SET similarity_score =
+        UPDATE _track_similarity_build SET similarity_score =
             co_listen_score    * 0.30 +
             co_album_score     * 0.20 +
             co_artist_score    * 0.20 +
@@ -4525,7 +4542,7 @@ pub fn compute_track_similarity(conn: &Connection) -> Result<usize> {
         [],
     )?;
 
-    tx.execute_batch(
+    conn.execute_batch(
         "
         DROP TABLE IF EXISTS _co_listen;
         DROP TABLE IF EXISTS _genre_shared;
@@ -4533,11 +4550,43 @@ pub fn compute_track_similarity(conn: &Connection) -> Result<usize> {
     ",
     )?;
 
-    let count: i64 = tx.query_row("SELECT COUNT(*) FROM track_similarity", [], |row| {
+    let count: i64 = conn.query_row("SELECT COUNT(*) FROM _track_similarity_build", [], |row| {
         row.get(0)
     })?;
 
+    let tx = conn.unchecked_transaction()?;
+    tx.execute("DELETE FROM track_similarity", [])?;
+    tx.execute(
+        "
+        INSERT INTO track_similarity (
+            track_a,
+            track_b,
+            similarity_score,
+            co_listen_score,
+            co_album_score,
+            co_artist_score,
+            genre_proximity,
+            duration_proximity,
+            era_proximity,
+            computed_at
+        )
+        SELECT
+            track_a,
+            track_b,
+            similarity_score,
+            co_listen_score,
+            co_album_score,
+            co_artist_score,
+            genre_proximity,
+            duration_proximity,
+            era_proximity,
+            computed_at
+        FROM _track_similarity_build
+        ",
+        [],
+    )?;
     tx.commit()?;
+    conn.execute_batch("DROP TABLE IF EXISTS _track_similarity_build;")?;
     Ok(count as usize)
 }
 
@@ -7865,6 +7914,61 @@ mod tests {
         )
         .optional()
         .expect("query server_config")
+    }
+
+    #[test]
+    fn compute_track_similarity_swaps_from_temp_build_table() {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        conn.execute_batch("PRAGMA foreign_keys = ON;")
+            .expect("foreign keys");
+        schema::run_migrations(&conn).expect("migrations");
+        conn.execute("INSERT INTO artists (id, name) VALUES (1, 'Artist')", [])
+            .expect("artist");
+        conn.execute(
+            "INSERT INTO albums (id, title, artist_id, year) VALUES (1, 'Album', 1, 1999)",
+            [],
+        )
+        .expect("album");
+        conn.execute(
+            "INSERT INTO tracks (id, title, artist_id, album_id, duration_ms)
+             VALUES
+                (1, 'One', 1, 1, 180000),
+                (2, 'Two', 1, 1, 181000),
+                (3, 'Three', 1, 1, 220000)",
+            [],
+        )
+        .expect("tracks");
+        conn.execute(
+            "INSERT INTO track_similarity (track_a, track_b, similarity_score)
+             VALUES (1, 2, 0.01)",
+            [],
+        )
+        .expect("stale similarity");
+
+        let count = compute_track_similarity(&conn).expect("compute similarity");
+        assert_eq!(count, 3);
+
+        let persisted_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM track_similarity", [], |row| {
+                row.get(0)
+            })
+            .expect("persisted count");
+        assert_eq!(persisted_count, 3);
+        let score: f64 = conn
+            .query_row(
+                "SELECT similarity_score FROM track_similarity WHERE track_a = 1 AND track_b = 2",
+                [],
+                |row| row.get(0),
+            )
+            .expect("score");
+        assert!(score > 0.01, "rebuild should replace stale similarity rows");
+        assert!(
+            conn.query_row("SELECT COUNT(*) FROM _track_similarity_build", [], |row| {
+                row.get::<_, i64>(0)
+            },)
+                .is_err(),
+            "temporary build table should be dropped after swap"
+        );
     }
 
     mod dj_transition_event {

--- a/noor-server/src/main.rs
+++ b/noor-server/src/main.rs
@@ -607,22 +607,38 @@ async fn main() -> Result<()> {
         info!("Last.fm scrobbling disabled (set LASTFM_API_SECRET to enable)");
     }
 
-    // Sportify (anonymous Spotify metadata proxy) — powers /discover. Default
-    // base URL ships in code; env var lets ops point at a self-hosted mirror.
-    let sportify_base_url = std::env::var("SPORTIFY_API_BASE_URL")
+    // Sportify (anonymous Spotify metadata proxy) powers /discover. Default
+    // base URL ships in code; env vars let ops point at a self-hosted mirror.
+    let configured_sportify_base_url = std::env::var("SPORTIFY_API_BASE_URL")
         .ok()
-        .filter(|s| !s.trim().is_empty())
-        .unwrap_or_else(|| "https://sportify.xcasper.space".to_string());
+        .filter(|s| !s.trim().is_empty());
+    let sportify_base_url = configured_sportify_base_url
+        .clone()
+        .unwrap_or_else(|| "https://spotify.xwolf.space".to_string());
+    let sportify_fallback_base_urls = if configured_sportify_base_url.is_some() {
+        Vec::new()
+    } else {
+        vec!["https://sportify.xcasper.space".to_string()]
+    };
     let sportify_client =
         match services::sportify::SportifyClient::new(services::sportify::SportifyClientConfig {
             base_url: sportify_base_url.clone(),
+            fallback_base_urls: sportify_fallback_base_urls.clone(),
             user_agent: format!(
                 "noor-server/{} (sportify discovery)",
                 env!("CARGO_PKG_VERSION")
             ),
         }) {
             Ok(client) => {
-                info!("Sportify discovery client ready ({})", sportify_base_url);
+                if sportify_fallback_base_urls.is_empty() {
+                    info!("Sportify discovery client ready ({})", sportify_base_url);
+                } else {
+                    info!(
+                        "Sportify discovery client ready ({} with fallback {})",
+                        sportify_base_url,
+                        sportify_fallback_base_urls.join(", ")
+                    );
+                }
                 Some(Arc::new(client))
             }
             Err(e) => {

--- a/noor-server/src/server/routes/search_routes.rs
+++ b/noor-server/src/server/routes/search_routes.rs
@@ -1,5 +1,6 @@
 use crate::SharedState;
 use crate::db::queries;
+use anyhow::Context;
 use axum::{
     extract::{Query, State},
     http::StatusCode,
@@ -119,7 +120,7 @@ async fn fetch_spotify_playlist_search_compact(
         return Ok(Vec::new());
     }
 
-    let results = cached_search(
+    let results = match cached_search(
         client,
         db,
         cfg,
@@ -128,7 +129,18 @@ async fn fetch_spotify_playlist_search_compact(
         limit,
         0,
     )
-    .await?;
+    .await
+    {
+        Ok(results) if !results.playlists.is_empty() => results,
+        Ok(results) => results,
+        Err(primary_error) => {
+            crate::services::spotify::catalog::search_playlists_from_saved_credentials(
+                db, query, limit, 0,
+            )
+            .await
+            .with_context(|| format!("sportify playlist search failed: {primary_error}"))?
+        }
+    };
 
     Ok(results
         .playlists

--- a/noor-server/src/server/routes/sportify_routes.rs
+++ b/noor-server/src/server/routes/sportify_routes.rs
@@ -69,19 +69,47 @@ pub(super) async fn sportify_discovery_search(
     let cached = db
         .with_conn(|conn| sp_cache::get_search(conn, &cache_cfg, q, kind, limit, offset))
         .map_err(super::internal)?;
+    let cached = cached.filter(|p| {
+        !(matches!(
+            kind,
+            crate::services::sportify::client::SportifySearchKind::Playlist
+        ) && p.playlists.is_empty())
+    });
 
     let payload = match cached {
         Some(p) => p,
         None => {
-            let fetched = sportify_client
-                .search(q, kind, limit, offset)
-                .await
-                .map_err(|e| {
-                    (
+            let primary = sportify_client.search(q, kind, limit, offset).await;
+            let fetched = match primary {
+                Ok(fetched) => fetched,
+                Err(primary_error)
+                    if matches!(
+                        kind,
+                        crate::services::sportify::client::SportifySearchKind::Playlist
+                    ) =>
+                {
+                    crate::services::spotify::catalog::search_playlists_from_saved_credentials(
+                        &db, q, limit, offset,
+                    )
+                    .await
+                    .map_err(|fallback_error| {
+                        (
+                            StatusCode::BAD_GATEWAY,
+                            Json(json!({
+                                "error": format!(
+                                    "sportify_search: {primary_error}; spotify_fallback: {fallback_error}"
+                                )
+                            })),
+                        )
+                    })?
+                }
+                Err(e) => {
+                    return Err((
                         StatusCode::BAD_GATEWAY,
                         Json(json!({ "error": format!("sportify_search: {e}") })),
-                    )
-                })?;
+                    ));
+                }
+            };
             db.with_conn(|conn| sp_cache::put_search(conn, q, kind, limit, offset, &fetched))
                 .map_err(super::internal)?;
             fetched
@@ -271,12 +299,23 @@ pub(super) async fn sportify_discovery_playlist(
     {
         Some(p) => p,
         None => {
-            let fetched = sportify_client.playlist(id).await.map_err(|e| {
-                (
-                    StatusCode::BAD_GATEWAY,
-                    Json(json!({ "error": format!("sportify_playlist_fetch: {e}") })),
-                )
-            })?;
+            let fetched = match sportify_client.playlist(id).await {
+                Ok(fetched) => fetched,
+                Err(primary_error) => {
+                    crate::services::spotify::catalog::playlist_from_saved_credentials(&db, id)
+                        .await
+                        .map_err(|fallback_error| {
+                            (
+                                StatusCode::BAD_GATEWAY,
+                                Json(json!({
+                                    "error": format!(
+                                        "sportify_playlist_fetch: {primary_error}; spotify_fallback: {fallback_error}"
+                                    )
+                                })),
+                            )
+                        })?
+                }
+            };
             db.with_conn(|conn| {
                 sp_cache::put_playlist_meta(conn, id, &fetched)?;
                 Ok::<_, anyhow::Error>(())

--- a/noor-server/src/server/routes/tidal_home_routes.rs
+++ b/noor-server/src/server/routes/tidal_home_routes.rs
@@ -19,6 +19,17 @@ const MOOD_THUMBNAIL_FETCH_CONCURRENCY: usize = 4;
 const MOOD_THUMBNAIL_PROBE_TIMEOUT: Duration = Duration::from_secs(4);
 const TIDAL_HOME_MODULES_PAGE_PATH: &str = "pages/home";
 const ROUTE_TIMING_INFO_THRESHOLD_MS: u128 = 500;
+const DEFAULT_TIDAL_MOOD_CATEGORIES: &[(&str, &str)] = &[
+    ("mood_party", "Party"),
+    ("mood_workout", "Workout"),
+    ("mood_focus", "Focus"),
+    ("mood_relax", "Relax"),
+    ("mood_sleep", "Sleep"),
+    ("mood_love", "Love"),
+    ("m_happy", "Happy"),
+    ("m_celebration", "Celebration"),
+    ("mood_djselector", "DJ Selector"),
+];
 
 enum MoodProbeOutcome {
     Modules {
@@ -446,7 +457,7 @@ fn resolve_page_path(section: &str, id: Option<&str>) -> Result<String, StatusCo
     // (verified live: all 404 with subStatus 2001 "Not found"). `moods` now
     // has its own dedicated route at /api/tidal/moods + /api/tidal/mood-page/{slug}
     // because its modules are PAGE_LINKS, not the usual TRACK_LIST/etc shape.
-    // Empty top-level whitelist for now — this generic route is kept for
+    // Empty top-level whitelist for now. This generic route is kept for
     // future slugs (pages/explore, pages/hires, pages/videos, etc).
     let allowed_top = matches!(section, "");
     let allowed_with_id = matches!(section, "mood" | "genre");
@@ -652,38 +663,32 @@ pub(super) async fn get_tidal_moods(
             json!({ "categories": cached, "source": "tidal", "cached": true }),
         ));
     }
-    let client = TidalClient::with_http(
-        tidal_http_client.clone(),
-        tokens.access_token.clone(),
-        tokens.country_code.clone(),
-    );
-    let raw = match client.get_page_raw("pages/moods").await {
-        Ok(r) => r,
-        Err(e) if super::error_looks_like_auth(&e) => {
-            let refreshed = super::recover_tidal_session(&state, &http_client, &tokens)
-                .await
-                .map_err(|_| StatusCode::BAD_GATEWAY)?;
-            let retry = TidalClient::with_http(
-                tidal_http_client.clone(),
-                refreshed.access_token.clone(),
-                refreshed.country_code.clone(),
-            );
-            retry.get_page_raw("pages/moods").await.map_err(|e| {
-                tracing::warn!("TIDAL get_tidal_moods failed after refresh: {e}");
-                StatusCode::BAD_GATEWAY
-            })?
-        }
-        Err(e) => {
-            tracing::warn!("TIDAL get_tidal_moods failed: {e}");
-            return Err(StatusCode::BAD_GATEWAY);
-        }
-    };
-    let categories = extract_page_links(&raw);
+    let categories = default_tidal_mood_categories();
     let (response_categories, pending_probe_slugs, cached_probe_hits) =
         apply_cached_mood_category_probes(categories, &tokens.country_code, &page_modules_cache);
     let pending_probe_count = pending_probe_slugs.len();
 
     put_cached_tidal_mood_categories(&mood_cache, response_categories.clone());
+
+    {
+        let state_bg = state.clone();
+        let mood_cache_bg = mood_cache.clone();
+        let page_modules_cache_bg = page_modules_cache.clone();
+        let tokens_bg = tokens.clone();
+        let http_client_bg = http_client;
+        let tidal_http_client_bg = tidal_http_client.clone();
+        tokio::spawn(async move {
+            refresh_tidal_moods_cache(
+                state_bg,
+                mood_cache_bg,
+                page_modules_cache_bg,
+                tokens_bg,
+                http_client_bg,
+                tidal_http_client_bg,
+            )
+            .await;
+        });
+    }
 
     if !pending_probe_slugs.is_empty() {
         let mood_cache_bg = mood_cache.clone();
@@ -731,8 +736,88 @@ pub(super) async fn get_tidal_moods(
         );
     }
     Ok(Json(
-        json!({ "categories": response_categories, "source": "tidal" }),
+        json!({ "categories": response_categories, "source": "tidal", "fallback": true }),
     ))
+}
+
+async fn refresh_tidal_moods_cache(
+    state: SharedState,
+    mood_cache: TidalMoodCategoriesCache,
+    page_modules_cache: TidalPageModulesCache,
+    tokens: crate::services::tidal::auth::TidalTokens,
+    http_client: reqwest::Client,
+    tidal_http_client: reqwest::Client,
+) {
+    let started_at = Instant::now();
+    let client = TidalClient::with_http(
+        tidal_http_client.clone(),
+        tokens.access_token.clone(),
+        tokens.country_code.clone(),
+    );
+    let raw = match client.get_page_raw("pages/moods").await {
+        Ok(r) => r,
+        Err(e) if super::error_looks_like_auth(&e) => {
+            let Ok(refreshed) = super::recover_tidal_session(&state, &http_client, &tokens).await
+            else {
+                tracing::warn!("TIDAL get_tidal_moods refresh failed");
+                return;
+            };
+            let retry = TidalClient::with_http(
+                tidal_http_client.clone(),
+                refreshed.access_token.clone(),
+                refreshed.country_code.clone(),
+            );
+            match retry.get_page_raw("pages/moods").await {
+                Ok(r) => r,
+                Err(e) => {
+                    tracing::warn!("TIDAL get_tidal_moods failed after refresh: {e}");
+                    return;
+                }
+            }
+        }
+        Err(e) => {
+            tracing::warn!("TIDAL get_tidal_moods failed: {e}");
+            return;
+        }
+    };
+    let live_categories = extract_page_links(&raw);
+    if live_categories.is_empty() {
+        tracing::warn!("TIDAL get_tidal_moods returned no PAGE_LINKS categories");
+        return;
+    }
+
+    let (response_categories, pending_probe_slugs, cached_probe_hits) =
+        apply_cached_mood_category_probes(
+            live_categories,
+            &tokens.country_code,
+            &page_modules_cache,
+        );
+    put_cached_tidal_mood_categories(&mood_cache, response_categories.clone());
+
+    if !pending_probe_slugs.is_empty() {
+        let probe_client = TidalClient::with_http(
+            tidal_http_client,
+            tokens.access_token.clone(),
+            tokens.country_code.clone(),
+        );
+        run_mood_thumbnail_probe_refresh(
+            mood_cache.clone(),
+            page_modules_cache,
+            probe_client,
+            tokens.country_code.clone(),
+            response_categories.clone(),
+            pending_probe_slugs,
+        )
+        .await;
+    }
+
+    tracing::info!(
+        route = "tidal_moods_refresh",
+        elapsed_ms = started_at.elapsed().as_millis(),
+        cached_probe_hits,
+        category_count = response_categories.len(),
+        "TIDAL moods background refresh complete"
+    );
 }
 
 fn apply_cached_mood_category_probes(
@@ -784,6 +869,21 @@ fn apply_mood_probe_results(
                 }
             }
             Some(category)
+        })
+        .collect()
+}
+
+fn default_tidal_mood_categories() -> Vec<Value> {
+    DEFAULT_TIDAL_MOOD_CATEGORIES
+        .iter()
+        .map(|(slug, title)| {
+            json!({
+                "slug": slug,
+                "title": title,
+                "icon": null,
+                "imageId": null,
+                "thumbnail": null,
+            })
         })
         .collect()
 }

--- a/noor-server/src/services/sportify/client.rs
+++ b/noor-server/src/services/sportify/client.rs
@@ -23,6 +23,7 @@ use super::models::{
 #[derive(Debug, Clone)]
 pub struct SportifyClientConfig {
     pub base_url: String,
+    pub fallback_base_urls: Vec<String>,
     pub user_agent: String,
 }
 
@@ -70,12 +71,34 @@ mod tests {
         assert_eq!(items.as_array().unwrap().len(), 1);
         assert_eq!(items[0]["id"], "spotify-playlist-3");
     }
+
+    #[test]
+    fn client_config_collects_fallback_base_urls() {
+        let client = SportifyClient::new(SportifyClientConfig {
+            base_url: "https://primary.example/".to_string(),
+            fallback_base_urls: vec![
+                "https://fallback.example/".to_string(),
+                "https://primary.example".to_string(),
+            ],
+            user_agent: "noor-test".to_string(),
+        })
+        .expect("client");
+
+        assert_eq!(
+            client.base_urls,
+            vec![
+                "https://primary.example".to_string(),
+                "https://fallback.example".to_string()
+            ]
+        );
+    }
 }
 
 impl Default for SportifyClientConfig {
     fn default() -> Self {
         Self {
             base_url: "https://sportify.xcasper.space".to_string(),
+            fallback_base_urls: Vec::new(),
             user_agent: "noor-server/sportify".to_string(),
         }
     }
@@ -112,7 +135,7 @@ impl SportifySearchKind {
 #[derive(Clone)]
 pub struct SportifyClient {
     http: reqwest::Client,
-    base_url: String,
+    base_urls: Vec<String>,
 }
 
 impl SportifyClient {
@@ -128,16 +151,47 @@ impl SportifyClient {
             .timeout(std::time::Duration::from_secs(10))
             .build()
             .context("build sportify reqwest client")?;
-        Ok(Self {
-            http,
-            base_url: config.base_url.trim_end_matches('/').to_string(),
-        })
+        let mut base_urls = Vec::new();
+        for raw in std::iter::once(config.base_url).chain(config.fallback_base_urls) {
+            let normalized = raw.trim().trim_end_matches('/').to_string();
+            if !normalized.is_empty() && !base_urls.iter().any(|u| u == &normalized) {
+                base_urls.push(normalized);
+            }
+        }
+        if base_urls.is_empty() {
+            return Err(anyhow!("no sportify base URL configured"));
+        }
+        Ok(Self { http, base_urls })
     }
 
     /// Issue a GET, validate the standard envelope, and return the raw body
     /// JSON (envelope fields included). Callers extract the resource field.
     async fn fetch_raw(&self, path: &str, query: &[(&str, String)]) -> Result<Value> {
-        let url = format!("{}{}", self.base_url, path);
+        let mut errors = Vec::new();
+        for base_url in &self.base_urls {
+            match self.fetch_raw_from_base(base_url, path, query).await {
+                Ok(value) => return Ok(value),
+                Err(e) => {
+                    tracing::debug!("sportify {} via {} failed: {}", path, base_url, e);
+                    errors.push(format!("{}: {}", base_url, e));
+                }
+            }
+        }
+
+        Err(anyhow!(
+            "all sportify proxies failed for {}: {}",
+            path,
+            errors.join("; ")
+        ))
+    }
+
+    async fn fetch_raw_from_base(
+        &self,
+        base_url: &str,
+        path: &str,
+        query: &[(&str, String)],
+    ) -> Result<Value> {
+        let url = format!("{}{}", base_url, path);
         let resp = self
             .http
             .get(&url)
@@ -196,39 +250,43 @@ impl SportifyClient {
         offset: u32,
     ) -> Result<SportifySearchResults> {
         let limit = limit.clamp(1, 50);
-        let value = self
-            .fetch_raw(
-                "/api/search",
-                &[
-                    ("q", query.to_string()),
-                    ("type", kind.as_str().to_string()),
-                    ("limit", limit.to_string()),
-                    ("offset", offset.to_string()),
-                ],
-            )
-            .await?;
-
-        // Sportify search usually returns `{ results: [...] }`, but has also
-        // shipped nested `{ results: { items: [...] } }` and typed buckets.
-        // Normalize all of those into the requested result bucket.
-        let mut out = SportifySearchResults::default();
-        let array = extract_search_items(&value, kind);
-
-        match kind {
-            SportifySearchKind::Track => {
-                out.tracks = serde_json::from_value(array).unwrap_or_default();
-            }
-            SportifySearchKind::Album => {
-                out.albums = serde_json::from_value(array).unwrap_or_default();
-            }
-            SportifySearchKind::Artist => {
-                out.artists = serde_json::from_value(array).unwrap_or_default();
-            }
-            SportifySearchKind::Playlist => {
-                out.playlists = serde_json::from_value(array).unwrap_or_default();
+        let query_params = [
+            ("q", query.to_string()),
+            ("type", kind.as_str().to_string()),
+            ("limit", limit.to_string()),
+            ("offset", offset.to_string()),
+        ];
+        let mut errors = Vec::new();
+        for (idx, base_url) in self.base_urls.iter().enumerate() {
+            match self
+                .fetch_raw_from_base(base_url, "/api/search", &query_params)
+                .await
+            {
+                Ok(value) => {
+                    let out = search_results_from_value(&value, kind);
+                    if matches!(kind, SportifySearchKind::Playlist)
+                        && out.playlists.is_empty()
+                        && idx + 1 < self.base_urls.len()
+                    {
+                        tracing::debug!(
+                            "sportify playlist search via {} returned no playlist rows",
+                            base_url
+                        );
+                        continue;
+                    }
+                    return Ok(out);
+                }
+                Err(e) => {
+                    tracing::debug!("sportify /api/search via {} failed: {}", base_url, e);
+                    errors.push(format!("{}: {}", base_url, e));
+                }
             }
         }
-        Ok(out)
+
+        Err(anyhow!(
+            "all sportify proxies failed for /api/search: {}",
+            errors.join("; ")
+        ))
     }
 
     pub async fn track(&self, spotify_id: &str) -> Result<SportifyTrack> {
@@ -296,6 +354,30 @@ fn extract_search_items(value: &Value, kind: SportifySearchKind) -> Value {
                 .and_then(|v| unwrap_items(v, kind))
         })
         .unwrap_or_else(|| Value::Array(Vec::new()))
+}
+
+fn search_results_from_value(value: &Value, kind: SportifySearchKind) -> SportifySearchResults {
+    // Sportify search usually returns `{ results: [...] }`, but has also
+    // shipped nested `{ results: { items: [...] } }` and typed buckets.
+    // Normalize all of those into the requested result bucket.
+    let mut out = SportifySearchResults::default();
+    let array = extract_search_items(value, kind);
+
+    match kind {
+        SportifySearchKind::Track => {
+            out.tracks = serde_json::from_value(array).unwrap_or_default();
+        }
+        SportifySearchKind::Album => {
+            out.albums = serde_json::from_value(array).unwrap_or_default();
+        }
+        SportifySearchKind::Artist => {
+            out.artists = serde_json::from_value(array).unwrap_or_default();
+        }
+        SportifySearchKind::Playlist => {
+            out.playlists = serde_json::from_value(array).unwrap_or_default();
+        }
+    }
+    out
 }
 
 fn truncate_for_log(s: &str) -> String {

--- a/noor-server/src/services/sportify/recommend.rs
+++ b/noor-server/src/services/sportify/recommend.rs
@@ -182,7 +182,9 @@ pub async fn cached_search(
     offset: u32,
 ) -> Result<SportifySearchResults> {
     if let Some(s) = db.with_conn(|conn| sp_cache::get_search(conn, cfg, q, kind, limit, offset))? {
-        return Ok(s);
+        if !(matches!(kind, SportifySearchKind::Playlist) && s.playlists.is_empty()) {
+            return Ok(s);
+        }
     }
     let fetched = client.search(q, kind, limit, offset).await?;
     db.with_conn(|conn| sp_cache::put_search(conn, q, kind, limit, offset, &fetched))?;
@@ -446,6 +448,7 @@ mod tests {
     fn test_client() -> SportifyClient {
         SportifyClient::new(SportifyClientConfig {
             base_url: "http://127.0.0.1:9".to_string(),
+            fallback_base_urls: Vec::new(),
             user_agent: "noor-test".to_string(),
         })
         .expect("sportify client")

--- a/noor-server/src/services/spotify/catalog.rs
+++ b/noor-server/src/services/spotify/catalog.rs
@@ -1,0 +1,530 @@
+use anyhow::{Context, Result};
+use reqwest::Client;
+use serde::Deserialize;
+use std::collections::HashMap;
+
+use crate::db::Database;
+use crate::services::sportify::models::{
+    SportifyAlbumRef, SportifyArtistRef, SportifyExternalIds, SportifyImage, SportifyPlaylist,
+    SportifyPlaylistOwner, SportifySearchResults, SportifyTrack,
+};
+
+use super::auth;
+
+const SPOTIFY_API_BASE: &str = "https://api.spotify.com/v1";
+
+#[derive(Debug, Deserialize, Default)]
+struct SpotifyImageDto {
+    #[serde(default)]
+    url: Option<String>,
+    #[serde(default)]
+    width: Option<i32>,
+    #[serde(default)]
+    height: Option<i32>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct SpotifyOwnerDto {
+    #[serde(default, alias = "displayName")]
+    display_name: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct SpotifyFollowersDto {
+    #[serde(default)]
+    total: Option<i64>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct SpotifyTracksSummaryDto {
+    #[serde(default)]
+    total: Option<i32>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct SpotifyPlaylistSearchDto {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    images: Vec<SpotifyImageDto>,
+    #[serde(default)]
+    owner: Option<SpotifyOwnerDto>,
+    #[serde(default)]
+    followers: Option<SpotifyFollowersDto>,
+    #[serde(default)]
+    tracks: Option<SpotifyTracksSummaryDto>,
+    #[serde(default)]
+    external_urls: HashMap<String, String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct SpotifySearchResponse {
+    #[serde(default)]
+    playlists: Option<SpotifyPaging<SpotifyPlaylistSearchDto>>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct SpotifyPaging<T> {
+    #[serde(default)]
+    items: Vec<Option<T>>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct SpotifyArtistDto {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct SpotifyAlbumDto {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    images: Vec<SpotifyImageDto>,
+    #[serde(default)]
+    release_date: Option<String>,
+    #[serde(default)]
+    total_tracks: Option<i32>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct SpotifyExternalIdsDto {
+    #[serde(default)]
+    isrc: Option<String>,
+    #[serde(default)]
+    ean: Option<String>,
+    #[serde(default)]
+    upc: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct SpotifyTrackDto {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    artists: Vec<SpotifyArtistDto>,
+    #[serde(default)]
+    album: Option<SpotifyAlbumDto>,
+    #[serde(default)]
+    duration_ms: Option<i64>,
+    #[serde(default)]
+    explicit: Option<bool>,
+    #[serde(default)]
+    track_number: Option<i32>,
+    #[serde(default)]
+    disc_number: Option<i32>,
+    #[serde(default)]
+    preview_url: Option<String>,
+    #[serde(default)]
+    popularity: Option<i32>,
+    #[serde(default)]
+    external_ids: Option<SpotifyExternalIdsDto>,
+    #[serde(default)]
+    external_urls: HashMap<String, String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct SpotifyPlaylistTrackItemDto {
+    #[serde(default)]
+    track: Option<SpotifyTrackDto>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct SpotifyPlaylistTracksDto {
+    #[serde(default)]
+    total: Option<i32>,
+    #[serde(default)]
+    items: Vec<SpotifyPlaylistTrackItemDto>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct SpotifyPlaylistDetailDto {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    images: Vec<SpotifyImageDto>,
+    #[serde(default)]
+    owner: Option<SpotifyOwnerDto>,
+    #[serde(default)]
+    followers: Option<SpotifyFollowersDto>,
+    #[serde(default)]
+    tracks: Option<SpotifyPlaylistTracksDto>,
+    #[serde(default)]
+    external_urls: HashMap<String, String>,
+}
+
+struct SpotifyCatalogClient {
+    http: Client,
+    token: String,
+}
+
+impl SpotifyCatalogClient {
+    fn new(http: Client, token: String) -> Self {
+        Self { http, token }
+    }
+
+    async fn get_json<T: for<'de> Deserialize<'de>>(
+        &self,
+        path: &str,
+        query: &[(&str, String)],
+    ) -> Result<T> {
+        let response = self
+            .http
+            .get(format!("{}{}", SPOTIFY_API_BASE, path))
+            .bearer_auth(&self.token)
+            .query(query)
+            .send()
+            .await
+            .with_context(|| format!("spotify catalog request failed: {}", path))?;
+
+        let status = response.status();
+        let body = response.text().await.context("read spotify catalog body")?;
+        if !status.is_success() {
+            anyhow::bail!(
+                "spotify catalog {} returned HTTP {}: {}",
+                path,
+                status,
+                truncate_for_log(&body)
+            );
+        }
+
+        serde_json::from_str(&body).with_context(|| format!("parse spotify catalog {}", path))
+    }
+
+    async fn search_playlists(
+        &self,
+        query: &str,
+        limit: u32,
+        offset: u32,
+    ) -> Result<SportifySearchResults> {
+        let payload: SpotifySearchResponse = self
+            .get_json(
+                "/search",
+                &[
+                    ("q", query.to_string()),
+                    ("type", "playlist".to_string()),
+                    ("limit", limit.clamp(1, 50).to_string()),
+                    ("offset", offset.to_string()),
+                ],
+            )
+            .await?;
+
+        Ok(SportifySearchResults {
+            playlists: payload
+                .playlists
+                .map(|page| {
+                    page.items
+                        .into_iter()
+                        .flatten()
+                        .map(playlist_from_search)
+                        .collect()
+                })
+                .unwrap_or_default(),
+            ..SportifySearchResults::default()
+        })
+    }
+
+    async fn playlist(&self, spotify_id: &str) -> Result<SportifyPlaylist> {
+        let payload: SpotifyPlaylistDetailDto = self
+            .get_json(
+                &format!("/playlists/{}", spotify_id),
+                &[(
+                    "fields",
+                    [
+                        "id,name,description,images,owner(display_name),followers(total)",
+                        "tracks(total,items(track(id,name,artists(id,name),album(id,name,images,release_date,total_tracks),duration_ms,explicit,track_number,disc_number,preview_url,popularity,external_ids,external_urls)))",
+                    ]
+                    .join(","),
+                )],
+            )
+            .await?;
+
+        Ok(playlist_from_detail(payload))
+    }
+}
+
+pub async fn search_playlists_from_saved_credentials(
+    db: &Database,
+    query: &str,
+    limit: u32,
+    offset: u32,
+) -> Result<SportifySearchResults> {
+    let client = catalog_client_from_saved_credentials(db).await?;
+    client.search_playlists(query, limit, offset).await
+}
+
+pub async fn playlist_from_saved_credentials(
+    db: &Database,
+    spotify_id: &str,
+) -> Result<SportifyPlaylist> {
+    let client = catalog_client_from_saved_credentials(db).await?;
+    client.playlist(spotify_id).await
+}
+
+async fn catalog_client_from_saved_credentials(db: &Database) -> Result<SpotifyCatalogClient> {
+    let creds = db
+        .with_conn(|conn| Ok(auth::load_credentials(conn).ok().flatten()))?
+        .context("spotify credentials not configured")?;
+    let http = Client::new();
+    let token = auth::fetch_app_token(&http, &creds)
+        .await
+        .context("fetch spotify catalog token")?;
+    Ok(SpotifyCatalogClient::new(http, token.access_token))
+}
+
+fn playlist_from_search(dto: SpotifyPlaylistSearchDto) -> SportifyPlaylist {
+    let total_tracks = dto.tracks.and_then(|tracks| tracks.total);
+    let owner = dto.owner.and_then(|owner| {
+        owner
+            .display_name
+            .map(|name| SportifyPlaylistOwner::Object {
+                id: None,
+                name: Some(name),
+            })
+    });
+    SportifyPlaylist {
+        id: dto.id,
+        name: dto.name,
+        description: dto.description,
+        images: dto.images.into_iter().map(image_from_dto).collect(),
+        owner,
+        followers: dto.followers.and_then(|followers| followers.total),
+        total_tracks,
+        url: dto.external_urls.get("spotify").cloned(),
+        ..SportifyPlaylist::default()
+    }
+}
+
+fn playlist_from_detail(dto: SpotifyPlaylistDetailDto) -> SportifyPlaylist {
+    let (total_tracks, tracks) = dto
+        .tracks
+        .map(|tracks| {
+            (
+                tracks.total,
+                tracks
+                    .items
+                    .into_iter()
+                    .filter_map(|item| item.track)
+                    .map(track_from_dto)
+                    .collect(),
+            )
+        })
+        .unwrap_or((None, Vec::new()));
+    let owner = dto.owner.and_then(|owner| {
+        owner
+            .display_name
+            .map(|name| SportifyPlaylistOwner::Object {
+                id: None,
+                name: Some(name),
+            })
+    });
+
+    SportifyPlaylist {
+        id: dto.id,
+        name: dto.name,
+        description: dto.description,
+        images: dto.images.into_iter().map(image_from_dto).collect(),
+        owner,
+        followers: dto.followers.and_then(|followers| followers.total),
+        total_tracks,
+        url: dto.external_urls.get("spotify").cloned(),
+        tracks,
+        ..SportifyPlaylist::default()
+    }
+}
+
+fn track_from_dto(dto: SpotifyTrackDto) -> SportifyTrack {
+    let album = dto.album.map(|album| SportifyAlbumRef {
+        id: album.id,
+        name: album.name,
+        images: album.images.into_iter().map(image_from_dto).collect(),
+        release_date: album.release_date,
+        total_tracks: album.total_tracks,
+    });
+
+    SportifyTrack {
+        id: dto.id,
+        name: dto.name,
+        artists: dto
+            .artists
+            .into_iter()
+            .map(|artist| SportifyArtistRef {
+                id: artist.id,
+                name: artist.name,
+                uri: None,
+            })
+            .collect(),
+        thumbnail: album
+            .as_ref()
+            .and_then(|album| {
+                album
+                    .images
+                    .iter()
+                    .max_by_key(|image| image.width.unwrap_or(0))
+            })
+            .and_then(|image| image.url.clone()),
+        album,
+        duration_ms: dto.duration_ms,
+        explicit: dto.explicit,
+        track_number: dto.track_number,
+        disc_number: dto.disc_number,
+        preview_url: dto.preview_url,
+        popularity: dto.popularity,
+        external_ids: dto.external_ids.map(|ids| SportifyExternalIds {
+            isrc: ids.isrc,
+            ean: ids.ean,
+            upc: ids.upc,
+        }),
+        external_urls: dto.external_urls,
+        ..SportifyTrack::default()
+    }
+}
+
+fn image_from_dto(dto: SpotifyImageDto) -> SportifyImage {
+    SportifyImage {
+        url: dto.url,
+        width: dto.width,
+        height: dto.height,
+    }
+}
+
+fn truncate_for_log(s: &str) -> String {
+    if s.len() > 256 {
+        format!("{}...", &s[..256])
+    } else {
+        s.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_search_playlist_total_from_nested_tracks() {
+        let payload = SpotifyPlaylistSearchDto {
+            id: Some("playlist-1".to_string()),
+            name: Some("Lofi".to_string()),
+            tracks: Some(SpotifyTracksSummaryDto { total: Some(42) }),
+            owner: Some(SpotifyOwnerDto {
+                display_name: Some("Spotify".to_string()),
+            }),
+            ..SpotifyPlaylistSearchDto::default()
+        };
+
+        let playlist = playlist_from_search(payload);
+
+        assert_eq!(playlist.spotify_id().as_deref(), Some("playlist-1"));
+        assert_eq!(playlist.title().as_deref(), Some("Lofi"));
+        assert_eq!(playlist.total_track_count(), Some(42));
+        assert_eq!(
+            playlist
+                .owner
+                .as_ref()
+                .and_then(|owner| owner.display_name()),
+            Some("Spotify")
+        );
+    }
+
+    #[test]
+    fn maps_search_response_skips_null_playlist_rows() {
+        let payload = SpotifySearchResponse {
+            playlists: Some(SpotifyPaging {
+                items: vec![
+                    None,
+                    Some(SpotifyPlaylistSearchDto {
+                        id: Some("playlist-1".to_string()),
+                        name: Some("Lofi".to_string()),
+                        ..SpotifyPlaylistSearchDto::default()
+                    }),
+                ],
+            }),
+        };
+
+        let playlists: Vec<SportifyPlaylist> = payload
+            .playlists
+            .map(|page| {
+                page.items
+                    .into_iter()
+                    .flatten()
+                    .map(playlist_from_search)
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        assert_eq!(playlists.len(), 1);
+        assert_eq!(playlists[0].spotify_id().as_deref(), Some("playlist-1"));
+    }
+
+    #[test]
+    fn maps_playlist_detail_tracks_for_tidal_resolution() {
+        let payload = SpotifyPlaylistDetailDto {
+            id: Some("playlist-1".to_string()),
+            tracks: Some(SpotifyPlaylistTracksDto {
+                total: Some(1),
+                items: vec![SpotifyPlaylistTrackItemDto {
+                    track: Some(SpotifyTrackDto {
+                        id: Some("track-1".to_string()),
+                        name: Some("Song".to_string()),
+                        artists: vec![SpotifyArtistDto {
+                            id: Some("artist-1".to_string()),
+                            name: Some("Artist".to_string()),
+                        }],
+                        album: Some(SpotifyAlbumDto {
+                            id: Some("album-1".to_string()),
+                            name: Some("Album".to_string()),
+                            images: vec![SpotifyImageDto {
+                                url: Some("https://i.scdn.co/image/test".to_string()),
+                                width: Some(640),
+                                height: Some(640),
+                            }],
+                            ..SpotifyAlbumDto::default()
+                        }),
+                        external_ids: Some(SpotifyExternalIdsDto {
+                            isrc: Some("USABC1234567".to_string()),
+                            ..SpotifyExternalIdsDto::default()
+                        }),
+                        ..SpotifyTrackDto::default()
+                    }),
+                }],
+            }),
+            ..SpotifyPlaylistDetailDto::default()
+        };
+
+        let playlist = playlist_from_detail(payload);
+        let track = playlist.tracks.first().expect("track");
+
+        assert_eq!(playlist.total_track_count(), Some(1));
+        assert_eq!(track.id.as_deref(), Some("track-1"));
+        assert_eq!(track.primary_artist(), Some("Artist"));
+        assert_eq!(
+            track.album.as_ref().and_then(|album| album.name.as_deref()),
+            Some("Album")
+        );
+        assert_eq!(
+            track
+                .external_ids
+                .as_ref()
+                .and_then(|ids| ids.isrc.as_deref()),
+            Some("USABC1234567")
+        );
+        assert_eq!(
+            track.best_thumbnail().as_deref(),
+            Some("https://i.scdn.co/image/test")
+        );
+    }
+}

--- a/noor-server/src/services/spotify/mod.rs
+++ b/noor-server/src/services/spotify/mod.rs
@@ -1,2 +1,3 @@
 pub mod auth;
+pub mod catalog;
 pub mod enrichment;


### PR DESCRIPTION
## Summary
- speed up mood and Spotify playlist hydration paths
- hydrate mood artwork thumbnails through the frontend cache
- reduce radio similarity writer lock time while preserving behavior

## Scope notes
- Chart work is intentionally excluded.
- DJ/drop-preview work is intentionally excluded.

## Verification
- cargo test -p noor-server sportify
- cargo check -p noor-server
- cargo fmt --all -- --check
- pnpm check
- pnpm test -- tidal-moods-cache