### PR TITLE
Standardize chart layout

### DIFF
--- a/docs/plans/2026-05-29-daily-chart-ingestion.md
+++ b/docs/plans/2026-05-29-daily-chart-ingestion.md
@@ -1,0 +1,488 @@
+# Daily Chart Ingestion Plan
+
+## Goal
+
+Build a daily chart ingestion pipeline that gives `/charts` richer, Kworb-style market views while preserving NOORwave's playback contract: every chart row should resolve to local library data when possible, then to a playable TIDAL candidate, then to a pending external row if unresolved.
+
+Kworb is useful as a product reference because it shows a country by service matrix and per-service daily chart pages. It should not be the default production dependency unless source permission is confirmed. Prefer official or already-integrated APIs first, then treat third-party HTML as an optional, rate-limited fallback.
+
+## Observed Reference Shape
+
+Kworb is not one chart. It is a broad music data site with several useful shapes:
+
+- Home overview and navigation across iTunes, worldwide, artists, charts, radio, Spotify, YouTube, and trending.
+- Current cross-provider country matrix.
+- Global artist ranking that combines Apple Music, Spotify, iTunes, YouTube, Shazam, and Deezer signals.
+- Spotify daily and weekly country charts with totals and track history links.
+- Worldwide and European iTunes and Apple Music song and album charts.
+- YouTube video rankings, language filters, artist pages, country pages, and top lists.
+- Radio estimates with audience, audience delta, formats, peak audience, and cross-provider positions.
+- Artist detail pages showing where a track or artist is charting across services and countries.
+
+Kworb `/charts` shows a matrix by country and source:
+
+- Country
+- iTunes top song
+- Spotify top song
+- Apple Music top song
+- YouTube top video
+- Shazam top song
+- Deezer top song
+
+Kworb Spotify country pages expose richer daily rows:
+
+- Rank and rank movement
+- Artist and title
+- Days on chart
+- Peak position
+- Daily streams and stream delta
+- Seven-day streams and delta
+- Total streams
+- Spotify track id embedded in the track-history URL
+
+## Source Catalog
+
+Model chart ingestion as a source catalog, not a one-off Spotify feature. Each source has a stable key, parser, resolver policy, retention policy, and UI capability flag.
+
+Initial source families:
+
+- `charts_matrix`: current top item by country and provider. Good for a fast "what is number one everywhere" view.
+- `spotify_daily`: daily track charts by region. Best first playable source because Spotify rows carry strong identifiers.
+- `spotify_weekly`: weekly track charts by region. Same resolver path as daily.
+- `spotify_totals`: accumulated Spotify totals and historical track stats. Useful for context, not urgent for playback.
+- `global_artist`: combined artist points by provider and top country. Good for artist discovery and "global heat".
+- `itunes_worldwide`: worldwide and European song or album points. Mostly display plus TIDAL resolve by artist and title.
+- `apple_music_worldwide`: worldwide and European song or album points. Mostly display plus TIDAL resolve by artist and title.
+- `youtube_daily`: 24-hour video views and likes. Should route through video surfaces, not normal track playback.
+- `radio_estimates`: audience and format estimates. Good for trend context and cross-provider comparison.
+- `artist_positions`: per-artist cross-service positions. Better as an artist detail enhancement than the first `/charts` page.
+
+Each source family can support several regions, periods, and entity types:
+
+- `entity_type`: `track`, `album`, `artist`, `video`
+- `period`: `live`, `daily`, `weekly`, `totals`
+- `region`: `global`, ISO country code, or provider-specific region key
+
+## Source Strategy
+
+### Phase 0: Catalog and Snapshot Shell
+
+Add the shared schema, source registry, snapshot read API, and resolver queue without enabling every provider. This keeps the first backend change small and gives `/charts` a stable local data contract.
+
+The first UI can read local snapshots even before all sources exist.
+
+### Phase 1: Charts Matrix and Spotify Daily Charts
+
+Use the country matrix as the browse model and Spotify daily as the first detailed playable source. The `/charts` page should not read as "Spotify charts". It should read as a market pulse surface with provider columns for iTunes, Spotify, Apple Music, YouTube, Shazam, and Deezer.
+
+Provider priority for detailed playable rows:
+
+1. Official Spotify Charts daily CSV or page data where accessible.
+2. Existing Sportify playlist/detail endpoints for metadata enrichment only.
+3. Kworb Spotify daily pages only if allowed, behind a feature flag.
+
+Do not block UI requests on external fetches. Ingestion runs in the background and `/charts` reads local snapshots.
+
+### Phase 2: Weekly, Totals, and Artist Heat
+
+Add weekly Spotify snapshots, Spotify totals, and global artist rankings. These are useful for trend context but do not need to resolve every row to playback before they can be displayed.
+
+### Phase 3: Last.fm Continuity
+
+Keep the existing Last.fm trending shelf as a live fallback and comparison source. Last.fm remains useful for broad "now moving" trends but should not be the only charts data source.
+
+### Phase 4: Extra Sources
+
+Add providers only when we can resolve rows reliably:
+
+- Apple Music: display-only until we have a resolver path.
+- iTunes: display-only or TIDAL resolve by artist and title.
+- YouTube: video route integration, not normal track playback.
+- Shazam and Deezer: display and TIDAL resolve by artist and title.
+
+## Backend Data Model
+
+Add new append-only migrations:
+
+### `chart_sources`
+
+- `id INTEGER PRIMARY KEY`
+- `source_key TEXT UNIQUE NOT NULL`
+- `display_name TEXT NOT NULL`
+- `provider TEXT NOT NULL`
+- `enabled INTEGER NOT NULL DEFAULT 1`
+- `default_region TEXT`
+- `refresh_interval_hours INTEGER NOT NULL DEFAULT 24`
+- `last_success_at INTEGER`
+- `last_error TEXT`
+
+Example `source_key` values:
+
+- `charts_matrix`
+- `spotify_daily`
+- `spotify_weekly`
+- `spotify_totals`
+- `lastfm_worldwide`
+- `global_artist`
+- `apple_music_daily`
+- `itunes_daily`
+- `youtube_daily`
+- `radio_estimates`
+- `artist_positions`
+
+### `chart_snapshots`
+
+- `id INTEGER PRIMARY KEY`
+- `source_key TEXT NOT NULL`
+- `region TEXT NOT NULL`
+- `period TEXT NOT NULL`
+- `chart_date TEXT NOT NULL`
+- `fetched_at INTEGER NOT NULL`
+- `etag TEXT`
+- `content_hash TEXT`
+- `status TEXT NOT NULL`
+- unique `(source_key, region, period, chart_date)`
+
+`period` starts with `daily` and `weekly`.
+
+### `chart_entries`
+
+- `id INTEGER PRIMARY KEY`
+- `snapshot_id INTEGER NOT NULL`
+- `rank INTEGER NOT NULL`
+- `rank_delta INTEGER`
+- `artist TEXT NOT NULL`
+- `title TEXT NOT NULL`
+- `entity_type TEXT NOT NULL DEFAULT 'track'`
+- `album TEXT`
+- `external_track_id TEXT`
+- `external_artist_id TEXT`
+- `external_video_id TEXT`
+- `external_url TEXT`
+- `streams INTEGER`
+- `stream_delta INTEGER`
+- `views INTEGER`
+- `likes INTEGER`
+- `audience REAL`
+- `audience_delta REAL`
+- `points REAL`
+- `points_delta REAL`
+- `seven_day_streams INTEGER`
+- `total_streams INTEGER`
+- `days_on_chart INTEGER`
+- `peak_rank INTEGER`
+- `provider_positions_json TEXT`
+- `raw_json TEXT`
+- unique `(snapshot_id, rank)`
+
+### `chart_entry_resolutions`
+
+- `entry_id INTEGER PRIMARY KEY`
+- `external_candidate_id INTEGER`
+- `local_track_id INTEGER`
+- `tidal_id INTEGER`
+- `status TEXT NOT NULL`
+- `score REAL`
+- `resolved_at INTEGER`
+- `attempts INTEGER NOT NULL DEFAULT 0`
+- `last_error TEXT`
+
+`status` values:
+
+- `local`
+- `tidal`
+- `pending`
+- `unresolved`
+- `not_playable`
+
+Use `external_candidate_id` to point at the existing `external_track_candidates` table when a row is not already a local track. Do not create a parallel candidate system for chart rows. The chart resolution table should store chart-specific state and rank context, not duplicate the long-lived external candidate resolver.
+
+## Ingestion Flow
+
+1. Scheduler picks due `(source_key, region, period)` jobs once per day.
+2. Provider fetches raw data with timeout, user-agent, and rate limit.
+3. Parser normalizes rows into `ChartEntrySeed`.
+4. Snapshot transaction inserts `chart_snapshots` and `chart_entries`.
+5. Resolver job starts after insert and processes entries in bounded batches.
+6. Resolution order:
+   - Match local by external id where available.
+   - Match local by ISRC where available.
+   - Match local by normalized artist and title.
+   - Resolve to TIDAL using existing search or direct id path.
+   - Leave as pending external when unresolved.
+7. UI reads snapshot immediately, then receives updated resolution state via polling or WebSocket event.
+
+## Daily Scheduling
+
+Start simple:
+
+- On server startup, enqueue any chart source whose latest successful snapshot is older than 20 hours.
+- Run an hourly lightweight scheduler tick inside `noor-server`.
+- Fetch daily charts at most once per source and region per day.
+- Provide `POST /api/charts/refresh` for manual refresh in dev only or admin-only later.
+
+No OS scheduler is required. This keeps portable and installed Windows behavior identical.
+
+## API Contract
+
+Add:
+
+- `GET /api/charts/sources`
+- `GET /api/charts/snapshots?source=spotify_daily&period=daily&region=AU&limit=50`
+- `GET /api/charts/snapshot/{id}`
+- `GET /api/charts/matrix?region_group=main`
+- `GET /api/charts/artists?source=global_artist&limit=100`
+- `POST /api/charts/refresh`
+
+Keep existing `GET /api/charts` as compatibility. It can map to the latest Last.fm snapshot or live Last.fm fallback until the new UI is ready.
+
+`ChartEntry` should gain:
+
+- `rank`
+- `rank_delta`
+- `period`
+- `region`
+- `chart_date`
+- `source_key`
+- `source_label`
+- `streams`
+- `stream_delta`
+- `resolution_status`
+
+## Frontend Plan
+
+Change `/charts` from two unrelated blocks into three sections:
+
+1. `Now moving`: existing Last.fm trending shelf.
+2. `Market pulse`: Kworb-style country/provider matrix backed by local snapshots.
+3. `Chart playlists`: existing Spotify editorial playlist cards.
+
+The first backend slice remains the additive snapshot endpoint because it is the safest TDD target. The first product UI should still show the market-pulse shape, even when data is empty, so it is clear that Spotify is only one provider.
+
+First visible `Market pulse` shell:
+
+- Rows: `Global`, `US`, `UK`, `AU`, `CA`, and `NZ` first
+- Columns: `iTunes`, `Spotify`, `Apple Music`, `YouTube`, `Shazam`, `Deezer`
+- Cell state: top item, loading, unavailable, unresolved, or source not enabled
+- Click behavior: open the provider and region drilldown when a detailed snapshot exists
+
+First detailed `Daily charts` drilldown:
+
+- Source: `Spotify`
+- Period: `Daily`
+- Region: selected from the matrix or quick switches
+- Layout: compact ranked list, not playlist cards
+
+Daily row shape:
+
+- Rank and movement
+- Artwork thumbnail when available
+- Title and artist
+- Source metric, starting with streams
+- Resolution state: in library, playable, resolving, or unresolved
+- Play and context menu actions only when the row is resolved enough
+
+The Kworb-style matrix should become the default mode after the matrix snapshot endpoint exists:
+
+- Rows are countries.
+- Columns are providers.
+- Cells show the current top track, artist, or video.
+- Clicking a cell opens the detailed snapshot for that provider and region.
+- Resolved cells play or queue directly.
+- Unresolved cells offer search, TIDAL resolve, or external open actions.
+
+Daily chart cards should:
+
+- Render immediately from local snapshots.
+- Show rank and movement.
+- Show streams when present.
+- Show views, likes, audience, or points when the selected source provides them.
+- Use existing `TrendingCard` playback behavior.
+- Show `Resolving...` only for pending rows, not for the whole grid.
+
+## Resolver Rules
+
+Reuse existing helpers where possible:
+
+- `buildTrackMenu`
+- `buildTidalTrackMenu`
+- pending external queue behavior
+- TIDAL search and import paths
+
+Never insert `tidal_id = 0` into durable storage. `0` can remain a frontend placeholder only.
+
+For daily snapshots, resolution is best-effort and incremental. A failed TIDAL lookup should not poison the chart row forever. Retry unresolved rows daily with capped attempts.
+
+## Rollout Steps
+
+1. Add schema and models.
+2. Add `ChartProvider` trait and provider capability flags.
+3. Add `ChartsMatrixProvider` and `SpotifyDailyProvider`.
+4. Add parser tests using saved fixture HTML or CSV.
+5. Add snapshot insert and stale-source scheduler.
+6. Add resolver job with bounded concurrency.
+7. Add `/api/charts/snapshots` and `/api/charts/matrix` read endpoints.
+8. Update `/charts` UI to read latest daily snapshot and matrix data.
+9. Add manual refresh and diagnostics.
+10. Add weekly, totals, artist heat, YouTube, radio, and iTunes/Apple Music in separate PR-sized steps.
+11. Consider optional Kworb provider behind `NOOR_CHARTS_KWORB=1` only after source permission and robots review.
+
+## TDD Tracer Bullets
+
+Use vertical slices. Do not write all tests first.
+
+### Slice 1: Latest Snapshot Read
+
+Public behavior: `GET /api/charts/snapshots?source=spotify_daily&period=daily&region=AU&limit=2` returns the latest local snapshot, sorted by rank, without network access.
+
+Red:
+
+- Add a backend route test that seeds two `chart_snapshots` for the same source and region, then asserts the endpoint returns only the newest `chart_date`.
+- Assert rank order and `resolution_status`.
+- Assert unresolved rows do not expose `tidal_id = 0`.
+
+Green:
+
+- Add append-only schema.
+- Add minimal insert helpers for test setup.
+- Add the read endpoint and DTO.
+
+Refactor:
+
+- Keep the existing `GET /api/charts` route unchanged.
+- Extract DTO conversion only after the route passes.
+
+### Slice 2: Provider Matrix Read
+
+Public behavior: `GET /api/charts/matrix?region_group=main` returns the latest top cell for each configured region and provider without network access.
+
+Red:
+
+- Add a backend route test that seeds latest snapshots for `itunes_daily`, `spotify_daily`, `apple_music_daily`, `youtube_daily`, `shazam_daily`, and `deezer_daily`.
+- Assert response rows are countries and columns are providers.
+- Assert missing providers return an explicit empty cell, not a route failure.
+
+Green:
+
+- Add a matrix read query over existing snapshot tables.
+- Add `/api/charts/matrix`.
+- Keep provider availability and source freshness in the response.
+
+### Slice 3: Idempotent Daily Upsert
+
+Public behavior: ingesting the same source, region, period, and chart date twice does not duplicate rows.
+
+Red:
+
+- Add a backend test that calls the snapshot upsert API twice with changed stream counts.
+- Assert there is one snapshot and one row per rank.
+- Assert updated metric values are visible through the read endpoint.
+
+Green:
+
+- Add transactional snapshot upsert.
+- Replace entries for the snapshot or upsert by rank, but keep the external contract stable.
+
+### Slice 4: Spotify Daily Parser
+
+Public behavior: a saved Spotify daily fixture becomes normalized chart rows with rank, title, artist, streams, external id, and date.
+
+Red:
+
+- Add a parser fixture test using saved HTML or CSV.
+- Assert the parser handles rank movement and missing optional metrics.
+
+Green:
+
+- Add `SpotifyDailyProvider` parser only.
+- Keep fetcher separate so parser tests never hit the network.
+
+### Slice 5: Resolver Candidate Link
+
+Public behavior: an unresolved chart row is linked to `external_track_candidates`, and a later TIDAL resolution updates the chart row without rewriting chart history.
+
+Red:
+
+- Add a backend test that ingests an unresolved row.
+- Assert an external candidate exists with the normalized artist and title.
+- Assert `chart_entry_resolutions.external_candidate_id` points at it.
+- Resolve the candidate, then assert the chart endpoint reports `resolution_status = tidal`.
+
+Green:
+
+- Reuse `upsert_external_track_candidate`.
+- Add the smallest chart-specific resolution update path.
+
+### Slice 6: Frontend Matrix and Snapshot Rendering
+
+Public behavior: `/charts` renders the provider matrix shell immediately, then renders a daily chart snapshot drilldown when a provider and region have data. Pending rows do not block resolved rows.
+
+Red:
+
+- Add a Svelte/Vitest test around the market pulse component with mocked matrix and snapshot payloads.
+- Assert provider columns include iTunes, Spotify, Apple Music, YouTube, Shazam, and Deezer.
+- Assert rank, title, source label, and pending state render in the drilldown.
+- Assert the existing Spotify playlist metadata cache test still passes.
+
+Green:
+
+- Add a small `MarketPulseShelf` component.
+- Wire it below the existing Last.fm shelf only after the component test passes.
+
+## Grill Findings
+
+### 1. The plan was too broad for a first implementation.
+
+Recommended answer: ship only the snapshot shell plus `spotify_daily` first. The Kworb-style matrix can be the second UI once the read contract exists.
+
+### 2. A generic metrics table can become a junk drawer.
+
+Recommended answer: keep common columns for rank, movement, streams, views, audience, points, and provider positions, but preserve provider-specific leftovers in `raw_json`. Do not add a new column for every provider quirk until the UI needs it.
+
+### 3. Chart resolution must not duplicate existing external candidate logic.
+
+Recommended answer: chart rows should link to `external_track_candidates`. The chart table owns chart context. The external candidate table owns dedupe and long-lived resolution.
+
+### 4. Scraping Kworb directly is a product and legal risk.
+
+Recommended answer: use Kworb to define the product shape. Enable a Kworb provider only behind `NOOR_CHARTS_KWORB=1` after source permission and robots review. First production source should be official Spotify chart data where accessible.
+
+### 5. The existing `/api/charts` contract is live data, not daily snapshots.
+
+Recommended answer: do not mutate it first. Add `/api/charts/snapshots` and `/api/charts/matrix`, then later decide whether `/api/charts` should alias the new default.
+
+### 6. The current `tidal_id = 0` placeholder is frontend-only and dangerous if persisted.
+
+Recommended answer: tests must assert no durable chart row stores `tidal_id = 0`. Unresolved means `tidal_id NULL`, `external_candidate_id` set, and `status = pending` or `unresolved`.
+
+### 7. Scheduler behavior can hide failures.
+
+Recommended answer: ingestion should be callable through a normal Rust service API first, with scheduler as a thin caller. Test ingestion directly before testing hourly ticks.
+
+### 8. The first UI must not wait for resolution.
+
+Recommended answer: render chart rows from snapshots immediately. Resolution should enrich rows incrementally, never gate first paint.
+
+## Test Plan
+
+Backend:
+
+- Parser fixtures for Spotify daily rows.
+- Snapshot upsert idempotency.
+- Resolver local match by external id, ISRC, and normalized artist/title.
+- Retry behavior for unresolved rows.
+- API contract tests for latest snapshot and empty source.
+
+Frontend:
+
+- Daily charts render from a cached snapshot payload.
+- Pending rows do not block resolved rows.
+- Source and region selection persists.
+- Existing Spotify playlist cards still use their metadata cache.
+
+## Open Decisions
+
+- Whether to include third-party HTML ingestion at all, or only official sources.
+- Which regions to enable by default: likely Global, US, UK, AU, CA, NZ, Germany, France, Japan.
+- How much history to retain locally: recommended 90 daily snapshots per source and region.
+- Whether chart data should influence automix/discovery scoring or stay display-only.

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -905,6 +905,8 @@ export type DjDeckStatus = {
 	profile_ready: boolean;
 	profile_status: 'ready' | 'missing' | 'analyzing' | 'retrying' | 'decode_failed' | string;
 	profile_error?: string;
+	profile_retry_after_ms?: number;
+	profile_retry_reason?: string;
 	profile_confidence?: number;
 	beat_count?: number;
 	downbeat_count?: number;

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -697,6 +697,107 @@ export interface ChartEntry {
 
 export type TrendingSource = 'lastfm' | 'tidal';
 
+export interface ChartSnapshotSummary {
+	id: number;
+	source_key: string;
+	region: string;
+	period: string;
+	chart_date: string;
+	fetched_at: number;
+	status: string;
+}
+
+export interface ChartSnapshotEntry {
+	id: number;
+	rank: number;
+	rank_delta: number | null;
+	artist: string;
+	title: string;
+	entity_type: 'track' | 'album' | 'artist' | 'video' | string;
+	album: string | null;
+	artwork_url: string | null;
+	external_track_id: string | null;
+	external_artist_id: string | null;
+	external_video_id: string | null;
+	external_url: string | null;
+	streams: number | null;
+	stream_delta: number | null;
+	views: number | null;
+	likes: number | null;
+	audience: number | null;
+	audience_delta: number | null;
+	points: number | null;
+	points_delta: number | null;
+	seven_day_streams: number | null;
+	total_streams: number | null;
+	days_on_chart: number | null;
+	peak_rank: number | null;
+	provider_positions_json: unknown | null;
+	raw_json: unknown | null;
+	external_candidate_id: number | null;
+	local_track_id: number | null;
+	tidal_id: number | null;
+	resolution_status: 'local' | 'tidal' | 'pending' | 'unresolved' | 'not_playable' | string;
+	resolution_score: number | null;
+}
+
+export interface ChartSnapshotResponse {
+	source: string;
+	period: string;
+	region: string;
+	limit: number;
+	snapshot: ChartSnapshotSummary | null;
+	entries: ChartSnapshotEntry[];
+}
+
+export interface ChartMatrixProvider {
+	source_key: string;
+	label: string;
+}
+
+export interface ChartMatrixCell {
+	snapshot_id: number;
+	entry_id: number;
+	source_key: string;
+	region: string;
+	chart_date: string;
+	rank: number;
+	rank_delta: number | null;
+	artist: string;
+	title: string;
+	entity_type: string;
+	artwork_url: string | null;
+	streams: number | null;
+	views: number | null;
+	points: number | null;
+	external_url: string | null;
+	tidal_id: number | null;
+	resolution_status: string;
+}
+
+export interface ChartMatrixRow {
+	region: string;
+	cells: Record<string, ChartMatrixCell | null>;
+}
+
+export interface ChartMatrixResponse {
+	region_group: string;
+	period: string;
+	providers: ChartMatrixProvider[];
+	rows: ChartMatrixRow[];
+}
+
+export interface ChartMatrixRefreshResponse {
+	source: string;
+	chart_date: string;
+	fetched_at: number;
+	report: {
+		rows_seen: number;
+		entries_written: number;
+		snapshots_written: number;
+	};
+}
+
 export interface LastfmGenre {
 	key: string;
 	label: string;
@@ -2523,6 +2624,33 @@ export const api = {
 			tag: string | null;
 			tracks: ChartEntry[];
 		}>('/api/charts', params);
+	},
+
+	getChartSnapshot(opts: {
+		source?: string;
+		period?: string;
+		region?: string;
+		limit?: number;
+	} = {}) {
+		const params: Record<string, string> = {};
+		if (opts.source) params.source = opts.source;
+		if (opts.period) params.period = opts.period;
+		if (opts.region) params.region = opts.region;
+		if (opts.limit != null) params.limit = String(opts.limit);
+		return fetchApi<ChartSnapshotResponse>('/api/charts/snapshots', params);
+	},
+
+	getChartMatrix(opts: { regionGroup?: string } = {}) {
+		const params: Record<string, string> = {};
+		if (opts.regionGroup) params.region_group = opts.regionGroup;
+		return fetchApi<ChartMatrixResponse>('/api/charts/matrix', params);
+	},
+
+	refreshChartMatrix() {
+		return fetchApi<ChartMatrixRefreshResponse>('/api/charts/matrix/refresh', undefined, {
+			method: 'POST',
+			body: JSON.stringify({}),
+		});
 	},
 
 	getLastfmGenres() {

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -916,9 +916,20 @@ export type DjDeckStatus = {
 	phrase_markers_ms: number[];
 	mix_in_markers_ms: number[];
 	mix_out_markers_ms: number[];
+	drop_markers_ms: number[];
+	manual_drop_markers_ms: number[];
 	passive_analysis_status?: 'ready' | 'missing' | 'retrying' | 'skipped' | string;
 	passive_analysis_reason?: string;
 	safe_crossfade_only: boolean;
+};
+
+export type DjDropPreviewStatus = {
+	status: 'armed' | 'fired' | 'skipped' | string;
+	planned_fire_ms?: number;
+	actual_fire_ms?: number;
+	incoming_drop_ms?: number;
+	source?: 'manual' | 'profile' | string;
+	reason?: string;
 };
 
 export type DjOverlayDetails = {
@@ -1000,6 +1011,7 @@ export type DjStatusResponse = {
 		media_ref_id: string;
 		bad_feedback_count: number;
 	};
+	drop_preview: DjDropPreviewStatus;
 };
 
 export type DjTimingHistoryEvent = {

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -3173,7 +3173,7 @@ export const api = {
 	// Workout, Focus, etc). Each entry has a slug that can be fed to
 	// getTidalMoodPage for the drill-down content.
 	getTidalMoods() {
-		return fetchApi<{ categories: TidalMoodCategory[]; source: string }>(
+		return fetchApi<{ categories: TidalMoodCategory[]; source: string; fallback?: boolean }>(
 			'/api/tidal/moods',
 		);
 	},

--- a/frontend/src/lib/components/charts/ChartMural.svelte
+++ b/frontend/src/lib/components/charts/ChartMural.svelte
@@ -1,0 +1,413 @@
+<script lang="ts">
+	import ArtworkImage from '$lib/components/ui/ArtworkImage.svelte';
+	import { lazyTidalArt } from '$lib/actions/lazy-tidal-art';
+
+	export type ChartMuralAccent = 'accent' | 'lastfm';
+
+	export type ChartMuralItem = {
+		id: string;
+		title: string;
+		subtitle: string;
+		artwork: string | null;
+		fallbackText: string;
+		tileLabel: string;
+		tileTitle: string;
+		lazy?: {
+			enabled: boolean;
+			query: {
+				artist: string | null;
+				title: string;
+			};
+			onResolve: (url: string) => void;
+		};
+	};
+
+	type Props = {
+		items?: ChartMuralItem[];
+		currentIndex?: number;
+		ariaLabel: string;
+		kindLabel: string;
+		title: string;
+		subtitle: string;
+		metric?: string;
+		actionLabel?: string;
+		actionDisabled?: boolean;
+		accent?: ChartMuralAccent;
+		loading?: boolean;
+		loadingLabel?: string;
+		onSelect?: (index: number) => void;
+		onJump?: (delta: number) => void;
+		onPlay?: () => void | Promise<void>;
+		onCardContext?: (event: MouseEvent) => void | Promise<void>;
+		onItemContext?: (event: MouseEvent, index: number) => void | Promise<void>;
+		onPauseChange?: (paused: boolean) => void;
+	};
+
+	let {
+		items = [],
+		currentIndex = 0,
+		ariaLabel,
+		kindLabel,
+		title,
+		subtitle,
+		metric = '',
+		actionLabel = 'Play',
+		actionDisabled = false,
+		accent = 'accent',
+		loading = false,
+		loadingLabel = 'Loading chart mural',
+		onSelect = () => {},
+		onJump = () => {},
+		onPlay = () => {},
+		onCardContext,
+		onItemContext,
+		onPauseChange,
+	}: Props = $props();
+
+	let currentItem = $derived(items[currentIndex] ?? items[0] ?? null);
+</script>
+
+{#if loading}
+	<div class="chart-mural-loading">{loadingLabel}</div>
+{:else if currentItem}
+	<div
+		class="chart-mural"
+		class:accent-lastfm={accent === 'lastfm'}
+		onmouseenter={() => onPauseChange?.(true)}
+		onmouseleave={() => onPauseChange?.(false)}
+		role="region"
+		aria-label={ariaLabel}
+		oncontextmenu={(event) => {
+			if (onCardContext) void onCardContext(event);
+		}}
+	>
+		<div class="chart-mural-bg" aria-hidden="true">
+			{#each items as item, index (item.id)}
+				<button
+					class="chart-mural-tile"
+					class:featured={currentItem.id === item.id}
+					type="button"
+					onclick={() => onSelect(index)}
+					oncontextmenu={(event) => {
+						if (onItemContext) void onItemContext(event, index);
+					}}
+					aria-label={item.tileLabel}
+					title={item.tileTitle}
+					use:lazyTidalArt={{
+						enabled: item.lazy?.enabled ?? false,
+						query: item.lazy?.query ?? { artist: null, title: item.title },
+						onResolve: item.lazy?.onResolve ?? (() => {}),
+					}}
+				>
+					<ArtworkImage
+						src={item.artwork}
+						size={320}
+						className="chart-mural-art"
+						fallbackText={item.fallbackText}
+						decorative
+					/>
+				</button>
+			{/each}
+		</div>
+		<div class="chart-mural-shade"></div>
+		<div class="chart-mural-content">
+			<div class="chart-mural-meta">
+				<span class="chart-mural-kind">{kindLabel}</span>
+				<h3 class="chart-mural-title">{title}</h3>
+				<p class="chart-mural-sub">{subtitle}</p>
+				<div class="chart-mural-actions">
+					<button
+						class="btn btn-primary chart-mural-play"
+						type="button"
+						disabled={actionDisabled}
+						onclick={() => void onPlay()}
+					>
+						<svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor" aria-hidden="true">
+							<path d="M3 2.5l10 5.5-10 5.5V2.5z"/>
+						</svg>
+						{actionLabel}
+					</button>
+					{#if metric}
+						<span>{metric}</span>
+					{/if}
+				</div>
+			</div>
+		</div>
+		{#if items.length > 1}
+			<button
+				class="chart-nav chart-nav--prev"
+				type="button"
+				onclick={() => onJump(-1)}
+				aria-label="Previous chart entry"
+			>
+				&lsaquo;
+			</button>
+			<button
+				class="chart-nav chart-nav--next"
+				type="button"
+				onclick={() => onJump(1)}
+				aria-label="Next chart entry"
+			>
+				&rsaquo;
+			</button>
+		{/if}
+	</div>
+{/if}
+
+<style>
+	.chart-mural {
+		--chart-mural-accent: var(--accent);
+		--chart-mural-soft: var(--accent-soft);
+		position: relative;
+		min-height: clamp(220px, 24vw, 360px);
+		border: 1px solid var(--panel-border);
+		border-radius: var(--radius-md);
+		overflow: hidden;
+		background: var(--panel-bg);
+	}
+
+	.chart-mural.accent-lastfm {
+		--chart-mural-accent: var(--service-lastfm);
+		--chart-mural-soft: color-mix(in srgb, var(--service-lastfm) 18%, var(--bg-surface));
+	}
+
+	.chart-mural-bg {
+		position: absolute;
+		inset: -7%;
+		z-index: 0;
+		display: grid;
+		grid-template-columns: repeat(10, minmax(0, 1fr));
+		grid-template-rows: repeat(2, minmax(0, 1fr));
+		background: linear-gradient(120deg, var(--panel-bg), color-mix(in srgb, var(--chart-mural-accent) 16%, transparent));
+	}
+
+	.chart-mural-bg::after {
+		content: '';
+		position: absolute;
+		inset: 0;
+		background:
+			radial-gradient(circle at 78% 42%, rgba(255,255,255,0.2), transparent 30%),
+			linear-gradient(90deg, rgba(0,0,0,0.08), transparent 42%, rgba(0,0,0,0.04));
+		pointer-events: none;
+	}
+
+	.chart-mural-tile {
+		appearance: none;
+		position: relative;
+		min-width: 0;
+		min-height: 0;
+		padding: 0;
+		border: 0;
+		background: var(--bg-raised);
+		color: var(--text-primary);
+		cursor: pointer;
+		overflow: hidden;
+		opacity: 0.96;
+		filter: saturate(1.18) brightness(1.14);
+		transform: skewX(-7deg) scaleX(1.08);
+		transform-origin: center;
+		transition:
+			filter var(--motion-fast),
+			opacity var(--motion-fast),
+			transform var(--motion-base),
+			box-shadow var(--motion-base);
+	}
+
+	.chart-mural-tile::after {
+		content: '';
+		position: absolute;
+		inset: 0;
+		background: linear-gradient(90deg, rgba(0,0,0,0.18), transparent 48%, rgba(0,0,0,0.2));
+		opacity: 0.18;
+		pointer-events: none;
+	}
+
+	.chart-mural-tile:hover,
+	.chart-mural-tile:focus-visible,
+	.chart-mural-tile.featured {
+		z-index: var(--z-raised);
+		opacity: 1;
+		filter: saturate(1.8) brightness(1.4);
+		transform: skewX(-7deg) scaleX(1.08) scale(1.045);
+		box-shadow:
+			0 0 0 1px rgba(255,255,255,0.3),
+			0 14px 30px rgba(0,0,0,0.32),
+			0 0 24px color-mix(in srgb, var(--chart-mural-accent) 34%, transparent);
+		outline: none;
+	}
+
+	:global(.chart-mural-art),
+	:global(.chart-mural-art.fallback) {
+		display: block;
+		width: 100%;
+		height: 100%;
+	}
+
+	:global(.chart-mural-art) {
+		object-fit: cover;
+		transform: skewX(7deg) scale(1.24);
+		transition: transform var(--motion-base);
+	}
+
+	.chart-mural-tile:hover :global(.chart-mural-art),
+	.chart-mural-tile:focus-visible :global(.chart-mural-art),
+	.chart-mural-tile.featured :global(.chart-mural-art) {
+		transform: skewX(7deg) scale(1.34);
+	}
+
+	:global(.chart-mural-art.fallback) {
+		display: grid;
+		place-items: center;
+		background: linear-gradient(135deg, var(--bg-raised), var(--chart-mural-soft));
+		color: rgba(255,255,255,0.78);
+		font-size: var(--font-size-xl);
+		font-weight: var(--font-weight-bold);
+	}
+
+	.chart-mural-shade {
+		position: absolute;
+		inset: 0;
+		z-index: var(--z-base);
+		background: linear-gradient(90deg, rgba(0,0,0,0.72) 0%, rgba(0,0,0,0.36) 42%, rgba(0,0,0,0.08) 78%, transparent 100%);
+		pointer-events: none;
+	}
+
+	.chart-mural-content {
+		position: relative;
+		z-index: calc(var(--z-base) + 1);
+		display: grid;
+		align-items: center;
+		min-height: inherit;
+		padding: var(--space-5);
+		pointer-events: none;
+	}
+
+	.chart-mural-meta {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-1);
+		max-width: min(42rem, 58vw);
+		text-shadow: 0 2px 18px rgba(0,0,0,0.62);
+	}
+
+	.chart-mural-kind {
+		color: var(--chart-mural-accent);
+		font-size: var(--font-size-2xs);
+		font-weight: var(--font-weight-semibold);
+		letter-spacing: 0;
+		text-transform: uppercase;
+	}
+
+	.chart-mural-title {
+		margin: 0;
+		color: var(--text-primary);
+		font-size: var(--font-size-4xl);
+		font-weight: var(--font-weight-bold);
+		line-height: var(--line-height-tight);
+		letter-spacing: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.chart-mural-sub {
+		margin: 0 0 var(--space-2);
+		color: var(--text-secondary);
+		font-size: var(--font-size-sm);
+	}
+
+	.chart-mural-actions {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		pointer-events: auto;
+	}
+
+	.chart-mural-actions span {
+		color: var(--text-secondary);
+		font-size: var(--font-size-xs);
+		font-weight: var(--font-weight-semibold);
+	}
+
+	.chart-mural-play {
+		display: flex;
+		align-items: center;
+		gap: var(--space-1);
+		font-size: var(--font-size-sm);
+		font-weight: var(--font-weight-semibold);
+	}
+
+	.chart-mural-play:disabled {
+		cursor: not-allowed;
+		opacity: 0.58;
+	}
+
+	.chart-nav {
+		position: absolute;
+		top: 50%;
+		z-index: var(--z-raised);
+		display: grid;
+		place-items: center;
+		width: clamp(32px, 3vw, 40px);
+		aspect-ratio: 1 / 1;
+		border: 1px solid var(--panel-border);
+		border-radius: 50%;
+		background: rgba(0,0,0,0.5);
+		color: var(--text-primary);
+		cursor: pointer;
+		font-size: var(--font-size-xl);
+		line-height: 1;
+		opacity: 0;
+		transform: translateY(-50%);
+		transition: opacity var(--motion-fast), background var(--motion-fast);
+	}
+
+	.chart-mural:hover .chart-nav,
+	.chart-nav:focus-visible {
+		opacity: 1;
+		outline: none;
+	}
+
+	.chart-nav:hover {
+		background: rgba(0,0,0,0.75);
+	}
+
+	.chart-nav--prev {
+		left: var(--space-3);
+	}
+
+	.chart-nav--next {
+		right: var(--space-3);
+	}
+
+	.chart-mural-loading {
+		display: grid;
+		place-items: center;
+		min-height: clamp(180px, 20vw, 280px);
+		border: 1px solid var(--panel-border);
+		border-radius: var(--radius-md);
+		background: var(--panel-bg);
+		color: var(--text-secondary);
+		font-size: var(--font-size-sm);
+		font-weight: var(--font-weight-semibold);
+	}
+
+	@media (max-width: 760px) {
+		.chart-mural-bg {
+			grid-template-columns: repeat(5, minmax(0, 1fr));
+			grid-template-rows: repeat(4, minmax(0, 1fr));
+		}
+
+		.chart-mural-content {
+			padding: var(--space-4);
+		}
+
+		.chart-mural-meta {
+			max-width: 100%;
+		}
+
+		.chart-mural-title {
+			font-size: var(--font-size-3xl);
+		}
+	}
+</style>

--- a/frontend/src/lib/components/charts/DailyChartShelf.svelte
+++ b/frontend/src/lib/components/charts/DailyChartShelf.svelte
@@ -23,6 +23,7 @@
 
 	const PERIOD = 'daily';
 	const LIMIT = 20;
+	const ROTATE_MS = 8000;
 
 	let selectedRegion = $state('global');
 	let selectedSource = $state('spotify_daily');
@@ -30,13 +31,20 @@
 	let data = $state<ChartSnapshotResponse | null>(null);
 	let resolvedTracks = $state<Record<number, TidalSearchTrack | null>>({});
 	let resolvingEntries = $state<Record<number, boolean>>({});
-	let loading = $state(true);
 	let matrixLoading = $state(true);
+	let loading = $state(true);
 	let refreshingMatrix = $state(false);
-	let error = $state(false);
 	let matrixError = $state(false);
+	let error = $state(false);
 	let requestToken = 0;
 	let refreshAttempted = false;
+	let snapshotRefreshAttempted = false;
+	let currentEntryIndex = $state(0);
+	let carouselPaused = $state(false);
+	let carouselTimer: ReturnType<typeof setInterval> | undefined;
+
+	let chartEntries = $derived(data?.entries ?? []);
+	let currentEntry = $derived(chartEntries[currentEntryIndex] ?? chartEntries[0] ?? null);
 
 	onMount(() => {
 		void loadMatrix();
@@ -44,15 +52,21 @@
 	});
 
 	$effect(() => {
-		const cells = selectedRegionCells();
-		if (cells.length === 0) return;
-		void resolveVisibleCells(cells);
+		if (chartEntries.length === 0) return;
+		void resolveVisibleEntries(chartEntries);
 	});
 
 	$effect(() => {
-		const entries = data?.entries ?? [];
-		if (entries.length === 0) return;
-		void resolveVisibleEntries(entries);
+		if (currentEntryIndex >= chartEntries.length) currentEntryIndex = 0;
+	});
+
+	$effect(() => {
+		stopCarousel();
+		if (chartEntries.length <= 1) return;
+		carouselTimer = setInterval(() => {
+			if (!carouselPaused) jumpEntry(1);
+		}, ROTATE_MS);
+		return stopCarousel;
 	});
 
 	async function loadMatrix() {
@@ -100,6 +114,16 @@
 			});
 			if (token !== requestToken) return;
 			data = next;
+			currentEntryIndex = 0;
+			if (
+				!snapshotRefreshAttempted &&
+				!refreshingMatrix &&
+				next.entries.length > 0 &&
+				next.entries.length < Math.min(10, LIMIT)
+			) {
+				snapshotRefreshAttempted = true;
+				void refreshMatrix();
+			}
 		} catch (e) {
 			console.error('[daily-charts] snapshot fetch failed', e);
 			if (token !== requestToken) return;
@@ -120,18 +144,6 @@
 		selectedRegion = region;
 		selectedSource = source;
 		void loadSnapshot(region, source);
-	}
-
-	function rankDeltaLabel(delta: number | null): string {
-		if (delta == null || delta === 0) return 'steady';
-		return delta > 0 ? `up ${delta}` : `down ${Math.abs(delta)}`;
-	}
-
-	function formatMetric(entry: ChartSnapshotEntry): string {
-		if (entry.streams != null) return `${entry.streams.toLocaleString()} streams`;
-		if (entry.views != null) return `${entry.views.toLocaleString()} views`;
-		if (entry.points != null) return `${entry.points.toLocaleString()} pts`;
-		return entryStatusLabel(entry);
 	}
 
 	function cellMetric(cell: ChartMatrixCell): string {
@@ -161,14 +173,6 @@
 		return REGIONS.find((region) => region.code === selectedRegion)?.label ?? selectedRegion;
 	}
 
-	function selectedRegionCells(): ChartMatrixCell[] {
-		const row = matrix?.rows.find((item) => item.region === selectedRegion);
-		if (!row || !matrix) return [];
-		return matrix.providers
-			.map((provider) => row.cells[provider.source_key])
-			.filter((cell): cell is ChartMatrixCell => Boolean(cell));
-	}
-
 	function selectedProviderLabel(): string {
 		return (
 			matrix?.providers.find((provider) => provider.source_key === selectedSource)?.label ??
@@ -176,16 +180,29 @@
 		);
 	}
 
-	async function resolveVisibleCells(cells: ChartMatrixCell[]) {
-		await Promise.all(cells.slice(0, 6).map((cell) => resolveCell(cell)));
+	function stopCarousel() {
+		if (carouselTimer) clearInterval(carouselTimer);
+		carouselTimer = undefined;
+	}
+
+	function selectEntry(entryId: number) {
+		const nextIndex = chartEntries.findIndex((entry) => entry.id === entryId);
+		if (nextIndex >= 0) currentEntryIndex = nextIndex;
+	}
+
+	function jumpEntry(delta: number) {
+		if (chartEntries.length === 0) return;
+		currentEntryIndex = (currentEntryIndex + delta + chartEntries.length) % chartEntries.length;
+	}
+
+	function rankDeltaLabel(delta: number | null): string {
+		if (delta == null || delta === 0) return 'Steady';
+		if (delta < 0) return `Up ${Math.abs(delta)}`;
+		return `Down ${delta}`;
 	}
 
 	async function resolveVisibleEntries(entries: ChartSnapshotEntry[]) {
-		await Promise.all(entries.slice(0, 12).map((entry) => resolveEntry(entry)));
-	}
-
-	async function resolveCell(cell: ChartMatrixCell): Promise<TidalSearchTrack | null> {
-		return resolveChartItem(cell.entry_id, cell.artist, cell.title, cell.entity_type, cell.tidal_id);
+		await Promise.all(entries.slice(0, LIMIT).map((entry) => resolveEntry(entry)));
 	}
 
 	async function resolveEntry(entry: ChartSnapshotEntry): Promise<TidalSearchTrack | null> {
@@ -220,8 +237,8 @@
 		}
 	}
 
-	async function playCell(cell: ChartMatrixCell) {
-		const hit = resolvedTracks[cell.entry_id] ?? (await resolveCell(cell));
+	async function playEntry(entry: ChartSnapshotEntry) {
+		const hit = resolvedTracks[entry.id] ?? (await resolveEntry(entry));
 		if (!hit) {
 			playerError.set({ message: "Couldn't find that chart entry on TIDAL." });
 			return;
@@ -231,19 +248,19 @@
 			title: hit.title,
 			artist_name: hit.artist_name,
 			album_title: hit.album_title,
-			artwork_url: hit.artwork_url ?? cell.artwork_url,
+			artwork_url: hit.artwork_url ?? entry.artwork_url,
 			duration_ms: hit.duration_ms,
 			artist_tidal_id: hit.artist_id,
 			album_tidal_id: hit.album_tidal_id,
 		});
 	}
 
-	function cellArtwork(cell: ChartMatrixCell): string | null {
-		return resolvedTracks[cell.entry_id]?.artwork_url ?? cell.artwork_url;
-	}
-
 	function entryArtwork(entry: ChartSnapshotEntry): string | null {
 		return resolvedTracks[entry.id]?.artwork_url ?? entry.artwork_url;
+	}
+
+	function entryFallbackText(entry: ChartSnapshotEntry): string {
+		return (entry.title.trim()[0] ?? 'N').toUpperCase();
 	}
 
 	function entryStatusLabel(entry: ChartSnapshotEntry): string {
@@ -254,19 +271,22 @@
 		return entry.resolution_status;
 	}
 
-	function cellFallbackText(cell: ChartMatrixCell): string {
-		return (cell.title.trim()[0] ?? 'N').toUpperCase();
+	function entryMetric(entry: ChartSnapshotEntry): string {
+		if (entry.streams != null) return `${entry.streams.toLocaleString()} streams`;
+		if (entry.views != null) return `${entry.views.toLocaleString()} views`;
+		if (entry.points != null) return `${entry.points.toLocaleString()} pts`;
+		return entryStatusLabel(entry);
 	}
 
-	function fallbackText(entry: ChartSnapshotEntry): string {
-		return (entry.title.trim()[0] ?? 'N').toUpperCase();
+	function entrySubtitle(entry: ChartSnapshotEntry): string {
+		return `#${entry.rank} ${rankDeltaLabel(entry.rank_delta)} - ${entry.artist}`;
 	}
 </script>
 
 <section class="daily-chart-shelf">
 	<div class="section-header">
 		<div class="section-title-group">
-			<p class="eyebrow">Charts · Provider matrix</p>
+			<p class="eyebrow">Charts - Provider matrix</p>
 			<h2>Market pulse</h2>
 		</div>
 		<div class="region-tabs" role="tablist" aria-label="Daily chart region">
@@ -286,54 +306,97 @@
 	</div>
 
 	{#if matrix?.providers.length}
-		<div class="region-pulse" aria-label={`${selectedRegionLabel()} provider leaders`}>
-			<div class="region-pulse-copy">
-				<p>{selectedRegionLabel()} chart leaders</p>
-				<h3>{selectedProviderLabel()}</h3>
-			</div>
-			<div class="provider-card-row">
-				{#each matrix.providers as provider (provider.source_key)}
-					{@const row = matrix.rows.find((item) => item.region === selectedRegion)}
-					{@const cell = row?.cells[provider.source_key] ?? null}
+		<div class="source-tabs" role="tablist" aria-label="Daily chart provider">
+			{#each matrix.providers as provider (provider.source_key)}
+				<button
+					type="button"
+					class="source-chip"
+					class:active={provider.source_key === selectedSource}
+					role="tab"
+					aria-selected={provider.source_key === selectedSource}
+					onclick={() => pickProvider(selectedRegion, provider.source_key)}
+				>
+					{provider.label}
+				</button>
+			{/each}
+		</div>
+	{/if}
+
+	{#if chartEntries.length > 0 && currentEntry}
+		<div
+			class="chart-mural-card"
+			onmouseenter={() => carouselPaused = true}
+			onmouseleave={() => carouselPaused = false}
+			role="region"
+			aria-label={`${selectedProviderLabel()} ${selectedRegionLabel()} top ${chartEntries.length}`}
+		>
+			<div class="chart-mural-bg" aria-hidden="true">
+				{#each chartEntries as entry (entry.id)}
 					<button
+						class="chart-mural-tile"
+						class:chart-mural-tile--featured={currentEntry.id === entry.id}
 						type="button"
-						class="provider-card"
-						class:active={selectedSource === provider.source_key}
-						class:empty={!cell}
-						onclick={() => {
-							if (cell) {
-								pickProvider(selectedRegion, provider.source_key);
-								void playCell(cell);
-							}
-						}}
-						aria-label={`${provider.label} ${selectedRegionLabel()} leader`}
+						onclick={() => selectEntry(entry.id)}
+						aria-label={`Select ${entry.title}`}
+						title={`${entry.rank}. ${entry.title} - ${entry.artist}`}
 					>
-						<span class="provider-name">{provider.label}</span>
-						{#if cell}
-							<div class="provider-art">
-								<ArtworkImage
-									src={cellArtwork(cell)}
-									size={320}
-									className="provider-card-art"
-									fallbackText={cellFallbackText(cell)}
-									decorative
-								/>
-							</div>
-							<strong>{cell.title}</strong>
-							<span>{cell.artist}</span>
-							<small>{cellMetric(cell)}</small>
-						{:else}
-							<div class="provider-art empty-art"></div>
-							<strong>No data</strong>
-							<span>{selectedRegionLabel()}</span>
-							<small>Provider missing</small>
-						{/if}
+						<ArtworkImage
+							src={entryArtwork(entry)}
+							size={320}
+							className="chart-mural-art"
+							fallbackText={entryFallbackText(entry)}
+							decorative
+						/>
 					</button>
 				{/each}
 			</div>
+			<div class="chart-mural-shade"></div>
+			<div class="chart-mural-content">
+				<div class="chart-mural-meta">
+					<span class="chart-mural-kind">
+						{selectedProviderLabel()} top {chartEntries.length} - {selectedRegionLabel()}
+					</span>
+					<h3 class="chart-mural-title">{currentEntry.title}</h3>
+					<p class="chart-mural-sub">{entrySubtitle(currentEntry)}</p>
+					<div class="chart-mural-actions">
+						<button class="btn btn-primary chart-mural-play" type="button" onclick={() => void playEntry(currentEntry)}>
+							<svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor" aria-hidden="true">
+								<path d="M3 2.5l10 5.5-10 5.5V2.5z"/>
+							</svg>
+							Play
+						</button>
+						<span>{entryMetric(currentEntry)}</span>
+					</div>
+				</div>
+			</div>
+			{#if chartEntries.length > 1}
+				<button class="chart-nav chart-nav--prev" type="button" onclick={() => jumpEntry(-1)} aria-label="Previous chart entry">&lsaquo;</button>
+				<button class="chart-nav chart-nav--next" type="button" onclick={() => jumpEntry(1)} aria-label="Next chart entry">&rsaquo;</button>
+			{/if}
 		</div>
+	{:else if loading}
+		<div class="chart-mural-loading">Loading chart mural</div>
+	{:else if error}
+		<EmptyState
+			title="Daily chart unavailable"
+			copy="Restart the NOOR server if this update just landed."
+		/>
+	{:else if !matrixLoading}
+		<EmptyState
+			title={`No ${selectedProviderLabel()} top list for ${selectedRegionLabel()}`}
+			copy="Try another provider or region."
+		/>
+	{/if}
 
+	{#if matrix?.providers.length}
 		<div class="matrix-shell" aria-label="Market pulse provider matrix">
+			<div class="matrix-heading">
+				<div>
+					<p>Provider comparison</p>
+					<h3>All markets</h3>
+				</div>
+				<span>{selectedRegionLabel()} focus</span>
+			</div>
 			<div class="matrix-grid">
 				<div class="matrix-head region-head">Region</div>
 				{#each matrix.providers as provider (provider.source_key)}
@@ -386,58 +449,13 @@
 		/>
 	{/if}
 
-	{#if data?.snapshot && data.entries.length > 0}
-		<div class="chart-list" aria-label="Daily chart entries">
-			<div class="list-heading">
-				<p>{selectedRegionLabel()} · {selectedProviderLabel()}</p>
-				<h3>Provider snapshot</h3>
-			</div>
-			{#each data.entries as entry (entry.id)}
-				<div class="chart-row">
-					<div class="rank">
-						<span>{entry.rank}</span>
-						<small>{rankDeltaLabel(entry.rank_delta)}</small>
-					</div>
-					<div class="art-cell">
-						<ArtworkImage
-							src={entryArtwork(entry)}
-							size={320}
-							className="daily-chart-art"
-							fallbackText={fallbackText(entry)}
-							decorative
-						/>
-					</div>
-					<div class="track-meta">
-						<strong>{entry.title}</strong>
-						<span>{entry.artist}</span>
-					</div>
-					<div class="metric">{formatMetric(entry)}</div>
-					<div class="status" data-status={entry.resolution_status}>
-						{entryStatusLabel(entry)}
-					</div>
-				</div>
-			{/each}
-		</div>
-	{:else if loading}
-		<div class="chart-list" aria-label="Loading daily chart">
-			{#each Array.from({ length: 6 }) as _, i (i)}
-				<div class="chart-row skeleton" aria-hidden="true"></div>
-			{/each}
-		</div>
-	{:else if error}
-		<EmptyState
-			title="Daily snapshots unavailable"
-			copy="Restart the NOOR server if this update just landed."
-		/>
-	{:else}
+	{#if !matrixLoading && !matrixError && !regionHasMatrixData(selectedRegion)}
 		<EmptyState
 			title={matrixHasData(matrix)
-				? `No Spotify daily list for ${selectedRegionLabel()}`
+				? `No provider leaders for ${selectedRegionLabel()}`
 				: 'No market snapshot yet'}
 			copy={matrixHasData(matrix)
-				? regionHasMatrixData(selectedRegion)
-					? `This region has provider leaders, but no ${selectedProviderLabel()} detail list yet.`
-					: 'This region has no provider snapshot yet. Global data is available above.'
+				? 'This region has no provider leaders yet. Global data is available above.'
 				: 'NOOR tried to refresh the provider matrix, but there is no stored chart data yet.'}
 		/>
 	{/if}
@@ -515,140 +533,299 @@
 		opacity: 0.55;
 	}
 
-	.region-pulse {
-		display: grid;
-		gap: var(--space-3);
-	}
-
-	.region-pulse-copy {
+	.source-tabs {
 		display: flex;
-		align-items: end;
-		justify-content: space-between;
-		gap: var(--gap-sm);
-	}
-
-	.region-pulse-copy p,
-	.region-pulse-copy h3 {
-		margin: 0;
-	}
-
-	.region-pulse-copy p {
-		font-size: var(--font-size-xs);
-		font-weight: var(--font-weight-semibold);
-		color: var(--text-secondary);
-		text-transform: uppercase;
-		letter-spacing: 0;
-	}
-
-	.region-pulse-copy h3 {
-		font-size: var(--font-size-xl);
-		font-weight: var(--font-weight-bold);
-		line-height: var(--line-height-tight);
-	}
-
-	.provider-card-row {
-		display: grid;
-		grid-template-columns: repeat(6, minmax(132px, 1fr));
-		gap: var(--space-2);
+		align-items: center;
+		gap: var(--space-1);
 		overflow-x: auto;
 		padding-bottom: var(--space-1);
 	}
 
-	.provider-card {
-		position: relative;
-		display: grid;
-		grid-template-rows: auto auto auto auto auto;
-		align-content: start;
-		gap: var(--space-1);
-		min-width: 132px;
-		min-height: clamp(210px, 19vw, 260px);
-		padding: var(--space-2);
+	.source-chip {
 		border: 1px solid var(--panel-border);
-		border-radius: var(--radius-sm);
+		border-radius: 999px;
 		background: var(--panel-bg);
-		color: var(--text-secondary);
-		text-align: left;
+		color: var(--text-muted);
 		cursor: pointer;
+		font-size: var(--font-size-xs);
+		font-weight: var(--font-weight-semibold);
+		line-height: 1;
+		padding: var(--space-2) var(--space-3);
+		white-space: nowrap;
 		transition: background var(--motion-base), border-color var(--motion-base), color var(--motion-base);
 	}
 
-	.provider-card:hover,
-	.provider-card:focus-visible,
-	.provider-card.active {
-		border-color: var(--accent-line);
+	.source-chip:hover,
+	.source-chip:focus-visible,
+	.source-chip.active {
 		background: var(--bg-hover);
+		border-color: var(--accent-line);
 		color: var(--text-primary);
 		outline: none;
 	}
 
-	.provider-card.empty {
-		cursor: default;
-		opacity: 0.62;
-	}
-
-	.provider-name {
-		font-size: var(--font-size-2xs);
-		font-weight: var(--font-weight-bold);
-		color: var(--service-spotify);
-		text-transform: uppercase;
-		letter-spacing: 0;
-	}
-
-	.provider-art {
-		width: 100%;
-		aspect-ratio: 1 / 1;
-		border-radius: var(--radius-xs);
+	.chart-mural-card {
+		position: relative;
+		min-height: clamp(220px, 24vw, 360px);
+		border: 1px solid var(--panel-border);
+		border-radius: var(--radius-md);
 		overflow: hidden;
-		background: var(--bg-raised);
+		background: var(--panel-bg);
 	}
 
-	:global(.provider-card-art) {
+	.chart-mural-bg {
+		position: absolute;
+		inset: -7%;
+		z-index: 0;
+		display: grid;
+		grid-template-columns: repeat(10, minmax(0, 1fr));
+		grid-template-rows: repeat(2, minmax(0, 1fr));
+		background: linear-gradient(120deg, var(--panel-bg), color-mix(in srgb, var(--accent-soft) 24%, transparent));
+	}
+
+	.chart-mural-bg::after {
+		content: '';
+		position: absolute;
+		inset: 0;
+		background:
+			radial-gradient(circle at 78% 42%, rgba(255,255,255,0.2), transparent 30%),
+			linear-gradient(90deg, rgba(0,0,0,0.06), transparent 42%, rgba(0,0,0,0.02));
+		pointer-events: none;
+	}
+
+	.chart-mural-tile {
+		appearance: none;
+		position: relative;
+		min-width: 0;
+		min-height: 0;
+		padding: 0;
+		border: 0;
+		background: var(--bg-raised);
+		color: var(--text-primary);
+		cursor: pointer;
+		overflow: hidden;
+		opacity: 0.96;
+		filter: saturate(1.18) brightness(1.16);
+		transform: skewX(-7deg) scaleX(1.08);
+		transform-origin: center;
+		transition:
+			filter var(--motion-fast),
+			opacity var(--motion-fast),
+			transform var(--motion-base),
+			box-shadow var(--motion-base);
+	}
+
+	.chart-mural-tile::after {
+		content: '';
+		position: absolute;
+		inset: 0;
+		background: linear-gradient(90deg, rgba(0,0,0,0.18), transparent 48%, rgba(0,0,0,0.2));
+		opacity: 0.18;
+		pointer-events: none;
+	}
+
+	.chart-mural-tile:hover,
+	.chart-mural-tile:focus-visible,
+	.chart-mural-tile--featured {
+		z-index: var(--z-raised);
+		opacity: 1;
+		filter: saturate(1.8) brightness(1.42);
+		transform: skewX(-7deg) scaleX(1.08) scale(1.045);
+		box-shadow:
+			0 0 0 1px rgba(255,255,255,0.32),
+			0 14px 30px rgba(0,0,0,0.32),
+			0 0 24px color-mix(in srgb, var(--accent) 38%, transparent);
+		outline: none;
+	}
+
+	:global(.chart-mural-art),
+	:global(.chart-mural-art.fallback) {
+		display: block;
 		width: 100%;
 		height: 100%;
-		object-fit: cover;
-		display: block;
 	}
 
-	:global(.provider-card-art.fallback),
-	.empty-art {
+	:global(.chart-mural-art) {
+		object-fit: cover;
+		transform: skewX(7deg) scale(1.24);
+		transition: transform var(--motion-base);
+	}
+
+	.chart-mural-tile:hover :global(.chart-mural-art),
+	.chart-mural-tile:focus-visible :global(.chart-mural-art),
+	.chart-mural-tile--featured :global(.chart-mural-art) {
+		transform: skewX(7deg) scale(1.34);
+	}
+
+	:global(.chart-mural-art.fallback) {
 		display: grid;
 		place-items: center;
-		background: linear-gradient(135deg, var(--bg-raised), var(--panel-bg));
-		color: var(--text-muted);
-		font-size: var(--font-size-2xl);
+		background: linear-gradient(135deg, var(--bg-raised), color-mix(in srgb, var(--accent-soft) 28%, var(--bg-surface)));
+		color: rgba(255,255,255,0.78);
+		font-size: var(--font-size-xl);
 		font-weight: var(--font-weight-bold);
 	}
 
-	.provider-card strong,
-	.provider-card span,
-	.provider-card small {
-		min-width: 0;
-		max-width: 100%;
+	.chart-mural-shade {
+		position: absolute;
+		inset: 0;
+		z-index: var(--z-base);
+		background: linear-gradient(90deg, rgba(0,0,0,0.7) 0%, rgba(0,0,0,0.34) 42%, rgba(0,0,0,0.06) 78%, transparent 100%);
+		pointer-events: none;
+	}
+
+	.chart-mural-content {
+		position: relative;
+		z-index: calc(var(--z-base) + 1);
+		display: grid;
+		align-items: center;
+		min-height: inherit;
+		padding: var(--space-5);
+		pointer-events: none;
+	}
+
+	.chart-mural-meta {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-1);
+		max-width: min(42rem, 58vw);
+		text-shadow: 0 2px 18px rgba(0,0,0,0.62);
+	}
+
+	.chart-mural-kind {
+		color: var(--accent);
+		font-size: var(--font-size-2xs);
+		font-weight: var(--font-weight-semibold);
+		letter-spacing: 0;
+		text-transform: uppercase;
+	}
+
+	.chart-mural-title {
+		margin: 0;
+		color: var(--text-primary);
+		font-size: var(--font-size-4xl);
+		font-weight: var(--font-weight-bold);
+		line-height: var(--line-height-tight);
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
 	}
 
-	.provider-card strong {
-		color: var(--text-primary);
+	.chart-mural-sub {
+		margin: 0 0 var(--space-2);
+		color: var(--text-secondary);
+		font-size: var(--font-size-sm);
+	}
+
+	.chart-mural-actions {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		pointer-events: auto;
+	}
+
+	.chart-mural-actions span {
+		color: var(--text-secondary);
+		font-size: var(--font-size-xs);
+		font-weight: var(--font-weight-semibold);
+	}
+
+	.chart-mural-play {
+		display: flex;
+		align-items: center;
+		gap: var(--space-1);
 		font-size: var(--font-size-sm);
 		font-weight: var(--font-weight-semibold);
-		line-height: var(--line-height-snug);
 	}
 
-	.provider-card span:not(.provider-name) {
-		font-size: var(--font-size-xs);
+	.chart-nav {
+		position: absolute;
+		top: 50%;
+		z-index: var(--z-raised);
+		display: grid;
+		place-items: center;
+		width: clamp(32px, 3vw, 40px);
+		aspect-ratio: 1 / 1;
+		border: 1px solid var(--panel-border);
+		border-radius: 50%;
+		background: rgba(0,0,0,0.5);
+		color: var(--text-primary);
+		cursor: pointer;
+		font-size: var(--font-size-xl);
+		line-height: 1;
+		opacity: 0;
+		transform: translateY(-50%);
+		transition: opacity var(--motion-fast), background var(--motion-fast);
+	}
+
+	.chart-mural-card:hover .chart-nav,
+	.chart-nav:focus-visible {
+		opacity: 1;
+		outline: none;
+	}
+
+	.chart-nav:hover {
+		background: rgba(0,0,0,0.75);
+	}
+
+	.chart-nav--prev {
+		left: var(--space-3);
+	}
+
+	.chart-nav--next {
+		right: var(--space-3);
+	}
+
+	.chart-mural-loading {
+		display: grid;
+		place-items: center;
+		min-height: clamp(180px, 20vw, 280px);
+		border: 1px solid var(--panel-border);
+		border-radius: var(--radius-md);
+		background: var(--panel-bg);
 		color: var(--text-secondary);
-	}
-
-	.provider-card small {
-		font-size: var(--font-size-2xs);
-		color: var(--text-muted);
+		font-size: var(--font-size-sm);
+		font-weight: var(--font-weight-semibold);
 	}
 
 	.matrix-shell {
+		display: grid;
+		gap: var(--space-2);
 		overflow-x: auto;
 		padding-bottom: var(--space-1);
+	}
+
+	.matrix-heading {
+		display: flex;
+		align-items: end;
+		justify-content: space-between;
+		gap: var(--gap-sm);
+		min-width: 920px;
+	}
+
+	.matrix-heading p,
+	.matrix-heading h3 {
+		margin: 0;
+	}
+
+	.matrix-heading p {
+		font-size: var(--font-size-xs);
+		font-weight: var(--font-weight-semibold);
+		color: var(--text-muted);
+		text-transform: uppercase;
+		letter-spacing: 0;
+	}
+
+	.matrix-heading h3 {
+		font-size: var(--font-size-lg);
+		font-weight: var(--font-weight-bold);
+		line-height: var(--line-height-tight);
+	}
+
+	.matrix-heading span {
+		color: var(--text-secondary);
+		font-size: var(--font-size-xs);
+		font-weight: var(--font-weight-semibold);
 	}
 
 	.matrix-grid {
@@ -772,162 +949,22 @@
 		color: var(--text-primary);
 	}
 
-	.chart-list {
-		display: grid;
-		gap: var(--space-1);
-	}
-
-	.list-heading {
-		display: flex;
-		align-items: baseline;
-		justify-content: space-between;
-		gap: var(--gap-sm);
-		padding-top: var(--space-1);
-	}
-
-	.list-heading p,
-	.list-heading h3 {
-		margin: 0;
-	}
-
-	.list-heading p {
-		font-size: var(--font-size-xs);
-		font-weight: var(--font-weight-semibold);
-		color: var(--text-muted);
-		text-transform: uppercase;
-		letter-spacing: 0;
-	}
-
-	.list-heading h3 {
-		font-size: var(--font-size-md);
-		font-weight: var(--font-weight-bold);
-		line-height: var(--line-height-tight);
-	}
-
-	.chart-row {
-		display: grid;
-		grid-template-columns: clamp(44px, 5vw, 64px) clamp(42px, 4vw, 52px) minmax(0, 1fr) auto auto;
-		align-items: center;
-		gap: var(--space-3);
-		min-height: clamp(56px, 6vw, 68px);
-		padding: var(--space-2) var(--space-3);
-		border: 1px solid var(--panel-border);
-		border-radius: var(--radius-sm);
-		background: var(--panel-bg);
-	}
-
-	.rank {
-		display: flex;
-		flex-direction: column;
-		gap: var(--space-1);
-		line-height: var(--line-height-tight);
-	}
-
-	.rank span {
-		font-size: var(--font-size-lg);
-		font-weight: var(--font-weight-bold);
-	}
-
-	.rank small {
-		font-size: var(--font-size-2xs);
-		color: var(--text-muted);
-		text-transform: uppercase;
-		letter-spacing: 0;
-	}
-
-	.art-cell {
-		width: clamp(42px, 4vw, 52px);
-		aspect-ratio: 1 / 1;
-		border-radius: var(--radius-xs);
-		overflow: hidden;
-		background: var(--bg-raised);
-	}
-
-	:global(.daily-chart-art) {
-		width: 100%;
-		height: 100%;
-		object-fit: cover;
-		display: block;
-	}
-
-	:global(.daily-chart-art.fallback) {
-		display: grid;
-		place-items: center;
-		color: var(--text-muted);
-		font-size: var(--font-size-sm);
-		font-weight: var(--font-weight-semibold);
-	}
-
-	.track-meta {
-		min-width: 0;
-		display: flex;
-		flex-direction: column;
-		gap: var(--space-1);
-	}
-
-	.track-meta strong,
-	.track-meta span {
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-	}
-
-	.track-meta strong {
-		font-size: var(--font-size-sm);
-		font-weight: var(--font-weight-semibold);
-		line-height: var(--line-height-snug);
-	}
-
-	.track-meta span {
-		font-size: var(--font-size-xs);
-		color: var(--text-secondary);
-	}
-
-	.metric,
-	.status {
-		font-size: var(--font-size-xs);
-		font-weight: var(--font-weight-semibold);
-		color: var(--text-secondary);
-		white-space: nowrap;
-	}
-
-	.status {
-		border-radius: 999px;
-		padding: var(--space-1) var(--space-2);
-		background: var(--bg-hover);
-		color: var(--text-muted);
-		text-transform: capitalize;
-	}
-
-	.status[data-status='local'],
-	.status[data-status='tidal'] {
-		color: var(--text-primary);
-	}
-
-	.skeleton {
-		min-height: clamp(56px, 6vw, 68px);
-		background: linear-gradient(90deg, var(--panel-bg), var(--bg-hover), var(--panel-bg));
-		background-size: 200% 100%;
-		animation: pulse 1.2s linear infinite;
-	}
-
-	@keyframes pulse {
-		from { background-position: 200% 0; }
-		to { background-position: -200% 0; }
-	}
-
 	@media (max-width: 760px) {
-		.provider-card-row {
-			grid-template-columns: repeat(6, minmax(118px, 38vw));
+		.chart-mural-bg {
+			grid-template-columns: repeat(5, minmax(0, 1fr));
+			grid-template-rows: repeat(4, minmax(0, 1fr));
 		}
 
-		.chart-row {
-			grid-template-columns: clamp(36px, 10vw, 48px) clamp(42px, 12vw, 52px) minmax(0, 1fr);
+		.chart-mural-content {
+			padding: var(--space-4);
 		}
 
-		.metric,
-		.status {
-			grid-column: 3;
+		.chart-mural-meta {
+			max-width: 100%;
+		}
+
+		.chart-mural-title {
+			font-size: var(--font-size-3xl);
 		}
 	}
 </style>

--- a/frontend/src/lib/components/charts/DailyChartShelf.svelte
+++ b/frontend/src/lib/components/charts/DailyChartShelf.svelte
@@ -6,11 +6,15 @@
 		type ChartMatrixResponse,
 		type ChartSnapshotEntry,
 		type ChartSnapshotResponse,
+		type TidalPlayable,
 		type TidalSearchTrack,
 	} from '$lib/api/client';
 	import EmptyState from '$lib/components/ui/EmptyState.svelte';
-	import ArtworkImage from '$lib/components/ui/ArtworkImage.svelte';
 	import { playTidalTrackNow, playerError } from '$lib/stores/player';
+	import { openContextMenu } from '$lib/stores/context_menu';
+	import { buildTidalTrackMenu } from '$lib/player/track_menu';
+	import SectionHeader from '$lib/components/ui/SectionHeader.svelte';
+	import ChartMural, { type ChartMuralItem } from '$lib/components/charts/ChartMural.svelte';
 
 	const REGIONS = [
 		{ code: 'global', label: 'Global' },
@@ -45,6 +49,17 @@
 
 	let chartEntries = $derived(data?.entries ?? []);
 	let currentEntry = $derived(chartEntries[currentEntryIndex] ?? chartEntries[0] ?? null);
+	let muralItems = $derived<ChartMuralItem[]>(
+		chartEntries.map((entry) => ({
+			id: String(entry.id),
+			title: entry.title,
+			subtitle: entrySubtitle(entry),
+			artwork: entryArtwork(entry),
+			fallbackText: entryFallbackText(entry),
+			tileLabel: `Select ${entry.title}`,
+			tileTitle: `${entry.rank}. ${entry.title} - ${entry.artist}`,
+		})),
+	);
 
 	onMount(() => {
 		void loadMatrix();
@@ -255,6 +270,41 @@
 		});
 	}
 
+	function playableFromHit(hit: TidalSearchTrack, fallbackArtwork: string | null): TidalPlayable {
+		return {
+			tidal_id: hit.tidal_id,
+			title: hit.title,
+			artist_name: hit.artist_name,
+			album_title: hit.album_title,
+			artwork_url: hit.artwork_url ?? fallbackArtwork,
+			duration_ms: hit.duration_ms,
+			artist_tidal_id: hit.artist_id,
+			album_tidal_id: hit.album_tidal_id,
+			local_id: hit.local_id,
+			is_in_library: hit.in_library,
+		};
+	}
+
+	async function openEntryContext(e: MouseEvent, entry: ChartSnapshotEntry) {
+		e.preventDefault();
+		e.stopPropagation();
+		const hit = resolvedTracks[entry.id] ?? (await resolveEntry(entry));
+		if (!hit) return;
+		const playable = playableFromHit(hit, entry.artwork_url);
+		openContextMenu(e, buildTidalTrackMenu(playable), playable.title);
+	}
+
+	async function openMatrixCellContext(e: MouseEvent, cell: ChartMatrixCell) {
+		e.preventDefault();
+		e.stopPropagation();
+		const hit =
+			resolvedTracks[cell.entry_id] ??
+			(await resolveChartItem(cell.entry_id, cell.artist, cell.title, cell.entity_type, cell.tidal_id));
+		if (!hit) return;
+		const playable = playableFromHit(hit, cell.artwork_url);
+		openContextMenu(e, buildTidalTrackMenu(playable), playable.title);
+	}
+
 	function entryArtwork(entry: ChartSnapshotEntry): string | null {
 		return resolvedTracks[entry.id]?.artwork_url ?? entry.artwork_url;
 	}
@@ -284,11 +334,8 @@
 </script>
 
 <section class="daily-chart-shelf">
-	<div class="section-header">
-		<div class="section-title-group">
-			<p class="eyebrow">Charts - Provider matrix</p>
-			<h2>Market pulse</h2>
-		</div>
+	<SectionHeader eyebrow="Charts - Provider matrix" title="Market pulse" variant="charts" level={2}>
+		{#snippet actions()}
 		<div class="region-tabs" role="tablist" aria-label="Daily chart region">
 			{#each REGIONS as region (region.code)}
 				<button
@@ -303,7 +350,8 @@
 				</button>
 			{/each}
 		</div>
-	</div>
+		{/snippet}
+	</SectionHeader>
 
 	{#if matrix?.providers.length}
 		<div class="source-tabs" role="tablist" aria-label="Daily chart provider">
@@ -323,59 +371,41 @@
 	{/if}
 
 	{#if chartEntries.length > 0 && currentEntry}
-		<div
-			class="chart-mural-card"
-			onmouseenter={() => carouselPaused = true}
-			onmouseleave={() => carouselPaused = false}
-			role="region"
-			aria-label={`${selectedProviderLabel()} ${selectedRegionLabel()} top ${chartEntries.length}`}
-		>
-			<div class="chart-mural-bg" aria-hidden="true">
-				{#each chartEntries as entry (entry.id)}
-					<button
-						class="chart-mural-tile"
-						class:chart-mural-tile--featured={currentEntry.id === entry.id}
-						type="button"
-						onclick={() => selectEntry(entry.id)}
-						aria-label={`Select ${entry.title}`}
-						title={`${entry.rank}. ${entry.title} - ${entry.artist}`}
-					>
-						<ArtworkImage
-							src={entryArtwork(entry)}
-							size={320}
-							className="chart-mural-art"
-							fallbackText={entryFallbackText(entry)}
-							decorative
-						/>
-					</button>
-				{/each}
-			</div>
-			<div class="chart-mural-shade"></div>
-			<div class="chart-mural-content">
-				<div class="chart-mural-meta">
-					<span class="chart-mural-kind">
-						{selectedProviderLabel()} top {chartEntries.length} - {selectedRegionLabel()}
-					</span>
-					<h3 class="chart-mural-title">{currentEntry.title}</h3>
-					<p class="chart-mural-sub">{entrySubtitle(currentEntry)}</p>
-					<div class="chart-mural-actions">
-						<button class="btn btn-primary chart-mural-play" type="button" onclick={() => void playEntry(currentEntry)}>
-							<svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor" aria-hidden="true">
-								<path d="M3 2.5l10 5.5-10 5.5V2.5z"/>
-							</svg>
-							Play
-						</button>
-						<span>{entryMetric(currentEntry)}</span>
-					</div>
-				</div>
-			</div>
-			{#if chartEntries.length > 1}
-				<button class="chart-nav chart-nav--prev" type="button" onclick={() => jumpEntry(-1)} aria-label="Previous chart entry">&lsaquo;</button>
-				<button class="chart-nav chart-nav--next" type="button" onclick={() => jumpEntry(1)} aria-label="Next chart entry">&rsaquo;</button>
-			{/if}
-		</div>
+		<ChartMural
+			items={muralItems}
+			currentIndex={currentEntryIndex}
+			ariaLabel={`${selectedProviderLabel()} ${selectedRegionLabel()} top ${chartEntries.length}`}
+			kindLabel={`${selectedProviderLabel()} top ${chartEntries.length} - ${selectedRegionLabel()}`}
+			title={currentEntry.title}
+			subtitle={entrySubtitle(currentEntry)}
+			metric={entryMetric(currentEntry)}
+			actionLabel="Play"
+			loading={loading && chartEntries.length === 0}
+			loadingLabel="Loading chart mural"
+			onSelect={(index) => {
+				const entry = chartEntries[index];
+				if (entry) selectEntry(entry.id);
+			}}
+			onJump={jumpEntry}
+			onPlay={() => playEntry(currentEntry)}
+			onCardContext={(event) => currentEntry && openEntryContext(event, currentEntry)}
+			onItemContext={(event, index) => {
+				const entry = chartEntries[index];
+				if (entry) void openEntryContext(event, entry);
+			}}
+			onPauseChange={(paused) => carouselPaused = paused}
+		/>
 	{:else if loading}
-		<div class="chart-mural-loading">Loading chart mural</div>
+		<ChartMural
+			items={[]}
+			currentIndex={0}
+			ariaLabel="Loading market pulse"
+			kindLabel=""
+			title=""
+			subtitle=""
+			loading
+			loadingLabel="Loading chart mural"
+		/>
 	{:else if error}
 		<EmptyState
 			title="Daily chart unavailable"
@@ -422,6 +452,9 @@
 								if (cell) pickProvider(row.region, provider.source_key);
 								else pickRegion(row.region);
 							}}
+							oncontextmenu={(e) => {
+								if (cell) void openMatrixCellContext(e, cell);
+							}}
 							aria-label={`${provider.label} ${row.region}`}
 						>
 							{#if cell}
@@ -466,36 +499,6 @@
 		display: flex;
 		flex-direction: column;
 		gap: var(--space-3);
-	}
-
-	.section-header {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		gap: var(--gap-sm);
-		flex-wrap: wrap;
-	}
-
-	.section-title-group {
-		display: flex;
-		flex-direction: column;
-		gap: var(--space-1);
-	}
-
-	.eyebrow {
-		margin: 0;
-		font-size: var(--font-size-xs);
-		font-weight: var(--font-weight-semibold);
-		text-transform: uppercase;
-		letter-spacing: 0;
-		color: var(--service-spotify);
-	}
-
-	h2 {
-		margin: 0;
-		font-size: var(--font-size-lg);
-		font-weight: var(--font-weight-bold);
-		line-height: var(--line-height-tight);
 	}
 
 	.region-tabs {
@@ -562,230 +565,6 @@
 		border-color: var(--accent-line);
 		color: var(--text-primary);
 		outline: none;
-	}
-
-	.chart-mural-card {
-		position: relative;
-		min-height: clamp(220px, 24vw, 360px);
-		border: 1px solid var(--panel-border);
-		border-radius: var(--radius-md);
-		overflow: hidden;
-		background: var(--panel-bg);
-	}
-
-	.chart-mural-bg {
-		position: absolute;
-		inset: -7%;
-		z-index: 0;
-		display: grid;
-		grid-template-columns: repeat(10, minmax(0, 1fr));
-		grid-template-rows: repeat(2, minmax(0, 1fr));
-		background: linear-gradient(120deg, var(--panel-bg), color-mix(in srgb, var(--accent-soft) 24%, transparent));
-	}
-
-	.chart-mural-bg::after {
-		content: '';
-		position: absolute;
-		inset: 0;
-		background:
-			radial-gradient(circle at 78% 42%, rgba(255,255,255,0.2), transparent 30%),
-			linear-gradient(90deg, rgba(0,0,0,0.06), transparent 42%, rgba(0,0,0,0.02));
-		pointer-events: none;
-	}
-
-	.chart-mural-tile {
-		appearance: none;
-		position: relative;
-		min-width: 0;
-		min-height: 0;
-		padding: 0;
-		border: 0;
-		background: var(--bg-raised);
-		color: var(--text-primary);
-		cursor: pointer;
-		overflow: hidden;
-		opacity: 0.96;
-		filter: saturate(1.18) brightness(1.16);
-		transform: skewX(-7deg) scaleX(1.08);
-		transform-origin: center;
-		transition:
-			filter var(--motion-fast),
-			opacity var(--motion-fast),
-			transform var(--motion-base),
-			box-shadow var(--motion-base);
-	}
-
-	.chart-mural-tile::after {
-		content: '';
-		position: absolute;
-		inset: 0;
-		background: linear-gradient(90deg, rgba(0,0,0,0.18), transparent 48%, rgba(0,0,0,0.2));
-		opacity: 0.18;
-		pointer-events: none;
-	}
-
-	.chart-mural-tile:hover,
-	.chart-mural-tile:focus-visible,
-	.chart-mural-tile--featured {
-		z-index: var(--z-raised);
-		opacity: 1;
-		filter: saturate(1.8) brightness(1.42);
-		transform: skewX(-7deg) scaleX(1.08) scale(1.045);
-		box-shadow:
-			0 0 0 1px rgba(255,255,255,0.32),
-			0 14px 30px rgba(0,0,0,0.32),
-			0 0 24px color-mix(in srgb, var(--accent) 38%, transparent);
-		outline: none;
-	}
-
-	:global(.chart-mural-art),
-	:global(.chart-mural-art.fallback) {
-		display: block;
-		width: 100%;
-		height: 100%;
-	}
-
-	:global(.chart-mural-art) {
-		object-fit: cover;
-		transform: skewX(7deg) scale(1.24);
-		transition: transform var(--motion-base);
-	}
-
-	.chart-mural-tile:hover :global(.chart-mural-art),
-	.chart-mural-tile:focus-visible :global(.chart-mural-art),
-	.chart-mural-tile--featured :global(.chart-mural-art) {
-		transform: skewX(7deg) scale(1.34);
-	}
-
-	:global(.chart-mural-art.fallback) {
-		display: grid;
-		place-items: center;
-		background: linear-gradient(135deg, var(--bg-raised), color-mix(in srgb, var(--accent-soft) 28%, var(--bg-surface)));
-		color: rgba(255,255,255,0.78);
-		font-size: var(--font-size-xl);
-		font-weight: var(--font-weight-bold);
-	}
-
-	.chart-mural-shade {
-		position: absolute;
-		inset: 0;
-		z-index: var(--z-base);
-		background: linear-gradient(90deg, rgba(0,0,0,0.7) 0%, rgba(0,0,0,0.34) 42%, rgba(0,0,0,0.06) 78%, transparent 100%);
-		pointer-events: none;
-	}
-
-	.chart-mural-content {
-		position: relative;
-		z-index: calc(var(--z-base) + 1);
-		display: grid;
-		align-items: center;
-		min-height: inherit;
-		padding: var(--space-5);
-		pointer-events: none;
-	}
-
-	.chart-mural-meta {
-		display: flex;
-		flex-direction: column;
-		gap: var(--space-1);
-		max-width: min(42rem, 58vw);
-		text-shadow: 0 2px 18px rgba(0,0,0,0.62);
-	}
-
-	.chart-mural-kind {
-		color: var(--accent);
-		font-size: var(--font-size-2xs);
-		font-weight: var(--font-weight-semibold);
-		letter-spacing: 0;
-		text-transform: uppercase;
-	}
-
-	.chart-mural-title {
-		margin: 0;
-		color: var(--text-primary);
-		font-size: var(--font-size-4xl);
-		font-weight: var(--font-weight-bold);
-		line-height: var(--line-height-tight);
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-	}
-
-	.chart-mural-sub {
-		margin: 0 0 var(--space-2);
-		color: var(--text-secondary);
-		font-size: var(--font-size-sm);
-	}
-
-	.chart-mural-actions {
-		display: flex;
-		align-items: center;
-		gap: var(--space-2);
-		pointer-events: auto;
-	}
-
-	.chart-mural-actions span {
-		color: var(--text-secondary);
-		font-size: var(--font-size-xs);
-		font-weight: var(--font-weight-semibold);
-	}
-
-	.chart-mural-play {
-		display: flex;
-		align-items: center;
-		gap: var(--space-1);
-		font-size: var(--font-size-sm);
-		font-weight: var(--font-weight-semibold);
-	}
-
-	.chart-nav {
-		position: absolute;
-		top: 50%;
-		z-index: var(--z-raised);
-		display: grid;
-		place-items: center;
-		width: clamp(32px, 3vw, 40px);
-		aspect-ratio: 1 / 1;
-		border: 1px solid var(--panel-border);
-		border-radius: 50%;
-		background: rgba(0,0,0,0.5);
-		color: var(--text-primary);
-		cursor: pointer;
-		font-size: var(--font-size-xl);
-		line-height: 1;
-		opacity: 0;
-		transform: translateY(-50%);
-		transition: opacity var(--motion-fast), background var(--motion-fast);
-	}
-
-	.chart-mural-card:hover .chart-nav,
-	.chart-nav:focus-visible {
-		opacity: 1;
-		outline: none;
-	}
-
-	.chart-nav:hover {
-		background: rgba(0,0,0,0.75);
-	}
-
-	.chart-nav--prev {
-		left: var(--space-3);
-	}
-
-	.chart-nav--next {
-		right: var(--space-3);
-	}
-
-	.chart-mural-loading {
-		display: grid;
-		place-items: center;
-		min-height: clamp(180px, 20vw, 280px);
-		border: 1px solid var(--panel-border);
-		border-radius: var(--radius-md);
-		background: var(--panel-bg);
-		color: var(--text-secondary);
-		font-size: var(--font-size-sm);
-		font-weight: var(--font-weight-semibold);
 	}
 
 	.matrix-shell {
@@ -925,9 +704,9 @@
 	}
 
 	.chip {
-		border: 0;
+		border: 1px solid var(--panel-border);
 		border-radius: 999px;
-		background: transparent;
+		background: var(--panel-bg);
 		color: var(--text-muted);
 		font-size: var(--font-size-xs);
 		font-weight: var(--font-weight-semibold);
@@ -935,36 +714,21 @@
 		padding: var(--space-2) var(--space-3);
 		cursor: pointer;
 		white-space: nowrap;
-		transition: background var(--motion-base), color var(--motion-base);
+		transition: background var(--motion-base), border-color var(--motion-base), color var(--motion-base);
 	}
 
 	.chip:hover,
 	.chip:focus-visible {
+		background: var(--bg-hover);
+		border-color: var(--accent-line);
 		color: var(--text-primary);
 		outline: none;
 	}
 
 	.chip.active {
 		background: var(--bg-hover);
+		border-color: var(--accent-line);
 		color: var(--text-primary);
 	}
 
-	@media (max-width: 760px) {
-		.chart-mural-bg {
-			grid-template-columns: repeat(5, minmax(0, 1fr));
-			grid-template-rows: repeat(4, minmax(0, 1fr));
-		}
-
-		.chart-mural-content {
-			padding: var(--space-4);
-		}
-
-		.chart-mural-meta {
-			max-width: 100%;
-		}
-
-		.chart-mural-title {
-			font-size: var(--font-size-3xl);
-		}
-	}
 </style>

--- a/frontend/src/lib/components/charts/DailyChartShelf.svelte
+++ b/frontend/src/lib/components/charts/DailyChartShelf.svelte
@@ -6,9 +6,11 @@
 		type ChartMatrixResponse,
 		type ChartSnapshotEntry,
 		type ChartSnapshotResponse,
+		type TidalSearchTrack,
 	} from '$lib/api/client';
 	import EmptyState from '$lib/components/ui/EmptyState.svelte';
 	import ArtworkImage from '$lib/components/ui/ArtworkImage.svelte';
+	import { playTidalTrackNow, playerError } from '$lib/stores/player';
 
 	const REGIONS = [
 		{ code: 'global', label: 'Global' },
@@ -19,13 +21,15 @@
 		{ code: 'NZ', label: 'NZ' },
 	];
 
-	const SOURCE = 'spotify_daily';
 	const PERIOD = 'daily';
 	const LIMIT = 20;
 
 	let selectedRegion = $state('global');
+	let selectedSource = $state('spotify_daily');
 	let matrix = $state<ChartMatrixResponse | null>(null);
 	let data = $state<ChartSnapshotResponse | null>(null);
+	let resolvedTracks = $state<Record<number, TidalSearchTrack | null>>({});
+	let resolvingEntries = $state<Record<number, boolean>>({});
 	let loading = $state(true);
 	let matrixLoading = $state(true);
 	let refreshingMatrix = $state(false);
@@ -36,7 +40,19 @@
 
 	onMount(() => {
 		void loadMatrix();
-		void loadSnapshot(selectedRegion);
+		void loadSnapshot(selectedRegion, selectedSource);
+	});
+
+	$effect(() => {
+		const cells = selectedRegionCells();
+		if (cells.length === 0) return;
+		void resolveVisibleCells(cells);
+	});
+
+	$effect(() => {
+		const entries = data?.entries ?? [];
+		if (entries.length === 0) return;
+		void resolveVisibleEntries(entries);
 	});
 
 	async function loadMatrix() {
@@ -63,7 +79,7 @@
 		try {
 			await api.refreshChartMatrix();
 			matrix = await api.getChartMatrix();
-			void loadSnapshot(selectedRegion);
+			void loadSnapshot(selectedRegion, selectedSource);
 		} catch (e) {
 			console.error('[daily-charts] matrix refresh failed', e);
 		} finally {
@@ -71,13 +87,13 @@
 		}
 	}
 
-	async function loadSnapshot(region: string) {
+	async function loadSnapshot(region: string, source: string) {
 		const token = ++requestToken;
 		loading = true;
 		error = false;
 		try {
 			const next = await api.getChartSnapshot({
-				source: SOURCE,
+				source,
 				period: PERIOD,
 				region,
 				limit: LIMIT,
@@ -97,7 +113,13 @@
 	function pickRegion(region: string) {
 		if (region === selectedRegion) return;
 		selectedRegion = region;
-		void loadSnapshot(region);
+		void loadSnapshot(region, selectedSource);
+	}
+
+	function pickProvider(region: string, source: string) {
+		selectedRegion = region;
+		selectedSource = source;
+		void loadSnapshot(region, source);
 	}
 
 	function rankDeltaLabel(delta: number | null): string {
@@ -109,14 +131,17 @@
 		if (entry.streams != null) return `${entry.streams.toLocaleString()} streams`;
 		if (entry.views != null) return `${entry.views.toLocaleString()} views`;
 		if (entry.points != null) return `${entry.points.toLocaleString()} pts`;
-		return entry.resolution_status;
+		return entryStatusLabel(entry);
 	}
 
 	function cellMetric(cell: ChartMatrixCell): string {
 		if (cell.streams != null) return `${cell.streams.toLocaleString()} streams`;
 		if (cell.views != null) return `${cell.views.toLocaleString()} views`;
 		if (cell.points != null) return `${cell.points.toLocaleString()} pts`;
-		return cell.resolution_status;
+		if (resolvedTracks[cell.entry_id]?.in_library) return 'In library';
+		if (resolvedTracks[cell.entry_id]) return 'TIDAL ready';
+		if (resolvingEntries[cell.entry_id]) return 'Resolving';
+		return 'Tap to resolve';
 	}
 
 	function matrixHasData(next: ChartMatrixResponse | null): boolean {
@@ -134,6 +159,103 @@
 
 	function selectedRegionLabel(): string {
 		return REGIONS.find((region) => region.code === selectedRegion)?.label ?? selectedRegion;
+	}
+
+	function selectedRegionCells(): ChartMatrixCell[] {
+		const row = matrix?.rows.find((item) => item.region === selectedRegion);
+		if (!row || !matrix) return [];
+		return matrix.providers
+			.map((provider) => row.cells[provider.source_key])
+			.filter((cell): cell is ChartMatrixCell => Boolean(cell));
+	}
+
+	function selectedProviderLabel(): string {
+		return (
+			matrix?.providers.find((provider) => provider.source_key === selectedSource)?.label ??
+			'Spotify'
+		);
+	}
+
+	async function resolveVisibleCells(cells: ChartMatrixCell[]) {
+		await Promise.all(cells.slice(0, 6).map((cell) => resolveCell(cell)));
+	}
+
+	async function resolveVisibleEntries(entries: ChartSnapshotEntry[]) {
+		await Promise.all(entries.slice(0, 12).map((entry) => resolveEntry(entry)));
+	}
+
+	async function resolveCell(cell: ChartMatrixCell): Promise<TidalSearchTrack | null> {
+		return resolveChartItem(cell.entry_id, cell.artist, cell.title, cell.entity_type, cell.tidal_id);
+	}
+
+	async function resolveEntry(entry: ChartSnapshotEntry): Promise<TidalSearchTrack | null> {
+		return resolveChartItem(entry.id, entry.artist, entry.title, entry.entity_type, entry.tidal_id);
+	}
+
+	async function resolveChartItem(
+		entryId: number,
+		artist: string,
+		title: string,
+		entityType: string,
+		tidalId: number | null,
+	): Promise<TidalSearchTrack | null> {
+		if (tidalId || entityType === 'video') return null;
+		if (entryId in resolvedTracks || resolvingEntries[entryId]) {
+			return resolvedTracks[entryId] ?? null;
+		}
+
+		resolvingEntries = { ...resolvingEntries, [entryId]: true };
+		try {
+			const query = [artist, title].filter(Boolean).join(' ');
+			const results = await api.searchTidal(query, 1);
+			const hit = results.tracks[0] ?? null;
+			resolvedTracks = { ...resolvedTracks, [entryId]: hit };
+			return hit;
+		} catch (e) {
+			console.error('[daily-charts] tidal resolve failed', e);
+			resolvedTracks = { ...resolvedTracks, [entryId]: null };
+			return null;
+		} finally {
+			resolvingEntries = { ...resolvingEntries, [entryId]: false };
+		}
+	}
+
+	async function playCell(cell: ChartMatrixCell) {
+		const hit = resolvedTracks[cell.entry_id] ?? (await resolveCell(cell));
+		if (!hit) {
+			playerError.set({ message: "Couldn't find that chart entry on TIDAL." });
+			return;
+		}
+		await playTidalTrackNow({
+			tidal_id: hit.tidal_id,
+			title: hit.title,
+			artist_name: hit.artist_name,
+			album_title: hit.album_title,
+			artwork_url: hit.artwork_url ?? cell.artwork_url,
+			duration_ms: hit.duration_ms,
+			artist_tidal_id: hit.artist_id,
+			album_tidal_id: hit.album_tidal_id,
+		});
+	}
+
+	function cellArtwork(cell: ChartMatrixCell): string | null {
+		return resolvedTracks[cell.entry_id]?.artwork_url ?? cell.artwork_url;
+	}
+
+	function entryArtwork(entry: ChartSnapshotEntry): string | null {
+		return resolvedTracks[entry.id]?.artwork_url ?? entry.artwork_url;
+	}
+
+	function entryStatusLabel(entry: ChartSnapshotEntry): string {
+		if (entry.tidal_id || entry.resolution_status === 'tidal') return 'TIDAL ready';
+		if (resolvedTracks[entry.id]?.in_library) return 'In library';
+		if (resolvedTracks[entry.id]) return 'TIDAL ready';
+		if (resolvingEntries[entry.id]) return 'Resolving';
+		return entry.resolution_status;
+	}
+
+	function cellFallbackText(cell: ChartMatrixCell): string {
+		return (cell.title.trim()[0] ?? 'N').toUpperCase();
 	}
 
 	function fallbackText(entry: ChartSnapshotEntry): string {
@@ -164,6 +286,53 @@
 	</div>
 
 	{#if matrix?.providers.length}
+		<div class="region-pulse" aria-label={`${selectedRegionLabel()} provider leaders`}>
+			<div class="region-pulse-copy">
+				<p>{selectedRegionLabel()} chart leaders</p>
+				<h3>{selectedProviderLabel()}</h3>
+			</div>
+			<div class="provider-card-row">
+				{#each matrix.providers as provider (provider.source_key)}
+					{@const row = matrix.rows.find((item) => item.region === selectedRegion)}
+					{@const cell = row?.cells[provider.source_key] ?? null}
+					<button
+						type="button"
+						class="provider-card"
+						class:active={selectedSource === provider.source_key}
+						class:empty={!cell}
+						onclick={() => {
+							if (cell) {
+								pickProvider(selectedRegion, provider.source_key);
+								void playCell(cell);
+							}
+						}}
+						aria-label={`${provider.label} ${selectedRegionLabel()} leader`}
+					>
+						<span class="provider-name">{provider.label}</span>
+						{#if cell}
+							<div class="provider-art">
+								<ArtworkImage
+									src={cellArtwork(cell)}
+									size={320}
+									className="provider-card-art"
+									fallbackText={cellFallbackText(cell)}
+									decorative
+								/>
+							</div>
+							<strong>{cell.title}</strong>
+							<span>{cell.artist}</span>
+							<small>{cellMetric(cell)}</small>
+						{:else}
+							<div class="provider-art empty-art"></div>
+							<strong>No data</strong>
+							<span>{selectedRegionLabel()}</span>
+							<small>Provider missing</small>
+						{/if}
+					</button>
+				{/each}
+			</div>
+		</div>
+
 		<div class="matrix-shell" aria-label="Market pulse provider matrix">
 			<div class="matrix-grid">
 				<div class="matrix-head region-head">Region</div>
@@ -185,7 +354,11 @@
 							type="button"
 							class="matrix-cell"
 							class:filled={Boolean(cell)}
-							onclick={() => pickRegion(row.region)}
+							class:active={Boolean(cell) && row.region === selectedRegion && provider.source_key === selectedSource}
+							onclick={() => {
+								if (cell) pickProvider(row.region, provider.source_key);
+								else pickRegion(row.region);
+							}}
 							aria-label={`${provider.label} ${row.region}`}
 						>
 							{#if cell}
@@ -215,6 +388,10 @@
 
 	{#if data?.snapshot && data.entries.length > 0}
 		<div class="chart-list" aria-label="Daily chart entries">
+			<div class="list-heading">
+				<p>{selectedRegionLabel()} · {selectedProviderLabel()}</p>
+				<h3>Provider snapshot</h3>
+			</div>
 			{#each data.entries as entry (entry.id)}
 				<div class="chart-row">
 					<div class="rank">
@@ -223,7 +400,7 @@
 					</div>
 					<div class="art-cell">
 						<ArtworkImage
-							src={entry.artwork_url}
+							src={entryArtwork(entry)}
 							size={320}
 							className="daily-chart-art"
 							fallbackText={fallbackText(entry)}
@@ -236,7 +413,7 @@
 					</div>
 					<div class="metric">{formatMetric(entry)}</div>
 					<div class="status" data-status={entry.resolution_status}>
-						{entry.resolution_status}
+						{entryStatusLabel(entry)}
 					</div>
 				</div>
 			{/each}
@@ -259,7 +436,7 @@
 				: 'No market snapshot yet'}
 			copy={matrixHasData(matrix)
 				? regionHasMatrixData(selectedRegion)
-					? 'This region has provider leaders, but no Spotify daily detail list yet.'
+					? `This region has provider leaders, but no ${selectedProviderLabel()} detail list yet.`
 					: 'This region has no provider snapshot yet. Global data is available above.'
 				: 'NOOR tried to refresh the provider matrix, but there is no stored chart data yet.'}
 		/>
@@ -338,6 +515,137 @@
 		opacity: 0.55;
 	}
 
+	.region-pulse {
+		display: grid;
+		gap: var(--space-3);
+	}
+
+	.region-pulse-copy {
+		display: flex;
+		align-items: end;
+		justify-content: space-between;
+		gap: var(--gap-sm);
+	}
+
+	.region-pulse-copy p,
+	.region-pulse-copy h3 {
+		margin: 0;
+	}
+
+	.region-pulse-copy p {
+		font-size: var(--font-size-xs);
+		font-weight: var(--font-weight-semibold);
+		color: var(--text-secondary);
+		text-transform: uppercase;
+		letter-spacing: 0;
+	}
+
+	.region-pulse-copy h3 {
+		font-size: var(--font-size-xl);
+		font-weight: var(--font-weight-bold);
+		line-height: var(--line-height-tight);
+	}
+
+	.provider-card-row {
+		display: grid;
+		grid-template-columns: repeat(6, minmax(132px, 1fr));
+		gap: var(--space-2);
+		overflow-x: auto;
+		padding-bottom: var(--space-1);
+	}
+
+	.provider-card {
+		position: relative;
+		display: grid;
+		grid-template-rows: auto auto auto auto auto;
+		align-content: start;
+		gap: var(--space-1);
+		min-width: 132px;
+		min-height: clamp(210px, 19vw, 260px);
+		padding: var(--space-2);
+		border: 1px solid var(--panel-border);
+		border-radius: var(--radius-sm);
+		background: var(--panel-bg);
+		color: var(--text-secondary);
+		text-align: left;
+		cursor: pointer;
+		transition: background var(--motion-base), border-color var(--motion-base), color var(--motion-base);
+	}
+
+	.provider-card:hover,
+	.provider-card:focus-visible,
+	.provider-card.active {
+		border-color: var(--accent-line);
+		background: var(--bg-hover);
+		color: var(--text-primary);
+		outline: none;
+	}
+
+	.provider-card.empty {
+		cursor: default;
+		opacity: 0.62;
+	}
+
+	.provider-name {
+		font-size: var(--font-size-2xs);
+		font-weight: var(--font-weight-bold);
+		color: var(--service-spotify);
+		text-transform: uppercase;
+		letter-spacing: 0;
+	}
+
+	.provider-art {
+		width: 100%;
+		aspect-ratio: 1 / 1;
+		border-radius: var(--radius-xs);
+		overflow: hidden;
+		background: var(--bg-raised);
+	}
+
+	:global(.provider-card-art) {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		display: block;
+	}
+
+	:global(.provider-card-art.fallback),
+	.empty-art {
+		display: grid;
+		place-items: center;
+		background: linear-gradient(135deg, var(--bg-raised), var(--panel-bg));
+		color: var(--text-muted);
+		font-size: var(--font-size-2xl);
+		font-weight: var(--font-weight-bold);
+	}
+
+	.provider-card strong,
+	.provider-card span,
+	.provider-card small {
+		min-width: 0;
+		max-width: 100%;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.provider-card strong {
+		color: var(--text-primary);
+		font-size: var(--font-size-sm);
+		font-weight: var(--font-weight-semibold);
+		line-height: var(--line-height-snug);
+	}
+
+	.provider-card span:not(.provider-name) {
+		font-size: var(--font-size-xs);
+		color: var(--text-secondary);
+	}
+
+	.provider-card small {
+		font-size: var(--font-size-2xs);
+		color: var(--text-muted);
+	}
+
 	.matrix-shell {
 		overflow-x: auto;
 		padding-bottom: var(--space-1);
@@ -389,7 +697,8 @@
 	.matrix-region:hover,
 	.matrix-cell:hover,
 	.matrix-cell:focus-visible,
-	.matrix-region:focus-visible {
+	.matrix-region:focus-visible,
+	.matrix-cell.active {
 		background: var(--bg-hover);
 		border-color: var(--accent-line);
 		color: var(--text-primary);
@@ -466,6 +775,33 @@
 	.chart-list {
 		display: grid;
 		gap: var(--space-1);
+	}
+
+	.list-heading {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: var(--gap-sm);
+		padding-top: var(--space-1);
+	}
+
+	.list-heading p,
+	.list-heading h3 {
+		margin: 0;
+	}
+
+	.list-heading p {
+		font-size: var(--font-size-xs);
+		font-weight: var(--font-weight-semibold);
+		color: var(--text-muted);
+		text-transform: uppercase;
+		letter-spacing: 0;
+	}
+
+	.list-heading h3 {
+		font-size: var(--font-size-md);
+		font-weight: var(--font-weight-bold);
+		line-height: var(--line-height-tight);
 	}
 
 	.chart-row {
@@ -581,6 +917,10 @@
 	}
 
 	@media (max-width: 760px) {
+		.provider-card-row {
+			grid-template-columns: repeat(6, minmax(118px, 38vw));
+		}
+
 		.chart-row {
 			grid-template-columns: clamp(36px, 10vw, 48px) clamp(42px, 12vw, 52px) minmax(0, 1fr);
 		}

--- a/frontend/src/lib/components/charts/DailyChartShelf.svelte
+++ b/frontend/src/lib/components/charts/DailyChartShelf.svelte
@@ -119,10 +119,21 @@
 		return cell.resolution_status;
 	}
 
-	function matrixHasData(next: ChartMatrixResponse): boolean {
-		return next.rows.some((row) =>
+	function matrixHasData(next: ChartMatrixResponse | null): boolean {
+		return Boolean(next?.rows.some((row) =>
 			next.providers.some((provider) => Boolean(row.cells[provider.source_key])),
+		));
+	}
+
+	function regionHasMatrixData(region: string): boolean {
+		const row = matrix?.rows.find((item) => item.region === region);
+		return Boolean(
+			row && matrix?.providers.some((provider) => Boolean(row.cells[provider.source_key])),
 		);
+	}
+
+	function selectedRegionLabel(): string {
+		return REGIONS.find((region) => region.code === selectedRegion)?.label ?? selectedRegion;
 	}
 
 	function fallbackText(entry: ChartSnapshotEntry): string {
@@ -243,8 +254,14 @@
 		/>
 	{:else}
 		<EmptyState
-			title="No market snapshot yet"
-			copy="NOOR tried to refresh the provider matrix, but there is no stored chart data yet."
+			title={matrixHasData(matrix)
+				? `No Spotify daily list for ${selectedRegionLabel()}`
+				: 'No market snapshot yet'}
+			copy={matrixHasData(matrix)
+				? regionHasMatrixData(selectedRegion)
+					? 'This region has provider leaders, but no Spotify daily detail list yet.'
+					: 'This region has no provider snapshot yet. Global data is available above.'
+				: 'NOOR tried to refresh the provider matrix, but there is no stored chart data yet.'}
 		/>
 	{/if}
 </section>

--- a/frontend/src/lib/components/charts/DailyChartShelf.svelte
+++ b/frontend/src/lib/components/charts/DailyChartShelf.svelte
@@ -1,0 +1,576 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import {
+		api,
+		type ChartMatrixCell,
+		type ChartMatrixResponse,
+		type ChartSnapshotEntry,
+		type ChartSnapshotResponse,
+	} from '$lib/api/client';
+	import EmptyState from '$lib/components/ui/EmptyState.svelte';
+	import ArtworkImage from '$lib/components/ui/ArtworkImage.svelte';
+
+	const REGIONS = [
+		{ code: 'global', label: 'Global' },
+		{ code: 'US', label: 'US' },
+		{ code: 'UK', label: 'UK' },
+		{ code: 'AU', label: 'AU' },
+		{ code: 'CA', label: 'CA' },
+		{ code: 'NZ', label: 'NZ' },
+	];
+
+	const SOURCE = 'spotify_daily';
+	const PERIOD = 'daily';
+	const LIMIT = 20;
+
+	let selectedRegion = $state('global');
+	let matrix = $state<ChartMatrixResponse | null>(null);
+	let data = $state<ChartSnapshotResponse | null>(null);
+	let loading = $state(true);
+	let matrixLoading = $state(true);
+	let refreshingMatrix = $state(false);
+	let error = $state(false);
+	let matrixError = $state(false);
+	let requestToken = 0;
+	let refreshAttempted = false;
+
+	onMount(() => {
+		void loadMatrix();
+		void loadSnapshot(selectedRegion);
+	});
+
+	async function loadMatrix() {
+		matrixLoading = true;
+		matrixError = false;
+		try {
+			const next = await api.getChartMatrix();
+			matrix = next;
+			if (!refreshAttempted && !matrixHasData(next)) {
+				refreshAttempted = true;
+				await refreshMatrix();
+			}
+		} catch (e) {
+			console.error('[daily-charts] matrix fetch failed', e);
+			matrix = null;
+			matrixError = true;
+		} finally {
+			matrixLoading = false;
+		}
+	}
+
+	async function refreshMatrix() {
+		refreshingMatrix = true;
+		try {
+			await api.refreshChartMatrix();
+			matrix = await api.getChartMatrix();
+			void loadSnapshot(selectedRegion);
+		} catch (e) {
+			console.error('[daily-charts] matrix refresh failed', e);
+		} finally {
+			refreshingMatrix = false;
+		}
+	}
+
+	async function loadSnapshot(region: string) {
+		const token = ++requestToken;
+		loading = true;
+		error = false;
+		try {
+			const next = await api.getChartSnapshot({
+				source: SOURCE,
+				period: PERIOD,
+				region,
+				limit: LIMIT,
+			});
+			if (token !== requestToken) return;
+			data = next;
+		} catch (e) {
+			console.error('[daily-charts] snapshot fetch failed', e);
+			if (token !== requestToken) return;
+			data = null;
+			error = true;
+		} finally {
+			if (token === requestToken) loading = false;
+		}
+	}
+
+	function pickRegion(region: string) {
+		if (region === selectedRegion) return;
+		selectedRegion = region;
+		void loadSnapshot(region);
+	}
+
+	function rankDeltaLabel(delta: number | null): string {
+		if (delta == null || delta === 0) return 'steady';
+		return delta > 0 ? `up ${delta}` : `down ${Math.abs(delta)}`;
+	}
+
+	function formatMetric(entry: ChartSnapshotEntry): string {
+		if (entry.streams != null) return `${entry.streams.toLocaleString()} streams`;
+		if (entry.views != null) return `${entry.views.toLocaleString()} views`;
+		if (entry.points != null) return `${entry.points.toLocaleString()} pts`;
+		return entry.resolution_status;
+	}
+
+	function cellMetric(cell: ChartMatrixCell): string {
+		if (cell.streams != null) return `${cell.streams.toLocaleString()} streams`;
+		if (cell.views != null) return `${cell.views.toLocaleString()} views`;
+		if (cell.points != null) return `${cell.points.toLocaleString()} pts`;
+		return cell.resolution_status;
+	}
+
+	function matrixHasData(next: ChartMatrixResponse): boolean {
+		return next.rows.some((row) =>
+			next.providers.some((provider) => Boolean(row.cells[provider.source_key])),
+		);
+	}
+
+	function fallbackText(entry: ChartSnapshotEntry): string {
+		return (entry.title.trim()[0] ?? 'N').toUpperCase();
+	}
+</script>
+
+<section class="daily-chart-shelf">
+	<div class="section-header">
+		<div class="section-title-group">
+			<p class="eyebrow">Charts · Provider matrix</p>
+			<h2>Market pulse</h2>
+		</div>
+		<div class="region-tabs" role="tablist" aria-label="Daily chart region">
+			{#each REGIONS as region (region.code)}
+				<button
+					type="button"
+					class="chip"
+					class:active={region.code === selectedRegion}
+					role="tab"
+					aria-selected={region.code === selectedRegion}
+					onclick={() => pickRegion(region.code)}
+				>
+					{region.label}
+				</button>
+			{/each}
+		</div>
+	</div>
+
+	{#if matrix?.providers.length}
+		<div class="matrix-shell" aria-label="Market pulse provider matrix">
+			<div class="matrix-grid">
+				<div class="matrix-head region-head">Region</div>
+				{#each matrix.providers as provider (provider.source_key)}
+					<div class="matrix-head">{provider.label}</div>
+				{/each}
+				{#each matrix.rows as row (row.region)}
+					<button
+						type="button"
+						class="matrix-region"
+						class:active={row.region === selectedRegion}
+						onclick={() => pickRegion(row.region)}
+					>
+						{row.region === 'global' ? 'Global' : row.region}
+					</button>
+					{#each matrix.providers as provider (provider.source_key)}
+						{@const cell = row.cells[provider.source_key]}
+						<button
+							type="button"
+							class="matrix-cell"
+							class:filled={Boolean(cell)}
+							onclick={() => pickRegion(row.region)}
+							aria-label={`${provider.label} ${row.region}`}
+						>
+							{#if cell}
+								<strong>{cell.title}</strong>
+								<span>{cell.artist}</span>
+								<small>{cellMetric(cell)}</small>
+							{:else}
+								<span>No data</span>
+							{/if}
+						</button>
+					{/each}
+				{/each}
+			</div>
+		</div>
+	{:else if matrixLoading}
+		<div class="provider-strip" aria-label="Loading chart providers">
+			{#each Array.from({ length: 6 }) as _, i (i)}
+				<span class="provider-skeleton">{refreshingMatrix ? 'Refreshing' : 'Loading'}</span>
+			{/each}
+		</div>
+	{:else if matrixError}
+		<EmptyState
+			title="Market matrix unavailable"
+			copy="Restart the NOOR server if this update just landed."
+		/>
+	{/if}
+
+	{#if data?.snapshot && data.entries.length > 0}
+		<div class="chart-list" aria-label="Daily chart entries">
+			{#each data.entries as entry (entry.id)}
+				<div class="chart-row">
+					<div class="rank">
+						<span>{entry.rank}</span>
+						<small>{rankDeltaLabel(entry.rank_delta)}</small>
+					</div>
+					<div class="art-cell">
+						<ArtworkImage
+							src={entry.artwork_url}
+							size={320}
+							className="daily-chart-art"
+							fallbackText={fallbackText(entry)}
+							decorative
+						/>
+					</div>
+					<div class="track-meta">
+						<strong>{entry.title}</strong>
+						<span>{entry.artist}</span>
+					</div>
+					<div class="metric">{formatMetric(entry)}</div>
+					<div class="status" data-status={entry.resolution_status}>
+						{entry.resolution_status}
+					</div>
+				</div>
+			{/each}
+		</div>
+	{:else if loading}
+		<div class="chart-list" aria-label="Loading daily chart">
+			{#each Array.from({ length: 6 }) as _, i (i)}
+				<div class="chart-row skeleton" aria-hidden="true"></div>
+			{/each}
+		</div>
+	{:else if error}
+		<EmptyState
+			title="Daily snapshots unavailable"
+			copy="Restart the NOOR server if this update just landed."
+		/>
+	{:else}
+		<EmptyState
+			title="No market snapshot yet"
+			copy="NOOR tried to refresh the provider matrix, but there is no stored chart data yet."
+		/>
+	{/if}
+</section>
+
+<style>
+	.daily-chart-shelf {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-3);
+	}
+
+	.section-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: var(--gap-sm);
+		flex-wrap: wrap;
+	}
+
+	.section-title-group {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-1);
+	}
+
+	.eyebrow {
+		margin: 0;
+		font-size: var(--font-size-xs);
+		font-weight: var(--font-weight-semibold);
+		text-transform: uppercase;
+		letter-spacing: 0;
+		color: var(--service-spotify);
+	}
+
+	h2 {
+		margin: 0;
+		font-size: var(--font-size-lg);
+		font-weight: var(--font-weight-bold);
+		line-height: var(--line-height-tight);
+	}
+
+	.region-tabs {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--space-1);
+		padding: var(--space-1);
+		border: 1px solid var(--panel-border);
+		border-radius: 999px;
+		background: var(--panel-bg);
+		overflow-x: auto;
+		max-width: 100%;
+	}
+
+	.provider-strip {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(min(112px, 100%), 1fr));
+		gap: var(--space-1);
+	}
+
+	.provider-strip span {
+		border: 1px solid var(--panel-border);
+		border-radius: 999px;
+		background: var(--panel-bg);
+		color: var(--text-secondary);
+		font-size: var(--font-size-xs);
+		font-weight: var(--font-weight-semibold);
+		line-height: 1;
+		padding: var(--space-2) var(--space-3);
+		text-align: center;
+		white-space: nowrap;
+	}
+
+	.provider-skeleton {
+		opacity: 0.55;
+	}
+
+	.matrix-shell {
+		overflow-x: auto;
+		padding-bottom: var(--space-1);
+	}
+
+	.matrix-grid {
+		display: grid;
+		grid-template-columns: clamp(72px, 8vw, 96px) repeat(6, minmax(136px, 1fr));
+		gap: var(--space-1);
+		min-width: 920px;
+	}
+
+	.matrix-head,
+	.matrix-region,
+	.matrix-cell {
+		border: 1px solid var(--panel-border);
+		background: var(--panel-bg);
+		color: var(--text-secondary);
+		border-radius: var(--radius-xs);
+	}
+
+	.matrix-head {
+		padding: var(--space-2) var(--space-3);
+		font-size: var(--font-size-xs);
+		font-weight: var(--font-weight-bold);
+		line-height: 1;
+		text-align: left;
+	}
+
+	.region-head {
+		color: var(--text-muted);
+	}
+
+	.matrix-region,
+	.matrix-cell {
+		min-height: clamp(58px, 6vw, 74px);
+		padding: var(--space-2) var(--space-3);
+		cursor: pointer;
+		transition: background var(--motion-base), border-color var(--motion-base), color var(--motion-base);
+	}
+
+	.matrix-region {
+		font-size: var(--font-size-sm);
+		font-weight: var(--font-weight-bold);
+		text-align: left;
+	}
+
+	.matrix-region.active,
+	.matrix-region:hover,
+	.matrix-cell:hover,
+	.matrix-cell:focus-visible,
+	.matrix-region:focus-visible {
+		background: var(--bg-hover);
+		border-color: var(--accent-line);
+		color: var(--text-primary);
+		outline: none;
+	}
+
+	.matrix-cell {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+		justify-content: center;
+		gap: var(--space-1);
+		text-align: left;
+		min-width: 0;
+	}
+
+	.matrix-cell strong,
+	.matrix-cell span,
+	.matrix-cell small {
+		max-width: 100%;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.matrix-cell strong {
+		color: var(--text-primary);
+		font-size: var(--font-size-xs);
+		font-weight: var(--font-weight-semibold);
+		line-height: var(--line-height-snug);
+	}
+
+	.matrix-cell span {
+		font-size: var(--font-size-xs);
+		color: var(--text-secondary);
+	}
+
+	.matrix-cell small {
+		font-size: var(--font-size-2xs);
+		color: var(--text-muted);
+		line-height: 1;
+	}
+
+	.matrix-cell:not(.filled) {
+		color: var(--text-muted);
+		opacity: 0.72;
+	}
+
+	.chip {
+		border: 0;
+		border-radius: 999px;
+		background: transparent;
+		color: var(--text-muted);
+		font-size: var(--font-size-xs);
+		font-weight: var(--font-weight-semibold);
+		line-height: 1;
+		padding: var(--space-2) var(--space-3);
+		cursor: pointer;
+		white-space: nowrap;
+		transition: background var(--motion-base), color var(--motion-base);
+	}
+
+	.chip:hover,
+	.chip:focus-visible {
+		color: var(--text-primary);
+		outline: none;
+	}
+
+	.chip.active {
+		background: var(--bg-hover);
+		color: var(--text-primary);
+	}
+
+	.chart-list {
+		display: grid;
+		gap: var(--space-1);
+	}
+
+	.chart-row {
+		display: grid;
+		grid-template-columns: clamp(44px, 5vw, 64px) clamp(42px, 4vw, 52px) minmax(0, 1fr) auto auto;
+		align-items: center;
+		gap: var(--space-3);
+		min-height: clamp(56px, 6vw, 68px);
+		padding: var(--space-2) var(--space-3);
+		border: 1px solid var(--panel-border);
+		border-radius: var(--radius-sm);
+		background: var(--panel-bg);
+	}
+
+	.rank {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-1);
+		line-height: var(--line-height-tight);
+	}
+
+	.rank span {
+		font-size: var(--font-size-lg);
+		font-weight: var(--font-weight-bold);
+	}
+
+	.rank small {
+		font-size: var(--font-size-2xs);
+		color: var(--text-muted);
+		text-transform: uppercase;
+		letter-spacing: 0;
+	}
+
+	.art-cell {
+		width: clamp(42px, 4vw, 52px);
+		aspect-ratio: 1 / 1;
+		border-radius: var(--radius-xs);
+		overflow: hidden;
+		background: var(--bg-raised);
+	}
+
+	:global(.daily-chart-art) {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		display: block;
+	}
+
+	:global(.daily-chart-art.fallback) {
+		display: grid;
+		place-items: center;
+		color: var(--text-muted);
+		font-size: var(--font-size-sm);
+		font-weight: var(--font-weight-semibold);
+	}
+
+	.track-meta {
+		min-width: 0;
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-1);
+	}
+
+	.track-meta strong,
+	.track-meta span {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.track-meta strong {
+		font-size: var(--font-size-sm);
+		font-weight: var(--font-weight-semibold);
+		line-height: var(--line-height-snug);
+	}
+
+	.track-meta span {
+		font-size: var(--font-size-xs);
+		color: var(--text-secondary);
+	}
+
+	.metric,
+	.status {
+		font-size: var(--font-size-xs);
+		font-weight: var(--font-weight-semibold);
+		color: var(--text-secondary);
+		white-space: nowrap;
+	}
+
+	.status {
+		border-radius: 999px;
+		padding: var(--space-1) var(--space-2);
+		background: var(--bg-hover);
+		color: var(--text-muted);
+		text-transform: capitalize;
+	}
+
+	.status[data-status='local'],
+	.status[data-status='tidal'] {
+		color: var(--text-primary);
+	}
+
+	.skeleton {
+		min-height: clamp(56px, 6vw, 68px);
+		background: linear-gradient(90deg, var(--panel-bg), var(--bg-hover), var(--panel-bg));
+		background-size: 200% 100%;
+		animation: pulse 1.2s linear infinite;
+	}
+
+	@keyframes pulse {
+		from { background-position: 200% 0; }
+		to { background-position: -200% 0; }
+	}
+
+	@media (max-width: 760px) {
+		.chart-row {
+			grid-template-columns: clamp(36px, 10vw, 48px) clamp(42px, 12vw, 52px) minmax(0, 1fr);
+		}
+
+		.metric,
+		.status {
+			grid-column: 3;
+		}
+	}
+</style>

--- a/frontend/src/lib/components/charts/TrendingShelf.svelte
+++ b/frontend/src/lib/components/charts/TrendingShelf.svelte
@@ -15,12 +15,17 @@
 	import {
 		api,
 		type ChartEntry,
+		type TidalPlayable,
 		type Track,
 		type LastfmCountry,
 		type LastfmGenre,
 	} from '$lib/api/client';
 	import { playTrackNow } from '$lib/stores/player';
+	import { openContextMenu } from '$lib/stores/context_menu';
 	import { playChartTidalTrack } from '$lib/player/play_trending';
+	import { canPlayTrack, getPlayableLabel } from '$lib/player/playable';
+	import { buildTrackMenu, buildTidalTrackMenu } from '$lib/player/track_menu';
+	import SectionHeader from '$lib/components/ui/SectionHeader.svelte';
 	import {
 		selectedTrendingMode,
 		selectedCountry,
@@ -28,7 +33,7 @@
 		type TrendingMode,
 	} from '$lib/stores/trending-prefs';
 	import { getCached, putCached } from '$lib/stores/trending-cache';
-	import TrendingCard from '$lib/components/TrendingCard.svelte';
+	import ChartMural, { type ChartMuralItem } from '$lib/components/charts/ChartMural.svelte';
 	import EmptyState from '$lib/components/ui/EmptyState.svelte';
 
 	interface Props {
@@ -36,7 +41,7 @@
 	}
 	let { limit = 12 }: Props = $props();
 
-	// `tidal` is intentionally absent — the editorial-chart endpoint returns
+	// `tidal` is intentionally absent - the editorial-chart endpoint returns
 	// 404 ("not confirmed" in the Tidal client warning), so exposing the tab
 	// would always render an empty state. Add it back here when that endpoint
 	// is sorted; the store/type/backend route still accept the value.
@@ -45,6 +50,7 @@
 		{ id: 'country', label: 'Country' },
 		{ id: 'genre', label: 'Genre' },
 	];
+	const ROTATE_MS = 8000;
 
 	let countries = $state<LastfmCountry[]>([]);
 	let genres = $state<LastfmGenre[]>([]);
@@ -55,8 +61,32 @@
 	// state before the on-mount fetch flips it on.
 	let loading = $state(true);
 	let error = $state(false);
+	let currentEntryIndex = $state(0);
+	let muralPaused = $state(false);
+	let resolvingEntries = $state<Record<string, boolean>>({});
+	let lazyArtwork = $state<Record<string, string>>({});
 
 	let lastToken = '';
+	let visibleEntries = $derived(tracks.slice(0, limit));
+	let currentEntry = $derived(visibleEntries[currentEntryIndex] ?? visibleEntries[0] ?? null);
+	let muralItems = $derived<ChartMuralItem[]>(
+		visibleEntries.map((entry, index) => ({
+			id: entryKey(entry, index),
+			title: entryTitle(entry),
+			subtitle: entrySubtitle(entry, index),
+			artwork: entryArtwork(entry, index),
+			fallbackText: entryFallbackText(entry),
+			tileLabel: `Select ${entryTitle(entry)}`,
+			tileTitle: `${index + 1}. ${entryTitle(entry)} - ${entryArtist(entry) ?? 'Unknown artist'}`,
+			lazy: {
+				enabled: needsLazyArtwork(entry, index),
+				query: { artist: entryArtist(entry), title: entryTitle(entry) },
+				onResolve: (url) => {
+					lazyArtwork = { ...lazyArtwork, [entryKey(entry, index)]: url };
+				},
+			},
+		})),
+	);
 
 	function tokenFor(mode: TrendingMode, country: string, genre: string): string {
 		if (mode === 'country') return `country:${country}`;
@@ -66,7 +96,7 @@
 
 	// Per-entry key for the grid each-block. Last.fm-only entries arrive with
 	// `tidal_playable.tidal_id === 0` (placeholder), so `??` falls through to
-	// the index-based fallback, since 0 is falsy-but-not-nullish — without
+	// the index-based fallback, since 0 is falsy-but-not-nullish - without
 	// this, every unresolved card collides on key `0` and Svelte throws
 	// `each_key_duplicate`, which prevents the whole shelf from rendering.
 	function entryKey(entry: ChartEntry, i: number): string {
@@ -79,12 +109,106 @@
 		return `lf:${i}:${artist}:${title}`;
 	}
 
+	function optionalStringField(entry: ChartEntry, key: 'display_title' | 'display_subtitle'): string | null {
+		const value = (entry as unknown as Record<string, unknown>)[key];
+		return typeof value === 'string' && value.trim() ? value : null;
+	}
+
+	function entryTitle(entry: ChartEntry): string {
+		return optionalStringField(entry, 'display_title') ?? entry.local_track?.title ?? entry.tidal_playable?.title ?? 'Unknown track';
+	}
+
+	function entryArtist(entry: ChartEntry): string | null {
+		return optionalStringField(entry, 'display_subtitle') ?? entry.local_track?.artist_name ?? entry.tidal_playable?.artist_name ?? null;
+	}
+
+	function entryTarget(entry: ChartEntry): Track | TidalPlayable | null {
+		return entry.local_track ?? entry.tidal_playable ?? null;
+	}
+
+	const LASTFM_PLACEHOLDER_HASH = '2a96cbd8b46e442fc41c2b86b821562f';
+	function usableArtwork(...candidates: (string | null | undefined)[]): string | null {
+		for (const candidate of candidates) {
+			if (!candidate) continue;
+			const trimmed = candidate.trim();
+			if (!trimmed) continue;
+			if (trimmed.includes(LASTFM_PLACEHOLDER_HASH)) continue;
+			return trimmed;
+		}
+		return null;
+	}
+
+	function entryArtwork(entry: ChartEntry, index: number): string | null {
+		return usableArtwork(
+			lazyArtwork[entryKey(entry, index)],
+			entry.local_track?.artwork_url,
+			entry.tidal_playable?.artwork_url,
+			entry.image_url,
+		);
+	}
+
+	function needsLazyArtwork(entry: ChartEntry, index: number): boolean {
+		return entryArtwork(entry, index) === null;
+	}
+
+	function entryFallbackText(entry: ChartEntry): string {
+		return (entryTitle(entry).trim()[0] ?? 'N').toUpperCase();
+	}
+
+	function entrySubtitle(entry: ChartEntry, index: number): string {
+		return `#${index + 1} - ${entryArtist(entry) ?? 'Unknown artist'}`;
+	}
+
+	function isEntryUnresolved(entry: ChartEntry): boolean {
+		return entry.local_track === null &&
+			entry.tidal_playable !== null &&
+			entry.tidal_playable.tidal_id <= 0;
+	}
+
+	function isEntryPlayable(entry: ChartEntry): boolean {
+		const target = entryTarget(entry);
+		return target !== null && (canPlayTrack(target) || isEntryUnresolved(entry));
+	}
+
+	function entryStatusLabel(entry: ChartEntry, index: number): string {
+		const key = entryKey(entry, index);
+		if (resolvingEntries[key]) return 'Resolving';
+		if (entry.local_track) return 'In library';
+		if (isEntryUnresolved(entry)) return 'Resolve on TIDAL';
+		if (entry.tidal_playable) return 'TIDAL ready';
+		return 'Unavailable';
+	}
+
+	function entryActionLabel(entry: ChartEntry, index: number): string {
+		const key = entryKey(entry, index);
+		if (resolvingEntries[key]) return 'Resolving...';
+		if (isEntryUnresolved(entry)) return 'Resolve on TIDAL';
+		const target = entryTarget(entry);
+		return target ? getPlayableLabel(target) : 'Unavailable';
+	}
+
+	function currentKindLabel(): string {
+		return `Last.fm top ${visibleEntries.length} - ${subLabel}`;
+	}
+
 	onMount(() => {
 		// Migrate stale 'tidal' from the pre-merge source key before reads happen.
 		if (!MODES.some((m) => m.id === get(selectedTrendingMode))) {
 			selectedTrendingMode.set('worldwide');
 		}
 		void loadCurated();
+	});
+
+	$effect(() => {
+		if (currentEntryIndex >= visibleEntries.length) currentEntryIndex = 0;
+	});
+
+	$effect(() => {
+		if (visibleEntries.length <= 1) return;
+		const timer = setInterval(() => {
+			if (!muralPaused) jumpEntry(1);
+		}, ROTATE_MS);
+		return () => clearInterval(timer);
 	});
 
 	// Idiomatic Svelte 5: $effect tracks $store reads and re-runs on any change.
@@ -108,6 +232,7 @@
 		const cached = getCached(token);
 		if (cached) {
 			tracks = cached;
+			currentEntryIndex = 0;
 			loading = false;
 			error = false;
 			return;
@@ -131,7 +256,7 @@
 	}
 
 	async function load(mode: TrendingMode, country: string, genre: string, token: string) {
-		// Keep `tracks` populated while we fetch — replacing only when new data
+		// Keep `tracks` populated while we fetch - replacing only when new data
 		// lands avoids the flash-to-empty-state and the resulting grid reflow.
 		loading = true;
 		error = false;
@@ -148,6 +273,7 @@
 			}
 			const next = data.tracks ?? [];
 			tracks = next;
+			currentEntryIndex = 0;
 			// Only cache non-empty payloads so a transient 5xx returning [] doesn't
 			// poison the cache for 6h.
 			if (next.length > 0) putCached(token, next);
@@ -177,6 +303,46 @@
 		void playTrackNow(t.id);
 	}
 
+	function selectEntry(index: number) {
+		currentEntryIndex = index;
+	}
+
+	function jumpEntry(delta: number) {
+		if (visibleEntries.length === 0) return;
+		currentEntryIndex = (currentEntryIndex + delta + visibleEntries.length) % visibleEntries.length;
+	}
+
+	async function playEntry(entry: ChartEntry, index: number) {
+		const target = entryTarget(entry);
+		if (!target || (!canPlayTrack(target) && !isEntryUnresolved(entry))) return;
+		if (entry.local_track) {
+			onTrack(entry.local_track);
+			return;
+		}
+		if (!entry.tidal_playable) return;
+		const key = entryKey(entry, index);
+		resolvingEntries = { ...resolvingEntries, [key]: isEntryUnresolved(entry) };
+		try {
+			await playChartTidalTrack(entry.tidal_playable);
+		} finally {
+			resolvingEntries = { ...resolvingEntries, [key]: false };
+		}
+	}
+
+	function handleEntryContext(e: MouseEvent, entry: ChartEntry) {
+		e.preventDefault();
+		e.stopPropagation();
+		const local = entry.local_track;
+		if (local) {
+			openContextMenu(e, buildTrackMenu(local), local.title);
+			return;
+		}
+		const tidal = entry.tidal_playable;
+		if (tidal) {
+			openContextMenu(e, buildTidalTrackMenu(tidal), tidal.title);
+		}
+	}
+
 	const subLabel = $derived.by(() => {
 		const m = $selectedTrendingMode;
 		if (m === 'country') {
@@ -191,31 +357,29 @@
 </script>
 
 <section class="trending-shelf">
-	<div class="section-header">
-		<div class="section-title-group">
-			<p class="eyebrow">From Last.fm <span class="eyebrow-dot" aria-hidden="true">·</span> Now moving</p>
-			<h2>Trending <span class="sub">· {subLabel}</span></h2>
-		</div>
-		<div class="trending-controls">
-			<div class="chip-group" role="tablist" aria-label="Trending scope">
-				{#each MODES as m (m.id)}
-					<button
-						type="button"
-						class="chip"
-						class:active={m.id === $selectedTrendingMode}
-						onclick={() => pickMode(m.id)}
-						role="tab"
-						aria-selected={m.id === $selectedTrendingMode}
-					>
-						{m.label}
-					</button>
-				{/each}
+	<SectionHeader eyebrow="From Last.fm - Now moving" title="Trending" subtitle={subLabel} variant="charts" level={2}>
+		{#snippet actions()}
+			<div class="trending-controls">
+				<div class="chip-group" role="tablist" aria-label="Trending scope">
+					{#each MODES as m (m.id)}
+						<button
+							type="button"
+							class="chip"
+							class:active={m.id === $selectedTrendingMode}
+							onclick={() => pickMode(m.id)}
+							role="tab"
+							aria-selected={m.id === $selectedTrendingMode}
+						>
+							{m.label}
+						</button>
+					{/each}
+				</div>
+				<!-- Always-rendered, fixed-width slot - flips opacity instead of mounting/unmounting,
+				     so the chip group doesn't reflow when fetches start/finish. -->
+				<span class="loading-indicator" class:visible={loading} aria-hidden={!loading}>Loading...</span>
 			</div>
-			<!-- Always-rendered, fixed-width slot — flips opacity instead of mounting/unmounting,
-			     so the chip group doesn't reflow when fetches start/finish. -->
-			<span class="loading-indicator" class:visible={loading} aria-hidden={!loading}>Loading…</span>
-		</div>
-	</div>
+		{/snippet}
+	</SectionHeader>
 
 	<!-- Always-rendered subrow; content swaps by mode. Reserves stable vertical
 	     space so the grid below doesn't jump when modes change. -->
@@ -249,22 +413,32 @@
 		{/if}
 	</div>
 
-	{#if tracks.length > 0}
-		<div class="trending-grid">
-			{#each tracks.slice(0, limit) as entry, i (entryKey(entry, i))}
-				<TrendingCard {entry} index={i} {onTrack} onTidal={playChartTidalTrack} />
-			{/each}
-		</div>
-	{:else if loading}
-		<!-- Skeleton grid so the area isn't blank during the first fetch (was a
-		     "did the page break?" UX cliff with the previous render-nothing branch). -->
-		<div class="trending-grid">
-			{#each Array.from({ length: Math.min(limit, 8) }) as _, i (i)}
-				<div class="skeleton-card" aria-hidden="true"></div>
-			{/each}
-		</div>
+	{#if tracks.length > 0 || loading}
+		<ChartMural
+			items={muralItems}
+			currentIndex={currentEntryIndex}
+			ariaLabel={`Last.fm ${subLabel} top ${visibleEntries.length}`}
+			kindLabel={currentKindLabel()}
+			title={currentEntry ? entryTitle(currentEntry) : ''}
+			subtitle={currentEntry ? entrySubtitle(currentEntry, currentEntryIndex) : ''}
+			metric={currentEntry ? currentEntry.genre ?? entryStatusLabel(currentEntry, currentEntryIndex) : ''}
+			actionLabel={currentEntry ? entryActionLabel(currentEntry, currentEntryIndex) : 'Unavailable'}
+			actionDisabled={!currentEntry || !isEntryPlayable(currentEntry)}
+			accent="lastfm"
+			loading={loading && tracks.length === 0}
+			loadingLabel="Loading Last.fm chart"
+			onSelect={selectEntry}
+			onJump={jumpEntry}
+			onPlay={() => currentEntry && playEntry(currentEntry, currentEntryIndex)}
+			onCardContext={(event) => currentEntry && handleEntryContext(event, currentEntry)}
+			onItemContext={(event, index) => {
+				const entry = visibleEntries[index];
+				if (entry) handleEntryContext(event, entry);
+			}}
+			onPauseChange={(paused) => muralPaused = paused}
+		/>
 	{:else if error}
-		<EmptyState title="Couldn’t load this chart" copy="Try another scope or check the Last.fm key in Settings." />
+		<EmptyState title="Couldn't load this chart" copy="Try another scope or check the Last.fm key in Settings." />
 	{:else}
 		<EmptyState title="Nothing trending here yet" copy="Try another country, genre, or scope." />
 	{/if}
@@ -274,53 +448,13 @@
 	.trending-shelf {
 		display: flex;
 		flex-direction: column;
-		gap: 14px;
-	}
-
-	.section-header {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		gap: 16px;
-		flex-wrap: wrap;
-	}
-
-	.section-title-group {
-		display: flex;
-		flex-direction: column;
-		gap: 4px;
-	}
-
-	.section-title-group h2 {
-		font-size: var(--font-size-lg);
-		font-weight: var(--font-weight-bold);
-		margin: 0;
-	}
-
-	.section-title-group h2 .sub {
-		color: var(--text-muted);
-		font-weight: var(--font-weight-medium);
-		font-size: var(--font-size-md);
-		margin-left: 2px;
-	}
-
-	.eyebrow {
-		font-size: var(--font-size-xs);
-		font-weight: var(--font-weight-semibold);
-		text-transform: uppercase;
-		letter-spacing: 0.08em;
-		color: var(--service-lastfm);
-		margin: 0;
-	}
-	.eyebrow-dot {
-		color: var(--text-muted);
-		margin: 0 4px;
+		gap: var(--space-3);
 	}
 
 	.trending-controls {
 		display: flex;
 		align-items: center;
-		gap: 12px;
+		gap: var(--space-2);
 		flex-wrap: nowrap; /* keeps chip-group + loading slot on a single line */
 		min-width: 0;
 	}
@@ -328,46 +462,55 @@
 	.chip-group {
 		display: inline-flex;
 		gap: var(--space-1);
-		padding: 2px;
+		padding: var(--space-1);
 		background: var(--panel-bg);
 		border: 1px solid var(--panel-border);
 		border-radius: 999px;
 	}
 
 	.chip {
-		background: transparent;
-		border: none;
+		background: var(--panel-bg);
+		border: 1px solid var(--panel-border);
 		color: var(--text-muted);
 		font: inherit;
 		font-size: var(--font-size-xs);
-		font-weight: var(--font-weight-medium);
-		padding: 4px 10px;
+		font-weight: var(--font-weight-semibold);
+		line-height: 1;
+		padding: var(--space-2) var(--space-3);
 		border-radius: 999px;
 		cursor: pointer;
-		transition: background var(--motion-fast), color var(--motion-fast);
+		white-space: nowrap;
+		transition: background var(--motion-base), border-color var(--motion-base), color var(--motion-base);
 	}
 
-	.chip:hover { color: var(--text-primary); }
+	.chip:hover,
+	.chip:focus-visible {
+		background: var(--bg-hover);
+		border-color: var(--accent-line);
+		color: var(--text-primary);
+		outline: none;
+	}
 
 	.chip.active {
 		background: var(--bg-hover);
+		border-color: var(--accent-line);
 		color: var(--text-primary);
 	}
 
 	.chip-row {
 		display: flex;
 		flex-wrap: wrap;
-		gap: 6px;
+		gap: var(--space-1);
 		/* Reserves one row of chip height even when worldwide mode renders no
 		   chips, so switching modes doesn't shift the grid below. */
-		min-height: 28px;
+		min-height: clamp(28px, 2vw, 36px);
 	}
 
 	.chip.secondary {
-		background: rgba(255, 255, 255, 0.04);
+		background: var(--panel-bg);
 	}
 	.chip.secondary.active {
-		background: rgba(255, 255, 255, 0.16);
+		background: var(--bg-hover);
 	}
 
 	.loading-indicator {
@@ -375,43 +518,13 @@
 		color: var(--text-muted);
 		font-style: italic;
 		/* Reserve the slot so the chip group never reflows when loading toggles. */
-		min-width: 60px;
+		min-width: clamp(52px, 4vw, 68px);
 		opacity: 0;
-		transition: opacity 0.18s ease;
+		transition: opacity var(--motion-fast);
 		pointer-events: none;
 	}
 	.loading-indicator.visible {
 		opacity: 1;
 	}
 
-	.trending-grid {
-		display: grid;
-		grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
-		gap: 14px;
-	}
-
-	@media (max-width: 720px) {
-		.trending-grid {
-			grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
-			gap: 10px;
-		}
-	}
-
-	.skeleton-card {
-		aspect-ratio: 1;
-		border-radius: var(--radius-md);
-		background: linear-gradient(
-			110deg,
-			rgba(255, 255, 255, 0.04) 30%,
-			rgba(255, 255, 255, 0.08) 50%,
-			rgba(255, 255, 255, 0.04) 70%
-		);
-		background-size: 200% 100%;
-		animation: skeleton-shimmer 1.4s ease-in-out infinite;
-	}
-
-	@keyframes skeleton-shimmer {
-		0% { background-position: 200% 0; }
-		100% { background-position: -200% 0; }
-	}
 </style>

--- a/frontend/src/lib/components/charts/daily_chart_shelf_contract.test.ts
+++ b/frontend/src/lib/components/charts/daily_chart_shelf_contract.test.ts
@@ -11,11 +11,14 @@ const chartsPage = readFileSync(
 );
 
 describe('daily chart shelf contract', () => {
-	test('loads the additive snapshot endpoint without replacing trending or playlists', () => {
+	test('loads chart snapshots and the provider matrix without replacing trending or playlists', () => {
 		expect(source).toContain('api.getChartSnapshot');
 		expect(source).toContain('api.getChartMatrix');
 		expect(source).toContain('api.refreshChartMatrix');
 		expect(source).toContain("let selectedSource = $state('spotify_daily')");
+		expect(source).toContain('const LIMIT = 20');
+		expect(source).toContain('snapshotRefreshAttempted');
+		expect(source).toContain('next.entries.length < Math.min(10, LIMIT)');
 
 		const trendingIndex = chartsPage.indexOf('<TrendingShelf limit={12} />');
 		const dailyIndex = chartsPage.indexOf('<DailyChartShelf />');
@@ -28,10 +31,9 @@ describe('daily chart shelf contract', () => {
 
 	test('keeps empty and restart states visible when refresh cannot populate data', () => {
 		expect(source).toContain('No market snapshot yet');
-		expect(source).toContain('No Spotify daily list for');
+		expect(source).toContain('No provider leaders for');
 		expect(source).toContain('Global data is available above');
 		expect(source).toContain('NOOR tried to refresh the provider matrix');
-		expect(source).toContain('Daily snapshots unavailable');
 		expect(source).toContain('Restart the NOOR server');
 	});
 
@@ -43,20 +45,23 @@ describe('daily chart shelf contract', () => {
 		expect(source).toContain('regionHasMatrixData(selectedRegion)');
 	});
 
-	test('makes region tabs and provider cards change the active provider snapshot', () => {
-		expect(source).toContain('selectedRegionCells()');
+	test('uses provider chips and a top 20 mural instead of duplicate leader cards', () => {
+		expect(source).toContain('source-tabs');
+		expect(source).toContain('chart-mural-card');
+		expect(source).toContain('chartEntries as entry');
+		expect(source).toContain('currentEntry');
 		expect(source).toContain('pickProvider(selectedRegion, provider.source_key)');
-		expect(source).toContain('loadSnapshot(region, source)');
-		expect(source).toContain('Provider snapshot');
+		expect(source).not.toContain('provider-card');
+		expect(source).not.toContain('Provider snapshot');
 	});
 
-	test('resolves visible provider leaders against TIDAL for artwork and playback', () => {
+	test('resolves visible chart entries against TIDAL for artwork and playback', () => {
 		expect(source).toContain('api.searchTidal(query, 1)');
 		expect(source).toContain('resolvedTracks');
 		expect(source).toContain('playTidalTrackNow');
 		expect(source).toContain('TIDAL ready');
-		expect(source).toContain('provider-card-art');
-		expect(source).toContain('resolveVisibleEntries(entries)');
-		expect(source).toContain('entryStatusLabel(entry)');
+		expect(source).toContain('chart-mural-art');
+		expect(source).toContain('async function resolveVisibleEntries(entries');
+		expect(source).toContain('async function playEntry(entry');
 	});
 });

--- a/frontend/src/lib/components/charts/daily_chart_shelf_contract.test.ts
+++ b/frontend/src/lib/components/charts/daily_chart_shelf_contract.test.ts
@@ -28,6 +28,8 @@ describe('daily chart shelf contract', () => {
 
 	test('keeps empty and restart states visible when refresh cannot populate data', () => {
 		expect(source).toContain('No market snapshot yet');
+		expect(source).toContain('No Spotify daily list for');
+		expect(source).toContain('Global data is available above');
 		expect(source).toContain('NOOR tried to refresh the provider matrix');
 		expect(source).toContain('Daily snapshots unavailable');
 		expect(source).toContain('Restart the NOOR server');
@@ -38,5 +40,6 @@ describe('daily chart shelf contract', () => {
 		expect(source).toContain('{provider.label}');
 		expect(source).toContain('row.cells[provider.source_key]');
 		expect(source).toContain('matrixHasData(next)');
+		expect(source).toContain('regionHasMatrixData(selectedRegion)');
 	});
 });

--- a/frontend/src/lib/components/charts/daily_chart_shelf_contract.test.ts
+++ b/frontend/src/lib/components/charts/daily_chart_shelf_contract.test.ts
@@ -15,7 +15,7 @@ describe('daily chart shelf contract', () => {
 		expect(source).toContain('api.getChartSnapshot');
 		expect(source).toContain('api.getChartMatrix');
 		expect(source).toContain('api.refreshChartMatrix');
-		expect(source).toContain("const SOURCE = 'spotify_daily'");
+		expect(source).toContain("let selectedSource = $state('spotify_daily')");
 
 		const trendingIndex = chartsPage.indexOf('<TrendingShelf limit={12} />');
 		const dailyIndex = chartsPage.indexOf('<DailyChartShelf />');
@@ -41,5 +41,22 @@ describe('daily chart shelf contract', () => {
 		expect(source).toContain('row.cells[provider.source_key]');
 		expect(source).toContain('matrixHasData(next)');
 		expect(source).toContain('regionHasMatrixData(selectedRegion)');
+	});
+
+	test('makes region tabs and provider cards change the active provider snapshot', () => {
+		expect(source).toContain('selectedRegionCells()');
+		expect(source).toContain('pickProvider(selectedRegion, provider.source_key)');
+		expect(source).toContain('loadSnapshot(region, source)');
+		expect(source).toContain('Provider snapshot');
+	});
+
+	test('resolves visible provider leaders against TIDAL for artwork and playback', () => {
+		expect(source).toContain('api.searchTidal(query, 1)');
+		expect(source).toContain('resolvedTracks');
+		expect(source).toContain('playTidalTrackNow');
+		expect(source).toContain('TIDAL ready');
+		expect(source).toContain('provider-card-art');
+		expect(source).toContain('resolveVisibleEntries(entries)');
+		expect(source).toContain('entryStatusLabel(entry)');
 	});
 });

--- a/frontend/src/lib/components/charts/daily_chart_shelf_contract.test.ts
+++ b/frontend/src/lib/components/charts/daily_chart_shelf_contract.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, test } from 'vitest';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const source = readFileSync(join(here, 'DailyChartShelf.svelte'), 'utf8');
+const muralSource = readFileSync(join(here, 'ChartMural.svelte'), 'utf8');
 const chartsPage = readFileSync(
 	join(here, '..', '..', '..', 'routes', 'charts', '+page.svelte'),
 	'utf8',
@@ -20,13 +21,19 @@ describe('daily chart shelf contract', () => {
 		expect(source).toContain('snapshotRefreshAttempted');
 		expect(source).toContain('next.entries.length < Math.min(10, LIMIT)');
 
-		const trendingIndex = chartsPage.indexOf('<TrendingShelf limit={12} />');
+		const trendingIndex = chartsPage.indexOf('<TrendingShelf limit={20} />');
 		const dailyIndex = chartsPage.indexOf('<DailyChartShelf />');
-		const playlistsIndex = chartsPage.indexOf('<h2 class="block-title">Spotify chart playlists</h2>');
+		const playlistsIndex = chartsPage.indexOf('title="Chart playlists"');
 
 		expect(trendingIndex).toBeGreaterThan(-1);
 		expect(dailyIndex).toBeGreaterThan(trendingIndex);
 		expect(playlistsIndex).toBeGreaterThan(dailyIndex);
+		expect(chartsPage).toContain('PageHeader');
+		expect(chartsPage).toContain('variant="editorial"');
+		expect(chartsPage).toContain('SectionHeader');
+		expect(chartsPage).toContain('variant="charts"');
+		expect(chartsPage).toContain('level={2}');
+		expect(chartsPage).not.toContain('style="background-image');
 	});
 
 	test('keeps empty and restart states visible when refresh cannot populate data', () => {
@@ -46,13 +53,19 @@ describe('daily chart shelf contract', () => {
 	});
 
 	test('uses provider chips and a top 20 mural instead of duplicate leader cards', () => {
+		expect(source).toContain('SectionHeader');
+		expect(source).toContain('variant="charts"');
+		expect(source).toContain('level={2}');
 		expect(source).toContain('source-tabs');
-		expect(source).toContain('chart-mural-card');
-		expect(source).toContain('chartEntries as entry');
+		expect(source).toContain('ChartMural');
+		expect(source).toContain('type ChartMuralItem');
+		expect(muralSource).toContain('chart-mural');
+		expect(source).toContain('chartEntries.map((entry');
 		expect(source).toContain('currentEntry');
 		expect(source).toContain('pickProvider(selectedRegion, provider.source_key)');
 		expect(source).not.toContain('provider-card');
 		expect(source).not.toContain('Provider snapshot');
+		expect(source).not.toContain('chart-mural-card');
 	});
 
 	test('resolves visible chart entries against TIDAL for artwork and playback', () => {
@@ -60,8 +73,30 @@ describe('daily chart shelf contract', () => {
 		expect(source).toContain('resolvedTracks');
 		expect(source).toContain('playTidalTrackNow');
 		expect(source).toContain('TIDAL ready');
-		expect(source).toContain('chart-mural-art');
+		expect(muralSource).toContain('chart-mural-art');
 		expect(source).toContain('async function resolveVisibleEntries(entries');
 		expect(source).toContain('async function playEntry(entry');
+	});
+
+	test('uses shared context menus and standardized pill controls', () => {
+		expect(source).toContain('openContextMenu');
+		expect(source).toContain('buildTidalTrackMenu');
+		expect(source).toContain('openEntryContext');
+		expect(source).toContain('openMatrixCellContext');
+		expect(source).toContain('oncontextmenu');
+		expect(source).toContain('border: 1px solid var(--panel-border)');
+		expect(source).toContain('border-color: var(--accent-line)');
+	});
+
+	test('keeps chart page titles neutral with shared headers and artwork images', () => {
+		expect(chartsPage).toContain('<PageHeader');
+		expect(chartsPage).toContain('variant="editorial"');
+		expect(chartsPage).toContain('<SectionHeader');
+		expect(chartsPage).toContain('<ArtworkImage');
+		expect(chartsPage).toContain('className="chart-playlist-art"');
+		expect(chartsPage).not.toContain('service-spotify');
+		expect(source).not.toContain('service-spotify');
+		expect(muralSource).toContain('.chart-mural-title');
+		expect(muralSource).toContain('color: var(--text-primary)');
 	});
 });

--- a/frontend/src/lib/components/charts/daily_chart_shelf_contract.test.ts
+++ b/frontend/src/lib/components/charts/daily_chart_shelf_contract.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, test } from 'vitest';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(join(here, 'DailyChartShelf.svelte'), 'utf8');
+const chartsPage = readFileSync(
+	join(here, '..', '..', '..', 'routes', 'charts', '+page.svelte'),
+	'utf8',
+);
+
+describe('daily chart shelf contract', () => {
+	test('loads the additive snapshot endpoint without replacing trending or playlists', () => {
+		expect(source).toContain('api.getChartSnapshot');
+		expect(source).toContain('api.getChartMatrix');
+		expect(source).toContain('api.refreshChartMatrix');
+		expect(source).toContain("const SOURCE = 'spotify_daily'");
+
+		const trendingIndex = chartsPage.indexOf('<TrendingShelf limit={12} />');
+		const dailyIndex = chartsPage.indexOf('<DailyChartShelf />');
+		const playlistsIndex = chartsPage.indexOf('<h2 class="block-title">Spotify chart playlists</h2>');
+
+		expect(trendingIndex).toBeGreaterThan(-1);
+		expect(dailyIndex).toBeGreaterThan(trendingIndex);
+		expect(playlistsIndex).toBeGreaterThan(dailyIndex);
+	});
+
+	test('keeps empty and restart states visible when refresh cannot populate data', () => {
+		expect(source).toContain('No market snapshot yet');
+		expect(source).toContain('NOOR tried to refresh the provider matrix');
+		expect(source).toContain('Daily snapshots unavailable');
+		expect(source).toContain('Restart the NOOR server');
+	});
+
+	test('shows the full provider matrix target, not just Spotify', () => {
+		expect(source).toContain('matrix.providers as provider');
+		expect(source).toContain('{provider.label}');
+		expect(source).toContain('row.cells[provider.source_key]');
+		expect(source).toContain('matrixHasData(next)');
+	});
+});

--- a/frontend/src/lib/components/charts/trending_shelf_contract.test.ts
+++ b/frontend/src/lib/components/charts/trending_shelf_contract.test.ts
@@ -1,0 +1,83 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, test } from 'vitest';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(join(here, 'TrendingShelf.svelte'), 'utf8');
+const muralSource = readFileSync(join(here, 'ChartMural.svelte'), 'utf8');
+
+describe('trending shelf contract', () => {
+	test('renders Last.fm charts with the market-pulse mural treatment', () => {
+		expect(source).toContain('ChartMural');
+		expect(source).toContain('type ChartMuralItem');
+		expect(source).toContain('<ChartMural');
+		expect(source).toContain('accent="lastfm"');
+		expect(source).toContain('muralItems');
+		expect(muralSource).toContain('chart-mural');
+		expect(muralSource).toContain('chart-mural-bg');
+		expect(muralSource).toContain('chart-mural-tile');
+		expect(muralSource).toContain('chart-mural-art');
+		expect(source).toContain('currentEntry');
+		expect(source).toContain('visibleEntries');
+		expect(source).toContain('ROTATE_MS');
+		expect(muralSource).toContain('repeat(10, minmax(0, 1fr))');
+		expect(muralSource).toContain('repeat(5, minmax(0, 1fr))');
+		expect(muralSource).toContain('ArtworkImage');
+		expect(muralSource).toContain('size={320}');
+		expect(muralSource).toContain('use:lazyTidalArt');
+		expect(source).not.toContain('TrendingCard');
+		expect(source).not.toContain('lastfm-mural');
+	});
+
+	test('keeps Last.fm scopes, cache, and empty states wired', () => {
+		expect(source).toContain('SectionHeader');
+		expect(source).toContain('variant="charts"');
+		expect(source).toContain('level={2}');
+		expect(source).toContain('api.getLastfmCountries()');
+		expect(source).toContain('api.getLastfmGenres()');
+		expect(source).toContain("api.getTrending({ source: 'lastfm', limit, country })");
+		expect(source).toContain("api.getTrending({ source: 'lastfm', limit, tag: genre })");
+		expect(source).toContain('getCached(token)');
+		expect(source).toContain('putCached(token, next)');
+		expect(source).toContain('Couldn');
+		expect(source).toContain('Nothing trending here yet');
+		expect(source).not.toContain('lastfm-more');
+		expect(source).not.toContain('lastfm-chart-list');
+		expect(source).not.toContain('artistSignals');
+		expect(source).not.toContain('tagSignals');
+		expect(source).not.toContain('loadSignalPanels');
+		expect(source).not.toContain('lastfm-signal-grid');
+		expect(source).not.toContain('artist-signal-art');
+		expect(source).not.toContain('tag-signal-chip');
+	});
+
+	test('preserves playback, TIDAL resolution, artwork fallback, and menus', () => {
+		expect(source).toContain('playTrackNow');
+		expect(source).toContain('playChartTidalTrack');
+		expect(source).toContain('isEntryUnresolved');
+		expect(source).toContain('Resolve on TIDAL');
+		expect(source).toContain('LASTFM_PLACEHOLDER_HASH');
+		expect(source).toContain('needsLazyArtwork');
+		expect(source).toContain('buildTrackMenu');
+		expect(source).toContain('buildTidalTrackMenu');
+		expect(source).toContain('handleEntryContext');
+		expect(source).toContain('onCardContext');
+		expect(source).toContain('onItemContext');
+	});
+
+	test('standardizes pill controls with bordered active chips', () => {
+		expect(source).toContain('border: 1px solid var(--panel-border)');
+		expect(source).toContain('border-color: var(--accent-line)');
+		expect(source).toContain('padding: var(--space-2) var(--space-3)');
+		expect(source).not.toContain('padding: 4px 10px');
+	});
+
+	test('keeps mural titles neutral while allowing small source accents', () => {
+		expect(muralSource).toContain('.chart-mural-title');
+		expect(muralSource).toContain('color: var(--text-primary)');
+		expect(muralSource).toContain('.chart-mural-kind');
+		expect(muralSource).toContain('color: var(--chart-mural-accent)');
+		expect(muralSource).not.toContain('.chart-mural-title {\n\t\tcolor: var(--chart-mural-accent)');
+	});
+});

--- a/frontend/src/lib/components/dj-cockpit/QueuePairPanel.svelte
+++ b/frontend/src/lib/components/dj-cockpit/QueuePairPanel.svelte
@@ -11,11 +11,33 @@
 
 	function confidenceLabel(deck?: DjDeckStatus) {
 		if (deck?.profile_status === 'decode_failed') return 'Analysis failed';
-		if (deck?.profile_status === 'retrying') return 'Retrying analysis';
+		if (deck?.profile_status === 'retrying') return retryLabel(deck);
 		if (deck?.profile_status === 'analyzing') return 'Analyzing';
 		if (!deck?.profile_ready) return 'Profile missing';
 		if (deck.profile_confidence == null) return 'Profile ready';
 		return `${Math.round(deck.profile_confidence * 100)}% confidence`;
+	}
+
+	function retryLabel(deck: DjDeckStatus) {
+		const wait = formatRetryWait(deck.profile_retry_after_ms);
+		if (!wait) return 'Retrying analysis';
+		return `Retrying analysis in ${wait}`;
+	}
+
+	function formatRetryWait(ms?: number) {
+		if (ms == null || ms <= 0) return null;
+		const seconds = Math.ceil(ms / 1000);
+		if (seconds < 60) return `${seconds}s`;
+		const minutes = Math.ceil(seconds / 60);
+		return `${minutes}m`;
+	}
+
+	function retryReasonLabel(deck?: DjDeckStatus) {
+		if (!deck?.profile_retry_reason) return null;
+		if (deck.profile_retry_reason === 'asset_not_ready') return 'TIDAL asset unavailable';
+		if (deck.profile_retry_reason === 'dash_prebuffer') return 'DASH prebuffer retry';
+		if (deck.profile_retry_reason === 'timeout') return 'Analysis timeout';
+		return 'Transient analysis failure';
 	}
 
 	function passiveAnalysisLabel(deck?: DjDeckStatus) {
@@ -55,6 +77,9 @@
 						{/if}
 						{#if item.deck.profile_error}
 							<span class="error-detail" title={item.deck.profile_error}>{item.deck.profile_error}</span>
+						{/if}
+						{#if retryReasonLabel(item.deck)}
+							<span class="error-detail">{retryReasonLabel(item.deck)}</span>
 						{/if}
 						{#if item.deck.passive_analysis_reason}
 							<span class="error-detail" title={item.deck.passive_analysis_reason}>

--- a/frontend/src/lib/components/dj-cockpit/TransitionLane.svelte
+++ b/frontend/src/lib/components/dj-cockpit/TransitionLane.svelte
@@ -97,6 +97,24 @@
 	let recentTimingHistory = $derived(recentTimingEvents.slice(0, 5));
 	let timingSummary = $derived(status?.timing_history_summary ?? null);
 	let overlayDetails = $derived(status?.overlay_details ?? null);
+	let dropPreview = $derived(status?.drop_preview ?? null);
+	let dropPreviewVisible = $derived(Boolean(dropPreview && dropPreview.status !== 'skipped'));
+	let dropPreviewLabel = $derived(
+		dropPreview?.status === 'fired'
+			? 'Drop preview fired'
+			: dropPreview?.status === 'armed'
+				? 'Drop preview armed'
+				: 'Drop preview skipped',
+	);
+	let dropPreviewCopy = $derived(
+		dropPreview?.status === 'fired'
+			? `Fired at ${formatTimingMs(dropPreview.actual_fire_ms)}. Incoming drop ${formatTimingMs(dropPreview.incoming_drop_ms)}.`
+			: dropPreview?.status === 'armed'
+				? `Armed for ${formatTimingMs(dropPreview.planned_fire_ms)}. Incoming drop ${formatTimingMs(dropPreview.incoming_drop_ms)}.`
+				: dropPreview?.reason
+					? `Skipped: ${formatDropPreviewReason(dropPreview.reason)}.`
+					: 'Skipped.',
+	);
 
 	function formatTimingMs(value: number | null | undefined) {
 		return typeof value === 'number' ? `${value} ms` : 'pending';
@@ -118,6 +136,20 @@
 			return 'unknown';
 		}
 		return value ? 'yes' : 'no';
+	}
+
+	function formatDropPreviewReason(reason: string | null | undefined) {
+		const labels: Record<string, string> = {
+			disabled: 'DJ disabled',
+			pair_missing: 'Pair missing',
+			profiles_missing: 'Profiles missing',
+			safe_crossfade_only: 'Safe crossfade only',
+			profile_low_confidence: 'Profile confidence low',
+			harmonic_incompatible: 'Harmonic mismatch',
+			missing_incoming_drop: 'Incoming drop missing',
+			no_safe_mid_song_marker: 'No safe mid-song marker',
+		};
+		return reason ? (labels[reason] ?? reason) : 'none';
 	}
 
 	function runtimeReasonLabel(reason: string | null | undefined) {
@@ -299,6 +331,12 @@
 	{:else}
 		<p class:pending={!transitionArmed} class:success={transitionArmed} role="status">{laneCopy}</p>
 	{/if}
+	{#if dropPreviewVisible}
+		<p class="drop-preview" class:success={dropPreview?.status === 'fired'} role="status">
+			<strong>{dropPreviewLabel}</strong>
+			<span>{dropPreviewCopy}</span>
+		</p>
+	{/if}
 
 	<TransitionWaveform current={status?.current} next={status?.next} {status} />
 
@@ -417,6 +455,30 @@
 				<div>
 					<dt>Planning status</dt>
 					<dd>{status?.planning_status ?? 'none'}</dd>
+				</div>
+				<div>
+					<dt>Drop preview</dt>
+					<dd>{dropPreview?.status ?? 'none'}</dd>
+				</div>
+				<div>
+					<dt>Preview planned</dt>
+					<dd>{formatTimingMs(dropPreview?.planned_fire_ms)}</dd>
+				</div>
+				<div>
+					<dt>Preview actual</dt>
+					<dd>{formatTimingMs(dropPreview?.actual_fire_ms)}</dd>
+				</div>
+				<div>
+					<dt>Preview drop</dt>
+					<dd>{formatTimingMs(dropPreview?.incoming_drop_ms)}</dd>
+				</div>
+				<div>
+					<dt>Preview source</dt>
+					<dd>{dropPreview?.source ?? 'none'}</dd>
+				</div>
+				<div>
+					<dt>Preview reason</dt>
+					<dd>{formatDropPreviewReason(dropPreview?.reason)}</dd>
 				</div>
 				<div>
 					<dt>Confidence floor</dt>
@@ -579,6 +641,24 @@
 		border: 1px solid color-mix(in srgb, var(--state-success) 28%, transparent);
 		background: color-mix(in srgb, var(--state-success) 9%, transparent);
 		color: var(--text-secondary);
+	}
+
+	.drop-preview {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--space-2);
+		align-items: center;
+		padding: var(--space-3);
+		border: 1px solid color-mix(in srgb, var(--accent-primary) 30%, transparent);
+		border-radius: var(--radius-sm);
+		background: color-mix(in srgb, var(--accent-primary) 8%, transparent);
+		color: var(--text-secondary);
+		font-size: var(--font-size-sm);
+		line-height: var(--line-height-snug);
+	}
+
+	.drop-preview strong {
+		color: var(--accent-primary);
 	}
 
 	.pending {

--- a/frontend/src/lib/components/home/HomeMoodsRail.svelte
+++ b/frontend/src/lib/components/home/HomeMoodsRail.svelte
@@ -2,16 +2,20 @@
 	import { onMount } from 'svelte';
 	import { api, type TidalMoodCategory } from '$lib/api/client';
 	import { wheelToHorizontal } from '$lib/actions/wheel-to-horizontal';
+	import ArtworkImage from '$lib/components/ui/ArtworkImage.svelte';
 	import { openContextMenu } from '$lib/stores/context_menu';
 	import { goto } from '$app/navigation';
 	import {
 		getCachedMoodCategories,
-		putCachedMoodCategories,
+		moodCategoriesNeedThumbnails,
+		putCompleteMoodCategories,
 	} from '$lib/stores/tidal-moods-cache';
 
 	const PREVIEW_LIMIT = 8;
 	const LOAD_ARM_DELAY_MS = 0;
 	const FALLBACK_LOAD_DELAY_MS = 3000;
+	const THUMBNAIL_REFRESH_DELAY_MS = 1800;
+	const MAX_THUMBNAIL_REFRESH_ATTEMPTS = 3;
 
 	// Sync-read the shared moods cache on script init so a second visit
 	// within the 6h TTL renders instantly without a network round-trip.
@@ -24,24 +28,32 @@
 	let loading = $state(!cachedOnMount);
 	let errored = $state(false);
 	let sectionEl = $state<HTMLElement | null>(null);
-	let loadStarted = false;
+	let inFlight = false;
+	let thumbnailRefreshAttempts = 0;
+	let thumbnailRefreshTimer: ReturnType<typeof setTimeout> | null = null;
 
 	async function loadMoods() {
-		if (loadStarted) return;
-		loadStarted = true;
+		if (inFlight) return;
+		inFlight = true;
 		try {
 			const data = await api.getTidalMoods();
 			const all = data.categories ?? [];
-			if (all.length > 0) putCachedMoodCategories(all);
+			if (all.length > 0) putCompleteMoodCategories(all);
 			categories = all.slice(0, PREVIEW_LIMIT);
+			scheduleThumbnailRefresh(all);
 		} catch {
 			errored = true;
 		} finally {
 			loading = false;
+			inFlight = false;
 		}
 	}
 
 	onMount(() => {
+		if (cachedOnMount && moodCategoriesNeedThumbnails(cachedOnMount)) {
+			scheduleThumbnailRefresh(cachedOnMount);
+			return () => clearThumbnailRefresh();
+		}
 		if (cachedOnMount) return;
 
 		let observer: IntersectionObserver | null = null;
@@ -68,9 +80,27 @@
 		return () => {
 			clearTimeout(armTimer);
 			if (fallbackTimer) clearTimeout(fallbackTimer);
+			clearThumbnailRefresh();
 			observer?.disconnect();
 		};
 	});
+
+	function clearThumbnailRefresh() {
+		if (!thumbnailRefreshTimer) return;
+		clearTimeout(thumbnailRefreshTimer);
+		thumbnailRefreshTimer = null;
+	}
+
+	function scheduleThumbnailRefresh(nextCategories: TidalMoodCategory[]) {
+		clearThumbnailRefresh();
+		if (!moodCategoriesNeedThumbnails(nextCategories)) {
+			thumbnailRefreshAttempts = 0;
+			return;
+		}
+		if (thumbnailRefreshAttempts >= MAX_THUMBNAIL_REFRESH_ATTEMPTS) return;
+		thumbnailRefreshAttempts += 1;
+		thumbnailRefreshTimer = setTimeout(() => void loadMoods(), THUMBNAIL_REFRESH_DELAY_MS);
+	}
 
 	function menu(slug: string, title: string) {
 		return [{ label: `Open ${title}`, onSelect: () => void goto(`/moods/${slug}`) }];
@@ -95,11 +125,13 @@
 						oncontextmenu={(e) => { e.preventDefault(); openContextMenu(e, menu(c.slug, c.title), c.title); }}
 					>
 						<div class="art-wrap">
-							{#if c.thumbnail}
-								<div class="art" style="background-image:url('{c.thumbnail}')"></div>
-							{:else}
-								<div class="art fallback">~</div>
-							{/if}
+							<ArtworkImage
+								className="mood-art"
+								src={c.thumbnail}
+								alt={c.title}
+								size={320}
+								fallbackText="~"
+							/>
 						</div>
 						<p class="card-title">{c.title}</p>
 					</a>
@@ -164,9 +196,10 @@
 	.card:hover, .card:focus-visible { background: var(--bg-hover); border-color: var(--panel-border); outline: none; }
 	.card:focus-visible { border-color: var(--accent-line); }
 	.art-wrap { position: relative; aspect-ratio: 1 / 1; width: 100%; border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-hover); }
-	.art { width: 100%; height: 100%; background-size: cover; background-position: center; transition: transform var(--motion-base); }
-	.card:hover .art { transform: scale(1.05); }
-	.art.fallback { display: flex; align-items: center; justify-content: center; font-size: var(--font-size-4xl); color: var(--text-muted); }
+	:global(.mood-art) { width: 100%; height: 100%; object-fit: cover; display: block; transition: transform var(--motion-base); }
+	:global(.mood-art.fallback) { display: flex; align-items: center; justify-content: center; background: var(--bg-hover); }
+	:global(.mood-art.fallback span) { font-size: var(--font-size-4xl); color: var(--text-muted); }
+	.card:hover :global(.mood-art) { transform: scale(1.05); }
 	.card-title { margin: 0; font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; line-height: var(--line-height-snug); }
 
 	.card.skeleton { cursor: default; pointer-events: none; }

--- a/frontend/src/lib/components/home/HomeMoodsRail.svelte
+++ b/frontend/src/lib/components/home/HomeMoodsRail.svelte
@@ -10,8 +10,8 @@
 	} from '$lib/stores/tidal-moods-cache';
 
 	const PREVIEW_LIMIT = 8;
-	const LOAD_ARM_DELAY_MS = 2500;
-	const FALLBACK_LOAD_DELAY_MS = 10000;
+	const LOAD_ARM_DELAY_MS = 0;
+	const FALLBACK_LOAD_DELAY_MS = 3000;
 
 	// Sync-read the shared moods cache on script init so a second visit
 	// within the 6h TTL renders instantly without a network round-trip.

--- a/frontend/src/lib/components/ui/PageHeader.svelte
+++ b/frontend/src/lib/components/ui/PageHeader.svelte
@@ -5,18 +5,20 @@
 		title,
 		subtitle = '',
 		eyebrow = '',
+		variant = 'default',
 		actions,
 		meta
 	}: {
 		title: string;
 		subtitle?: string;
 		eyebrow?: string;
+		variant?: 'default' | 'editorial';
 		actions?: Snippet;
 		meta?: Snippet;
 	} = $props();
 </script>
 
-<header class="page-header">
+<header class="page-header" class:editorial={variant === 'editorial'}>
 	<div class="intro">
 		{#if eyebrow}
 			<p class="eyebrow">{eyebrow}</p>
@@ -71,6 +73,13 @@
 		font-size: var(--font-size-2xl);
 		font-weight: var(--font-weight-bold);
 		line-height: var(--line-height-tight);
+		letter-spacing: 0;
+	}
+
+	.page-header.editorial h1 {
+		color: var(--text-primary);
+		font-size: var(--font-size-3xl);
+		font-weight: var(--font-weight-bold);
 		letter-spacing: 0;
 	}
 

--- a/frontend/src/lib/components/ui/SectionHeader.svelte
+++ b/frontend/src/lib/components/ui/SectionHeader.svelte
@@ -5,21 +5,29 @@
 		title,
 		subtitle = '',
 		eyebrow = '',
+		variant = 'default',
+		level = 3,
 		actions
 	}: {
 		title: string;
 		subtitle?: string;
 		eyebrow?: string;
+		variant?: 'default' | 'charts';
+		level?: 2 | 3;
 		actions?: Snippet;
 	} = $props();
 </script>
 
-<div class="section-header">
+<div class="section-header" class:charts={variant === 'charts'}>
 	<div class="copy">
 		{#if eyebrow}
 			<p class="eyebrow">{eyebrow}</p>
 		{/if}
-		<h3>{title}</h3>
+		{#if level === 2}
+			<h2 class="title">{title}</h2>
+		{:else}
+			<h3 class="title">{title}</h3>
+		{/if}
 		{#if subtitle}
 			<p class="subtitle">{subtitle}</p>
 		{/if}
@@ -57,6 +65,42 @@
 
 	.subtitle {
 		color: var(--text-secondary);
+	}
+
+	.title {
+		margin: 0;
+	}
+
+	.section-header.charts {
+		align-items: center;
+	}
+
+	.section-header.charts .copy {
+		gap: var(--space-1);
+	}
+
+	.section-header.charts .eyebrow {
+		margin: 0;
+		color: var(--text-muted);
+		font-size: var(--font-size-xs);
+		font-weight: var(--font-weight-semibold);
+		letter-spacing: 0;
+		line-height: 1;
+	}
+
+	.section-header.charts .title {
+		color: var(--text-primary);
+		font-size: var(--font-size-lg);
+		font-weight: var(--font-weight-bold);
+		line-height: var(--line-height-tight);
+		letter-spacing: 0;
+	}
+
+	.section-header.charts .subtitle {
+		margin: 0;
+		color: var(--text-secondary);
+		font-size: var(--font-size-sm);
+		line-height: var(--line-height-snug);
 	}
 
 	.actions {

--- a/frontend/src/lib/components/wallpaper/palettes.ts
+++ b/frontend/src/lib/components/wallpaper/palettes.ts
@@ -3,7 +3,8 @@
 export type PaletteId = 'iris' | 'sunset' | 'verdant' | 'cosmos' | 'mono'
                       | 'ember' | 'arctic' | 'sakura' | 'abyss' | 'citrus'
                       | 'slate' | 'paper' | 'moss' | 'plum' | 'acid' | 'neon'
-                      | 'futuro' | 'constr';
+                      | 'futuro' | 'constr' | 'obsidian' | 'carbon' | 'blackout'
+                      | 'nocturne';
 
 export type Rgb = [number, number, number];
 
@@ -356,6 +357,78 @@ export const PALETTES: Palette[] = [
 			c3: [0.05, 0.05, 0.08],
 			c4: [0.32, 0.26, 0.20]
 		}
+	},
+	{
+		id: 'obsidian',
+		label: 'Obsidian',
+		sublabel: 'Black glass / graphite / frost',
+		ui: {
+			accent: '#9aa4b2',
+			accentStrong: '#d7dce4',
+			accentSoft: 'rgba(154, 164, 178, 0.12)',
+			accentLine: 'rgba(154, 164, 178, 0.26)',
+			accentGlow: 'rgba(154, 164, 178, 0.18)'
+		},
+		shader: {
+			c1: [0.00, 0.00, 0.01],
+			c2: [0.08, 0.09, 0.11],
+			c3: [0.38, 0.42, 0.48],
+			c4: [0.84, 0.87, 0.92]
+		}
+	},
+	{
+		id: 'carbon',
+		label: 'Carbon',
+		sublabel: 'Pitch black / nickel / signal amber',
+		ui: {
+			accent: '#f0a83a',
+			accentStrong: '#ffd18a',
+			accentSoft: 'rgba(240, 168, 58, 0.12)',
+			accentLine: 'rgba(240, 168, 58, 0.25)',
+			accentGlow: 'rgba(240, 168, 58, 0.18)'
+		},
+		shader: {
+			c1: [0.00, 0.00, 0.00],
+			c2: [0.05, 0.05, 0.06],
+			c3: [0.34, 0.35, 0.36],
+			c4: [0.94, 0.58, 0.18]
+		}
+	},
+	{
+		id: 'blackout',
+		label: 'Blackout',
+		sublabel: 'Near black / cyan / ultraviolet',
+		ui: {
+			accent: '#36d9ff',
+			accentStrong: '#9beeff',
+			accentSoft: 'rgba(54, 217, 255, 0.12)',
+			accentLine: 'rgba(54, 217, 255, 0.27)',
+			accentGlow: 'rgba(54, 217, 255, 0.19)'
+		},
+		shader: {
+			c1: [0.00, 0.00, 0.02],
+			c2: [0.01, 0.03, 0.07],
+			c3: [0.12, 0.80, 1.00],
+			c4: [0.44, 0.18, 0.92]
+		}
+	},
+	{
+		id: 'nocturne',
+		label: 'Nocturne',
+		sublabel: 'Ink black / wine / blue flame',
+		ui: {
+			accent: '#8aa8ff',
+			accentStrong: '#c0ceff',
+			accentSoft: 'rgba(138, 168, 255, 0.12)',
+			accentLine: 'rgba(138, 168, 255, 0.27)',
+			accentGlow: 'rgba(138, 168, 255, 0.19)'
+		},
+		shader: {
+			c1: [0.01, 0.00, 0.02],
+			c2: [0.08, 0.02, 0.07],
+			c3: [0.44, 0.07, 0.20],
+			c4: [0.18, 0.36, 0.95]
+		}
 	}
 ];
 
@@ -363,4 +436,12 @@ export const DEFAULT_PALETTE: PaletteId = 'futuro';
 
 export function paletteById(id: PaletteId): Palette {
 	return PALETTES.find((p) => p.id === id) ?? PALETTES[0];
+}
+
+export function rgbCss(c: Rgb): string {
+	return `rgb(${Math.round(c[0] * 255)}, ${Math.round(c[1] * 255)}, ${Math.round(c[2] * 255)})`;
+}
+
+export function rgbaCss(c: Rgb, alpha: number): string {
+	return `rgba(${Math.round(c[0] * 255)}, ${Math.round(c[1] * 255)}, ${Math.round(c[2] * 255)}, ${alpha})`;
 }

--- a/frontend/src/lib/components/wallpaper/palettes_contract.test.ts
+++ b/frontend/src/lib/components/wallpaper/palettes_contract.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { PALETTES, paletteById, rgbaCss } from './palettes';
+
+describe('wallpaper palettes', () => {
+	it('includes black and dark colour schemes', () => {
+		const darkIds = ['obsidian', 'carbon', 'blackout', 'nocturne'];
+
+		for (const id of darkIds) {
+			const palette = paletteById(id as (typeof PALETTES)[number]['id']);
+			expect(palette.id).toBe(id);
+			expect(palette.shader.c1.every((channel) => channel <= 0.02)).toBe(true);
+		}
+	});
+
+	it('can express shader colours as translucent CSS for the no-wallpaper background', () => {
+		expect(rgbaCss([0.12, 0.8, 1], 0.18)).toBe('rgba(31, 204, 255, 0.18)');
+	});
+});

--- a/frontend/src/lib/stores/spotify-chart-meta-cache.test.ts
+++ b/frontend/src/lib/stores/spotify-chart-meta-cache.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
+import type { SpotifyPlaylistDetail } from '$lib/api/client';
+import {
+	clearSpotifyChartMetaCache,
+	getCachedSpotifyChartMeta,
+	getCachedSpotifyChartMetaMap,
+	putCachedSpotifyChartMeta,
+} from './spotify-chart-meta-cache';
+
+function playlist(title: string, thumbnail: string | null): SpotifyPlaylistDetail {
+	return {
+		source: 'spotify',
+		spotifyId: 'spotify-id',
+		type: 'playlist',
+		title,
+		description: null,
+		thumbnail,
+		owner: null,
+		followers: null,
+		totalTracks: null,
+		snapshotId: null,
+		tracks: [],
+	};
+}
+
+describe('Spotify chart metadata cache', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-05-29T00:00:00Z'));
+		clearSpotifyChartMetaCache();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	test('returns cached playlist title and artwork without refetching', () => {
+		putCachedSpotifyChartMeta('chart-1', playlist('Top 50', 'https://img.example/top.jpg'));
+
+		expect(getCachedSpotifyChartMeta('chart-1')).toEqual({
+			title: 'Top 50',
+			thumbnail: 'https://img.example/top.jpg',
+		});
+		expect(getCachedSpotifyChartMetaMap(['chart-1', 'missing'])).toEqual({
+			'chart-1': {
+				title: 'Top 50',
+				thumbnail: 'https://img.example/top.jpg',
+			},
+		});
+	});
+
+	test('expires playlist metadata after six hours', () => {
+		putCachedSpotifyChartMeta('chart-1', playlist('Top 50', null));
+
+		vi.setSystemTime(new Date('2026-05-29T07:00:00Z'));
+
+		expect(getCachedSpotifyChartMeta('chart-1')).toBeNull();
+	});
+});

--- a/frontend/src/lib/stores/spotify-chart-meta-cache.ts
+++ b/frontend/src/lib/stores/spotify-chart-meta-cache.ts
@@ -1,0 +1,82 @@
+import type { SpotifyPlaylistDetail } from '$lib/api/client';
+
+const STORAGE_KEY = 'noor:spotify-chart-meta:v1';
+const TTL_MS = 6 * 60 * 60 * 1000;
+
+export type SpotifyChartMeta = {
+	thumbnail: string | null;
+	title: string | null;
+};
+
+type CacheEntry = SpotifyChartMeta & {
+	insertedAt: number;
+};
+
+let cache: Record<string, CacheEntry> = {};
+let hydrated = false;
+
+function hydrate(): void {
+	if (hydrated || typeof localStorage === 'undefined') return;
+	hydrated = true;
+	try {
+		const raw = localStorage.getItem(STORAGE_KEY);
+		if (!raw) return;
+		const parsed = JSON.parse(raw);
+		if (parsed && typeof parsed === 'object') cache = parsed;
+	} catch {
+		cache = {};
+	}
+}
+
+function persist(): void {
+	if (typeof localStorage === 'undefined') return;
+	try {
+		localStorage.setItem(STORAGE_KEY, JSON.stringify(cache));
+	} catch {
+		// Storage can be disabled or full. The in-memory cache still helps.
+	}
+}
+
+export function getCachedSpotifyChartMeta(id: string): SpotifyChartMeta | null {
+	hydrate();
+	const entry = cache[id];
+	if (!entry) return null;
+	if (Date.now() - entry.insertedAt > TTL_MS) {
+		delete cache[id];
+		persist();
+		return null;
+	}
+	return { thumbnail: entry.thumbnail, title: entry.title };
+}
+
+export function getCachedSpotifyChartMetaMap(ids: string[]): Record<string, SpotifyChartMeta> {
+	hydrate();
+	const out: Record<string, SpotifyChartMeta> = {};
+	for (const id of ids) {
+		const entry = getCachedSpotifyChartMeta(id);
+		if (entry) out[id] = entry;
+	}
+	return out;
+}
+
+export function putCachedSpotifyChartMeta(id: string, playlist: SpotifyPlaylistDetail): void {
+	hydrate();
+	cache[id] = {
+		thumbnail: playlist.thumbnail,
+		title: playlist.title,
+		insertedAt: Date.now(),
+	};
+	persist();
+}
+
+export function clearSpotifyChartMetaCache(): void {
+	cache = {};
+	hydrated = true;
+	if (typeof localStorage !== 'undefined') {
+		try {
+			localStorage.removeItem(STORAGE_KEY);
+		} catch {
+			/* ignore */
+		}
+	}
+}

--- a/frontend/src/lib/stores/tidal-moods-cache.test.ts
+++ b/frontend/src/lib/stores/tidal-moods-cache.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test, beforeEach } from 'vitest';
+import {
+	clearCachedMoods,
+	getCachedMoodCategories,
+	moodCategoriesNeedThumbnails,
+	putCompleteMoodCategories,
+} from './tidal-moods-cache';
+import type { TidalMoodCategory } from '$lib/api/client';
+
+const completeCategories: TidalMoodCategory[] = [
+	{
+		slug: 'mood_party',
+		title: 'Party',
+		icon: null,
+		imageId: null,
+		thumbnail: 'https://resources.tidal.com/images/party/320x320.jpg',
+	},
+];
+
+const incompleteCategories: TidalMoodCategory[] = [
+	{
+		slug: 'mood_party',
+		title: 'Party',
+		icon: null,
+		imageId: null,
+		thumbnail: null,
+	},
+];
+
+describe('TIDAL moods cache', () => {
+	beforeEach(() => {
+		clearCachedMoods();
+	});
+
+	test('treats mood lists without thumbnails as provisional', () => {
+		expect(moodCategoriesNeedThumbnails(incompleteCategories)).toBe(true);
+		expect(moodCategoriesNeedThumbnails(completeCategories)).toBe(false);
+	});
+
+	test('does not cache incomplete mood thumbnail probes for six hours', () => {
+		putCompleteMoodCategories(incompleteCategories);
+
+		expect(getCachedMoodCategories()).toBeNull();
+
+		putCompleteMoodCategories(completeCategories);
+
+		expect(getCachedMoodCategories()).toEqual(completeCategories);
+	});
+});

--- a/frontend/src/lib/stores/tidal-moods-cache.ts
+++ b/frontend/src/lib/stores/tidal-moods-cache.ts
@@ -33,6 +33,14 @@ export function putCachedMoodCategories(categories: TidalMoodCategory[]): void {
 	landing = { categories, insertedAt: Date.now() };
 }
 
+export function moodCategoriesNeedThumbnails(categories: TidalMoodCategory[]): boolean {
+	return categories.length > 0 && categories.some((category) => !category.thumbnail);
+}
+
+export function putCompleteMoodCategories(categories: TidalMoodCategory[]): void {
+	if (!moodCategoriesNeedThumbnails(categories)) putCachedMoodCategories(categories);
+}
+
 export function getCachedMoodPage(slug: string): TidalHomeModule[] | null {
 	const e = drilldown.get(slug);
 	if (!e) return null;

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -77,7 +77,7 @@
 		TIDAL_PKCE_RELOGIN_DISMISSED_KEY,
 		shouldShowLegacyReloginNotice,
 	} from '$lib/tidal/login';
-	import { paletteById } from '$lib/components/wallpaper/palettes';
+	import { paletteById, rgbaCss } from '$lib/components/wallpaper/palettes';
 	import {
 		MOBILE_MORE_ROUTES,
 		MOBILE_TAB_ROUTES,
@@ -583,6 +583,9 @@
 		root.setProperty('--accent-soft', p.ui.accentSoft);
 		root.setProperty('--accent-line', p.ui.accentLine);
 		root.setProperty('--accent-glow', p.ui.accentGlow);
+		root.setProperty('--atlas-haze-a', rgbaCss(p.shader.c2, 0.18));
+		root.setProperty('--atlas-haze-b', rgbaCss(p.shader.c3, 0.13));
+		root.setProperty('--atlas-haze-c', rgbaCss(p.shader.c4, 0.10));
 	}
 
 	function toggleTheme() {

--- a/frontend/src/routes/charts/+page.svelte
+++ b/frontend/src/routes/charts/+page.svelte
@@ -5,6 +5,9 @@
   import { goto } from '$app/navigation';
   import TrendingShelf from '$lib/components/charts/TrendingShelf.svelte';
   import DailyChartShelf from '$lib/components/charts/DailyChartShelf.svelte';
+  import PageHeader from '$lib/components/ui/PageHeader.svelte';
+  import SectionHeader from '$lib/components/ui/SectionHeader.svelte';
+  import ArtworkImage from '$lib/components/ui/ArtworkImage.svelte';
   import {
     getCachedSpotifyChartMetaMap,
     putCachedSpotifyChartMeta,
@@ -82,24 +85,28 @@
 <svelte:head><title>Charts . NOOR</title></svelte:head>
 
 <div class="page">
-  <header class="page-header">
-    <p class="eyebrow">Charts</p>
-    <h1>What's hot</h1>
-    <p class="sub">Worldwide trending tracks from Last.fm and editorial Spotify chart playlists.</p>
-  </header>
+  <PageHeader
+    eyebrow="Charts"
+    title="What's hot"
+    subtitle="Worldwide trending tracks from Last.fm and editorial Spotify chart playlists."
+    variant="editorial"
+  />
 
   <section class="trending-block">
-    <TrendingShelf limit={12} />
+    <TrendingShelf limit={20} />
   </section>
 
   <section class="daily-block">
     <DailyChartShelf />
   </section>
 
-  <section>
-    <h2 class="block-title">Spotify chart playlists</h2>
-    <p class="block-sub">Click any to play on TIDAL.</p>
-  </section>
+  <SectionHeader
+    eyebrow="Spotify playlists"
+    title="Chart playlists"
+    subtitle="Click any to play on TIDAL."
+    variant="charts"
+    level={2}
+  />
 
   <div class="grid">
     {#each CHARTS as c (c.id)}
@@ -110,11 +117,13 @@
         oncontextmenu={(e) => { e.preventDefault(); openContextMenu(e, chartMenu(c.id, c.title), c.title); }}
       >
         <div class="art-wrap">
-          {#if m?.thumbnail}
-            <div class="art" style="background-image:url('{m.thumbnail}')"></div>
-          {:else}
-            <div class="art fallback">M</div>
-          {/if}
+          <ArtworkImage
+            src={m?.thumbnail ?? null}
+            alt={m?.title ?? c.title}
+            size={320}
+            className="chart-playlist-art"
+            fallbackText="M"
+          />
         </div>
         <div class="meta">
           <p class="title">{m?.title ?? c.title}</p>
@@ -126,13 +135,7 @@
 </div>
 
 <style>
-  .page { max-width: var(--content-width); margin: 0 auto; padding: 32px 28px 96px; display: flex; flex-direction: column; gap: 24px; }
-  .page-header { display: flex; flex-direction: column; gap: 4px; }
-  .eyebrow { font-size: var(--font-size-xs); letter-spacing: 0.08em; text-transform: uppercase; color: var(--service-spotify); margin: 0; font-weight: var(--font-weight-bold); }
-  .page-header h1 { margin: 0; font-size: var(--font-size-3xl); font-weight: 800; }
-  .page-header .sub { margin: 0; font-size: var(--font-size-sm); color: var(--text-secondary); }
-  .block-title { margin: 0 0 4px; font-size: var(--font-size-lg); font-weight: var(--font-weight-bold); color: var(--text-primary); }
-  .block-sub { margin: 0 0 var(--space-3); font-size: var(--font-size-sm); color: var(--text-secondary); }
+  .page { max-width: var(--content-width); margin: 0 auto; padding: var(--space-5) var(--space-4) var(--space-7); display: flex; flex-direction: column; gap: var(--space-5); }
   .trending-block { display: flex; flex-direction: column; gap: var(--gap); }
 
   .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(min(180px, 100%), 1fr)); gap: var(--gap); }
@@ -153,9 +156,9 @@
   .card:hover, .card:focus-visible { background: var(--bg-hover); border-color: var(--panel-border); outline: none; }
   .card:focus-visible { border-color: var(--accent-line); }
   .art-wrap { position: relative; aspect-ratio: 1 / 1; width: 100%; border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-hover); }
-  .art { width: 100%; height: 100%; background-size: cover; background-position: center; transition: transform var(--motion-base); }
-  .card:hover .art { transform: scale(1.05); }
-  .art.fallback { display: flex; align-items: center; justify-content: center; font-size: var(--font-size-4xl); color: var(--text-muted); }
+  :global(.chart-playlist-art) { width: 100%; height: 100%; object-fit: cover; transition: transform var(--motion-base); }
+  .card:hover :global(.chart-playlist-art) { transform: scale(1.05); }
+  :global(.chart-playlist-art.fallback) { display: flex; align-items: center; justify-content: center; background: var(--bg-hover); color: var(--text-muted); font-size: var(--font-size-4xl); font-weight: var(--font-weight-bold); }
   .meta { display: flex; flex-direction: column; gap: var(--space-1); min-width: 0; }
   .meta .title { margin: 0; font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; line-height: var(--line-height-snug); }
   .meta .sub { font-size: var(--font-size-xs); color: var(--text-secondary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }

--- a/frontend/src/routes/charts/+page.svelte
+++ b/frontend/src/routes/charts/+page.svelte
@@ -4,6 +4,12 @@
   import { openContextMenu } from '$lib/stores/context_menu';
   import { goto } from '$app/navigation';
   import TrendingShelf from '$lib/components/charts/TrendingShelf.svelte';
+  import DailyChartShelf from '$lib/components/charts/DailyChartShelf.svelte';
+  import {
+    getCachedSpotifyChartMetaMap,
+    putCachedSpotifyChartMeta,
+    type SpotifyChartMeta,
+  } from '$lib/stores/spotify-chart-meta-cache';
 
   // Editorial Spotify chart playlists. Stable IDs that change daily/weekly
   // server-side but the playlist identity is fixed. Click navigates to the
@@ -27,14 +33,19 @@
 
   // Best-effort cover fetch. The playlist endpoint also returns tracks and
   // TIDAL resolution state, so keep these requests away from first paint.
-  let meta = $state<Record<string, { thumbnail: string | null; title: string | null }>>({});
+  let meta = $state<Record<string, SpotifyChartMeta>>({});
   let metaTimer: ReturnType<typeof setTimeout> | null = null;
   let metaAbort: AbortController | null = null;
 
   onMount(() => {
+    const cached = getCachedSpotifyChartMetaMap(CHARTS.map((chart) => chart.id));
+    meta = cached;
+    const missing = CHARTS.filter((chart) => !cached[chart.id]);
+    if (missing.length === 0) return;
+
     metaAbort = new AbortController();
     metaTimer = setTimeout(() => {
-      void loadPlaylistMeta(metaAbort?.signal);
+      void loadPlaylistMeta(missing, metaAbort?.signal);
     }, 1600);
   });
 
@@ -43,14 +54,15 @@
     metaAbort?.abort();
   });
 
-  async function loadPlaylistMeta(signal: AbortSignal | undefined) {
-    const queue = [...CHARTS];
+  async function loadPlaylistMeta(charts: typeof CHARTS, signal: AbortSignal | undefined) {
+    const queue = [...charts];
     const workers = Array.from({ length: 2 }, async () => {
       while (queue.length > 0 && !signal?.aborted) {
         const c = queue.shift();
         if (!c) return;
         try {
           const { playlist } = await api.getSpotifyPlaylist(c.id, signal);
+          putCachedSpotifyChartMeta(c.id, playlist);
           meta[c.id] = { thumbnail: playlist.thumbnail, title: playlist.title };
         } catch {
           // Quiet: proxy outage just keeps the fallback glyph + hardcoded title.
@@ -78,6 +90,10 @@
 
   <section class="trending-block">
     <TrendingShelf limit={12} />
+  </section>
+
+  <section class="daily-block">
+    <DailyChartShelf />
   </section>
 
   <section>

--- a/frontend/src/routes/charts/+page.svelte
+++ b/frontend/src/routes/charts/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { onDestroy, onMount } from 'svelte';
   import { api } from '$lib/api/client';
   import { openContextMenu } from '$lib/stores/context_menu';
   import { goto } from '$app/navigation';
@@ -25,24 +25,40 @@
     { id: '37i9dQZF1DX4dyzvuaRJ0n', title: 'mint', sub: 'Editorial' },
   ];
 
-  // Best-effort cover fetch. The existing playlist endpoint also returns
-  // tracks + does TIDAL resolution server-side, so this is heavier than it
-  // needs to be -- see FOLLOWUPS for a lightweight metadata endpoint. When
-  // the sportify proxy is slow or down, cards just fall back to the glyph.
+  // Best-effort cover fetch. The playlist endpoint also returns tracks and
+  // TIDAL resolution state, so keep these requests away from first paint.
   let meta = $state<Record<string, { thumbnail: string | null; title: string | null }>>({});
+  let metaTimer: ReturnType<typeof setTimeout> | null = null;
+  let metaAbort: AbortController | null = null;
 
   onMount(() => {
-    void Promise.allSettled(
-      CHARTS.map(async (c) => {
+    metaAbort = new AbortController();
+    metaTimer = setTimeout(() => {
+      void loadPlaylistMeta(metaAbort?.signal);
+    }, 1600);
+  });
+
+  onDestroy(() => {
+    if (metaTimer) clearTimeout(metaTimer);
+    metaAbort?.abort();
+  });
+
+  async function loadPlaylistMeta(signal: AbortSignal | undefined) {
+    const queue = [...CHARTS];
+    const workers = Array.from({ length: 2 }, async () => {
+      while (queue.length > 0 && !signal?.aborted) {
+        const c = queue.shift();
+        if (!c) return;
         try {
-          const { playlist } = await api.getSpotifyPlaylist(c.id);
+          const { playlist } = await api.getSpotifyPlaylist(c.id, signal);
           meta[c.id] = { thumbnail: playlist.thumbnail, title: playlist.title };
         } catch {
           // Quiet: proxy outage just keeps the fallback glyph + hardcoded title.
         }
-      }),
-    );
-  });
+      }
+    });
+    await Promise.allSettled(workers);
+  }
 
   function chartMenu(id: string, title: string) {
     return [

--- a/frontend/src/routes/dj/dj_page_contract.test.ts
+++ b/frontend/src/routes/dj/dj_page_contract.test.ts
@@ -112,8 +112,12 @@ describe('dj cockpit page contract', () => {
 		expect(transitionLane).toContain('current_profile_decode_failed');
 		expect(queuePair).toContain('Analysis failed');
 		expect(queuePair).toContain('Retrying analysis');
+		expect(queuePair).toContain('Retrying analysis in');
+		expect(queuePair).toContain('TIDAL asset unavailable');
 		expect(queuePair).toContain('Analyzing');
 		expect(queuePair).toContain('profile_error');
+		expect(queuePair).toContain('profile_retry_after_ms');
+		expect(queuePair).toContain('profile_retry_reason');
 		expect(queuePair).toContain('Passive DSP retrying');
 		expect(queuePair).toContain('passive_analysis_status');
 		expect(queuePair).toContain('passive_analysis_reason');

--- a/frontend/src/routes/moods/+page.svelte
+++ b/frontend/src/routes/moods/+page.svelte
@@ -1,16 +1,20 @@
 <script lang="ts">
   import { onMount, untrack } from 'svelte';
   import { ApiError, api, type TidalMoodCategory } from '$lib/api/client';
+  import ArtworkImage from '$lib/components/ui/ArtworkImage.svelte';
   import { tidalStatus } from '$lib/stores/tidal';
   import { openContextMenu } from '$lib/stores/context_menu';
   import { goto } from '$app/navigation';
   import {
     getCachedMoodCategories,
-    putCachedMoodCategories,
+    moodCategoriesNeedThumbnails,
+    putCompleteMoodCategories,
     clearCachedMoods,
   } from '$lib/stores/tidal-moods-cache';
 
   type State = 'loading' | 'ready' | 'empty' | 'disconnected' | 'error';
+  const THUMBNAIL_REFRESH_DELAY_MS = 1800;
+  const MAX_THUMBNAIL_REFRESH_ATTEMPTS = 3;
 
   // Sync-read the cache on script init so revisiting /moods within the
   // 6h TTL renders instantly without a skeleton flash. Mirrors the
@@ -20,10 +24,17 @@
   let viewState = $state<State>(
     cachedOnMount && cachedOnMount.length > 0 ? 'ready' : 'loading'
   );
+  let inFlight = false;
+  let thumbnailRefreshAttempts = 0;
+  let thumbnailRefreshTimer: ReturnType<typeof setTimeout> | null = null;
 
   onMount(() => {
-    if (cachedOnMount && cachedOnMount.length > 0) return;
+    if (cachedOnMount && cachedOnMount.length > 0) {
+      if (moodCategoriesNeedThumbnails(cachedOnMount)) scheduleThumbnailRefresh(cachedOnMount);
+      return () => clearThumbnailRefresh();
+    }
     void load();
+    return () => clearThumbnailRefresh();
   });
 
   $effect(() => {
@@ -33,12 +44,15 @@
   });
 
   async function load() {
-    viewState = 'loading';
+    if (inFlight) return;
+    inFlight = true;
+    if (categories.length === 0) viewState = 'loading';
     try {
       const data = await api.getTidalMoods();
       categories = data.categories ?? [];
-      if (categories.length > 0) putCachedMoodCategories(categories);
+      if (categories.length > 0) putCompleteMoodCategories(categories);
       viewState = categories.length > 0 ? 'ready' : 'empty';
+      scheduleThumbnailRefresh(categories);
     } catch (e) {
       if (e instanceof ApiError && e.status === 503) {
         clearCachedMoods();
@@ -46,7 +60,26 @@
       } else {
         viewState = 'error';
       }
+    } finally {
+      inFlight = false;
     }
+  }
+
+  function clearThumbnailRefresh() {
+    if (!thumbnailRefreshTimer) return;
+    clearTimeout(thumbnailRefreshTimer);
+    thumbnailRefreshTimer = null;
+  }
+
+  function scheduleThumbnailRefresh(nextCategories: TidalMoodCategory[]) {
+    clearThumbnailRefresh();
+    if (!moodCategoriesNeedThumbnails(nextCategories)) {
+      thumbnailRefreshAttempts = 0;
+      return;
+    }
+    if (thumbnailRefreshAttempts >= MAX_THUMBNAIL_REFRESH_ATTEMPTS) return;
+    thumbnailRefreshAttempts += 1;
+    thumbnailRefreshTimer = setTimeout(() => void load(), THUMBNAIL_REFRESH_DELAY_MS);
   }
 
   function buildMenu(slug: string, title: string) {
@@ -74,11 +107,13 @@
           oncontextmenu={(e) => { e.preventDefault(); openContextMenu(e, buildMenu(c.slug, c.title), c.title); }}
         >
           <div class="art-wrap">
-            {#if c.thumbnail}
-              <div class="art" style="background-image:url('{c.thumbnail}')"></div>
-            {:else}
-              <div class="art fallback">~</div>
-            {/if}
+            <ArtworkImage
+              className="mood-art"
+              src={c.thumbnail}
+              alt={c.title}
+              size={320}
+              fallbackText="~"
+            />
           </div>
           <p class="card-title">{c.title}</p>
         </a>
@@ -120,8 +155,9 @@
   .card:hover, .card:focus-visible { background: var(--bg-hover); border-color: var(--panel-border); outline: none; }
   .card:focus-visible { border-color: var(--accent-line); }
   .art-wrap { position: relative; aspect-ratio: 1 / 1; width: 100%; border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-hover); }
-  .art { width: 100%; height: 100%; background-size: cover; background-position: center; transition: transform var(--motion-base); }
-  .card:hover .art { transform: scale(1.05); }
-  .art.fallback { display: flex; align-items: center; justify-content: center; font-size: var(--font-size-4xl); color: var(--text-muted); }
+  :global(.mood-art) { width: 100%; height: 100%; object-fit: cover; display: block; transition: transform var(--motion-base); }
+  :global(.mood-art.fallback) { display: flex; align-items: center; justify-content: center; background: var(--bg-hover); }
+  :global(.mood-art.fallback span) { font-size: var(--font-size-4xl); color: var(--text-muted); }
+  .card:hover :global(.mood-art) { transform: scale(1.05); }
   .card-title { margin: 0; font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; line-height: var(--line-height-snug); }
 </style>

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -66,7 +66,7 @@
 		WALLPAPER_FPS_MAX,
 		WALLPAPER_FPS_MIN
 	} from '$lib/stores/wallpaper';
-	import { PALETTES, type PaletteId } from '$lib/components/wallpaper/palettes';
+	import { PALETTES, rgbCss, type Palette, type PaletteId } from '$lib/components/wallpaper/palettes';
 	import { palette, setPalette } from '$lib/stores/palette';
 	import { uiZoom, setZoom, zoomIn, zoomOut, resetZoom, MIN as ZOOM_MIN, MAX as ZOOM_MAX, WHEEL_STEP as ZOOM_STEP } from '$lib/stores/uiZoom';
 	import { audioSettings } from '$lib/stores/audio_settings';
@@ -1501,10 +1501,6 @@
 		visibleSettingsCategories.find((category) => category.id === activeCategory) ?? visibleSettingsCategories[0]
 	);
 
-	function rgbCss(c: [number, number, number]): string {
-		return `rgb(${Math.round(c[0] * 255)}, ${Math.round(c[1] * 255)}, ${Math.round(c[2] * 255)})`;
-	}
-
 	let activePalette = $derived(PALETTES.find((p) => p.id === $palette) ?? PALETTES[0]);
 	let activeSwatches = $derived([
 		activePalette.shader.c1,
@@ -1513,6 +1509,34 @@
 		activePalette.shader.c4
 	]);
 	let extendedWallpaperCount = $derived(WALLPAPERS.filter((option) => option.extended).length);
+	let paletteMenuOpen = $state(false);
+
+	function paletteSwatchesFor(p: Palette) {
+		return [p.shader.c1, p.shader.c2, p.shader.c3, p.shader.c4];
+	}
+
+	function choosePalette(id: PaletteId) {
+		setPalette(id);
+		paletteMenuOpen = false;
+	}
+
+	function closePaletteMenuOnFocusOut(e: FocusEvent) {
+		const current = e.currentTarget;
+		const next = e.relatedTarget;
+		if (!(current instanceof HTMLElement)) return;
+		if (next instanceof Node && current.contains(next)) return;
+		paletteMenuOpen = false;
+	}
+
+	function onPaletteTriggerKeydown(e: KeyboardEvent) {
+		if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
+			e.preventDefault();
+			paletteMenuOpen = true;
+		}
+		if (e.key === 'Escape') {
+			paletteMenuOpen = false;
+		}
+	}
 </script>
 
 <svelte:head>
@@ -1608,18 +1632,71 @@
 	>
 		<div class="settings-main">
 			{#if activeCategory === 'appearance'}
-			<section class="glass-panel section-panel">
-				<SectionHeader eyebrow="Palette" title="Colour scheme" subtitle="UI accent and wallpaper colors." />
+			<section class="glass-panel section-panel palette-section" class:palette-section-open={paletteMenuOpen}>
+				<SectionHeader eyebrow="Palette" title="Colour scheme" subtitle="UI accent, wallpaper, and no-wallpaper colours." />
 				<div class="palette-row">
-					<select
-						class="palette-select"
-						value={$palette}
-						onchange={(e) => setPalette((e.currentTarget as HTMLSelectElement).value as PaletteId)}
+					<div
+						class="palette-picker"
+						onfocusout={closePaletteMenuOnFocusOut}
 					>
-						{#each PALETTES as p (p.id)}
-							<option value={p.id}>{p.label} — {p.sublabel}</option>
-						{/each}
-					</select>
+						<button
+							type="button"
+							class="palette-trigger"
+							aria-haspopup="listbox"
+							aria-expanded={paletteMenuOpen}
+							onclick={() => (paletteMenuOpen = !paletteMenuOpen)}
+							onkeydown={onPaletteTriggerKeydown}
+						>
+							<span class="palette-band" aria-hidden="true">
+								<svg viewBox="0 0 96 16" preserveAspectRatio="none">
+									<defs>
+										<linearGradient id="active-palette-band" x1="0" x2="1" y1="0" y2="0">
+											{#each activeSwatches as c, i (i)}
+												<stop offset={`${(i / (activeSwatches.length - 1)) * 100}%`} stop-color={rgbCss(c)} />
+											{/each}
+										</linearGradient>
+									</defs>
+									<rect width="96" height="16" rx="3" fill="url(#active-palette-band)" />
+								</svg>
+							</span>
+							<span class="palette-trigger-copy">
+								<strong>{activePalette.label}</strong>
+								<small>{activePalette.sublabel}</small>
+							</span>
+							<span class="palette-trigger-caret" aria-hidden="true">▾</span>
+						</button>
+						{#if paletteMenuOpen}
+							<div class="palette-menu" role="listbox" aria-label="Colour scheme">
+								{#each PALETTES as p (p.id)}
+									<button
+										type="button"
+										class="palette-option"
+										class:active={$palette === p.id}
+										role="option"
+										aria-selected={$palette === p.id}
+										onclick={() => choosePalette(p.id)}
+									>
+										<span class="palette-band" aria-hidden="true">
+											<svg viewBox="0 0 96 16" preserveAspectRatio="none">
+												<defs>
+													<linearGradient id={`palette-band-${p.id}`} x1="0" x2="1" y1="0" y2="0">
+														{#each paletteSwatchesFor(p) as c, i (i)}
+															<stop offset={`${(i / 3) * 100}%`} stop-color={rgbCss(c)} />
+														{/each}
+													</linearGradient>
+												</defs>
+												<rect width="96" height="16" rx="3" fill={`url(#palette-band-${p.id})`} />
+											</svg>
+										</span>
+										<span class="palette-option-copy">
+											<strong>{p.label}</strong>
+											<small>{p.sublabel}</small>
+										</span>
+									</button>
+								{/each}
+							</div>
+						{/if}
+					</div>
 					<div class="palette-swatches" aria-hidden="true">
 						{#each activeSwatches as c, i (i)}
 							<span class="palette-swatch" style={`background: ${rgbCss(c)}`}></span>
@@ -1675,9 +1752,9 @@
 				<div class="wallpaper-big-preview">
 					{#if previewShader}
 						<ShaderWallpaper shader={previewShader} maxDpr={1} targetFps={$wallpaperFps} interactive={true} />
-					{:else if !previewShader && $wallpaper !== 'none'}
-						<div class="wallpaper-big-preview-hint">
-							<span>Hover a tile to preview</span>
+					{:else if previewTileId === 'none' || $wallpaper === 'none'}
+						<div class="wallpaper-none-preview">
+							<span>No wallpaper</span>
 						</div>
 					{:else}
 						<div class="wallpaper-big-preview-hint">
@@ -3422,9 +3499,113 @@
 		flex-wrap: wrap;
 	}
 
-	.palette-select {
+	.palette-picker {
+		position: relative;
 		flex: 1;
 		min-width: 220px;
+	}
+
+	.palette-trigger,
+	.palette-option {
+		width: 100%;
+		display: grid;
+		grid-template-columns: minmax(76px, 96px) minmax(0, 1fr) auto;
+		align-items: center;
+		gap: 10px;
+		text-align: left;
+		border: 1px solid var(--border-subtle);
+		background: color-mix(in srgb, var(--instrument-surface) 78%, transparent);
+		color: var(--text-primary);
+		cursor: pointer;
+	}
+
+	.palette-trigger {
+		min-height: 46px;
+		padding: 8px 10px;
+		border-radius: var(--radius-sm);
+	}
+
+	.palette-trigger:hover,
+	.palette-trigger:focus-visible,
+	.palette-option:hover,
+	.palette-option:focus-visible,
+	.palette-option.active {
+		border-color: color-mix(in srgb, var(--accent-strong) 48%, transparent);
+		background: color-mix(in srgb, var(--accent-soft) 56%, var(--instrument-surface));
+		outline: none;
+	}
+
+	.palette-band {
+		display: block;
+		min-width: 0;
+		height: 16px;
+		border-radius: 4px;
+		overflow: hidden;
+		border: 1px solid rgba(255, 255, 255, 0.16);
+		background: var(--bg-raised);
+		box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.24) inset;
+	}
+
+	.palette-band svg {
+		display: block;
+		width: 100%;
+		height: 100%;
+	}
+
+	.palette-trigger-copy,
+	.palette-option-copy {
+		min-width: 0;
+		display: grid;
+		gap: 2px;
+	}
+
+	.palette-trigger-copy strong,
+	.palette-option-copy strong {
+		font-size: var(--font-size-sm);
+		font-weight: var(--font-weight-semibold);
+		color: var(--text-primary);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.palette-trigger-copy small,
+	.palette-option-copy small {
+		font-size: var(--font-size-xs);
+		color: var(--text-tertiary);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.palette-trigger-caret {
+		font-size: var(--font-size-xs);
+		color: var(--text-secondary);
+		line-height: 1;
+	}
+
+	.palette-menu {
+		position: absolute;
+		inset-inline: 0;
+		top: calc(100% + 6px);
+		z-index: var(--z-overlay);
+		max-height: min(420px, 58vh);
+		overflow-y: auto;
+		display: grid;
+		gap: 4px;
+		padding: 6px;
+		border-radius: var(--radius-sm);
+		border: 1px solid var(--border-strong);
+		background: rgba(10, 10, 14, 0.97);
+		backdrop-filter: var(--blur-modal);
+		-webkit-backdrop-filter: var(--blur-modal);
+		box-shadow: var(--panel-shadow);
+	}
+
+	.palette-option {
+		grid-template-columns: minmax(68px, 88px) minmax(0, 1fr);
+		padding: 8px;
+		border-radius: var(--radius-xs);
 	}
 
 	.palette-swatches {
@@ -3484,6 +3665,32 @@
 		align-items: center;
 		justify-content: center;
 	}
+
+	.wallpaper-none-preview {
+		position: absolute;
+		inset: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background:
+			radial-gradient(circle at 14% 12%, var(--atlas-haze-a), transparent 34%),
+			radial-gradient(circle at 88% 16%, var(--atlas-haze-b), transparent 32%),
+			radial-gradient(circle at 72% 88%, var(--atlas-haze-c), transparent 34%),
+			var(--atlas-bg);
+	}
+
+	.wallpaper-none-preview span {
+		padding: 5px 10px;
+		border-radius: 999px;
+		border: 1px solid var(--border-subtle);
+		background: color-mix(in srgb, var(--bg-base) 68%, transparent);
+		color: var(--text-secondary);
+		font-size: var(--font-size-xs);
+		font-weight: var(--font-weight-semibold);
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+	}
+
 	.wallpaper-big-preview-hint span {
 		font-size: var(--font-size-xs);
 		letter-spacing: 0.08em;
@@ -3588,9 +3795,9 @@
 
 	.wallpaper-tile-swatch-none {
 		background:
-			radial-gradient(circle at 30% 30%, rgba(151, 126, 255, 0.35), transparent 60%),
-			radial-gradient(circle at 70% 70%, rgba(120, 160, 255, 0.25), transparent 60%),
-			#0a0a0e;
+			radial-gradient(circle at 28% 28%, var(--atlas-haze-a), transparent 64%),
+			radial-gradient(circle at 76% 72%, var(--atlas-haze-b), transparent 62%),
+			var(--atlas-bg);
 	}
 
 	.wallpaper-tile-label {
@@ -3665,6 +3872,11 @@
 		flex-direction: column;
 		gap: 14px;
 		border-radius: var(--radius-md);
+	}
+
+	.palette-section-open {
+		position: relative;
+		z-index: calc(var(--z-overlay) + 1);
 	}
 
 	.settings-grid.single-column .settings-main {

--- a/noor-mix/src/planner/mod.rs
+++ b/noor-mix/src/planner/mod.rs
@@ -439,6 +439,7 @@ pub fn drop_preview_16_program(
     sample_rate: u32,
     channels: u16,
     duration_ms: u32,
+    outgoing: &DjProfile,
     incoming: &DjProfile,
 ) -> Option<TransitionProgram> {
     let sample_rate = sample_rate.max(1);
@@ -447,6 +448,18 @@ pub fn drop_preview_16_program(
         (u64::from(duration_ms).saturating_mul(u64::from(sample_rate)) / 1_000).max(1);
     let swap_start = duration_samples / 2;
     let drop_frame = first_valid_preview_drop_frame(incoming, sample_rate)?;
+    let rate = drop_preview_autosync_rate(outgoing, incoming)?;
+    let mut automation = drop_preview_overlay_automation(duration_samples);
+    if (rate - 1.0).abs() > PLAYBACK_RATE_EPSILON {
+        automation.push(AutomationEvent {
+            param: Param::PlaybackRate(DeckId::B),
+            start_sample: 0,
+            end_sample: duration_samples,
+            from: rate,
+            to: rate,
+            curve: Curve::Linear,
+        });
+    }
     Some(TransitionProgram {
         tier: Tier::FullBlend,
         template: "DropPreview16".to_string(),
@@ -460,8 +473,20 @@ pub fn drop_preview_16_program(
         fade_start: swap_start,
         resolve_at: duration_samples,
         loops: vec![],
-        automation: drop_preview_overlay_automation(duration_samples),
+        automation,
     })
+}
+
+fn drop_preview_autosync_rate(outgoing: &DjProfile, incoming: &DjProfile) -> Option<f32> {
+    let outgoing_bpm = outgoing.bpm?.max(1.0);
+    let incoming_bpm = incoming.bpm?.max(1.0);
+    let comparable_incoming_bpm = scoring::nearest_tempo_family_bpm(outgoing_bpm, incoming_bpm);
+    if scoring::bpm_delta_pct(outgoing_bpm, comparable_incoming_bpm) > 3.0 {
+        return None;
+    }
+    let rate = outgoing_bpm / comparable_incoming_bpm;
+    (rate.is_finite() && (SMALL_TEMPO_NUDGE_MIN..=SMALL_TEMPO_NUDGE_MAX).contains(&rate))
+        .then_some(rate)
 }
 
 fn duration_samples(template: TransitionTemplate, policy: &Policy, bar_samples: u64) -> u64 {
@@ -1539,10 +1564,12 @@ mod tests {
 
     #[test]
     fn drop_preview_16_program_aligns_profile_drop_to_preview_midpoint() {
+        let outgoing = profile(Some(120.0), Some("8A"), 4);
         let mut incoming = profile(Some(120.0), Some("8A"), 4);
         incoming.drop_seconds = vec![32.0];
 
-        let program = drop_preview_16_program(48_000, 2, 16_000, &incoming).expect("drop preview");
+        let program =
+            drop_preview_16_program(48_000, 2, 16_000, &outgoing, &incoming).expect("drop preview");
 
         assert_eq!(program.template, "DropPreview16");
         assert_eq!(program.resolve_at, 768_000);
@@ -1553,28 +1580,33 @@ mod tests {
 
     #[test]
     fn drop_preview_16_program_prefers_manual_drop_marker() {
+        let outgoing = profile(Some(120.0), Some("8A"), 4);
         let mut incoming = profile(Some(120.0), Some("8A"), 4);
         incoming.drop_seconds = vec![32.0];
         incoming.manual_drop_seconds = vec![24.0];
 
-        let program = drop_preview_16_program(48_000, 2, 16_000, &incoming).expect("drop preview");
+        let program =
+            drop_preview_16_program(48_000, 2, 16_000, &outgoing, &incoming).expect("drop preview");
 
         assert_eq!(program.deck_b_start_frame, 768_000);
     }
 
     #[test]
     fn drop_preview_16_program_rejects_missing_drop_marker() {
+        let outgoing = profile(Some(120.0), Some("8A"), 4);
         let incoming = profile(Some(120.0), Some("8A"), 4);
 
-        assert!(drop_preview_16_program(48_000, 2, 16_000, &incoming).is_none());
+        assert!(drop_preview_16_program(48_000, 2, 16_000, &outgoing, &incoming).is_none());
     }
 
     #[test]
     fn drop_preview_16_program_caps_preview_gain() {
+        let outgoing = profile(Some(120.0), Some("8A"), 4);
         let mut incoming = profile(Some(120.0), Some("8A"), 4);
         incoming.drop_seconds = vec![32.0];
 
-        let program = drop_preview_16_program(48_000, 2, 16_000, &incoming).expect("drop preview");
+        let program =
+            drop_preview_16_program(48_000, 2, 16_000, &outgoing, &incoming).expect("drop preview");
 
         assert!(program.automation.iter().any(|event| {
             event.param == Param::DeckGain(DeckId::A) && event.from == 0.0 && event.to == 0.0
@@ -1585,6 +1617,33 @@ mod tests {
         assert!(!program.automation.iter().any(|event| {
             event.param == Param::DeckGain(DeckId::B) && (event.from == 1.0 || event.to == 1.0)
         }));
+    }
+
+    #[test]
+    fn drop_preview_16_program_autosyncs_small_tempo_delta() {
+        let outgoing = profile(Some(120.0), Some("8A"), 4);
+        let mut incoming = profile(Some(122.0), Some("8A"), 4);
+        incoming.drop_seconds = vec![32.0];
+
+        let program =
+            drop_preview_16_program(48_000, 2, 16_000, &outgoing, &incoming).expect("drop preview");
+        let rate = program
+            .automation
+            .iter()
+            .find(|event| event.param == Param::PlaybackRate(DeckId::B))
+            .expect("incoming playback rate automation");
+
+        assert!((rate.from - 120.0 / 122.0).abs() < 0.0001);
+        assert_eq!(rate.from, rate.to);
+    }
+
+    #[test]
+    fn drop_preview_16_program_rejects_unsyncable_tempo_delta() {
+        let outgoing = profile(Some(120.0), Some("8A"), 4);
+        let mut incoming = profile(Some(130.0), Some("8A"), 4);
+        incoming.drop_seconds = vec![32.0];
+
+        assert!(drop_preview_16_program(48_000, 2, 16_000, &outgoing, &incoming).is_none());
     }
 
     #[test]

--- a/noor-mix/src/planner/mod.rs
+++ b/noor-mix/src/planner/mod.rs
@@ -1538,6 +1538,56 @@ mod tests {
     }
 
     #[test]
+    fn drop_preview_16_program_aligns_profile_drop_to_preview_midpoint() {
+        let mut incoming = profile(Some(120.0), Some("8A"), 4);
+        incoming.drop_seconds = vec![32.0];
+
+        let program = drop_preview_16_program(48_000, 2, 16_000, &incoming).expect("drop preview");
+
+        assert_eq!(program.template, "DropPreview16");
+        assert_eq!(program.resolve_at, 768_000);
+        assert_eq!(program.swap_start, 384_000);
+        assert_eq!(program.deck_b_start_frame, 1_152_000);
+        program.validate().expect("drop preview program");
+    }
+
+    #[test]
+    fn drop_preview_16_program_prefers_manual_drop_marker() {
+        let mut incoming = profile(Some(120.0), Some("8A"), 4);
+        incoming.drop_seconds = vec![32.0];
+        incoming.manual_drop_seconds = vec![24.0];
+
+        let program = drop_preview_16_program(48_000, 2, 16_000, &incoming).expect("drop preview");
+
+        assert_eq!(program.deck_b_start_frame, 768_000);
+    }
+
+    #[test]
+    fn drop_preview_16_program_rejects_missing_drop_marker() {
+        let incoming = profile(Some(120.0), Some("8A"), 4);
+
+        assert!(drop_preview_16_program(48_000, 2, 16_000, &incoming).is_none());
+    }
+
+    #[test]
+    fn drop_preview_16_program_caps_preview_gain() {
+        let mut incoming = profile(Some(120.0), Some("8A"), 4);
+        incoming.drop_seconds = vec![32.0];
+
+        let program = drop_preview_16_program(48_000, 2, 16_000, &incoming).expect("drop preview");
+
+        assert!(program.automation.iter().any(|event| {
+            event.param == Param::DeckGain(DeckId::A) && event.from == 0.0 && event.to == 0.0
+        }));
+        assert!(program.automation.iter().any(|event| {
+            event.param == Param::DeckGain(DeckId::B) && event.from == 0.65 && event.to == 0.65
+        }));
+        assert!(!program.automation.iter().any(|event| {
+            event.param == Param::DeckGain(DeckId::B) && (event.from == 1.0 || event.to == 1.0)
+        }));
+    }
+
+    #[test]
     fn filter_sweep_eq_wash_program_uses_requested_duration() {
         let program = filter_sweep_eq_wash_program(48_000, 2, 10_000);
 

--- a/noor-mix/src/planner/mod.rs
+++ b/noor-mix/src/planner/mod.rs
@@ -59,7 +59,11 @@ impl Planner {
         else {
             return TransitionTemplate::SafeCrossfade;
         };
-        if camelot_distance > 7 {
+        let harmonic_fit = matches!(camelot_distance, 0 | 1 | 7);
+        if !harmonic_fit {
+            if bold_filter_candidate {
+                return TransitionTemplate::FilterSweep;
+            }
             return TransitionTemplate::SafeCrossfade;
         }
 
@@ -69,7 +73,7 @@ impl Planner {
                 && incoming.has_full_dj_profile()
                 && outgoing.phrase_bar_indices.len() >= 2
                 && incoming.phrase_bar_indices.len() >= 2
-                && matches!(camelot_distance, 0 | 1 | 7))
+                && harmonic_fit)
         {
             return TransitionTemplate::SafeCrossfade;
         }
@@ -82,7 +86,7 @@ impl Planner {
         if outgoing_phrases >= 2 && incoming_phrases >= 2 && bpm_delta <= 3.0 {
             return TransitionTemplate::BassSwap16;
         }
-        if matches!(camelot_distance, 0 | 1 | 7) && bpm_delta <= 3.0 {
+        if harmonic_fit && bpm_delta <= 3.0 {
             return TransitionTemplate::LongHarmonicBlend;
         }
         if bold_filter_candidate {
@@ -888,6 +892,18 @@ mod tests {
                 &Policy::default()
             ),
             TransitionTemplate::LongHarmonicBlend
+        );
+    }
+
+    #[test]
+    fn choose_template_rejects_distant_same_mode_camelot_for_balanced_intent() {
+        assert_eq!(
+            Planner::choose_template(
+                &profile(Some(120.0), Some("8A"), 4),
+                &profile(Some(121.0), Some("3A"), 4),
+                &Policy::default()
+            ),
+            TransitionTemplate::SafeCrossfade
         );
     }
 

--- a/noor-mix/src/planner/mod.rs
+++ b/noor-mix/src/planner/mod.rs
@@ -40,14 +40,14 @@ impl Planner {
         if drop_tease_candidate_ready(outgoing, incoming, policy) {
             return TransitionTemplate::DropTease16;
         }
-        if matches!(policy.mix_intent, MixIntent::Bold)
+        let bold_filter_candidate = matches!(policy.mix_intent, MixIntent::Bold)
             && !outgoing.phrase_bar_indices.is_empty()
-            && !incoming.phrase_bar_indices.is_empty()
-        {
-            return TransitionTemplate::FilterSweep;
-        }
+            && !incoming.phrase_bar_indices.is_empty();
 
         if bpm_delta > 8.0 {
+            if bold_filter_candidate {
+                return TransitionTemplate::FilterSweep;
+            }
             return TransitionTemplate::SlamCut;
         }
 
@@ -84,6 +84,9 @@ impl Planner {
         }
         if matches!(camelot_distance, 0 | 1 | 7) && bpm_delta <= 3.0 {
             return TransitionTemplate::LongHarmonicBlend;
+        }
+        if bold_filter_candidate {
+            return TransitionTemplate::FilterSweep;
         }
         TransitionTemplate::FilterSweep
     }
@@ -905,7 +908,7 @@ mod tests {
     }
 
     #[test]
-    fn choose_template_bold_prefers_filter_sweep_for_compatible_profiles() {
+    fn choose_template_bold_preserves_bass_swap_32_for_compatible_profiles() {
         let policy = Policy {
             mix_intent: MixIntent::Bold,
             ..Policy::default()
@@ -916,7 +919,39 @@ mod tests {
                 &profile(Some(121.0), Some("8A"), 32),
                 &policy
             ),
-            TransitionTemplate::FilterSweep
+            TransitionTemplate::BassSwap32
+        );
+    }
+
+    #[test]
+    fn choose_template_bold_preserves_bass_swap_16_for_medium_phrases() {
+        let policy = Policy {
+            mix_intent: MixIntent::Bold,
+            ..Policy::default()
+        };
+        assert_eq!(
+            Planner::choose_template(
+                &profile(Some(120.0), Some("8A"), 2),
+                &profile(Some(121.0), Some("8A"), 2),
+                &policy
+            ),
+            TransitionTemplate::BassSwap16
+        );
+    }
+
+    #[test]
+    fn choose_template_bold_preserves_long_harmonic_blend_for_short_compatible_profiles() {
+        let policy = Policy {
+            mix_intent: MixIntent::Bold,
+            ..Policy::default()
+        };
+        assert_eq!(
+            Planner::choose_template(
+                &profile(Some(120.0), Some("8A"), 1),
+                &profile(Some(121.0), Some("9A"), 1),
+                &policy
+            ),
+            TransitionTemplate::LongHarmonicBlend
         );
     }
 
@@ -1366,7 +1401,7 @@ mod tests {
             &profile(Some(121.0), Some("8A"), 4),
             &bold,
         );
-        assert_eq!(selected, TransitionTemplate::FilterSweep);
+        assert_eq!(selected, TransitionTemplate::BassSwap32);
 
         let policy = Policy {
             safety_template_override: Some(TransitionTemplate::DropTease16),

--- a/noor-mix/src/planner/mod.rs
+++ b/noor-mix/src/planner/mod.rs
@@ -13,6 +13,7 @@ const SMALL_TEMPO_NUDGE_MIN: f32 = 0.97;
 const SMALL_TEMPO_NUDGE_MAX: f32 = 1.03;
 const PLAYBACK_RATE_EPSILON: f32 = 0.0001;
 const DROP_TEASE_CONFIDENCE_FLOOR: f32 = 0.65;
+const DROP_PREVIEW_GAIN: f32 = 0.65;
 const PLANNER_SAMPLE_RATE: u32 = 48_000;
 
 pub struct Planner;
@@ -37,9 +38,6 @@ impl Planner {
         };
         let comparable_incoming_bpm = scoring::nearest_tempo_family_bpm(outgoing_bpm, incoming_bpm);
         let bpm_delta = scoring::bpm_delta_pct(outgoing_bpm, comparable_incoming_bpm);
-        if drop_tease_candidate_ready(outgoing, incoming, policy) {
-            return TransitionTemplate::DropTease16;
-        }
         let bold_filter_candidate = matches!(policy.mix_intent, MixIntent::Bold)
             && !outgoing.phrase_bar_indices.is_empty()
             && !incoming.phrase_bar_indices.is_empty();
@@ -181,6 +179,7 @@ fn build_program(
     program
 }
 
+#[allow(dead_code)]
 fn drop_tease_candidate_ready(outgoing: &DjProfile, incoming: &DjProfile, policy: &Policy) -> bool {
     if !matches!(policy.mix_intent, MixIntent::Bold) {
         return false;
@@ -436,6 +435,35 @@ pub fn drop_tease_16_program(
     }
 }
 
+pub fn drop_preview_16_program(
+    sample_rate: u32,
+    channels: u16,
+    duration_ms: u32,
+    incoming: &DjProfile,
+) -> Option<TransitionProgram> {
+    let sample_rate = sample_rate.max(1);
+    let channels = channels.max(1);
+    let duration_samples =
+        (u64::from(duration_ms).saturating_mul(u64::from(sample_rate)) / 1_000).max(1);
+    let swap_start = duration_samples / 2;
+    let drop_frame = first_valid_preview_drop_frame(incoming, sample_rate)?;
+    Some(TransitionProgram {
+        tier: Tier::FullBlend,
+        template: "DropPreview16".to_string(),
+        sample_rate,
+        channels,
+        deck_a_start_frame: 0,
+        deck_b_start_frame: drop_frame.saturating_sub(swap_start),
+        sync_start: 0,
+        intro_start: 0,
+        swap_start,
+        fade_start: swap_start,
+        resolve_at: duration_samples,
+        loops: vec![],
+        automation: drop_preview_overlay_automation(duration_samples),
+    })
+}
+
 fn duration_samples(template: TransitionTemplate, policy: &Policy, bar_samples: u64) -> u64 {
     match template {
         TransitionTemplate::BassSwap32 => bar_samples * 32,
@@ -533,6 +561,56 @@ fn drop_tease_overlay_automation(duration_samples: u64) -> Vec<AutomationEvent> 
             curve: Curve::EqualPowerIn,
         },
     ]
+}
+
+fn drop_preview_overlay_automation(duration_samples: u64) -> Vec<AutomationEvent> {
+    let end_sample = duration_samples.max(1);
+    let fade_in_end = (end_sample / 4).max(1);
+    let fade_out_start = (end_sample * 3 / 4).max(fade_in_end);
+    vec![
+        AutomationEvent {
+            param: Param::DeckGain(DeckId::A),
+            start_sample: 0,
+            end_sample,
+            from: 0.0,
+            to: 0.0,
+            curve: Curve::Linear,
+        },
+        AutomationEvent {
+            param: Param::DeckGain(DeckId::B),
+            start_sample: 0,
+            end_sample: fade_in_end,
+            from: 0.0,
+            to: DROP_PREVIEW_GAIN,
+            curve: Curve::EqualPowerIn,
+        },
+        AutomationEvent {
+            param: Param::DeckGain(DeckId::B),
+            start_sample: fade_in_end,
+            end_sample: fade_out_start.max(fade_in_end + 1),
+            from: DROP_PREVIEW_GAIN,
+            to: DROP_PREVIEW_GAIN,
+            curve: Curve::Linear,
+        },
+        AutomationEvent {
+            param: Param::DeckGain(DeckId::B),
+            start_sample: fade_out_start,
+            end_sample,
+            from: DROP_PREVIEW_GAIN,
+            to: 0.0,
+            curve: Curve::EqualPowerIn,
+        },
+    ]
+}
+
+fn first_valid_preview_drop_frame(incoming: &DjProfile, sample_rate: u32) -> Option<u64> {
+    incoming
+        .manual_drop_seconds
+        .iter()
+        .chain(incoming.drop_seconds.iter())
+        .copied()
+        .find(|seconds| seconds.is_finite() && *seconds >= 0.0)
+        .map(|seconds| (seconds * sample_rate as f32).round() as u64)
 }
 
 fn bass_swap_eq_handoff(duration_samples: u64) -> Vec<AutomationEvent> {
@@ -750,6 +828,7 @@ mod tests {
             outro_start_seconds: Some(180.0),
             breakdown_seconds: vec![],
             drop_seconds: vec![],
+            manual_drop_seconds: vec![],
             safe_transition_windows: vec![TransitionWindow {
                 start_seconds: 0.0,
                 end_seconds: 8.0,
@@ -1318,7 +1397,7 @@ mod tests {
     }
 
     #[test]
-    fn choose_template_bold_selects_drop_tease_for_confident_drop_candidate() {
+    fn choose_template_bold_keeps_drop_tease_out_of_end_transition() {
         let policy = Policy {
             mix_intent: MixIntent::Bold,
             ..Policy::default()
@@ -1329,7 +1408,7 @@ mod tests {
 
         assert_eq!(
             Planner::choose_template(&outgoing, &incoming, &policy),
-            TransitionTemplate::DropTease16
+            TransitionTemplate::BassSwap32
         );
     }
 
@@ -1392,7 +1471,7 @@ mod tests {
     #[test]
     fn drop_tease_plan_aligns_incoming_drop_to_overlay_swap() {
         let policy = Policy {
-            mix_intent: MixIntent::Bold,
+            safety_template_override: Some(TransitionTemplate::DropTease16),
             ..Policy::default()
         };
         let outgoing = profile(Some(120.0), Some("8A"), 4);

--- a/noor-mix/src/planner/policy.rs
+++ b/noor-mix/src/planner/policy.rs
@@ -32,7 +32,7 @@ impl Default for Policy {
         Self {
             max_pitch_shift_pct: 3.0,
             energy_step_max: 0.15,
-            default_crossfade_ms: 8_000,
+            default_crossfade_ms: 12_000,
             transition_speed_bias: TransitionSpeedBias::Neutral,
             mix_intent: MixIntent::Balanced,
             safety_template_override: None,

--- a/noor-mix/src/profile.rs
+++ b/noor-mix/src/profile.rs
@@ -14,6 +14,8 @@ pub struct DjProfile {
     pub outro_start_seconds: Option<f32>,
     pub breakdown_seconds: Vec<f32>,
     pub drop_seconds: Vec<f32>,
+    #[serde(default)]
+    pub manual_drop_seconds: Vec<f32>,
     pub safe_transition_windows: Vec<TransitionWindow>,
     pub vocal_presence_by_bar: Vec<f32>,
     pub vocal_density_by_bar: Vec<f32>,

--- a/noor-server/src/db/queries.rs
+++ b/noor-server/src/db/queries.rs
@@ -4730,6 +4730,14 @@ pub struct ExternalTrackCandidateRow {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResolvedLastfmExternalSightingRow {
+    pub seed_track_id: i64,
+    pub resolved_track_id: i64,
+    pub similarity: f64,
+    pub source_payload_json: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExternalTidalResolutionCandidateRow {
     pub id: i64,
     pub title: String,
@@ -5655,14 +5663,29 @@ pub fn get_external_track_candidates_for_training(
         "SELECT id, tidal_id, mbid, dedupe_key, title, artist_name, genre_tags_json,
                 duration_ms, expires_at, updated_at,
                 (
-                    SELECT json_group_array(source)
+                    SELECT json_group_array(tag)
                     FROM (
-                        SELECT DISTINCT source
+                        SELECT DISTINCT source AS tag
                         FROM external_track_candidate_sightings s
                         WHERE s.candidate_id = c.id
                           AND s.expires_at > ?1
-                        ORDER BY source
+                        UNION
+                        SELECT DISTINCT
+                            CASE
+                                WHEN s.source = 'lastfm_similar'
+                                 AND s.source_payload_json LIKE '%\"branch_from\":%'
+                                 AND s.source_payload_json NOT LIKE '%\"branch_from\":null%'
+                                THEN 'lastfm_branch'
+                                WHEN s.source = 'lastfm_similar'
+                                THEN 'lastfm_direct'
+                            END AS tag
+                        FROM external_track_candidate_sightings s
+                        WHERE s.candidate_id = c.id
+                          AND s.expires_at > ?1
+                          AND s.source = 'lastfm_similar'
+                        ORDER BY tag
                     )
+                    WHERE tag IS NOT NULL
                 ) AS source_tags_json,
                 resolved_track_id
          FROM external_track_candidates c
@@ -5686,6 +5709,41 @@ pub fn get_external_track_candidates_for_training(
                 updated_at: row.get(9)?,
                 source_tags_json: row.get(10)?,
                 resolved_track_id: row.get(11)?,
+            })
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(rows)
+}
+
+pub fn get_resolved_lastfm_external_sightings_for_training(
+    conn: &Connection,
+    now: &str,
+    limit: i64,
+) -> Result<Vec<ResolvedLastfmExternalSightingRow>> {
+    let mut stmt = conn.prepare(
+        "SELECT s.seed_track_id,
+                c.resolved_track_id,
+                COALESCE(s.similarity, 0.0),
+                s.source_payload_json
+         FROM external_track_candidate_sightings s
+         JOIN external_track_candidates c ON c.id = s.candidate_id
+         WHERE s.source = 'lastfm_similar'
+           AND s.expires_at > ?1
+           AND c.expires_at > ?1
+           AND c.resolved_track_id IS NOT NULL
+           AND c.resolved_track_id <> s.seed_track_id
+         ORDER BY COALESCE(s.similarity, 0.0) DESC,
+                  s.expires_at DESC,
+                  s.candidate_id DESC
+         LIMIT ?2",
+    )?;
+    let rows = stmt
+        .query_map(params![now, limit.max(1)], |row| {
+            Ok(ResolvedLastfmExternalSightingRow {
+                seed_track_id: row.get(0)?,
+                resolved_track_id: row.get(1)?,
+                similarity: row.get(2)?,
+                source_payload_json: row.get(3)?,
             })
         })?
         .collect::<rusqlite::Result<Vec<_>>>()?;
@@ -9654,7 +9712,112 @@ mod tests {
         assert_eq!(rows[0].dedupe_key, "fresh");
         assert_eq!(
             rows[0].source_tags_json.as_deref(),
-            Some(r#"["lastfm_similar"]"#)
+            Some(r#"["lastfm_direct","lastfm_similar"]"#)
+        );
+    }
+
+    #[test]
+    fn external_training_tags_derive_lastfm_branch_from_cached_payload() {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        schema::run_migrations(&conn).expect("migrations");
+        conn.execute("INSERT INTO artists (id, name) VALUES (1, 'Artist')", [])
+            .expect("seed artist");
+        conn.execute(
+            "INSERT INTO tracks (id, title, artist_id) VALUES (1, 'Seed', 1)",
+            [],
+        )
+        .expect("seed track");
+        let candidate = upsert_external_track_candidate(
+            &conn,
+            &ExternalTrackCandidateUpsert {
+                tidal_id: None,
+                mbid: None,
+                dedupe_key: "branch-candidate".to_string(),
+                title: "Branch".to_string(),
+                artist_name: "Outside".to_string(),
+                genre_tags_json: None,
+                duration_ms: Some(180_000),
+                expires_at: "2026-03-01 00:00:00".to_string(),
+            },
+        )
+        .expect("candidate");
+        upsert_external_candidate_sighting(
+            &conn,
+            &ExternalCandidateSightingUpsert {
+                candidate_id: candidate.id,
+                seed_track_id: 1,
+                source: "lastfm_similar".to_string(),
+                source_payload_json: Some(
+                    r#"{"match":0.42,"branch_from":"Parent Artist - Parent Track"}"#.to_string(),
+                ),
+                similarity: Some(0.42),
+                expires_at: "2026-03-01 00:00:00".to_string(),
+            },
+        )
+        .expect("sighting");
+
+        let rows = get_external_track_candidates_for_training(&conn, "2026-02-01 00:00:00", 10)
+            .expect("training candidates");
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0].source_tags_json.as_deref(),
+            Some(r#"["lastfm_branch","lastfm_similar"]"#)
+        );
+    }
+
+    #[test]
+    fn resolved_lastfm_sightings_for_training_include_cached_payload() {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        schema::run_migrations(&conn).expect("migrations");
+        conn.execute("INSERT INTO artists (id, name) VALUES (1, 'Artist')", [])
+            .expect("seed artist");
+        conn.execute(
+            "INSERT INTO tracks (id, title, artist_id)
+             VALUES (1, 'Seed', 1), (2, 'Resolved', 1)",
+            [],
+        )
+        .expect("seed tracks");
+        let candidate = upsert_external_track_candidate(
+            &conn,
+            &ExternalTrackCandidateUpsert {
+                tidal_id: Some(9002),
+                mbid: None,
+                dedupe_key: "resolved-lastfm".to_string(),
+                title: "Resolved".to_string(),
+                artist_name: "Artist".to_string(),
+                genre_tags_json: None,
+                duration_ms: Some(180_000),
+                expires_at: "2026-03-01 00:00:00".to_string(),
+            },
+        )
+        .expect("candidate");
+        mark_external_candidate_resolved(&conn, Some(9002), "Resolved", "Artist", 2)
+            .expect("mark resolved");
+        upsert_external_candidate_sighting(
+            &conn,
+            &ExternalCandidateSightingUpsert {
+                candidate_id: candidate.id,
+                seed_track_id: 1,
+                source: "lastfm_similar".to_string(),
+                source_payload_json: Some(r#"{"match":0.77}"#.to_string()),
+                similarity: Some(0.77),
+                expires_at: "2026-03-01 00:00:00".to_string(),
+            },
+        )
+        .expect("sighting");
+
+        let rows =
+            get_resolved_lastfm_external_sightings_for_training(&conn, "2026-02-01 00:00:00", 10)
+                .expect("resolved sightings");
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].seed_track_id, 1);
+        assert_eq!(rows[0].resolved_track_id, 2);
+        assert_eq!(rows[0].similarity, 0.77);
+        assert_eq!(
+            rows[0].source_payload_json.as_deref(),
+            Some(r#"{"match":0.77}"#)
         );
     }
 

--- a/noor-server/src/db/queries.rs
+++ b/noor-server/src/db/queries.rs
@@ -4353,27 +4353,44 @@ pub struct TrackSimilarityResult {
 /// Fixes: Stage 1 now enumerates ALL pairs per album/artist (not just MIN/MAX).
 ///        Stage 2 uses indexed temp tables so scores merge correctly.
 pub fn compute_track_similarity(conn: &Connection) -> Result<usize> {
-    // Run all stages inside a single transaction so a kill or error mid-way
-    // can't leave the table in a half-populated state (rows inserted but
-    // component scores never updated). Dropping `tx` without commit rolls back.
-    let tx = conn.unchecked_transaction()?;
-
-    tx.execute("DELETE FROM track_similarity", [])?;
+    // Do the expensive work in temporary tables so the background rebuild does
+    // not hold SQLite's single writer slot while playback is trying to update
+    // playback_state. The real table is swapped in one short transaction at
+    // the end.
+    conn.execute_batch(
+        "
+        DROP TABLE IF EXISTS _track_similarity_build;
+        CREATE TEMP TABLE _track_similarity_build (
+            track_a INTEGER NOT NULL,
+            track_b INTEGER NOT NULL,
+            similarity_score REAL NOT NULL DEFAULT 0,
+            co_listen_score REAL DEFAULT 0,
+            co_album_score REAL DEFAULT 0,
+            co_artist_score REAL DEFAULT 0,
+            genre_proximity REAL DEFAULT 0,
+            duration_proximity REAL DEFAULT 0,
+            era_proximity REAL DEFAULT 0,
+            computed_at TEXT DEFAULT (datetime('now')),
+            PRIMARY KEY (track_a, track_b),
+            CHECK (track_a < track_b)
+        );
+    ",
+    )?;
 
     // ── Stage 1: candidate pairs ─────────────────────────────────────────────
     // Each INSERT must satisfy CHECK (track_a < track_b), ensured by `b.id > a.id`.
 
-    tx.execute_batch(
+    conn.execute_batch(
         "
         -- 1a: Same-album pairs (all combinations, not just min/max)
-        INSERT OR IGNORE INTO track_similarity (track_a, track_b)
+        INSERT OR IGNORE INTO _track_similarity_build (track_a, track_b)
         SELECT a.id, b.id
         FROM tracks a
         JOIN tracks b ON b.album_id = a.album_id AND b.id > a.id
         WHERE a.album_id IS NOT NULL;
 
         -- 1b: Same-artist pairs (cap at artists with <=100 tracks)
-        INSERT OR IGNORE INTO track_similarity (track_a, track_b)
+        INSERT OR IGNORE INTO _track_similarity_build (track_a, track_b)
         SELECT a.id, b.id
         FROM tracks a
         JOIN tracks b ON b.artist_id = a.artist_id AND b.id > a.id
@@ -4382,7 +4399,7 @@ pub fn compute_track_similarity(conn: &Connection) -> Result<usize> {
         );
 
         -- 1c: Shared-genre pairs (deduplicated by GROUP BY, limited to avoid explosion)
-        INSERT OR IGNORE INTO track_similarity (track_a, track_b)
+        INSERT OR IGNORE INTO _track_similarity_build (track_a, track_b)
         SELECT a.track_id, b.track_id
         FROM track_genres a
         JOIN track_genres b ON b.genre_id = a.genre_id AND b.track_id > a.track_id
@@ -4393,7 +4410,7 @@ pub fn compute_track_similarity(conn: &Connection) -> Result<usize> {
 
     // ── Stage 2: aggregate signals into indexed temp tables ──────────────────
 
-    tx.execute_batch(
+    conn.execute_batch(
         "
         DROP TABLE IF EXISTS _co_listen;
         CREATE TEMP TABLE _co_listen AS
@@ -4432,13 +4449,13 @@ pub fn compute_track_similarity(conn: &Connection) -> Result<usize> {
     // ── Stage 3: score each component ────────────────────────────────────────
 
     // co_album: 1.0 if same album
-    tx.execute(
+    conn.execute(
         "
-        UPDATE track_similarity SET co_album_score = 1.0
+        UPDATE _track_similarity_build SET co_album_score = 1.0
         WHERE EXISTS (
             SELECT 1 FROM tracks a, tracks b
-            WHERE a.id = track_similarity.track_a
-              AND b.id = track_similarity.track_b
+            WHERE a.id = _track_similarity_build.track_a
+              AND b.id = _track_similarity_build.track_b
               AND a.album_id IS NOT NULL
               AND a.album_id = b.album_id
         )
@@ -4447,13 +4464,13 @@ pub fn compute_track_similarity(conn: &Connection) -> Result<usize> {
     )?;
 
     // co_artist: 1.0 if same artist
-    tx.execute(
+    conn.execute(
         "
-        UPDATE track_similarity SET co_artist_score = 1.0
+        UPDATE _track_similarity_build SET co_artist_score = 1.0
         WHERE EXISTS (
             SELECT 1 FROM tracks a, tracks b
-            WHERE a.id = track_similarity.track_a
-              AND b.id = track_similarity.track_b
+            WHERE a.id = _track_similarity_build.track_a
+              AND b.id = _track_similarity_build.track_b
               AND a.artist_id IS NOT NULL
               AND a.artist_id = b.artist_id
         )
@@ -4462,23 +4479,23 @@ pub fn compute_track_similarity(conn: &Connection) -> Result<usize> {
     )?;
 
     // genre_proximity: shared genres / max genres on any single track
-    tx.execute("
-        UPDATE track_similarity SET genre_proximity = COALESCE((
+    conn.execute("
+        UPDATE _track_similarity_build SET genre_proximity = COALESCE((
             SELECT CAST(gs.shared AS REAL) / NULLIF(
                 (SELECT MAX(c) FROM (SELECT COUNT(DISTINCT genre_id) AS c FROM track_genres GROUP BY track_id)),
                 0)
             FROM _genre_shared gs
-            WHERE gs.ta = track_similarity.track_a AND gs.tb = track_similarity.track_b
+            WHERE gs.ta = _track_similarity_build.track_a AND gs.tb = _track_similarity_build.track_b
         ), 0)
     ", [])?;
 
     // duration_proximity: 1 - |dur_a - dur_b| / 180s, clamped 0-1
-    tx.execute(
+    conn.execute(
         "
-        UPDATE track_similarity SET duration_proximity = COALESCE((
+        UPDATE _track_similarity_build SET duration_proximity = COALESCE((
             SELECT 1.0 - MIN(CAST(ABS(a.duration_ms - b.duration_ms) AS REAL) / 180000.0, 1.0)
             FROM tracks a, tracks b
-            WHERE a.id = track_similarity.track_a AND b.id = track_similarity.track_b
+            WHERE a.id = _track_similarity_build.track_a AND b.id = _track_similarity_build.track_b
               AND a.duration_ms IS NOT NULL AND b.duration_ms IS NOT NULL
         ), 0)
     ",
@@ -4486,25 +4503,25 @@ pub fn compute_track_similarity(conn: &Connection) -> Result<usize> {
     )?;
 
     // co_listen: normalized co-occurrence count
-    tx.execute(
+    conn.execute(
         "
-        UPDATE track_similarity SET co_listen_score = COALESCE((
+        UPDATE _track_similarity_build SET co_listen_score = COALESCE((
             SELECT cl.n / NULLIF((SELECT MAX(n) FROM _co_listen), 0)
             FROM _co_listen cl
-            WHERE cl.ta = track_similarity.track_a AND cl.tb = track_similarity.track_b
+            WHERE cl.ta = _track_similarity_build.track_a AND cl.tb = _track_similarity_build.track_b
         ), 0)
     ",
         [],
     )?;
 
     // era_proximity: 1 - |year_a - year_b| / 25, clamped 0-1. Zero when either year is unknown.
-    tx.execute(
+    conn.execute(
         "
-        UPDATE track_similarity SET era_proximity = COALESCE((
+        UPDATE _track_similarity_build SET era_proximity = COALESCE((
             SELECT 1.0 - MIN(CAST(ABS(ya.year - yb.year) AS REAL) / 25.0, 1.0)
             FROM _track_year ya, _track_year yb
-            WHERE ya.track_id = track_similarity.track_a
-              AND yb.track_id = track_similarity.track_b
+            WHERE ya.track_id = _track_similarity_build.track_a
+              AND yb.track_id = _track_similarity_build.track_b
         ), 0)
     ",
         [],
@@ -4512,9 +4529,9 @@ pub fn compute_track_similarity(conn: &Connection) -> Result<usize> {
 
     // Final weighted score. era_proximity replaces some duration_proximity weight
     // because era is a stronger taste signal than song length.
-    tx.execute(
+    conn.execute(
         "
-        UPDATE track_similarity SET similarity_score =
+        UPDATE _track_similarity_build SET similarity_score =
             co_listen_score    * 0.30 +
             co_album_score     * 0.20 +
             co_artist_score    * 0.20 +
@@ -4525,7 +4542,7 @@ pub fn compute_track_similarity(conn: &Connection) -> Result<usize> {
         [],
     )?;
 
-    tx.execute_batch(
+    conn.execute_batch(
         "
         DROP TABLE IF EXISTS _co_listen;
         DROP TABLE IF EXISTS _genre_shared;
@@ -4533,11 +4550,43 @@ pub fn compute_track_similarity(conn: &Connection) -> Result<usize> {
     ",
     )?;
 
-    let count: i64 = tx.query_row("SELECT COUNT(*) FROM track_similarity", [], |row| {
+    let count: i64 = conn.query_row("SELECT COUNT(*) FROM _track_similarity_build", [], |row| {
         row.get(0)
     })?;
 
+    let tx = conn.unchecked_transaction()?;
+    tx.execute("DELETE FROM track_similarity", [])?;
+    tx.execute(
+        "
+        INSERT INTO track_similarity (
+            track_a,
+            track_b,
+            similarity_score,
+            co_listen_score,
+            co_album_score,
+            co_artist_score,
+            genre_proximity,
+            duration_proximity,
+            era_proximity,
+            computed_at
+        )
+        SELECT
+            track_a,
+            track_b,
+            similarity_score,
+            co_listen_score,
+            co_album_score,
+            co_artist_score,
+            genre_proximity,
+            duration_proximity,
+            era_proximity,
+            computed_at
+        FROM _track_similarity_build
+        ",
+        [],
+    )?;
     tx.commit()?;
+    conn.execute_batch("DROP TABLE IF EXISTS _track_similarity_build;")?;
     Ok(count as usize)
 }
 
@@ -7923,6 +7972,61 @@ mod tests {
         )
         .optional()
         .expect("query server_config")
+    }
+
+    #[test]
+    fn compute_track_similarity_swaps_from_temp_build_table() {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        conn.execute_batch("PRAGMA foreign_keys = ON;")
+            .expect("foreign keys");
+        schema::run_migrations(&conn).expect("migrations");
+        conn.execute("INSERT INTO artists (id, name) VALUES (1, 'Artist')", [])
+            .expect("artist");
+        conn.execute(
+            "INSERT INTO albums (id, title, artist_id, year) VALUES (1, 'Album', 1, 1999)",
+            [],
+        )
+        .expect("album");
+        conn.execute(
+            "INSERT INTO tracks (id, title, artist_id, album_id, duration_ms)
+             VALUES
+                (1, 'One', 1, 1, 180000),
+                (2, 'Two', 1, 1, 181000),
+                (3, 'Three', 1, 1, 220000)",
+            [],
+        )
+        .expect("tracks");
+        conn.execute(
+            "INSERT INTO track_similarity (track_a, track_b, similarity_score)
+             VALUES (1, 2, 0.01)",
+            [],
+        )
+        .expect("stale similarity");
+
+        let count = compute_track_similarity(&conn).expect("compute similarity");
+        assert_eq!(count, 3);
+
+        let persisted_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM track_similarity", [], |row| {
+                row.get(0)
+            })
+            .expect("persisted count");
+        assert_eq!(persisted_count, 3);
+        let score: f64 = conn
+            .query_row(
+                "SELECT similarity_score FROM track_similarity WHERE track_a = 1 AND track_b = 2",
+                [],
+                |row| row.get(0),
+            )
+            .expect("score");
+        assert!(score > 0.01, "rebuild should replace stale similarity rows");
+        assert!(
+            conn.query_row("SELECT COUNT(*) FROM _track_similarity_build", [], |row| {
+                row.get::<_, i64>(0)
+            },)
+                .is_err(),
+            "temporary build table should be dropped after swap"
+        );
     }
 
     mod dj_transition_event {

--- a/noor-server/src/db/queries.rs
+++ b/noor-server/src/db/queries.rs
@@ -4,12 +4,426 @@ use anyhow::{Result, bail};
 use rusqlite::{Connection, OptionalExtension, Row, params, params_from_iter};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 pub const DISCOVERY_ENGINE_V2: &str = "v2";
 pub const DISCOVERY_ENGINE_V1: &str = "v1";
 pub const DISCOVERY_ENGINE_V2_FAMILY: &str = "discovery-fusion-v2";
 pub const DISCOVERY_ENGINE_V1_FAMILY: &str = "discovery-fusion";
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ChartSnapshotSummary {
+    pub id: i64,
+    pub source_key: String,
+    pub region: String,
+    pub period: String,
+    pub chart_date: String,
+    pub fetched_at: i64,
+    pub status: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ChartSnapshotEntryRow {
+    pub id: i64,
+    pub rank: i64,
+    pub rank_delta: Option<i64>,
+    pub artist: String,
+    pub title: String,
+    pub entity_type: String,
+    pub album: Option<String>,
+    pub artwork_url: Option<String>,
+    pub external_track_id: Option<String>,
+    pub external_artist_id: Option<String>,
+    pub external_video_id: Option<String>,
+    pub external_url: Option<String>,
+    pub streams: Option<i64>,
+    pub stream_delta: Option<i64>,
+    pub views: Option<i64>,
+    pub likes: Option<i64>,
+    pub audience: Option<f64>,
+    pub audience_delta: Option<f64>,
+    pub points: Option<f64>,
+    pub points_delta: Option<f64>,
+    pub seven_day_streams: Option<i64>,
+    pub total_streams: Option<i64>,
+    pub days_on_chart: Option<i64>,
+    pub peak_rank: Option<i64>,
+    pub provider_positions_json: Option<Value>,
+    pub raw_json: Option<Value>,
+    pub external_candidate_id: Option<i64>,
+    pub local_track_id: Option<i64>,
+    pub tidal_id: Option<i64>,
+    pub resolution_status: String,
+    pub resolution_score: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct LatestChartSnapshot {
+    pub snapshot: ChartSnapshotSummary,
+    pub entries: Vec<ChartSnapshotEntryRow>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ChartMatrixCell {
+    pub snapshot_id: i64,
+    pub entry_id: i64,
+    pub source_key: String,
+    pub region: String,
+    pub chart_date: String,
+    pub rank: i64,
+    pub rank_delta: Option<i64>,
+    pub artist: String,
+    pub title: String,
+    pub entity_type: String,
+    pub artwork_url: Option<String>,
+    pub streams: Option<i64>,
+    pub views: Option<i64>,
+    pub points: Option<f64>,
+    pub external_url: Option<String>,
+    pub tidal_id: Option<i64>,
+    pub resolution_status: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ChartMatrixRow {
+    pub region: String,
+    pub cells: BTreeMap<String, Option<ChartMatrixCell>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ChartSnapshotSeed<'a> {
+    pub source_key: &'a str,
+    pub region: &'a str,
+    pub period: &'a str,
+    pub chart_date: &'a str,
+    pub fetched_at: i64,
+    pub etag: Option<&'a str>,
+    pub content_hash: Option<&'a str>,
+    pub status: &'a str,
+}
+
+#[derive(Debug, Clone)]
+pub struct ChartEntrySeed<'a> {
+    pub rank: i64,
+    pub rank_delta: Option<i64>,
+    pub artist: &'a str,
+    pub title: &'a str,
+    pub entity_type: &'a str,
+    pub album: Option<&'a str>,
+    pub artwork_url: Option<&'a str>,
+    pub external_track_id: Option<&'a str>,
+    pub external_artist_id: Option<&'a str>,
+    pub external_video_id: Option<&'a str>,
+    pub external_url: Option<&'a str>,
+    pub streams: Option<i64>,
+    pub stream_delta: Option<i64>,
+    pub views: Option<i64>,
+    pub likes: Option<i64>,
+    pub audience: Option<f64>,
+    pub audience_delta: Option<f64>,
+    pub points: Option<f64>,
+    pub points_delta: Option<f64>,
+    pub seven_day_streams: Option<i64>,
+    pub total_streams: Option<i64>,
+    pub days_on_chart: Option<i64>,
+    pub peak_rank: Option<i64>,
+    pub provider_positions_json: Option<Value>,
+    pub raw_json: Option<Value>,
+    pub resolution_status: Option<&'a str>,
+    pub tidal_id: Option<i64>,
+    pub local_track_id: Option<i64>,
+    pub external_candidate_id: Option<i64>,
+    pub resolution_score: Option<f64>,
+}
+
+impl<'a> ChartEntrySeed<'a> {
+    pub fn track(rank: i64, artist: &'a str, title: &'a str) -> Self {
+        Self {
+            rank,
+            rank_delta: None,
+            artist,
+            title,
+            entity_type: "track",
+            album: None,
+            artwork_url: None,
+            external_track_id: None,
+            external_artist_id: None,
+            external_video_id: None,
+            external_url: None,
+            streams: None,
+            stream_delta: None,
+            views: None,
+            likes: None,
+            audience: None,
+            audience_delta: None,
+            points: None,
+            points_delta: None,
+            seven_day_streams: None,
+            total_streams: None,
+            days_on_chart: None,
+            peak_rank: None,
+            provider_positions_json: None,
+            raw_json: None,
+            resolution_status: None,
+            tidal_id: None,
+            local_track_id: None,
+            external_candidate_id: None,
+            resolution_score: None,
+        }
+    }
+}
+
+pub fn upsert_chart_snapshot(
+    conn: &Connection,
+    snapshot: &ChartSnapshotSeed<'_>,
+    entries: &[ChartEntrySeed<'_>],
+) -> Result<i64> {
+    let tx = conn.unchecked_transaction()?;
+    tx.execute(
+        "INSERT INTO chart_snapshots
+            (source_key, region, period, chart_date, fetched_at, etag, content_hash, status)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+         ON CONFLICT(source_key, region, period, chart_date)
+         DO UPDATE SET
+            fetched_at = excluded.fetched_at,
+            etag = excluded.etag,
+            content_hash = excluded.content_hash,
+            status = excluded.status",
+        params![
+            snapshot.source_key,
+            snapshot.region,
+            snapshot.period,
+            snapshot.chart_date,
+            snapshot.fetched_at,
+            snapshot.etag,
+            snapshot.content_hash,
+            snapshot.status,
+        ],
+    )?;
+    let snapshot_id: i64 = tx.query_row(
+        "SELECT id FROM chart_snapshots
+         WHERE source_key = ?1 AND region = ?2 AND period = ?3 AND chart_date = ?4",
+        params![
+            snapshot.source_key,
+            snapshot.region,
+            snapshot.period,
+            snapshot.chart_date,
+        ],
+        |row| row.get(0),
+    )?;
+    tx.execute(
+        "DELETE FROM chart_entries WHERE snapshot_id = ?1",
+        params![snapshot_id],
+    )?;
+
+    for entry in entries {
+        tx.execute(
+            "INSERT INTO chart_entries
+                (snapshot_id, rank, rank_delta, artist, title, entity_type, album, artwork_url,
+                 external_track_id, external_artist_id, external_video_id, external_url,
+                 streams, stream_delta, views, likes, audience, audience_delta, points,
+                 points_delta, seven_day_streams, total_streams, days_on_chart, peak_rank,
+                 provider_positions_json, raw_json)
+             VALUES
+                (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14,
+                 ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26)",
+            params![
+                snapshot_id,
+                entry.rank,
+                entry.rank_delta,
+                entry.artist,
+                entry.title,
+                entry.entity_type,
+                entry.album,
+                entry.artwork_url,
+                entry.external_track_id,
+                entry.external_artist_id,
+                entry.external_video_id,
+                entry.external_url,
+                entry.streams,
+                entry.stream_delta,
+                entry.views,
+                entry.likes,
+                entry.audience,
+                entry.audience_delta,
+                entry.points,
+                entry.points_delta,
+                entry.seven_day_streams,
+                entry.total_streams,
+                entry.days_on_chart,
+                entry.peak_rank,
+                entry.provider_positions_json,
+                entry.raw_json,
+            ],
+        )?;
+        let entry_id = tx.last_insert_rowid();
+        tx.execute(
+            "INSERT INTO chart_entry_resolutions
+                (entry_id, external_candidate_id, local_track_id, tidal_id, status, score)
+             VALUES (?1, ?2, ?3, NULLIF(?4, 0), ?5, ?6)",
+            params![
+                entry_id,
+                entry.external_candidate_id,
+                entry.local_track_id,
+                entry.tidal_id,
+                entry.resolution_status.unwrap_or("unresolved"),
+                entry.resolution_score,
+            ],
+        )?;
+    }
+
+    tx.commit()?;
+    Ok(snapshot_id)
+}
+
+pub fn get_latest_chart_snapshot(
+    conn: &Connection,
+    source_key: &str,
+    region: &str,
+    period: &str,
+    limit: u32,
+) -> Result<Option<LatestChartSnapshot>> {
+    let snapshot = conn
+        .query_row(
+            "SELECT id, source_key, region, period, chart_date, fetched_at, status
+             FROM chart_snapshots
+             WHERE source_key = ?1 AND region = ?2 AND period = ?3
+             ORDER BY chart_date DESC, fetched_at DESC, id DESC
+             LIMIT 1",
+            params![source_key, region, period],
+            |row| {
+                Ok(ChartSnapshotSummary {
+                    id: row.get(0)?,
+                    source_key: row.get(1)?,
+                    region: row.get(2)?,
+                    period: row.get(3)?,
+                    chart_date: row.get(4)?,
+                    fetched_at: row.get(5)?,
+                    status: row.get(6)?,
+                })
+            },
+        )
+        .optional()?;
+
+    let Some(snapshot) = snapshot else {
+        return Ok(None);
+    };
+
+    let mut stmt = conn.prepare(
+        "SELECT
+            e.id, e.rank, e.rank_delta, e.artist, e.title, e.entity_type,
+            e.album, e.artwork_url, e.external_track_id, e.external_artist_id,
+            e.external_video_id, e.external_url, e.streams, e.stream_delta,
+            e.views, e.likes, e.audience, e.audience_delta, e.points,
+            e.points_delta, e.seven_day_streams, e.total_streams,
+            e.days_on_chart, e.peak_rank, e.provider_positions_json, e.raw_json,
+            r.external_candidate_id, r.local_track_id, NULLIF(r.tidal_id, 0),
+            COALESCE(r.status, 'unresolved'), r.score
+         FROM chart_entries e
+         LEFT JOIN chart_entry_resolutions r ON r.entry_id = e.id
+         WHERE e.snapshot_id = ?1
+         ORDER BY e.rank ASC
+         LIMIT ?2",
+    )?;
+
+    let entries = stmt
+        .query_map(params![snapshot.id, limit], |row| {
+            Ok(ChartSnapshotEntryRow {
+                id: row.get(0)?,
+                rank: row.get(1)?,
+                rank_delta: row.get(2)?,
+                artist: row.get(3)?,
+                title: row.get(4)?,
+                entity_type: row.get(5)?,
+                album: row.get(6)?,
+                artwork_url: row.get(7)?,
+                external_track_id: row.get(8)?,
+                external_artist_id: row.get(9)?,
+                external_video_id: row.get(10)?,
+                external_url: row.get(11)?,
+                streams: row.get(12)?,
+                stream_delta: row.get(13)?,
+                views: row.get(14)?,
+                likes: row.get(15)?,
+                audience: row.get(16)?,
+                audience_delta: row.get(17)?,
+                points: row.get(18)?,
+                points_delta: row.get(19)?,
+                seven_day_streams: row.get(20)?,
+                total_streams: row.get(21)?,
+                days_on_chart: row.get(22)?,
+                peak_rank: row.get(23)?,
+                provider_positions_json: row.get(24)?,
+                raw_json: row.get(25)?,
+                external_candidate_id: row.get(26)?,
+                local_track_id: row.get(27)?,
+                tidal_id: row.get(28)?,
+                resolution_status: row.get(29)?,
+                resolution_score: row.get(30)?,
+            })
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+
+    Ok(Some(LatestChartSnapshot { snapshot, entries }))
+}
+
+pub fn get_chart_matrix(
+    conn: &Connection,
+    regions: &[&str],
+    source_keys: &[&str],
+    period: &str,
+) -> Result<Vec<ChartMatrixRow>> {
+    let mut stmt = conn.prepare(
+        "SELECT
+            s.id, e.id, s.source_key, s.region, s.chart_date,
+            e.rank, e.rank_delta, e.artist, e.title, e.entity_type,
+            e.artwork_url, e.streams, e.views, e.points, e.external_url,
+            NULLIF(r.tidal_id, 0), COALESCE(r.status, 'unresolved')
+         FROM chart_snapshots s
+         JOIN chart_entries e ON e.snapshot_id = s.id AND e.rank = 1
+         LEFT JOIN chart_entry_resolutions r ON r.entry_id = e.id
+         WHERE s.source_key = ?1 AND s.region = ?2 AND s.period = ?3
+         ORDER BY s.chart_date DESC, s.fetched_at DESC, s.id DESC
+         LIMIT 1",
+    )?;
+
+    let mut rows = Vec::with_capacity(regions.len());
+    for region in regions {
+        let mut cells = BTreeMap::new();
+        for source_key in source_keys {
+            let cell = stmt
+                .query_row(params![source_key, region, period], |row| {
+                    Ok(ChartMatrixCell {
+                        snapshot_id: row.get(0)?,
+                        entry_id: row.get(1)?,
+                        source_key: row.get(2)?,
+                        region: row.get(3)?,
+                        chart_date: row.get(4)?,
+                        rank: row.get(5)?,
+                        rank_delta: row.get(6)?,
+                        artist: row.get(7)?,
+                        title: row.get(8)?,
+                        entity_type: row.get(9)?,
+                        artwork_url: row.get(10)?,
+                        streams: row.get(11)?,
+                        views: row.get(12)?,
+                        points: row.get(13)?,
+                        external_url: row.get(14)?,
+                        tidal_id: row.get(15)?,
+                        resolution_status: row.get(16)?,
+                    })
+                })
+                .optional()?;
+            cells.insert((*source_key).to_string(), cell);
+        }
+        rows.push(ChartMatrixRow {
+            region: (*region).to_string(),
+            cells,
+        });
+    }
+
+    Ok(rows)
+}
 
 // ─── Server Config ────────────────────────────────────────
 

--- a/noor-server/src/db/schema.rs
+++ b/noor-server/src/db/schema.rs
@@ -49,6 +49,7 @@ const MIGRATIONS: &[&str] = &[
     MIGRATION_045,
     MIGRATION_046,
     MIGRATION_047,
+    MIGRATION_048,
 ];
 
 const MIGRATION_001: &str = r#"
@@ -1303,6 +1304,85 @@ ALTER TABLE dj_transition_events ADD COLUMN runtime_renderer_reason TEXT;
 
 const MIGRATION_047: &str = r#"
 ALTER TABLE audio_dj_profiles ADD COLUMN waveform_peaks_blob BLOB NOT NULL DEFAULT X'';
+"#;
+
+const MIGRATION_048: &str = r#"
+CREATE TABLE IF NOT EXISTS chart_sources (
+    id INTEGER PRIMARY KEY,
+    source_key TEXT UNIQUE NOT NULL,
+    display_name TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    enabled INTEGER NOT NULL DEFAULT 1,
+    default_region TEXT,
+    refresh_interval_hours INTEGER NOT NULL DEFAULT 24,
+    last_success_at INTEGER,
+    last_error TEXT
+);
+
+CREATE TABLE IF NOT EXISTS chart_snapshots (
+    id INTEGER PRIMARY KEY,
+    source_key TEXT NOT NULL,
+    region TEXT NOT NULL,
+    period TEXT NOT NULL,
+    chart_date TEXT NOT NULL,
+    fetched_at INTEGER NOT NULL,
+    etag TEXT,
+    content_hash TEXT,
+    status TEXT NOT NULL,
+    UNIQUE (source_key, region, period, chart_date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_chart_snapshots_latest
+    ON chart_snapshots(source_key, region, period, chart_date DESC, fetched_at DESC);
+
+CREATE TABLE IF NOT EXISTS chart_entries (
+    id INTEGER PRIMARY KEY,
+    snapshot_id INTEGER NOT NULL REFERENCES chart_snapshots(id) ON DELETE CASCADE,
+    rank INTEGER NOT NULL,
+    rank_delta INTEGER,
+    artist TEXT NOT NULL,
+    title TEXT NOT NULL,
+    entity_type TEXT NOT NULL DEFAULT 'track',
+    album TEXT,
+    artwork_url TEXT,
+    external_track_id TEXT,
+    external_artist_id TEXT,
+    external_video_id TEXT,
+    external_url TEXT,
+    streams INTEGER,
+    stream_delta INTEGER,
+    views INTEGER,
+    likes INTEGER,
+    audience REAL,
+    audience_delta REAL,
+    points REAL,
+    points_delta REAL,
+    seven_day_streams INTEGER,
+    total_streams INTEGER,
+    days_on_chart INTEGER,
+    peak_rank INTEGER,
+    provider_positions_json TEXT,
+    raw_json TEXT,
+    UNIQUE (snapshot_id, rank)
+);
+
+CREATE INDEX IF NOT EXISTS idx_chart_entries_snapshot_rank
+    ON chart_entries(snapshot_id, rank);
+
+CREATE TABLE IF NOT EXISTS chart_entry_resolutions (
+    entry_id INTEGER PRIMARY KEY REFERENCES chart_entries(id) ON DELETE CASCADE,
+    external_candidate_id INTEGER REFERENCES external_track_candidates(id) ON DELETE SET NULL,
+    local_track_id INTEGER REFERENCES tracks(id) ON DELETE SET NULL,
+    tidal_id INTEGER,
+    status TEXT NOT NULL,
+    score REAL,
+    resolved_at INTEGER,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    last_error TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_chart_entry_resolutions_status
+    ON chart_entry_resolutions(status, resolved_at);
 "#;
 
 pub fn run_migrations(conn: &Connection) -> Result<()> {

--- a/noor-server/src/main.rs
+++ b/noor-server/src/main.rs
@@ -607,22 +607,38 @@ async fn main() -> Result<()> {
         info!("Last.fm scrobbling disabled (set LASTFM_API_SECRET to enable)");
     }
 
-    // Sportify (anonymous Spotify metadata proxy) — powers /discover. Default
-    // base URL ships in code; env var lets ops point at a self-hosted mirror.
-    let sportify_base_url = std::env::var("SPORTIFY_API_BASE_URL")
+    // Sportify (anonymous Spotify metadata proxy) powers /discover. Default
+    // base URL ships in code; env vars let ops point at a self-hosted mirror.
+    let configured_sportify_base_url = std::env::var("SPORTIFY_API_BASE_URL")
         .ok()
-        .filter(|s| !s.trim().is_empty())
-        .unwrap_or_else(|| "https://sportify.xcasper.space".to_string());
+        .filter(|s| !s.trim().is_empty());
+    let sportify_base_url = configured_sportify_base_url
+        .clone()
+        .unwrap_or_else(|| "https://spotify.xwolf.space".to_string());
+    let sportify_fallback_base_urls = if configured_sportify_base_url.is_some() {
+        Vec::new()
+    } else {
+        vec!["https://sportify.xcasper.space".to_string()]
+    };
     let sportify_client =
         match services::sportify::SportifyClient::new(services::sportify::SportifyClientConfig {
             base_url: sportify_base_url.clone(),
+            fallback_base_urls: sportify_fallback_base_urls.clone(),
             user_agent: format!(
                 "noor-server/{} (sportify discovery)",
                 env!("CARGO_PKG_VERSION")
             ),
         }) {
             Ok(client) => {
-                info!("Sportify discovery client ready ({})", sportify_base_url);
+                if sportify_fallback_base_urls.is_empty() {
+                    info!("Sportify discovery client ready ({})", sportify_base_url);
+                } else {
+                    info!(
+                        "Sportify discovery client ready ({} with fallback {})",
+                        sportify_base_url,
+                        sportify_fallback_base_urls.join(", ")
+                    );
+                }
                 Some(Arc::new(client))
             }
             Err(e) => {

--- a/noor-server/src/main.rs
+++ b/noor-server/src/main.rs
@@ -71,6 +71,13 @@ pub struct NextPrebufferKey {
     pub generation: u64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DropPreviewRuntimeState {
+    pub track_id: i64,
+    pub generation: u64,
+    pub actual_fire_ms: i64,
+}
+
 /// Shared application state accessible by all modules
 pub struct AppState {
     pub db: db::Database,
@@ -123,6 +130,7 @@ pub struct AppState {
     pub current_stream_display: Option<StreamDisplayInfo>,
     pub pending_stream_display: Option<StreamDisplayInfo>,
     pub next_prebuffer_inflight: Option<NextPrebufferKey>,
+    pub last_drop_preview: Option<DropPreviewRuntimeState>,
     pub active_listen_session: Option<playback::player::ActiveListenSession>,
     pub live_listen_session: Option<playback::player::LiveListenSession>,
     pub external_playback_track: Option<db::models::Track>,
@@ -767,6 +775,7 @@ async fn main() -> Result<()> {
         current_stream_display: None,
         pending_stream_display: None,
         next_prebuffer_inflight: None,
+        last_drop_preview: None,
         active_listen_session: None,
         live_listen_session: None,
         external_playback_track: None,

--- a/noor-server/src/playback/automix.rs
+++ b/noor-server/src/playback/automix.rs
@@ -13,12 +13,15 @@
 //! `normalize_genre_key`) and `pub` / `pub(crate)` for items player.rs already
 //! exposed (`load_state`, `load_snapshot`, `build_session_taste_profile`).
 
+#[cfg(test)]
+use crate::db::models::AudioDjProfileKey;
 use crate::db::{
     models::{AudioDspFeatures, QueueItem, Track},
     queries,
 };
 use crate::playback::dj_queue_ranker::{
-    GeneratedCandidate, append_dj_reason, rank_generated_candidates,
+    GeneratedCandidate, GeneratedCandidatePolicy, append_dj_reason, rank_generated_candidates,
+    rank_generated_candidates_chain,
 };
 use crate::playback::player::{
     PlaybackSnapshot, build_session_taste_profile, load_snapshot, load_state, normalize_genre_key,
@@ -36,6 +39,8 @@ use crate::smart::taste_vector::adapters::from_session_profile;
 use crate::smart::taste_vector::{SeedContext, TasteVector};
 use anyhow::Result;
 use rusqlite::{Connection, params};
+#[cfg(test)]
+use serde::Serialize;
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 
@@ -53,6 +58,7 @@ struct ScoredTrack {
 pub(crate) struct AutomixSelection {
     pub(crate) track: Track,
     reason: Option<String>,
+    ranking_policy: GeneratedCandidatePolicy,
 }
 
 impl AutomixSelection {
@@ -60,7 +66,13 @@ impl AutomixSelection {
         Self {
             track,
             reason: Some(reason.into()),
+            ranking_policy: GeneratedCandidatePolicy::default(),
         }
+    }
+
+    fn with_ranking_policy(mut self, ranking_policy: GeneratedCandidatePolicy) -> Self {
+        self.ranking_policy = ranking_policy;
+        self
     }
 
     fn into_queue_pair(self) -> (Track, Option<String>) {
@@ -264,6 +276,7 @@ fn append_automix_external_candidates(
         .map(|row| GeneratedCandidate {
             track_id: None,
             tidal_id: row.tidal_id,
+            policy: Default::default(),
             item: row,
         })
         .collect::<Vec<_>>();
@@ -326,6 +339,7 @@ fn rank_automix_selections(
         .map(|selection| GeneratedCandidate {
             track_id: Some(selection.track.id),
             tidal_id: selection.track.tidal_id,
+            policy: selection.ranking_policy.clone(),
             item: selection,
         })
         .collect::<Vec<_>>();
@@ -333,7 +347,7 @@ fn rank_automix_selections(
         .iter()
         .map(|candidate| candidate.item.clone())
         .collect::<Vec<_>>();
-    rank_generated_candidates(conn, seed_track_id, generated)
+    rank_generated_candidates_chain(conn, seed_track_id, generated)
         .map(|ranked| {
             ranked
                 .into_iter()
@@ -419,6 +433,10 @@ pub(crate) fn build_automix_extension_with_reasons(
                 .iter()
                 .map(|row| (row.track_id, automix_neighbor_reason(row)))
                 .collect::<HashMap<_, _>>();
+            let neighbor_policies = neighbors
+                .iter()
+                .map(|row| (row.track_id, automix_neighbor_policy(row)))
+                .collect::<HashMap<_, _>>();
             let neighbor_ids = neighbors.iter().map(|row| row.track_id).collect::<Vec<_>>();
             let tracks = queue::get_tracks_by_ids(conn, &neighbor_ids)?;
             let track_map = tracks
@@ -429,6 +447,10 @@ pub(crate) fn build_automix_extension_with_reasons(
                 .into_iter()
                 .filter_map(|track_id| {
                     track_map.get(&track_id).cloned().map(|track| {
+                        let policy = neighbor_policies
+                            .get(&track_id)
+                            .cloned()
+                            .unwrap_or_default();
                         AutomixSelection::new(
                             track,
                             neighbor_reasons
@@ -436,6 +458,7 @@ pub(crate) fn build_automix_extension_with_reasons(
                                 .cloned()
                                 .unwrap_or_else(|| "automix: learned similarity".to_string()),
                         )
+                        .with_ranking_policy(policy)
                     })
                 })
                 .collect::<Vec<_>>();
@@ -584,6 +607,196 @@ pub(crate) fn build_automix_extension_with_reasons(
         .collect())
 }
 
+#[cfg(test)]
+#[derive(Debug, Serialize)]
+pub(crate) struct AutomixEvaluationReport {
+    pub(crate) seed_track_id: i64,
+    pub(crate) queue_len_before: i64,
+    pub(crate) queue_len_after: i64,
+    pub(crate) before: Vec<AutomixEvaluationRow>,
+    pub(crate) after: Vec<AutomixEvaluationRow>,
+}
+
+#[cfg(test)]
+#[derive(Debug, Serialize)]
+pub(crate) struct AutomixEvaluationRow {
+    pub(crate) order: usize,
+    pub(crate) track_id: i64,
+    pub(crate) title: String,
+    pub(crate) artist_name: Option<String>,
+    pub(crate) bpm: Option<f64>,
+    pub(crate) camelot_key: Option<String>,
+    pub(crate) profile_confidence: Option<f64>,
+    pub(crate) safe_crossfade_only: bool,
+    pub(crate) learned_score: Option<f64>,
+    pub(crate) primary_reason: Option<String>,
+    pub(crate) reason_tags: Vec<String>,
+    pub(crate) chain_score: Option<f64>,
+    pub(crate) dj_reasons: Vec<String>,
+    pub(crate) final_score: Option<f64>,
+    pub(crate) final_reason: Option<String>,
+}
+
+#[cfg(test)]
+pub(crate) fn evaluate_automix_for_seed(
+    conn: &Connection,
+    seed_track_id: i64,
+    limit: usize,
+) -> Result<AutomixEvaluationReport> {
+    let queue_len_before = queue_len(conn)?;
+    let seed = queue::get_track_by_id(conn, seed_track_id)?
+        .ok_or_else(|| anyhow::anyhow!("seed track {seed_track_id} not found"))?;
+    let model = queries::get_selected_discovery_embedding_model(conn)
+        .ok()
+        .flatten();
+    let learned_rows = if let Some(model) = model {
+        queries::get_track_neighbors(
+            conn,
+            model.id,
+            seed_track_id,
+            (limit * 4).max(24) as i64,
+            &[],
+        )
+        .unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+    let learned_by_track = learned_rows
+        .iter()
+        .map(|row| (row.track_id, row.clone()))
+        .collect::<HashMap<_, _>>();
+    let before_ids = learned_rows
+        .iter()
+        .take(limit)
+        .map(|row| row.track_id)
+        .collect::<Vec<_>>();
+    let before_tracks = queue::get_tracks_by_ids(conn, &before_ids)?;
+    let before_track_map = before_tracks
+        .into_iter()
+        .map(|track| (track.id, track))
+        .collect::<HashMap<_, _>>();
+    let before = before_ids
+        .into_iter()
+        .enumerate()
+        .filter_map(|(idx, track_id)| {
+            before_track_map.get(&track_id).map(|track| {
+                evaluation_row(conn, idx + 1, track, learned_by_track.get(&track.id), None)
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let selected = build_automix_extension_with_reasons(
+        conn,
+        &seed,
+        &[],
+        ShuffleMode::Off,
+        None,
+        limit,
+        true,
+    )?;
+    let after = selected
+        .iter()
+        .enumerate()
+        .map(|(idx, selection)| {
+            evaluation_row(
+                conn,
+                idx + 1,
+                &selection.track,
+                learned_by_track.get(&selection.track.id),
+                selection.reason.as_deref(),
+            )
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let queue_len_after = queue_len(conn)?;
+
+    Ok(AutomixEvaluationReport {
+        seed_track_id,
+        queue_len_before,
+        queue_len_after,
+        before,
+        after,
+    })
+}
+
+#[cfg(test)]
+fn evaluation_row(
+    conn: &Connection,
+    order: usize,
+    track: &Track,
+    learned: Option<&queries::EmbeddingNeighborRow>,
+    final_reason: Option<&str>,
+) -> Result<AutomixEvaluationRow> {
+    let dsp = queries::get_audio_dsp_features(conn, track.id)
+        .ok()
+        .flatten();
+    let profile = queries::get_audio_dj_profile_for_track(conn, track.id)
+        .ok()
+        .flatten();
+    let safe_crossfade_only = queries::get_audio_dj_profile_correction(
+        conn,
+        &AudioDjProfileKey {
+            media_ref_kind: "library_track".to_string(),
+            media_ref_id: track.id.to_string(),
+        },
+    )
+    .ok()
+    .flatten()
+    .is_some_and(|correction| correction.safe_crossfade_only);
+    let tags = learned
+        .and_then(|row| row.reason_json.as_deref())
+        .map(|reason_json| automix_reason_tags(Some(reason_json)))
+        .unwrap_or_default();
+    let dj_reasons = final_reason
+        .and_then(|reason| reason.split(" | dj: ").nth(1))
+        .map(|suffix| suffix.split(" | {").next().unwrap_or(suffix))
+        .map(|reasons| {
+            reasons
+                .split(',')
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default();
+    let chain_score = final_reason.and_then(|reason| reason_json_number(reason, "dj_score"));
+    let final_score = chain_score.or_else(|| learned.map(|row| row.score));
+
+    Ok(AutomixEvaluationRow {
+        order,
+        track_id: track.id,
+        title: track.title.clone(),
+        artist_name: track.artist_name.clone(),
+        bpm: dsp.as_ref().and_then(|features| features.bpm),
+        camelot_key: dsp
+            .as_ref()
+            .and_then(|features| features.camelot_key.clone()),
+        profile_confidence: profile.as_ref().map(|profile| profile.profile_confidence),
+        safe_crossfade_only,
+        learned_score: learned.map(|row| row.score),
+        primary_reason: learned.and_then(|row| row.primary_reason.clone()),
+        reason_tags: tags,
+        chain_score,
+        dj_reasons,
+        final_score,
+        final_reason: final_reason.map(str::to_string),
+    })
+}
+
+#[cfg(test)]
+fn reason_json_number(reason: &str, key: &str) -> Option<f64> {
+    let start = reason.rfind('{')?;
+    serde_json::from_str::<serde_json::Value>(&reason[start..])
+        .ok()?
+        .get(key)?
+        .as_f64()
+}
+
+#[cfg(test)]
+fn queue_len(conn: &Connection) -> Result<i64> {
+    conn.query_row("SELECT COUNT(*) FROM queue", [], |row| row.get(0))
+        .map_err(Into::into)
+}
+
 fn automix_neighbor_reason(row: &queries::EmbeddingNeighborRow) -> String {
     let reason = row
         .primary_reason
@@ -596,6 +809,73 @@ fn automix_neighbor_reason(row: &queries::EmbeddingNeighborRow) -> String {
         "{prefix} | {{\"score\":{:.4},\"behavioral_score\":{:.4},\"audio_score\":{:.4},\"metadata_score\":{:.4},\"confidence\":{:.4}}}",
         row.score, row.behavioral_score, row.audio_score, row.metadata_score, row.confidence
     )
+}
+
+fn automix_neighbor_policy(row: &queries::EmbeddingNeighborRow) -> GeneratedCandidatePolicy {
+    let mut multiplier = 1.0;
+    let mut policy_reasons = Vec::new();
+    let reason_tags = automix_reason_tags(row.reason_json.as_deref());
+    let has_tag = |tag: &str| reason_tags.iter().any(|value| value == tag);
+
+    let has_lastfm_direct = has_tag("lastfm_direct");
+    let has_lastfm_branch = has_tag("lastfm_branch");
+    if has_lastfm_direct {
+        multiplier *= 1.06;
+        policy_reasons.push("lastfm direct");
+    }
+    if has_lastfm_branch {
+        multiplier *= 0.90;
+        policy_reasons.push("lastfm branch");
+    }
+
+    let primary_is_texture = row.primary_reason.as_deref() == Some("audio_texture");
+    let has_texture = primary_is_texture || has_tag("audio_texture");
+    let has_supporting_reason = reason_tags.iter().any(|tag| {
+        matches!(
+            tag.as_str(),
+            "artist_affinity"
+                | "genre_branch"
+                | "album_context"
+                | "bpm_match"
+                | "harmonic_match"
+                | "energy_match"
+                | "behavioral"
+                | "direct_transition"
+                | "lastfm_direct"
+                | "lastfm_branch"
+        )
+    }) || row.behavioral_score > 0.35
+        || row.metadata_score > 0.0
+        || row.support_transition > 0.0
+        || row.support_structure > 0.0
+        || row.support_colisten > 0.0;
+
+    if has_texture && !has_supporting_reason {
+        multiplier *= 0.82;
+        policy_reasons.push("texture-only learned signal");
+    }
+
+    GeneratedCandidatePolicy {
+        score_multiplier: multiplier,
+        reasons: policy_reasons,
+    }
+}
+
+fn automix_reason_tags(reason_json: Option<&str>) -> Vec<String> {
+    reason_json
+        .and_then(|raw| serde_json::from_str::<Vec<serde_json::Value>>(raw).ok())
+        .map(|values| {
+            values
+                .into_iter()
+                .filter_map(|value| {
+                    value
+                        .get("key")
+                        .and_then(|key| key.as_str())
+                        .map(str::to_string)
+                })
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 fn automix_metadata_reason(seed: &Track, track: &Track) -> String {
@@ -932,6 +1212,168 @@ mod tests {
             date_added: None,
             source: "tidal".to_string(),
             artwork_url: None,
+        }
+    }
+
+    fn create_dsp_schema(conn: &Connection) {
+        conn.execute_batch(
+            "
+            CREATE TABLE audio_dsp_features (
+                track_id INTEGER PRIMARY KEY,
+                bpm REAL,
+                key_signature TEXT,
+                camelot_key TEXT,
+                loudness_lufs REAL,
+                energy REAL,
+                danceability REAL,
+                beat_strength REAL,
+                spectral_centroid REAL,
+                stereo_width REAL,
+                is_instrumental INTEGER NOT NULL DEFAULT 0,
+                analysis_source TEXT NOT NULL DEFAULT 'test',
+                analysis_offset_ms INTEGER NOT NULL DEFAULT 0,
+                samples_analyzed INTEGER,
+                analyzed_at TEXT NOT NULL DEFAULT '2026-01-01T00:00:00Z',
+                analysis_version TEXT NOT NULL DEFAULT 'test'
+            );
+            ",
+        )
+        .expect("dsp schema");
+    }
+
+    fn insert_dsp(conn: &Connection, track_id: i64, bpm: f64, camelot_key: &str) {
+        conn.execute(
+            "INSERT INTO audio_dsp_features (track_id, bpm, camelot_key) VALUES (?1, ?2, ?3)",
+            params![track_id, bpm, camelot_key],
+        )
+        .expect("insert dsp");
+    }
+
+    fn policy(multiplier: f64, reason: &'static str) -> GeneratedCandidatePolicy {
+        GeneratedCandidatePolicy {
+            score_multiplier: multiplier,
+            reasons: vec![reason],
+        }
+    }
+
+    #[test]
+    fn learned_policy_penalizes_texture_only_when_dj_fit_disagrees() {
+        let conn = Connection::open_in_memory().expect("db");
+        create_dsp_schema(&conn);
+        insert_dsp(&conn, 1, 120.0, "1A");
+        insert_dsp(&conn, 2, 145.0, "6B");
+        insert_dsp(&conn, 3, 121.0, "2A");
+
+        let ranked = rank_automix_selections(
+            &conn,
+            1,
+            vec![
+                AutomixSelection::new(track_with_album(2, None), "automix: audio texture")
+                    .with_ranking_policy(policy(0.82, "texture-only learned signal")),
+                AutomixSelection::new(track_with_album(3, None), "automix: learned similarity"),
+            ],
+        );
+
+        assert_eq!(ranked[0].track.id, 3);
+        assert_eq!(ranked[1].track.id, 2);
+        assert!(
+            ranked[1]
+                .reason
+                .as_deref()
+                .unwrap_or_default()
+                .contains("texture-only learned signal")
+        );
+    }
+
+    #[test]
+    fn lastfm_direct_is_confidence_not_override() {
+        let conn = Connection::open_in_memory().expect("db");
+        create_dsp_schema(&conn);
+        insert_dsp(&conn, 1, 120.0, "1A");
+        insert_dsp(&conn, 2, 120.5, "1A");
+        insert_dsp(&conn, 3, 120.5, "1A");
+
+        let tied_facts = rank_automix_selections(
+            &conn,
+            1,
+            vec![
+                AutomixSelection::new(track_with_album(3, None), "automix: lastfm branch")
+                    .with_ranking_policy(policy(0.90, "lastfm branch")),
+                AutomixSelection::new(track_with_album(2, None), "automix: lastfm direct")
+                    .with_ranking_policy(policy(1.06, "lastfm direct")),
+            ],
+        );
+        assert_eq!(tied_facts[0].track.id, 2);
+
+        let conn = Connection::open_in_memory().expect("db");
+        create_dsp_schema(&conn);
+        insert_dsp(&conn, 1, 120.0, "1A");
+        insert_dsp(&conn, 2, 145.0, "6B");
+        insert_dsp(&conn, 3, 120.5, "1A");
+
+        let better_fit_branch = rank_automix_selections(
+            &conn,
+            1,
+            vec![
+                AutomixSelection::new(track_with_album(2, None), "automix: lastfm direct")
+                    .with_ranking_policy(policy(1.06, "lastfm direct")),
+                AutomixSelection::new(track_with_album(3, None), "automix: lastfm branch")
+                    .with_ranking_policy(policy(0.90, "lastfm branch")),
+            ],
+        );
+        assert_eq!(better_fit_branch[0].track.id, 3);
+    }
+
+    #[test]
+    #[ignore]
+    fn automix_diagnostic_for_seed() {
+        let db_path = crate::paths::resolve_db_path_from_env();
+        let limit = std::env::var("NOOR_AUTOMIX_LIMIT")
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .unwrap_or(8);
+        let seeds = std::env::var("NOOR_AUTOMIX_SEEDS")
+            .ok()
+            .or_else(|| std::env::var("NOOR_SEED").ok())
+            .unwrap_or_else(|| "1".to_string())
+            .split(',')
+            .filter_map(|value| value.trim().parse::<i64>().ok())
+            .collect::<Vec<_>>();
+        let db = crate::db::Database::open(&db_path).expect("open db");
+
+        for seed in seeds {
+            let report = db
+                .with_conn(|conn| evaluate_automix_for_seed(conn, seed, limit))
+                .expect("evaluate automix");
+            println!("{}", serde_json::to_string_pretty(&report).expect("json"));
+            println!("seed {}", report.seed_track_id);
+            println!("before:");
+            for row in &report.before {
+                println!(
+                    "#{:<2} {:<6} {:<32} bpm={:?} key={:?} learned={:?} primary={:?}",
+                    row.order,
+                    row.track_id,
+                    row.title.chars().take(32).collect::<String>(),
+                    row.bpm,
+                    row.camelot_key,
+                    row.learned_score,
+                    row.primary_reason
+                );
+            }
+            println!("after:");
+            for row in &report.after {
+                println!(
+                    "#{:<2} {:<6} {:<32} bpm={:?} key={:?} final={:?} reason={:?}",
+                    row.order,
+                    row.track_id,
+                    row.title.chars().take(32).collect::<String>(),
+                    row.bpm,
+                    row.camelot_key,
+                    row.final_score,
+                    row.final_reason
+                );
+            }
+            assert_eq!(report.queue_len_before, report.queue_len_after);
         }
     }
 

--- a/noor-server/src/playback/dj_engine.rs
+++ b/noor-server/src/playback/dj_engine.rs
@@ -1,10 +1,10 @@
 use anyhow::Result;
 use noor_mix::planner::{DJ_PLANNER_VERSION, MixIntent, TransitionSpeedBias, TransitionTemplate};
 use noor_mix::{DjProfile, Planner, Policy, TransitionProgram};
-use rusqlite::Connection;
+use rusqlite::{Connection, OptionalExtension};
 use serde::Serialize;
 
-use crate::db::models::{AudioDjProfileCorrectionRow, AudioDjProfileRow};
+use crate::db::models::{AudioDjProfileCorrectionRow, AudioDjProfileRow, AudioDspFeatures};
 use crate::db::{Database, queries};
 use crate::playback::dj_lookahead::DjMediaRef;
 use crate::services::audio_analysis::dj_profile::{decode_f32_blob, decode_u32_blob};
@@ -92,8 +92,8 @@ impl DjEngine {
                 )));
             }
 
-            let mut outgoing = profile_from_row(from_profile.as_ref().expect("checked"));
-            let mut incoming = profile_from_row(to_profile.as_ref().expect("checked"));
+            let mut outgoing = profile_from_row(conn, from_profile.as_ref().expect("checked"))?;
+            let mut incoming = profile_from_row(conn, to_profile.as_ref().expect("checked"))?;
             apply_correction(&mut outgoing, from_correction.as_ref());
             apply_correction(&mut incoming, to_correction.as_ref());
 
@@ -312,7 +312,7 @@ fn apply_correction(profile: &mut DjProfile, correction: Option<&AudioDjProfileC
     }
 }
 
-fn profile_from_row(row: &AudioDjProfileRow) -> DjProfile {
+fn profile_from_row(conn: &Connection, row: &AudioDjProfileRow) -> Result<DjProfile> {
     let beat_grid_seconds = decode_f32_blob(&row.beat_grid_blob).unwrap_or_default();
     let downbeat_seconds = decode_f32_blob(&row.downbeats_blob).unwrap_or_default();
     let phrase_bar_indices = decode_u32_blob(&row.phrase_boundaries_blob).unwrap_or_default();
@@ -320,10 +320,16 @@ fn profile_from_row(row: &AudioDjProfileRow) -> DjProfile {
     let mix_out_seconds = decode_f32_blob(&row.mix_out_blob).unwrap_or_default();
     let safe_transition_windows =
         decode_f32_blob(&row.safe_transition_windows_blob).unwrap_or_default();
-    DjProfile {
+    let dsp = dsp_features_for_profile(conn, row)?;
+    let energy = dsp
+        .as_ref()
+        .and_then(|features| features.energy)
+        .map(|value| value as f32)
+        .or_else(|| average_energy_contour(&row.energy_contour_blob));
+    Ok(DjProfile {
         bpm: estimate_bpm(&beat_grid_seconds),
-        camelot_key: Some("8A".to_string()),
-        energy: None,
+        camelot_key: dsp.and_then(|features| features.camelot_key),
+        energy,
         beat_grid_seconds,
         downbeat_seconds,
         phrase_bar_indices,
@@ -348,7 +354,40 @@ fn profile_from_row(row: &AudioDjProfileRow) -> DjProfile {
         profile_confidence: row.profile_confidence as f32,
         safe_crossfade_only: false,
         profile_version: row.profile_version.clone(),
+    })
+}
+
+fn dsp_features_for_profile(
+    conn: &Connection,
+    row: &AudioDjProfileRow,
+) -> Result<Option<AudioDspFeatures>> {
+    if let Some(track_id) = row.track_id {
+        return queries::get_audio_dsp_features(conn, track_id);
     }
+    let Some(tidal_id) = row.tidal_id else {
+        return Ok(None);
+    };
+    let track_id = conn
+        .query_row(
+            "SELECT id FROM tracks WHERE tidal_id = ?1 LIMIT 1",
+            rusqlite::params![tidal_id],
+            |row| row.get::<_, i64>(0),
+        )
+        .optional()?;
+    track_id
+        .map(|track_id| queries::get_audio_dsp_features(conn, track_id))
+        .unwrap_or(Ok(None))
+}
+
+fn average_energy_contour(blob: &[u8]) -> Option<f32> {
+    let contour = decode_f32_blob(blob)?;
+    let mut sum = 0.0_f32;
+    let mut count = 0_u32;
+    for value in contour.into_iter().filter(|value| value.is_finite()) {
+        sum += value.clamp(0.0, 1.0);
+        count += 1;
+    }
+    (count > 0).then_some(sum / count as f32)
 }
 
 fn estimate_bpm(beats: &[f32]) -> Option<f32> {
@@ -416,6 +455,19 @@ mod tests {
                     "INSERT OR IGNORE INTO tracks (id, title, artist_id) VALUES (?1, ?2, 1)",
                     rusqlite::params![id, format!("Track {id}")],
                 )?;
+                seed_dsp(conn, id, "8A", 0.5)?;
+            }
+            if kind == "tidal_track" {
+                let track_id = 100_000 + id;
+                conn.execute(
+                    "INSERT OR IGNORE INTO artists (id, name) VALUES (1, 'Artist')",
+                    [],
+                )?;
+                conn.execute(
+                    "INSERT OR IGNORE INTO tracks (id, title, artist_id, tidal_id) VALUES (?1, ?2, 1, ?3)",
+                    rusqlite::params![track_id, format!("Tidal Track {id}"), id],
+                )?;
+                seed_dsp(conn, track_id, "8A", 0.5)?;
             }
             if kind == "queue_item" {
                 conn.execute(
@@ -457,6 +509,30 @@ mod tests {
             queries::upsert_audio_dj_profile(conn, &row)
         })
         .expect("seed profile");
+    }
+
+    fn seed_dsp(conn: &Connection, track_id: i64, camelot_key: &str, energy: f64) -> Result<()> {
+        queries::upsert_audio_dsp_features(
+            conn,
+            &AudioDspFeatures {
+                track_id,
+                bpm: Some(120.0),
+                key_signature: None,
+                camelot_key: Some(camelot_key.to_string()),
+                loudness_lufs: Some(-12.0),
+                energy: Some(energy),
+                danceability: None,
+                beat_strength: None,
+                spectral_centroid: None,
+                stereo_width: None,
+                is_instrumental: false,
+                analysis_source: "test".to_string(),
+                analysis_offset_ms: 0,
+                samples_analyzed: None,
+                analyzed_at: "now".to_string(),
+                analysis_version: "test".to_string(),
+            },
+        )
     }
 
     fn seed_correction(db: &Database, key: AudioDjProfileKey, safe: bool, speed: Option<&str>) {
@@ -672,6 +748,54 @@ mod tests {
         .expect("program");
 
         assert_eq!(program.template, "FilterSweep");
+    }
+
+    #[test]
+    fn missing_dsp_camelot_uses_safe_crossfade_not_fake_harmonic_match() {
+        let db = db();
+        enable(&db);
+        seed_profile(&db, "library_track", 1, 0.9);
+        seed_profile(&db, "library_track", 2, 0.9);
+        db.with_conn(|conn| {
+            conn.execute(
+                "DELETE FROM audio_dsp_features WHERE track_id IN (1, 2)",
+                [],
+            )?;
+            Ok(())
+        })
+        .expect("remove dsp features");
+
+        let program = plan(
+            &db,
+            ref_for("library_track", 1),
+            ref_for("library_track", 2),
+        )
+        .expect("program");
+
+        assert_eq!(program.template, "SafeCrossfade");
+    }
+
+    #[test]
+    fn distant_camelot_keys_use_safe_crossfade() {
+        let db = db();
+        enable(&db);
+        seed_profile(&db, "library_track", 1, 0.9);
+        seed_profile(&db, "library_track", 2, 0.9);
+        db.with_conn(|conn| {
+            seed_dsp(conn, 1, "8A", 0.5)?;
+            seed_dsp(conn, 2, "3A", 0.5)?;
+            Ok(())
+        })
+        .expect("seed clashing dsp features");
+
+        let program = plan(
+            &db,
+            ref_for("library_track", 1),
+            ref_for("library_track", 2),
+        )
+        .expect("program");
+
+        assert_eq!(program.template, "SafeCrossfade");
     }
 
     #[test]

--- a/noor-server/src/playback/dj_engine.rs
+++ b/noor-server/src/playback/dj_engine.rs
@@ -112,6 +112,48 @@ impl DjEngine {
         })
     }
 
+    pub fn plan_drop_preview(
+        &self,
+        from: &DjMediaRef,
+        to: &DjMediaRef,
+        sample_rate: u32,
+        channels: u16,
+        duration_ms: u32,
+    ) -> Result<Option<TransitionProgram>> {
+        self.db.with_conn(|conn| {
+            if !queries::is_dj_engine_enabled(conn)? {
+                return Ok(None);
+            }
+
+            let from_key = from.profile_key();
+            let to_key = to.profile_key();
+            let Some(from_profile) = queries::get_audio_dj_profile(conn, &from_key)? else {
+                return Ok(None);
+            };
+            let Some(to_profile) = queries::get_audio_dj_profile(conn, &to_key)? else {
+                return Ok(None);
+            };
+            let from_correction = queries::get_audio_dj_profile_correction(conn, &from_key)?;
+            let to_correction = queries::get_audio_dj_profile_correction(conn, &to_key)?;
+
+            let mut outgoing = profile_from_row(conn, &from_profile)?;
+            let mut incoming = profile_from_row(conn, &to_profile)?;
+            apply_correction(&mut outgoing, from_correction.as_ref());
+            apply_correction(&mut incoming, to_correction.as_ref());
+            if runtime_safety_decision(&outgoing, &incoming).force_safe_crossfade {
+                return Ok(None);
+            }
+
+            Ok(noor_mix::planner::drop_preview_16_program(
+                sample_rate,
+                channels,
+                duration_ms,
+                &outgoing,
+                &incoming,
+            ))
+        })
+    }
+
     fn recent_bad_feedback_count(&self, media_ref: &DjMediaRef) -> Result<i64> {
         let key = media_ref.profile_key();
         self.db

--- a/noor-server/src/playback/dj_engine.rs
+++ b/noor-server/src/playback/dj_engine.rs
@@ -570,7 +570,7 @@ mod tests {
     }
 
     #[test]
-    fn bold_policy_prefers_filter_sweep_for_compatible_profiles() {
+    fn bold_policy_preserves_bass_swap_for_compatible_profiles() {
         let db = db();
         enable(&db);
         db.with_conn(|conn| queries::set_dj_global_policy(conn, "bold", "neutral"))
@@ -585,7 +585,7 @@ mod tests {
         )
         .expect("program");
 
-        assert_eq!(program.template, "FilterSweep");
+        assert_eq!(program.template, "BassSwap16");
         program.validate().expect("valid");
     }
 
@@ -597,6 +597,24 @@ mod tests {
             .expect("set bold policy");
         seed_profile(&db, "library_track", 1, 0.9);
         seed_profile(&db, "library_track", 2, 0.9);
+        db.with_conn(|conn| {
+            queries::upsert_audio_dj_profile_correction(
+                conn,
+                &AudioDjProfileCorrectionRow {
+                    media_ref_kind: "library_track".to_string(),
+                    media_ref_id: "2".to_string(),
+                    bpm_multiplier: Some(1.05),
+                    downbeat_offset_beats: None,
+                    phrase_offset_bars: None,
+                    safe_crossfade_only: false,
+                    transition_speed_bias: None,
+                    notes: None,
+                    created_at: "now".to_string(),
+                    updated_at: "now".to_string(),
+                },
+            )
+        })
+        .expect("tempo correction");
         let engine = DjEngine::new(db);
 
         let plan = engine

--- a/noor-server/src/playback/dj_engine.rs
+++ b/noor-server/src/playback/dj_engine.rs
@@ -240,6 +240,7 @@ fn fallback_profile() -> DjProfile {
         outro_start_seconds: Some(120.0),
         breakdown_seconds: vec![],
         drop_seconds: vec![],
+        manual_drop_seconds: vec![],
         safe_transition_windows: vec![noor_mix::profile::TransitionWindow {
             start_seconds: 0.0,
             end_seconds: 8.0,
@@ -339,6 +340,7 @@ fn profile_from_row(conn: &Connection, row: &AudioDjProfileRow) -> Result<DjProf
         outro_start_seconds: row.outro_start_seconds.map(|value| value as f32),
         breakdown_seconds: decode_f32_blob(&row.breakdown_blob).unwrap_or_default(),
         drop_seconds: decode_f32_blob(&row.drop_blob).unwrap_or_default(),
+        manual_drop_seconds: vec![],
         safe_transition_windows: safe_transition_windows
             .chunks_exact(3)
             .map(|chunk| noor_mix::profile::TransitionWindow {

--- a/noor-server/src/playback/dj_lookahead.rs
+++ b/noor-server/src/playback/dj_lookahead.rs
@@ -108,6 +108,28 @@ pub fn build_ephemeral_tidal_mix_pair(
     })
 }
 
+pub fn build_external_current_queue_pair(
+    conn: &Connection,
+    current: &Track,
+) -> Result<Option<DjLookaheadPair>> {
+    let current_ref = tidal_media_ref_for_track(current).or_else(|| {
+        (current.id > 0).then_some(DjMediaRef::LibraryTrack {
+            track_id: current.id,
+        })
+    });
+    let Some(current_ref) = current_ref else {
+        return Ok(None);
+    };
+    let next_row = load_first_queue_ref(conn)?;
+    Ok(Some(DjLookaheadPair {
+        current: Some(current_ref.clone()),
+        next: next_row.as_ref().map(|row| row.media_ref.clone()),
+        current_queue_item_id: None,
+        next_queue_item_id: next_row.as_ref().map(|row| row.queue_item_id),
+        queue_generation: compute_external_current_queue_generation(conn, &current_ref)?,
+    }))
+}
+
 fn compute_ephemeral_tidal_mix_generation(
     current: &Track,
     pending: &[PendingEphemeralTidalTrack],
@@ -122,6 +144,19 @@ fn compute_ephemeral_tidal_mix_generation(
         track.artist_name.hash(&mut hasher);
     }
     hasher.finish()
+}
+
+fn compute_external_current_queue_generation(
+    conn: &Connection,
+    current_ref: &DjMediaRef,
+) -> Result<u64> {
+    let mut hasher = DefaultHasher::new();
+    "external_current_queue".hash(&mut hasher);
+    let key = current_ref.profile_key();
+    key.media_ref_kind.hash(&mut hasher);
+    key.media_ref_id.hash(&mut hasher);
+    compute_queue_generation(conn)?.hash(&mut hasher);
+    Ok(hasher.finish())
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -421,6 +456,53 @@ mod tests {
         .queue_generation;
 
         assert_ne!(before, after);
+    }
+
+    #[test]
+    fn external_current_queue_pair_uses_first_persisted_queue_item() {
+        let conn = conn();
+        seed_track(&conn, 2, Some(202));
+        let next = seed_queue_track(&conn, 0, 2);
+        let current = ephemeral_track(-101, 101);
+
+        let pair = build_external_current_queue_pair(&conn, &current)
+            .unwrap()
+            .expect("pair");
+
+        assert_eq!(
+            pair.current,
+            Some(DjMediaRef::TidalTrack {
+                tidal_id: 101,
+                track_id: None
+            })
+        );
+        assert_eq!(
+            pair.next,
+            Some(DjMediaRef::TidalTrack {
+                tidal_id: 202,
+                track_id: Some(2)
+            })
+        );
+        assert_eq!(pair.current_queue_item_id, None);
+        assert_eq!(pair.next_queue_item_id, Some(next));
+    }
+
+    #[test]
+    fn external_current_queue_generation_includes_current_ref() {
+        let conn = conn();
+        seed_track(&conn, 2, Some(202));
+        seed_queue_track(&conn, 0, 2);
+
+        let first = build_external_current_queue_pair(&conn, &ephemeral_track(-101, 101))
+            .unwrap()
+            .expect("first")
+            .queue_generation;
+        let second = build_external_current_queue_pair(&conn, &ephemeral_track(-303, 303))
+            .unwrap()
+            .expect("second")
+            .queue_generation;
+
+        assert_ne!(first, second);
     }
 
     #[test]

--- a/noor-server/src/playback/dj_queue_ranker.rs
+++ b/noor-server/src/playback/dj_queue_ranker.rs
@@ -13,6 +13,22 @@ pub(crate) struct GeneratedCandidate<T> {
     pub(crate) item: T,
     pub(crate) track_id: Option<i64>,
     pub(crate) tidal_id: Option<i64>,
+    pub(crate) policy: GeneratedCandidatePolicy,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct GeneratedCandidatePolicy {
+    pub(crate) score_multiplier: f64,
+    pub(crate) reasons: Vec<&'static str>,
+}
+
+impl Default for GeneratedCandidatePolicy {
+    fn default() -> Self {
+        Self {
+            score_multiplier: 1.0,
+            reasons: Vec::new(),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -47,8 +63,8 @@ pub(crate) fn rank_generated_candidates<T>(
             .into_iter()
             .map(|candidate| RankedGeneratedCandidate {
                 item: candidate.item,
-                score: 1.0,
-                reasons: Vec::new(),
+                score: candidate.policy.score_multiplier,
+                reasons: candidate.policy.reasons,
             })
             .collect());
     }
@@ -59,7 +75,9 @@ pub(crate) fn rank_generated_candidates<T>(
         .enumerate()
         .map(|(ordinal, candidate)| {
             let facts = load_facts(conn, candidate.track_id, candidate.tidal_id)?;
-            let (score, reasons) = score_facts(&seed, &facts);
+            let (score, mut reasons) = score_facts(&seed, &facts);
+            let score = score * candidate.policy.score_multiplier;
+            reasons.extend(candidate.policy.reasons);
             Ok(ScoredCandidate {
                 ordinal,
                 ranked: RankedGeneratedCandidate {
@@ -81,6 +99,63 @@ pub(crate) fn rank_generated_candidates<T>(
     });
 
     Ok(scored.into_iter().map(|entry| entry.ranked).collect())
+}
+
+pub(crate) fn rank_generated_candidates_chain<T>(
+    conn: &Connection,
+    seed_track_id: i64,
+    candidates: Vec<GeneratedCandidate<T>>,
+) -> Result<Vec<RankedGeneratedCandidate<T>>> {
+    if candidates.len() <= 1 {
+        return Ok(candidates
+            .into_iter()
+            .map(|candidate| RankedGeneratedCandidate {
+                item: candidate.item,
+                score: candidate.policy.score_multiplier,
+                reasons: candidate.policy.reasons,
+            })
+            .collect());
+    }
+
+    let mut previous = load_facts_for_track(conn, seed_track_id)?;
+    let mut remaining = candidates
+        .into_iter()
+        .enumerate()
+        .map(|(ordinal, candidate)| {
+            let facts = load_facts(conn, candidate.track_id, candidate.tidal_id)?;
+            Ok((ordinal, candidate.item, facts, candidate.policy))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let mut ranked = Vec::with_capacity(remaining.len());
+
+    while !remaining.is_empty() {
+        let mut best_index = 0usize;
+        let mut best_score = f64::NEG_INFINITY;
+        for (idx, (ordinal, _, facts, policy)) in remaining.iter().enumerate() {
+            let (score, _) = score_facts(&previous, facts);
+            let score = score * policy.score_multiplier;
+            let score_order = score.partial_cmp(&best_score).unwrap_or(Ordering::Equal);
+            let is_better = score_order == Ordering::Greater
+                || (score_order == Ordering::Equal && *ordinal < remaining[best_index].0);
+            if is_better {
+                best_index = idx;
+                best_score = score;
+            }
+        }
+
+        let (_ordinal, item, facts, policy) = remaining.remove(best_index);
+        let (score, mut reasons) = score_facts(&previous, &facts);
+        let score = score * policy.score_multiplier;
+        reasons.extend(policy.reasons);
+        previous = facts;
+        ranked.push(RankedGeneratedCandidate {
+            item,
+            score,
+            reasons,
+        });
+    }
+
+    Ok(ranked)
 }
 
 pub(crate) fn append_dj_reason(existing: &str, score: f64, reasons: &[&'static str]) -> String {
@@ -409,11 +484,13 @@ mod tests {
                     item: "first",
                     track_id: None,
                     tidal_id: None,
+                    policy: Default::default(),
                 },
                 GeneratedCandidate {
                     item: "second",
                     track_id: None,
                     tidal_id: None,
+                    policy: Default::default(),
                 },
             ],
         )
@@ -471,11 +548,13 @@ mod tests {
                     item: "clash",
                     track_id: Some(3),
                     tidal_id: Some(9003),
+                    policy: Default::default(),
                 },
                 GeneratedCandidate {
                     item: "tidal-fit",
                     track_id: None,
                     tidal_id: Some(9002),
+                    policy: Default::default(),
                 },
             ],
         )
@@ -484,5 +563,112 @@ mod tests {
         assert_eq!(ranked[0].item, "tidal-fit");
         assert!(ranked[0].reasons.contains(&"tempo inside 3 percent"));
         assert!(ranked[0].reasons.contains(&"harmonic match"));
+    }
+
+    #[test]
+    fn rank_generated_candidates_chain_scores_each_pick_against_previous_pick() {
+        let conn = Connection::open_in_memory().expect("db");
+        conn.execute_batch(
+            "
+            CREATE TABLE tracks (id INTEGER PRIMARY KEY, tidal_id INTEGER);
+            CREATE TABLE audio_dsp_features (
+                track_id INTEGER PRIMARY KEY,
+                bpm REAL,
+                key_signature TEXT,
+                camelot_key TEXT,
+                loudness_lufs REAL,
+                energy REAL,
+                danceability REAL,
+                beat_strength REAL,
+                spectral_centroid REAL,
+                stereo_width REAL,
+                is_instrumental INTEGER NOT NULL DEFAULT 0,
+                analysis_source TEXT NOT NULL DEFAULT 'test',
+                analysis_offset_ms INTEGER NOT NULL DEFAULT 0,
+                samples_analyzed INTEGER,
+                analyzed_at TEXT NOT NULL DEFAULT '2026-01-01T00:00:00Z',
+                analysis_version TEXT NOT NULL DEFAULT 'test'
+            );
+            ",
+        )
+        .expect("schema");
+        for (track_id, bpm, key) in [
+            (1, 120.0, "1A"),
+            (2, 121.0, "2A"),
+            (3, 122.0, "6A"),
+            (4, 122.0, "3A"),
+        ] {
+            conn.execute(
+                "INSERT INTO audio_dsp_features (track_id, bpm, camelot_key) VALUES (?1, ?2, ?3)",
+                params![track_id, bpm, key],
+            )
+            .expect("features");
+        }
+
+        let ranked = rank_generated_candidates_chain(
+            &conn,
+            1,
+            vec![
+                GeneratedCandidate {
+                    item: "first-fit",
+                    track_id: Some(2),
+                    tidal_id: None,
+                    policy: Default::default(),
+                },
+                GeneratedCandidate {
+                    item: "seed-favored-clash-after-first",
+                    track_id: Some(3),
+                    tidal_id: None,
+                    policy: Default::default(),
+                },
+                GeneratedCandidate {
+                    item: "chain-fit",
+                    track_id: Some(4),
+                    tidal_id: None,
+                    policy: Default::default(),
+                },
+            ],
+        )
+        .expect("rank");
+
+        assert_eq!(
+            ranked.into_iter().map(|row| row.item).collect::<Vec<_>>(),
+            vec!["first-fit", "chain-fit", "seed-favored-clash-after-first"]
+        );
+    }
+
+    #[test]
+    fn rank_generated_candidates_chain_keeps_equal_scores_stable() {
+        let conn = Connection::open_in_memory().expect("db");
+        let ranked = rank_generated_candidates_chain(
+            &conn,
+            1,
+            vec![
+                GeneratedCandidate {
+                    item: "first",
+                    track_id: None,
+                    tidal_id: None,
+                    policy: Default::default(),
+                },
+                GeneratedCandidate {
+                    item: "second",
+                    track_id: None,
+                    tidal_id: None,
+                    policy: Default::default(),
+                },
+                GeneratedCandidate {
+                    item: "third",
+                    track_id: None,
+                    tidal_id: None,
+                    policy: Default::default(),
+                },
+            ],
+        )
+        .expect("rank");
+
+        assert_eq!(
+            ranked.into_iter().map(|row| row.item).collect::<Vec<_>>(),
+            vec!["first", "second", "third"]
+        );
     }
 }

--- a/noor-server/src/playback/player.rs
+++ b/noor-server/src/playback/player.rs
@@ -1865,6 +1865,7 @@ mod tests {
     use super::*;
     use crate::playback::automix::{
         automix_score, automix_scored_reason, build_automix_extension_with_reasons,
+        evaluate_automix_for_seed,
     };
 
     fn conn() -> Connection {
@@ -4504,6 +4505,248 @@ mod tests {
             !extension.is_empty(),
             "expected non-empty extension once a similarity row exists"
         );
+    }
+
+    #[test]
+    fn learned_automix_builds_chain_aware_order_from_overfetched_neighbors() {
+        let conn = conn();
+        conn.execute_batch(
+            "
+            CREATE TABLE track_neighbors (
+                track_id INTEGER NOT NULL,
+                neighbor_track_id INTEGER NOT NULL,
+                model_id INTEGER NOT NULL,
+                rank INTEGER NOT NULL,
+                score REAL NOT NULL DEFAULT 0,
+                behavioral_score REAL DEFAULT 0,
+                audio_score REAL DEFAULT 0,
+                metadata_score REAL DEFAULT 0,
+                reason_json TEXT,
+                computed_at TEXT DEFAULT (datetime('now')),
+                primary_reason TEXT,
+                confidence REAL NOT NULL DEFAULT 0,
+                support_count INTEGER NOT NULL DEFAULT 0,
+                candidate_in_degree INTEGER NOT NULL DEFAULT 0,
+                candidate_in_degree_percentile REAL NOT NULL DEFAULT 0,
+                play_count_seed INTEGER NOT NULL DEFAULT 0,
+                play_count_candidate INTEGER NOT NULL DEFAULT 0,
+                support_transition REAL NOT NULL DEFAULT 0,
+                support_colisten REAL NOT NULL DEFAULT 0,
+                support_structure REAL NOT NULL DEFAULT 0,
+                support_metadata REAL NOT NULL DEFAULT 0,
+                PRIMARY KEY (track_id, neighbor_track_id, model_id)
+            );
+            CREATE TABLE audio_dsp_features (
+                track_id INTEGER PRIMARY KEY,
+                bpm REAL,
+                key_signature TEXT,
+                camelot_key TEXT,
+                loudness_lufs REAL,
+                energy REAL,
+                danceability REAL,
+                beat_strength REAL,
+                spectral_centroid REAL,
+                stereo_width REAL,
+                is_instrumental INTEGER NOT NULL DEFAULT 0,
+                analysis_source TEXT NOT NULL DEFAULT 'test',
+                analysis_offset_ms INTEGER NOT NULL DEFAULT 0,
+                samples_analyzed INTEGER,
+                analyzed_at TEXT NOT NULL DEFAULT '2026-01-01T00:00:00Z',
+                analysis_version TEXT NOT NULL DEFAULT 'test'
+            );
+            INSERT INTO server_config (key, value) VALUES ('discovery_engine', 'v2');
+            INSERT INTO embedding_models (
+                id, model_key, family, dimension, status, is_active, trained_at, created_at
+            ) VALUES (
+                1, 'test-chain', 'discovery-fusion-v2', 3, 'ready', 1,
+                '2026-01-01 00:00:00', '2026-01-01 00:00:00'
+            );
+            INSERT INTO track_neighbors (
+                track_id, neighbor_track_id, model_id, rank, score, audio_score, primary_reason
+            ) VALUES
+                (1, 2, 1, 1, 0.90, 0.90, 'audio_texture'),
+                (1, 3, 1, 2, 0.89, 0.89, 'audio_texture'),
+                (1, 4, 1, 3, 0.88, 0.88, 'audio_texture');
+            INSERT INTO audio_dsp_features (track_id, bpm, camelot_key) VALUES
+                (1, 120.0, '1A'),
+                (2, 120.0, '2A'),
+                (3, 120.0, '12A'),
+                (4, 120.0, '3A');
+            ",
+        )
+        .expect("schema");
+        let seed = queue::get_track_by_id(&conn, 1).unwrap().unwrap();
+
+        let extension =
+            extension_tracks(&conn, &seed, &[], ShuffleMode::Off, 3, true).expect("extension call");
+
+        assert_eq!(
+            extension.iter().map(|track| track.id).collect::<Vec<_>>(),
+            vec![2, 4, 3]
+        );
+    }
+
+    #[test]
+    fn learned_automix_smoke_prefers_next_track_fit_over_vague_similarity() {
+        let conn = conn();
+        conn.execute_batch(
+            "
+            CREATE TABLE track_neighbors (
+                track_id INTEGER NOT NULL,
+                neighbor_track_id INTEGER NOT NULL,
+                model_id INTEGER NOT NULL,
+                rank INTEGER NOT NULL,
+                score REAL NOT NULL DEFAULT 0,
+                behavioral_score REAL DEFAULT 0,
+                audio_score REAL DEFAULT 0,
+                metadata_score REAL DEFAULT 0,
+                reason_json TEXT,
+                computed_at TEXT DEFAULT (datetime('now')),
+                primary_reason TEXT,
+                confidence REAL NOT NULL DEFAULT 0,
+                support_count INTEGER NOT NULL DEFAULT 0,
+                candidate_in_degree INTEGER NOT NULL DEFAULT 0,
+                candidate_in_degree_percentile REAL NOT NULL DEFAULT 0,
+                play_count_seed INTEGER NOT NULL DEFAULT 0,
+                play_count_candidate INTEGER NOT NULL DEFAULT 0,
+                support_transition REAL NOT NULL DEFAULT 0,
+                support_colisten REAL NOT NULL DEFAULT 0,
+                support_structure REAL NOT NULL DEFAULT 0,
+                support_metadata REAL NOT NULL DEFAULT 0,
+                PRIMARY KEY (track_id, neighbor_track_id, model_id)
+            );
+            CREATE TABLE audio_dsp_features (
+                track_id INTEGER PRIMARY KEY,
+                bpm REAL,
+                key_signature TEXT,
+                camelot_key TEXT,
+                loudness_lufs REAL,
+                energy REAL,
+                danceability REAL,
+                beat_strength REAL,
+                spectral_centroid REAL,
+                stereo_width REAL,
+                is_instrumental INTEGER NOT NULL DEFAULT 0,
+                analysis_source TEXT NOT NULL DEFAULT 'test',
+                analysis_offset_ms INTEGER NOT NULL DEFAULT 0,
+                samples_analyzed INTEGER,
+                analyzed_at TEXT NOT NULL DEFAULT '2026-01-01T00:00:00Z',
+                analysis_version TEXT NOT NULL DEFAULT 'test'
+            );
+            INSERT INTO server_config (key, value) VALUES ('discovery_engine', 'v2');
+            INSERT INTO embedding_models (
+                id, model_key, family, dimension, status, is_active, trained_at, created_at
+            ) VALUES (
+                1, 'test-smoke', 'discovery-fusion-v2', 3, 'ready', 1,
+                '2026-01-01 00:00:00', '2026-01-01 00:00:00'
+            );
+            INSERT INTO track_neighbors (
+                track_id, neighbor_track_id, model_id, rank, score, behavioral_score,
+                audio_score, metadata_score, reason_json, primary_reason, support_colisten
+            ) VALUES
+                (1, 2, 1, 1, 0.99, 0.80, 0.10, 0.10, '[{\"key\":\"behavioral\"}]', 'behavioral', 1.0),
+                (1, 3, 1, 2, 0.98, 0.00, 0.98, 0.00, '[{\"key\":\"audio_texture\"}]', 'audio_texture', 0.0),
+                (1, 4, 1, 3, 0.97, 0.00, 0.10, 0.00, '[{\"key\":\"lastfm_direct\"}]', 'lastfm_direct', 0.0),
+                (1, 5, 1, 4, 0.96, 0.00, 0.10, 0.00, '[{\"key\":\"lastfm_branch\"}]', 'lastfm_branch', 0.0),
+                (1, 6, 1, 5, 0.70, 0.00, 0.20, 0.30, '[{\"key\":\"bpm_match\"},{\"key\":\"harmonic_match\"}]', 'bpm_match', 0.0);
+            INSERT INTO audio_dsp_features (track_id, bpm, camelot_key) VALUES
+                (1, 120.0, '1A'),
+                (2, 150.0, '6B'),
+                (3, 120.0, '1A'),
+                (4, 145.0, '6B'),
+                (5, 120.0, '1A'),
+                (6, 120.0, '1A');
+            ",
+        )
+        .expect("schema");
+        let seed = queue::get_track_by_id(&conn, 1).unwrap().unwrap();
+
+        let extension =
+            extension_tracks(&conn, &seed, &[], ShuffleMode::Off, 5, true).expect("extension call");
+
+        assert_eq!(extension.first().map(|track| track.id), Some(6));
+        assert_eq!(
+            extension.iter().map(|track| track.id).collect::<Vec<_>>(),
+            vec![6, 5, 3, 4, 2]
+        );
+    }
+
+    #[test]
+    fn automix_evaluator_reports_before_after_without_queue_insert() {
+        let conn = conn();
+        conn.execute_batch(
+            "
+            CREATE TABLE track_neighbors (
+                track_id INTEGER NOT NULL,
+                neighbor_track_id INTEGER NOT NULL,
+                model_id INTEGER NOT NULL,
+                rank INTEGER NOT NULL,
+                score REAL NOT NULL DEFAULT 0,
+                behavioral_score REAL DEFAULT 0,
+                audio_score REAL DEFAULT 0,
+                metadata_score REAL DEFAULT 0,
+                reason_json TEXT,
+                computed_at TEXT DEFAULT (datetime('now')),
+                primary_reason TEXT,
+                confidence REAL NOT NULL DEFAULT 0,
+                support_count INTEGER NOT NULL DEFAULT 0,
+                candidate_in_degree INTEGER NOT NULL DEFAULT 0,
+                candidate_in_degree_percentile REAL NOT NULL DEFAULT 0,
+                play_count_seed INTEGER NOT NULL DEFAULT 0,
+                play_count_candidate INTEGER NOT NULL DEFAULT 0,
+                support_transition REAL NOT NULL DEFAULT 0,
+                support_colisten REAL NOT NULL DEFAULT 0,
+                support_structure REAL NOT NULL DEFAULT 0,
+                support_metadata REAL NOT NULL DEFAULT 0,
+                PRIMARY KEY (track_id, neighbor_track_id, model_id)
+            );
+            CREATE TABLE audio_dsp_features (
+                track_id INTEGER PRIMARY KEY,
+                bpm REAL,
+                key_signature TEXT,
+                camelot_key TEXT,
+                loudness_lufs REAL,
+                energy REAL,
+                danceability REAL,
+                beat_strength REAL,
+                spectral_centroid REAL,
+                stereo_width REAL,
+                is_instrumental INTEGER NOT NULL DEFAULT 0,
+                analysis_source TEXT NOT NULL DEFAULT 'test',
+                analysis_offset_ms INTEGER NOT NULL DEFAULT 0,
+                samples_analyzed INTEGER,
+                analyzed_at TEXT NOT NULL DEFAULT '2026-01-01T00:00:00Z',
+                analysis_version TEXT NOT NULL DEFAULT 'test'
+            );
+            INSERT INTO server_config (key, value) VALUES ('discovery_engine', 'v2');
+            INSERT INTO embedding_models (
+                id, model_key, family, dimension, status, is_active, trained_at, created_at
+            ) VALUES (
+                1, 'test-evaluator', 'discovery-fusion-v2', 3, 'ready', 1,
+                '2026-01-01 00:00:00', '2026-01-01 00:00:00'
+            );
+            INSERT INTO track_neighbors (
+                track_id, neighbor_track_id, model_id, rank, score, audio_score,
+                metadata_score, reason_json, primary_reason
+            ) VALUES
+                (1, 2, 1, 1, 0.90, 0.40, 0.20, '[{\"key\":\"bpm_match\"}]', 'bpm_match');
+            INSERT INTO audio_dsp_features (track_id, bpm, camelot_key) VALUES
+                (1, 120.0, '1A'),
+                (2, 120.5, '1A');
+            ",
+        )
+        .expect("schema");
+
+        let report = evaluate_automix_for_seed(&conn, 1, 1).expect("evaluate");
+
+        assert_eq!(report.queue_len_before, report.queue_len_after);
+        assert_eq!(report.before.len(), 1);
+        assert_eq!(report.after.len(), 1);
+        assert_eq!(report.before[0].track_id, 2);
+        assert_eq!(report.after[0].track_id, 2);
+        assert_eq!(report.after[0].bpm, Some(120.5));
+        assert_eq!(report.after[0].camelot_key.as_deref(), Some("1A"));
+        assert!(report.after[0].final_score.is_some());
     }
 
     /// Metadata fallback: seed has no embedding/similarity signal but the

--- a/noor-server/src/playback/player.rs
+++ b/noor-server/src/playback/player.rs
@@ -2780,12 +2780,12 @@ mod tests {
         }
 
         #[test]
-        fn v1_planner_logs_and_prepares_drop_tease_overlay_when_candidate_matches() {
+        fn v1_planner_keeps_drop_tease_overlay_out_of_end_transition() {
             let db = db_with_pair();
             make_pair_drop_tease_ready(&db);
             let transition = plan(&db);
 
-            assert_eq!(transition.program.template, "DropTease16");
+            assert_eq!(transition.program.template, "BassSwap32");
             let row: (String, String, Option<String>) = db
                 .with_conn(|conn| {
                     conn.query_row(
@@ -2800,9 +2800,8 @@ mod tests {
             let renderer_program: noor_mix::TransitionProgram =
                 serde_json::from_str(&row.1).expect("program");
 
-            assert_eq!(row.0, "DropTease16");
-            assert_eq!(renderer_program.template, "DropTease16");
-            assert_eq!(renderer_program.deck_b_start_frame, 768_000);
+            assert_eq!(row.0, "BassSwap32");
+            assert_eq!(renderer_program.template, "BassSwap32");
             assert_eq!(row.2, None);
         }
 

--- a/noor-server/src/playback/player.rs
+++ b/noor-server/src/playback/player.rs
@@ -505,11 +505,11 @@ const DJ_FILTER_SWEEP_TIMING_WINDOW: i64 = 20;
 const DJ_FILTER_SWEEP_TIMING_MIN_ROWS: usize = 4;
 const DJ_FILTER_SWEEP_MEDIAN_ABS_MAX_MS: i64 = 300;
 const DJ_FILTER_SWEEP_WORST_ABS_MAX_MS: i64 = 750;
-const DJ_FILTER_SWEEP_RENDER_MS: u32 = 12_000;
-const DJ_BASS_SWAP_16_RENDER_MS: u32 = 16_000;
-const DJ_BASS_SWAP_32_RENDER_MS: u32 = 32_000;
+const DJ_FILTER_SWEEP_RENDER_MS: u32 = 18_000;
+const DJ_BASS_SWAP_16_RENDER_MS: u32 = 24_000;
+const DJ_BASS_SWAP_32_RENDER_MS: u32 = 28_000;
 const DJ_SLAM_CUT_RENDER_MS: u32 = 200;
-const DJ_LONG_HARMONIC_BLEND_RENDER_MS: u32 = 16_000;
+const DJ_LONG_HARMONIC_BLEND_RENDER_MS: u32 = 24_000;
 
 fn dj_transition_fire_ahead_ms(conn: &Connection) -> Result<u32> {
     let deltas = dj_timing_calibration_deltas(conn, DJ_FIRE_AHEAD_WINDOW)?;
@@ -732,7 +732,7 @@ fn synced_overlap_from_grid_ms(
     sample_rate: u32,
 ) -> Option<i32> {
     const MIN_SYNC_OVERLAP_MS: i64 = 8_000;
-    const MAX_SYNC_OVERLAP_MS: i64 = 16_000;
+    const MAX_SYNC_OVERLAP_MS: i64 = 28_000;
     let preferred_ms = preferred_overlap_ms.max(250) as i64;
     let program_ms = program_samples
         .map(|samples| {
@@ -2398,7 +2398,7 @@ mod tests {
     mod dj_transition_logging {
         use super::*;
         use crate::db::models::{
-            AudioDjProfileCorrectionRow, AudioDjProfileKey, AudioDjProfileRow,
+            AudioDjProfileCorrectionRow, AudioDjProfileKey, AudioDjProfileRow, AudioDspFeatures,
         };
         use crate::db::schema;
         use crate::services::audio_analysis::dj_profile::{
@@ -2430,6 +2430,8 @@ mod tests {
                     [],
                 )?;
                 queries::set_dj_engine_enabled(conn, true)?;
+                seed_dsp(conn, 1, "8A")?;
+                seed_dsp(conn, 2, "8A")?;
                 seed_profile(conn, "tidal_track", "1", Some(1))?;
                 seed_profile(conn, "tidal_track", "2", Some(2))?;
                 Ok(())
@@ -2479,6 +2481,30 @@ mod tests {
                 computed_at: "now".to_string(),
             };
             queries::upsert_audio_dj_profile(conn, &row)
+        }
+
+        fn seed_dsp(conn: &Connection, track_id: i64, camelot_key: &str) -> Result<()> {
+            queries::upsert_audio_dsp_features(
+                conn,
+                &AudioDspFeatures {
+                    track_id,
+                    bpm: Some(120.0),
+                    key_signature: None,
+                    camelot_key: Some(camelot_key.to_string()),
+                    loudness_lufs: Some(-12.0),
+                    energy: Some(0.5),
+                    danceability: None,
+                    beat_strength: None,
+                    spectral_centroid: None,
+                    stereo_width: None,
+                    is_instrumental: false,
+                    analysis_source: "test".to_string(),
+                    analysis_offset_ms: 0,
+                    samples_analyzed: None,
+                    analyzed_at: "now".to_string(),
+                    analysis_version: "test".to_string(),
+                },
+            )
         }
 
         fn next_job(db: &Database) -> PlaybackPreparation {
@@ -2749,7 +2775,7 @@ mod tests {
 
             assert_eq!(row.0, "BassSwap16");
             assert_eq!(renderer_program.template, "BassSwap16");
-            assert_eq!(renderer_program.resolve_at, 768_000);
+            assert_eq!(renderer_program.resolve_at, 1_152_000);
             assert_eq!(row.2, None);
         }
 
@@ -2820,7 +2846,7 @@ mod tests {
 
             assert_eq!(row.0, "FilterSweep");
             assert_eq!(renderer_program.template, "FilterSweep");
-            assert_eq!(renderer_program.resolve_at, 576_000);
+            assert_eq!(renderer_program.resolve_at, 864_000);
             assert_eq!(row.2, None);
         }
 
@@ -2831,7 +2857,7 @@ mod tests {
             let (program, reason) = v1_renderable_program(&input, 48_000, 2, false);
 
             assert_eq!(program.template, "FilterSweep");
-            assert_eq!(program.resolve_at, 576_000);
+            assert_eq!(program.resolve_at, 864_000);
             assert_eq!(reason, None);
             assert!(
                 program
@@ -2857,7 +2883,7 @@ mod tests {
             let (program, reason) = v1_renderable_program(&input, 48_000, 2, false);
 
             assert_eq!(program.template, "BassSwap16");
-            assert_eq!(program.resolve_at, 768_000);
+            assert_eq!(program.resolve_at, 1_152_000);
             assert_eq!(program.deck_b_start_frame, 384_000);
             assert_eq!(reason, None);
             let rate = program
@@ -2880,7 +2906,7 @@ mod tests {
             let (program, reason) = v1_renderable_program(&input, 48_000, 2, false);
 
             assert_eq!(program.template, "BassSwap32");
-            assert_eq!(program.resolve_at, 1_536_000);
+            assert_eq!(program.resolve_at, 1_344_000);
             assert_eq!(reason, None);
             assert!(program.automation.iter().any(|event| event.param
                 == noor_mix::Param::LowGain(noor_mix::DeckId::B)
@@ -2913,7 +2939,7 @@ mod tests {
             let (program, reason) = v1_renderable_program(&input, 48_000, 2, false);
 
             assert_eq!(program.template, "LongHarmonicBlend");
-            assert_eq!(program.resolve_at, 768_000);
+            assert_eq!(program.resolve_at, 1_152_000);
             assert_eq!(reason, None);
             let rate = program
                 .automation
@@ -3006,12 +3032,12 @@ mod tests {
             let bass_swap_32 =
                 noor_mix::planner::bass_swap_32_program(48_000, 2, DJ_BASS_SWAP_32_RENDER_MS);
 
-            assert_eq!(dj_gapless_plan_from_program(&safe).overlap_ms, 8_000);
-            assert_eq!(dj_gapless_plan_from_program(&filter).overlap_ms, 12_000);
-            assert_eq!(dj_gapless_plan_from_program(&bass_swap).overlap_ms, 16_000);
+            assert_eq!(dj_gapless_plan_from_program(&safe).overlap_ms, 12_000);
+            assert_eq!(dj_gapless_plan_from_program(&filter).overlap_ms, 18_000);
+            assert_eq!(dj_gapless_plan_from_program(&bass_swap).overlap_ms, 24_000);
             assert_eq!(
                 dj_gapless_plan_from_program(&bass_swap_32).overlap_ms,
-                32_000
+                28_000
             );
         }
 
@@ -3653,6 +3679,20 @@ mod tests {
                 .expect("overlap");
 
         assert_eq!(overlap_ms, 9_000);
+    }
+
+    #[test]
+    fn synced_overlap_allows_longer_dj_handoff_windows() {
+        let overlap_ms = synced_overlap_from_grid_ms(
+            180_000,
+            &[0.0, 2.0, 4.0],
+            24_000,
+            Some(24_000 * 48),
+            48_000,
+        )
+        .expect("overlap");
+
+        assert_eq!(overlap_ms, 24_000);
     }
 
     #[test]

--- a/noor-server/src/playback/player.rs
+++ b/noor-server/src/playback/player.rs
@@ -1658,7 +1658,7 @@ pub fn peek_next_track(conn: &Connection, recently_cleared: bool) -> Result<Opti
         _ => current_index
             .and_then(|idx| queue_items.get(idx + 1))
             .or_else(|| {
-                if repeat_mode == "all" {
+                if current_index.is_none() || repeat_mode == "all" {
                     queue_items.first()
                 } else {
                     None
@@ -3817,6 +3817,24 @@ mod tests {
         let next = peek_next_track(&conn, false).unwrap().expect("next track");
 
         assert_eq!(next.id, 3);
+    }
+
+    #[test]
+    fn peek_next_track_returns_first_queue_item_when_unanchored() {
+        let conn = conn();
+        let tracks = load_tracks(&conn, &[1, 2]);
+        queue::replace_queue(&conn, &tracks, "test").unwrap();
+        conn.execute(
+            "UPDATE playback_state
+             SET current_track_id = NULL, current_queue_item_id = NULL, is_playing = 1
+             WHERE id = 1",
+            [],
+        )
+        .unwrap();
+
+        let next = peek_next_track(&conn, false).unwrap().expect("first track");
+
+        assert_eq!(next.id, 1);
     }
 
     #[test]

--- a/noor-server/src/playback/runtime/commands.rs
+++ b/noor-server/src/playback/runtime/commands.rs
@@ -23,6 +23,15 @@ pub enum PlaybackRuntimeCommand {
     },
     /// Pre-decode the next track in background so it can start gaplessly.
     PrepareNext(PreparedPlaybackJob),
+    /// Pre-decode an incoming deck for a mid-song drop preview overlay.
+    PrepareDropPreview(PreparedPlaybackJob),
+    /// Arm the active deck to start the prepared drop preview at an absolute
+    /// active-track sample position.
+    ArmDropPreview {
+        track_id: i64,
+        generation: u64,
+        trigger_position_samples: u64,
+    },
     /// Update the runtime's in-memory DJ gate after the persisted feature flag changes.
     SetDjEngineEnabled {
         enabled: bool,
@@ -45,6 +54,11 @@ pub enum PlaybackRuntimeCommand {
     /// Sent by the CPAL callback when the current track is within `crossfade_ms` of its end.
     /// If a pre-decoded next engine is ready, its stream is unpaused so both mix via the OS.
     CrossfadeStart {
+        track_id: i64,
+        generation: u64,
+        trigger_position_samples: u64,
+    },
+    DropPreviewStart {
         track_id: i64,
         generation: u64,
         trigger_position_samples: u64,
@@ -150,6 +164,11 @@ pub enum PlaybackRuntimeEvent {
         runtime_rendered_dj_mixer: bool,
         runtime_renderer_status: String,
         runtime_renderer_reason: String,
+    },
+    DropPreviewStarted {
+        track_id: i64,
+        generation: u64,
+        actual_start_ms: i64,
     },
     /// Fired when the current track is within `NEAR_END_THRESHOLD_MS` of its end.
     /// The listener should peek the next track and send `PrepareNext` to pre-buffer it.

--- a/noor-server/src/playback/runtime/commands.rs
+++ b/noor-server/src/playback/runtime/commands.rs
@@ -47,6 +47,7 @@ pub enum PlaybackRuntimeCommand {
     CrossfadeStart {
         track_id: i64,
         generation: u64,
+        trigger_position_samples: u64,
     },
     TrackTerminal {
         track_id: i64,

--- a/noor-server/src/playback/runtime/mod.rs
+++ b/noor-server/src/playback/runtime/mod.rs
@@ -1298,6 +1298,7 @@ fn start_prepared_overlay(
     event_tx: &tokio::sync::broadcast::Sender<PlaybackRuntimeEvent>,
     timing_status: &'static str,
     runtime_renderer_reason: DjRuntimeRendererReason,
+    actual_start_ms_override: Option<i64>,
     device_sample_rate: u32,
     device_channels: u16,
 ) -> Result<(), DjRuntimeRendererReason> {
@@ -1311,7 +1312,8 @@ fn start_prepared_overlay(
     };
     let outgoing_track_id = active.track_id;
     let outgoing_generation = active.generation;
-    let actual_start_ms = track_position_ms(&active.shared, device_sample_rate, device_channels);
+    let actual_start_ms = actual_start_ms_override
+        .unwrap_or_else(|| track_position_ms(&active.shared, device_sample_rate, device_channels));
     active.shared.crossfade_samples.store(0, Ordering::Relaxed);
 
     install_prepared_overlay_mixer_buffer(state)?;
@@ -1776,6 +1778,7 @@ fn run_runtime_loop(
                 PlaybackRuntimeCommand::CrossfadeStart {
                     track_id,
                     generation,
+                    trigger_position_samples,
                 } => {
                     // The OUTGOING engine just entered its fade-out window and is asking
                     // us to start the pre-decoded next engine, if one is ready.
@@ -1788,6 +1791,11 @@ fn run_runtime_loop(
                             .and_then(|e| e.shared.buffer.lock().ok().map(|g| g.is_ready()))
                             .unwrap_or(false);
                         if next_ready && !active_engine_suppresses_crossfade_after_seek(&state) {
+                            let trigger_actual_start_ms = samples_to_ms(
+                                trigger_position_samples,
+                                state.device_sample_rate,
+                                state.device_channels,
+                            );
                             let _ = prepare_dj_mixer_for_pair(
                                 &mut state,
                                 dj_mixer_max_block_samples(&output_config),
@@ -1800,6 +1808,7 @@ fn run_runtime_loop(
                                     &event_tx,
                                     "fired",
                                     DjRuntimeRendererReason::None,
+                                    Some(trigger_actual_start_ms),
                                     device_sample_rate,
                                     device_channels,
                                 ) {
@@ -1825,6 +1834,7 @@ fn run_runtime_loop(
                                     &buffered_source,
                                     &offset_source,
                                     "fired",
+                                    Some(trigger_actual_start_ms),
                                     runtime_renderer,
                                 );
                             }
@@ -1873,6 +1883,7 @@ fn run_runtime_loop(
                                     &event_tx,
                                     "late",
                                     late_fire_reason,
+                                    None,
                                     device_sample_rate,
                                     device_channels,
                                 ) {
@@ -1902,6 +1913,7 @@ fn run_runtime_loop(
                                     &buffered_source,
                                     &offset_source,
                                     "late",
+                                    None,
                                     runtime_renderer,
                                 );
                             }
@@ -2785,6 +2797,7 @@ fn promote_next_to_active(
     buffered_source: &Arc<Mutex<Arc<AtomicU64>>>,
     offset_source: &Arc<Mutex<Arc<AtomicU64>>>,
     timing_status: &'static str,
+    actual_start_ms_override: Option<i64>,
     runtime_renderer: DjRuntimeRendererOutcome,
 ) {
     state.prepared_dj_mixer = None;
@@ -2833,11 +2846,13 @@ fn promote_next_to_active(
     if let Some(mut outgoing) = outgoing {
         let outgoing_id = outgoing.track_id;
         let outgoing_generation = outgoing.generation;
-        let actual_start_ms = track_position_ms(
-            &outgoing.shared,
-            state.device_sample_rate,
-            state.device_channels,
-        );
+        let actual_start_ms = actual_start_ms_override.unwrap_or_else(|| {
+            track_position_ms(
+                &outgoing.shared,
+                state.device_sample_rate,
+                state.device_channels,
+            )
+        });
         if runtime_renderer.rendered {
             outgoing.stop();
         } else {
@@ -2880,10 +2895,14 @@ fn promote_next_to_active(
 }
 
 fn track_position_ms(shared: &PlaybackSharedState, sample_rate: u32, channels: u16) -> i64 {
+    let samples = shared.position_samples.load(Ordering::Relaxed);
+    samples_to_ms(samples, sample_rate, channels)
+}
+
+fn samples_to_ms(samples: u64, sample_rate: u32, channels: u16) -> i64 {
     if sample_rate == 0 || channels == 0 {
         return 0;
     }
-    let samples = shared.position_samples.load(Ordering::Relaxed);
     (samples.saturating_mul(1000) / (u64::from(sample_rate) * u64::from(channels))) as i64
 }
 
@@ -3922,6 +3941,7 @@ mod tests {
                 &event_tx,
                 "fired",
                 DjRuntimeRendererReason::None,
+                None,
                 48_000,
                 2
             )
@@ -3954,6 +3974,80 @@ mod tests {
                 assert!(runtime_rendered_dj_mixer);
                 assert_eq!(runtime_renderer_status, "rendered_overlay");
                 assert_eq!(runtime_renderer_reason, "none");
+            }
+            other => panic!("expected overlay event, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn prepared_overlay_reports_captured_fire_position() {
+        let mut state = test_runtime_loop_state();
+        start_dj_lookahead_in_state(
+            &mut state,
+            Some(DjMediaRef::LibraryTrack { track_id: 1 }),
+            Some(DjMediaRef::LibraryTrack { track_id: 2 }),
+            Some(11),
+            Some(12),
+            20,
+            48_000,
+        );
+
+        let active = test_engine_with_shared(1, 20);
+        active
+            .shared
+            .position_samples
+            .store(96_000, Ordering::Relaxed);
+        finish_engine_buffer(&active, &[0.1, 0.1, 0.2, 0.2]);
+
+        let mut transition = test_prepared_transition_program(20, Some(11), Some(12));
+        transition.transition_event_id = Some(100);
+        transition.program.template = "DropTease16".to_string();
+        transition.program.automation = vec![
+            noor_mix::AutomationEvent {
+                param: noor_mix::Param::DeckGain(noor_mix::DeckId::A),
+                start_sample: 0,
+                end_sample: transition.program.resolve_at,
+                from: 0.0,
+                to: 0.0,
+                curve: noor_mix::Curve::Linear,
+            },
+            noor_mix::AutomationEvent {
+                param: noor_mix::Param::DeckGain(noor_mix::DeckId::B),
+                start_sample: 0,
+                end_sample: transition.program.resolve_at,
+                from: 1.0,
+                to: 1.0,
+                curve: noor_mix::Curve::Linear,
+            },
+        ];
+
+        let mut next = test_engine_with_shared(2, 21);
+        next.job = PreparedPlaybackJob::test_fixture(2, 21).with_prepared_transition(transition);
+        finish_engine_buffer(&next, &[0.0, 0.0, 0.4, 0.4]);
+
+        state.engine = Some(active);
+        state.next_engine = Some(next);
+        assert!(prepare_dj_mixer_for_pair(&mut state, 64).is_ok());
+
+        let (event_tx, mut event_rx) = tokio::sync::broadcast::channel(8);
+        assert!(
+            start_prepared_overlay(
+                &mut state,
+                &event_tx,
+                "fired",
+                DjRuntimeRendererReason::None,
+                Some(2_500),
+                48_000,
+                2
+            )
+            .is_ok()
+        );
+
+        match event_rx.try_recv().expect("overlay event") {
+            PlaybackRuntimeEvent::DjTransitionPromoted {
+                actual_start_ms, ..
+            } => {
+                assert_eq!(actual_start_ms, 2_500);
             }
             other => panic!("expected overlay event, got {other:?}"),
         }
@@ -4003,6 +4097,7 @@ mod tests {
             &buffered_source,
             &offset_source,
             "fired",
+            None,
             DjRuntimeRendererOutcome::rendered_handoff(),
         );
 
@@ -4025,6 +4120,58 @@ mod tests {
                 assert!(runtime_rendered_dj_mixer);
                 assert_eq!(runtime_renderer_status, "rendered_handoff");
                 assert_eq!(runtime_renderer_reason, "none");
+            }
+            other => panic!("expected timing event, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mixer_promotion_reports_captured_fire_position() {
+        let mut state = test_runtime_loop_state();
+        start_dj_lookahead_in_state(
+            &mut state,
+            Some(DjMediaRef::LibraryTrack { track_id: 1 }),
+            Some(DjMediaRef::LibraryTrack { track_id: 2 }),
+            Some(11),
+            Some(12),
+            20,
+            48_000,
+        );
+
+        let active = test_engine_with_shared(1, 20);
+        active
+            .shared
+            .position_samples
+            .store(96_000, Ordering::Relaxed);
+        let mut transition = test_prepared_transition_program(20, Some(11), Some(12));
+        transition.transition_event_id = Some(101);
+        let mut next = test_engine_with_shared(2, 21);
+        next.job = PreparedPlaybackJob::test_fixture(2, 21).with_prepared_transition(transition);
+
+        state.engine = Some(active);
+        state.next_engine = Some(next);
+
+        let (event_tx, mut event_rx) = tokio::sync::broadcast::channel(8);
+        let position_source = Arc::new(Mutex::new(Arc::new(AtomicU64::new(0))));
+        let buffered_source = Arc::new(Mutex::new(Arc::new(AtomicU64::new(0))));
+        let offset_source = Arc::new(Mutex::new(Arc::new(AtomicU64::new(0))));
+
+        promote_next_to_active(
+            &mut state,
+            &event_tx,
+            &position_source,
+            &buffered_source,
+            &offset_source,
+            "fired",
+            Some(2_750),
+            DjRuntimeRendererOutcome::legacy_overlap(DjRuntimeRendererReason::PreparedMixerMissing),
+        );
+
+        match event_rx.try_recv().expect("timing event") {
+            PlaybackRuntimeEvent::DjTransitionPromoted {
+                actual_start_ms, ..
+            } => {
+                assert_eq!(actual_start_ms, 2_750);
             }
             other => panic!("expected timing event, got {other:?}"),
         }
@@ -4158,6 +4305,7 @@ mod tests {
             &buffered_source,
             &offset_source,
             "fired",
+            None,
             DjRuntimeRendererOutcome::legacy_overlap(DjRuntimeRendererReason::PreparedMixerMissing),
         );
 

--- a/noor-server/src/playback/runtime/mod.rs
+++ b/noor-server/src/playback/runtime/mod.rs
@@ -511,6 +511,11 @@ struct PreparedDjMixer {
     next_track_id: i64,
 }
 
+struct RuntimeDeckSnapshot {
+    deck: noor_mix::deck::DeckBuffer,
+    start_frame: u64,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct RuntimeDjLookahead {
     current: Option<DjMediaRef>,
@@ -905,24 +910,68 @@ fn dj_mixer_max_block_samples(output_config: &StreamConfig) -> usize {
     }
 }
 
-fn decoded_deck_buffer(
+fn decoded_deck_snapshot(
     engine: &PlaybackEngine,
     channels: u16,
-) -> Result<(noor_mix::deck::DeckBuffer, u64), DjRuntimeRendererReason> {
+    start_frame: u64,
+    required_frames: u64,
+    late_tolerance_frames: u64,
+    reason: DjRuntimeRendererReason,
+) -> Result<RuntimeDeckSnapshot, DjRuntimeRendererReason> {
     let guard = engine
         .shared
         .buffer
         .lock()
         .map_err(|_| DjRuntimeRendererReason::BufferLockFailed)?;
-    if !guard.finished || guard.samples.is_empty() {
-        return Err(DjRuntimeRendererReason::ActiveDeckNotDecoded);
+    if guard.samples.is_empty() {
+        return Err(reason);
     }
     let channels = usize::from(channels.max(1));
     let frames = (guard.samples.len() / channels) as u64;
-    Ok((
-        noor_mix::deck::DeckBuffer::new(guard.samples.clone(), channels as u16),
-        frames,
-    ))
+    if start_frame >= frames {
+        return Err(reason);
+    }
+    let available_frames = frames.saturating_sub(start_frame);
+    if available_frames.saturating_add(late_tolerance_frames) < required_frames.max(1) {
+        return Err(reason);
+    }
+    Ok(RuntimeDeckSnapshot {
+        deck: noor_mix::deck::DeckBuffer::new(guard.samples.clone(), channels as u16),
+        start_frame,
+    })
+}
+
+fn active_deck_snapshot(
+    engine: &PlaybackEngine,
+    channels: u16,
+    program_start_frame: u64,
+    required_frames: u64,
+    late_tolerance_frames: u64,
+) -> Result<RuntimeDeckSnapshot, DjRuntimeRendererReason> {
+    let guard = engine
+        .shared
+        .buffer
+        .lock()
+        .map_err(|_| DjRuntimeRendererReason::BufferLockFailed)?;
+    let channels = usize::from(channels.max(1));
+    let start_frame = if program_start_frame == 0 {
+        (guard.read_pos / channels) as u64
+    } else {
+        program_start_frame
+    };
+    drop(guard);
+    decoded_deck_snapshot(
+        engine,
+        channels as u16,
+        start_frame,
+        required_frames,
+        late_tolerance_frames,
+        DjRuntimeRendererReason::ActiveDeckNotDecoded,
+    )
+}
+
+fn dj_renderer_late_tolerance_frames(sample_rate: u32) -> u64 {
+    u64::from(sample_rate.max(1)) / 2
 }
 
 fn build_prepared_dj_mixer(
@@ -949,19 +998,33 @@ fn build_prepared_dj_mixer(
     if !handoff_mixer_program(&transition.program) && !overlay_mixer_program(&transition.program) {
         return Err(DjRuntimeRendererReason::ProgramNotMixerRenderable);
     }
-    let (deck_a, active_frames) =
-        decoded_deck_buffer(active, state.device_channels).map_err(|reason| match reason {
-            DjRuntimeRendererReason::BufferLockFailed => DjRuntimeRendererReason::BufferLockFailed,
-            _ => DjRuntimeRendererReason::ActiveDeckNotDecoded,
-        })?;
-    let (deck_b, _) =
-        decoded_deck_buffer(next, state.device_channels).map_err(|reason| match reason {
-            DjRuntimeRendererReason::BufferLockFailed => DjRuntimeRendererReason::BufferLockFailed,
-            _ => DjRuntimeRendererReason::NextDeckNotDecoded,
-        })?;
     let mut program = transition.program.clone();
-    align_runtime_program_source_frames(&mut program, active_frames);
-    let mixer = match noor_mix::Mixer::new(program.clone(), deck_a, deck_b, max_block_samples) {
+    let deck_b_consumed_frames = deck_b_consumed_frames(&program)
+        .ok_or(DjRuntimeRendererReason::ProgramNotMixerRenderable)?;
+    let tolerance_frames = dj_renderer_late_tolerance_frames(state.device_sample_rate);
+    let active_snapshot = active_deck_snapshot(
+        active,
+        state.device_channels,
+        program.deck_a_start_frame,
+        program.resolve_at,
+        tolerance_frames,
+    )?;
+    let next_snapshot = decoded_deck_snapshot(
+        next,
+        state.device_channels,
+        program.deck_b_start_frame,
+        deck_b_consumed_frames.saturating_add(1),
+        tolerance_frames,
+        DjRuntimeRendererReason::NextDeckNotDecoded,
+    )?;
+    program.deck_a_start_frame = active_snapshot.start_frame;
+    program.deck_b_start_frame = next_snapshot.start_frame;
+    let mixer = match noor_mix::Mixer::new(
+        program.clone(),
+        active_snapshot.deck,
+        next_snapshot.deck,
+        max_block_samples,
+    ) {
         Ok(mixer) => mixer,
         Err(error) => {
             warn!("Prepared DJ mixer rejected transition program: {error:?}");
@@ -980,19 +1043,15 @@ fn build_prepared_dj_mixer(
     })
 }
 
-fn align_runtime_program_source_frames(
-    program: &mut noor_mix::TransitionProgram,
-    active_frames: u64,
-) {
-    if program.deck_a_start_frame == 0 && program.resolve_at > 0 {
-        program.deck_a_start_frame = active_frames.saturating_sub(program.resolve_at);
-    }
-}
-
 fn handoff_mixer_program(program: &noor_mix::TransitionProgram) -> bool {
     matches!(
         program.template.as_str(),
-        "SafeCrossfade" | "BassSwap16" | "BassSwap32" | "LongHarmonicBlend" | "FilterSweep"
+        "SafeCrossfade"
+            | "SlamCut"
+            | "BassSwap16"
+            | "BassSwap32"
+            | "LongHarmonicBlend"
+            | "FilterSweep"
     ) && deck_b_consumed_frames(program).is_some()
 }
 
@@ -1095,6 +1154,8 @@ fn install_prepared_handoff_mixer_buffer(
         Ok(guard) => guard,
         Err(_) => return Err(DjRuntimeRendererReason::BufferLockFailed),
     };
+    let was_finished = guard.finished;
+    let previous_total_samples = next.shared.total_samples.load(Ordering::Relaxed);
     let remainder_start = deck_b_resume_sample.min(guard.samples.len());
     let remainder = guard.samples[remainder_start..].to_vec();
     rendered.extend_from_slice(&remainder);
@@ -1104,10 +1165,20 @@ fn install_prepared_handoff_mixer_buffer(
     guard.started_notified = false;
     guard.starved_notified = false;
     guard.finished_notified = false;
-    guard.finished = true;
+    guard.finished = was_finished;
+    let rendered_total_samples = next
+        .shared
+        .position_offset_samples
+        .load(Ordering::Relaxed)
+        .saturating_add(guard.samples.len() as u64);
+    let total_samples = if was_finished || previous_total_samples == 0 {
+        rendered_total_samples
+    } else {
+        previous_total_samples.max(rendered_total_samples)
+    };
     next.shared
         .total_samples
-        .store(guard.samples.len() as u64, Ordering::Relaxed);
+        .store(total_samples, Ordering::Relaxed);
     next.shared.publish_buffered_samples(guard.samples.len());
     next.shared.crossfade_samples.store(0, Ordering::Relaxed);
     next.shared
@@ -1717,6 +1788,10 @@ fn run_runtime_loop(
                             .and_then(|e| e.shared.buffer.lock().ok().map(|g| g.is_ready()))
                             .unwrap_or(false);
                         if next_ready && !active_engine_suppresses_crossfade_after_seek(&state) {
+                            let _ = prepare_dj_mixer_for_pair(
+                                &mut state,
+                                dj_mixer_max_block_samples(&output_config),
+                            );
                             if prepared_overlay_program(&state) {
                                 let device_sample_rate = state.device_sample_rate;
                                 let device_channels = state.device_channels;
@@ -3514,6 +3589,113 @@ mod tests {
     }
 
     #[test]
+    fn runtime_constructs_mixer_from_decoded_transition_windows() {
+        let mut state = test_runtime_loop_state();
+        start_dj_lookahead_in_state(
+            &mut state,
+            Some(DjMediaRef::LibraryTrack { track_id: 1 }),
+            Some(DjMediaRef::LibraryTrack { track_id: 2 }),
+            Some(11),
+            Some(12),
+            20,
+            48_000,
+        );
+
+        let active = test_engine_with_shared(1, 20);
+        {
+            let mut buffer = active.shared.buffer.lock().expect("active buffer");
+            buffer
+                .samples
+                .extend_from_slice(&[0.1, 0.1, 0.2, 0.2, 0.3, 0.3]);
+            buffer.read_pos = 2;
+        }
+
+        let mut next = test_engine_with_shared(2, 21);
+        next.job = PreparedPlaybackJob::test_fixture(2, 21)
+            .with_prepared_transition(test_prepared_transition_program(20, Some(11), Some(12)));
+        {
+            let mut buffer = next.shared.buffer.lock().expect("next buffer");
+            buffer
+                .samples
+                .extend_from_slice(&[0.0, 0.0, 0.4, 0.4, 0.5, 0.5]);
+        }
+
+        state.engine = Some(active);
+        state.next_engine = Some(next);
+
+        assert!(prepare_dj_mixer_for_pair(&mut state, 64).is_ok());
+        let prepared = state.prepared_dj_mixer.as_ref().expect("prepared mixer");
+        assert_eq!(prepared.program.deck_a_start_frame, 1);
+    }
+
+    #[test]
+    fn runtime_rebuilds_mixer_from_latest_active_read_position() {
+        let mut state = test_runtime_loop_state();
+        start_dj_lookahead_in_state(
+            &mut state,
+            Some(DjMediaRef::LibraryTrack { track_id: 1 }),
+            Some(DjMediaRef::LibraryTrack { track_id: 2 }),
+            Some(11),
+            Some(12),
+            20,
+            48_000,
+        );
+
+        let active = test_engine_with_shared(1, 20);
+        {
+            let mut buffer = active.shared.buffer.lock().expect("active buffer");
+            buffer
+                .samples
+                .extend_from_slice(&[0.1, 0.1, 0.2, 0.2, 0.3, 0.3, 0.4, 0.4]);
+        }
+
+        let mut next = test_engine_with_shared(2, 21);
+        next.job = PreparedPlaybackJob::test_fixture(2, 21)
+            .with_prepared_transition(test_prepared_transition_program(20, Some(11), Some(12)));
+        {
+            let mut buffer = next.shared.buffer.lock().expect("next buffer");
+            buffer
+                .samples
+                .extend_from_slice(&[0.0, 0.0, 0.4, 0.4, 0.5, 0.5]);
+        }
+
+        state.engine = Some(active);
+        state.next_engine = Some(next);
+
+        assert!(prepare_dj_mixer_for_pair(&mut state, 64).is_ok());
+        assert_eq!(
+            state
+                .prepared_dj_mixer
+                .as_ref()
+                .expect("early mixer")
+                .program
+                .deck_a_start_frame,
+            0
+        );
+
+        state
+            .engine
+            .as_ref()
+            .expect("active engine")
+            .shared
+            .buffer
+            .lock()
+            .expect("active buffer")
+            .read_pos = 4;
+
+        assert!(prepare_dj_mixer_for_pair(&mut state, 64).is_ok());
+        assert_eq!(
+            state
+                .prepared_dj_mixer
+                .as_ref()
+                .expect("rebuilt mixer")
+                .program
+                .deck_a_start_frame,
+            2
+        );
+    }
+
+    #[test]
     fn runtime_prepared_mixer_honors_program_start_frames() {
         let mut state = test_runtime_loop_state();
         start_dj_lookahead_in_state(
@@ -3564,6 +3746,7 @@ mod tests {
 
         let active = test_engine_with_shared(1, 20);
         finish_engine_buffer(&active, &[0.1, 0.1, 0.2, 0.2, 0.3, 0.3]);
+        active.shared.buffer.lock().expect("active buffer").read_pos = 2;
 
         let mut next = test_engine_with_shared(2, 21);
         next.job = PreparedPlaybackJob::test_fixture(2, 21)
@@ -3630,6 +3813,52 @@ mod tests {
         assert_eq!(buffer.samples.len(), 10);
         assert_samples_close(&buffer.samples[4..], &[0.4, 0.4, 0.5, 0.5, 0.6, 0.6]);
         assert_eq!(next.shared.total_samples.load(Ordering::Relaxed), 10);
+    }
+
+    #[test]
+    fn handoff_mixer_preserves_unfinished_next_buffer() {
+        let mut state = test_runtime_loop_state();
+        start_dj_lookahead_in_state(
+            &mut state,
+            Some(DjMediaRef::LibraryTrack { track_id: 1 }),
+            Some(DjMediaRef::LibraryTrack { track_id: 2 }),
+            Some(11),
+            Some(12),
+            20,
+            48_000,
+        );
+
+        let active = test_engine_with_shared(1, 20);
+        finish_engine_buffer(&active, &[0.1, 0.1, 0.2, 0.2, 0.3, 0.3]);
+
+        let mut next = test_engine_with_shared(2, 21);
+        next.job = PreparedPlaybackJob::test_fixture(2, 21)
+            .with_prepared_transition(test_prepared_transition_program(20, Some(11), Some(12)));
+        let estimated_total_samples =
+            estimate_total_samples_from_duration_ms(180_000, 48_000, 2).expect("estimated total");
+        next.shared
+            .total_samples
+            .store(estimated_total_samples, Ordering::Relaxed);
+        {
+            let mut buffer = next.shared.buffer.lock().expect("next buffer");
+            buffer
+                .samples
+                .extend_from_slice(&[0.0, 0.0, 0.4, 0.4, 0.5, 0.5, 0.6, 0.6]);
+        }
+
+        state.engine = Some(active);
+        state.next_engine = Some(next);
+
+        assert!(prepare_dj_mixer_for_pair(&mut state, 64).is_ok());
+        assert!(install_prepared_handoff_mixer_buffer(&mut state).is_ok());
+
+        let next = state.next_engine.as_ref().expect("next engine");
+        let buffer = next.shared.buffer.lock().expect("buffer lock");
+        assert!(!buffer.finished);
+        assert_eq!(
+            next.shared.total_samples.load(Ordering::Relaxed),
+            estimated_total_samples
+        );
     }
 
     #[test]

--- a/noor-server/src/playback/runtime/mod.rs
+++ b/noor-server/src/playback/runtime/mod.rs
@@ -287,6 +287,23 @@ impl PlaybackRuntimeHandle {
         self.send(PlaybackRuntimeCommand::PrepareNext(job))
     }
 
+    pub fn prepare_drop_preview(&self, job: PreparedPlaybackJob) -> Result<()> {
+        self.send(PlaybackRuntimeCommand::PrepareDropPreview(job))
+    }
+
+    pub fn arm_drop_preview(
+        &self,
+        track_id: i64,
+        generation: u64,
+        trigger_position_samples: u64,
+    ) -> Result<()> {
+        self.send(PlaybackRuntimeCommand::ArmDropPreview {
+            track_id,
+            generation,
+            trigger_position_samples,
+        })
+    }
+
     pub fn set_dj_engine_enabled(&self, enabled: bool) -> Result<()> {
         self.send(PlaybackRuntimeCommand::SetDjEngineEnabled { enabled })
     }
@@ -472,6 +489,9 @@ struct PlaybackRuntimeLoopState {
     /// window opens. Once unpaused it gets promoted to `engine` and the old
     /// `engine` slides into `fading_out_engine`.
     next_engine: Option<PlaybackEngine>,
+    /// Temporary incoming deck for a mid-song drop preview. It is never
+    /// promoted and is discarded after the preview overlay finishes.
+    drop_preview_engine: Option<PlaybackEngine>,
     /// Engine that's still audible during the crossfade fade-out window. It
     /// keeps producing audio (with a fade-out gain ramp) until its buffer
     /// drains, at which point it self-terminates and we drop it silently -
@@ -497,6 +517,7 @@ struct PlaybackRuntimeLoopState {
     dj_lookahead: Option<RuntimeDjLookahead>,
     dj_lookahead_failure: Option<DjLookaheadFailure>,
     prepared_dj_mixer: Option<PreparedDjMixer>,
+    prepared_drop_preview_mixer: Option<PreparedDjMixer>,
     last_dj_renderer_failure: Option<DjRuntimeRendererFailure>,
 }
 
@@ -979,10 +1000,6 @@ fn build_prepared_dj_mixer(
     transition: &PreparedTransitionProgram,
     max_block_samples: usize,
 ) -> Result<PreparedDjMixer, DjRuntimeRendererReason> {
-    let active = state
-        .engine
-        .as_ref()
-        .ok_or(DjRuntimeRendererReason::ActiveDeckNotDecoded)?;
     let next = state
         .next_engine
         .as_ref()
@@ -995,6 +1012,19 @@ fn build_prepared_dj_mixer(
     ) {
         return Err(DjRuntimeRendererReason::LookaheadPairMismatch);
     }
+    build_prepared_dj_mixer_for_engine(state, transition, next, max_block_samples)
+}
+
+fn build_prepared_dj_mixer_for_engine(
+    state: &PlaybackRuntimeLoopState,
+    transition: &PreparedTransitionProgram,
+    incoming: &PlaybackEngine,
+    max_block_samples: usize,
+) -> Result<PreparedDjMixer, DjRuntimeRendererReason> {
+    let active = state
+        .engine
+        .as_ref()
+        .ok_or(DjRuntimeRendererReason::ActiveDeckNotDecoded)?;
     if !handoff_mixer_program(&transition.program) && !overlay_mixer_program(&transition.program) {
         return Err(DjRuntimeRendererReason::ProgramNotMixerRenderable);
     }
@@ -1010,7 +1040,7 @@ fn build_prepared_dj_mixer(
         tolerance_frames,
     )?;
     let next_snapshot = decoded_deck_snapshot(
-        next,
+        incoming,
         state.device_channels,
         program.deck_b_start_frame,
         deck_b_consumed_frames.saturating_add(1),
@@ -1039,7 +1069,7 @@ fn build_prepared_dj_mixer(
         current_queue_item_id: transition.current_queue_item_id,
         next_queue_item_id: transition.next_queue_item_id,
         current_track_id: active.track_id,
-        next_track_id: next.track_id,
+        next_track_id: incoming.track_id,
     })
 }
 
@@ -1056,7 +1086,8 @@ fn handoff_mixer_program(program: &noor_mix::TransitionProgram) -> bool {
 }
 
 fn overlay_mixer_program(program: &noor_mix::TransitionProgram) -> bool {
-    program.template == "DropTease16" && deck_b_consumed_frames(program).is_some()
+    matches!(program.template.as_str(), "DropTease16" | "DropPreview16")
+        && deck_b_consumed_frames(program).is_some()
 }
 
 fn render_prepared_mixer_to_buffer(
@@ -1253,6 +1284,72 @@ fn install_prepared_overlay_mixer_buffer(
     Ok(())
 }
 
+fn install_prepared_drop_preview_mixer_buffer(
+    state: &mut PlaybackRuntimeLoopState,
+) -> Result<(), DjRuntimeRendererReason> {
+    let prepared = state
+        .prepared_drop_preview_mixer
+        .as_ref()
+        .ok_or(DjRuntimeRendererReason::PreparedMixerMissing)?;
+    if prepared.program.template != "DropPreview16" || !overlay_mixer_program(&prepared.program) {
+        return Err(DjRuntimeRendererReason::ProgramNotMixerRenderable);
+    }
+    if state
+        .engine
+        .as_ref()
+        .map(|engine| engine.track_id != prepared.current_track_id)
+        .unwrap_or(true)
+    {
+        return Err(DjRuntimeRendererReason::ActiveTrackChanged);
+    }
+    if state
+        .drop_preview_engine
+        .as_ref()
+        .map(|engine| engine.track_id != prepared.next_track_id)
+        .unwrap_or(true)
+    {
+        return Err(DjRuntimeRendererReason::NextTrackChanged);
+    }
+
+    let mut prepared = state
+        .prepared_drop_preview_mixer
+        .take()
+        .ok_or(DjRuntimeRendererReason::PreparedMixerMissing)?;
+    let channels = usize::from(state.device_channels.max(1));
+    let rendered = render_prepared_mixer_to_buffer(&mut prepared, channels)
+        .ok_or(DjRuntimeRendererReason::RenderBufferFailed)?;
+    let preview = state
+        .drop_preview_engine
+        .as_ref()
+        .ok_or(DjRuntimeRendererReason::NextDeckNotDecoded)?;
+    let mut guard = match preview.shared.buffer.lock() {
+        Ok(guard) => guard,
+        Err(_) => return Err(DjRuntimeRendererReason::BufferLockFailed),
+    };
+    guard.samples = rendered;
+    guard.read_pos = 0;
+    guard.started = false;
+    guard.started_notified = false;
+    guard.starved_notified = false;
+    guard.finished_notified = false;
+    guard.finished = true;
+    preview
+        .shared
+        .total_samples
+        .store(guard.samples.len() as u64, Ordering::Relaxed);
+    preview.shared.publish_buffered_samples(guard.samples.len());
+    preview.shared.crossfade_samples.store(0, Ordering::Relaxed);
+    preview
+        .shared
+        .crossfade_start_signaled
+        .store(true, Ordering::Relaxed);
+    preview
+        .shared
+        .fadein_start_samples
+        .store(u64::MAX, Ordering::Relaxed);
+    Ok(())
+}
+
 fn prepare_dj_mixer_for_pair(
     state: &mut PlaybackRuntimeLoopState,
     max_block_samples: usize,
@@ -1281,6 +1378,40 @@ fn prepare_dj_mixer_for_pair(
         Err(reason) => {
             state.prepared_dj_mixer = None;
             record_runtime_renderer_failure(state, &transition, reason);
+            Err(reason)
+        }
+    }
+}
+
+fn prepare_drop_preview_mixer(
+    state: &mut PlaybackRuntimeLoopState,
+    max_block_samples: usize,
+) -> Result<(), DjRuntimeRendererReason> {
+    if !state.dj_engine_enabled {
+        state.prepared_drop_preview_mixer = None;
+        return Err(DjRuntimeRendererReason::DjDisabled);
+    }
+    let Some((transition, incoming)) = state.drop_preview_engine.as_ref().and_then(|engine| {
+        engine
+            .job
+            .prepared_transition
+            .as_ref()
+            .map(|transition| (transition.clone(), engine))
+    }) else {
+        state.prepared_drop_preview_mixer = None;
+        return Err(DjRuntimeRendererReason::PreparedMixerMissing);
+    };
+    if transition.program.template != "DropPreview16" {
+        state.prepared_drop_preview_mixer = None;
+        return Err(DjRuntimeRendererReason::ProgramNotMixerRenderable);
+    }
+    match build_prepared_dj_mixer_for_engine(state, &transition, incoming, max_block_samples) {
+        Ok(prepared) => {
+            state.prepared_drop_preview_mixer = Some(prepared);
+            Ok(())
+        }
+        Err(reason) => {
+            state.prepared_drop_preview_mixer = None;
             Err(reason)
         }
     }
@@ -1339,6 +1470,30 @@ fn start_prepared_overlay(
     Ok(())
 }
 
+fn start_prepared_drop_preview_overlay(
+    state: &mut PlaybackRuntimeLoopState,
+    event_tx: &tokio::sync::broadcast::Sender<PlaybackRuntimeEvent>,
+    actual_start_ms: i64,
+) -> Result<(), DjRuntimeRendererReason> {
+    let Some(active) = state.engine.as_ref() else {
+        return Err(DjRuntimeRendererReason::ActiveDeckNotDecoded);
+    };
+    let active_track_id = active.track_id;
+    let active_generation = active.generation;
+
+    install_prepared_drop_preview_mixer_buffer(state)?;
+    let Some(preview) = state.drop_preview_engine.as_ref() else {
+        return Err(DjRuntimeRendererReason::NextDeckNotDecoded);
+    };
+    preview.shared.paused.store(false, Ordering::SeqCst);
+    let _ = event_tx.send(PlaybackRuntimeEvent::DropPreviewStarted {
+        track_id: active_track_id,
+        generation: active_generation,
+        actual_start_ms,
+    });
+    Ok(())
+}
+
 fn arm_active_transition_window(
     state: &mut PlaybackRuntimeLoopState,
     job: &PreparedPlaybackJob,
@@ -1380,6 +1535,30 @@ fn arm_active_transition_window(
     true
 }
 
+fn arm_drop_preview_in_state(
+    state: &PlaybackRuntimeLoopState,
+    track_id: i64,
+    generation: u64,
+    trigger_position_samples: u64,
+) -> bool {
+    let Some(active) = state
+        .engine
+        .as_ref()
+        .filter(|engine| engine.track_id == track_id && engine.generation == generation)
+    else {
+        return false;
+    };
+    active
+        .shared
+        .drop_preview_trigger_samples
+        .store(trigger_position_samples, Ordering::Relaxed);
+    active
+        .shared
+        .drop_preview_start_signaled
+        .store(false, Ordering::Relaxed);
+    true
+}
+
 fn gate_prepare_next_for_dj(
     state: &mut PlaybackRuntimeLoopState,
     job: &mut PreparedPlaybackJob,
@@ -1403,9 +1582,13 @@ fn set_dj_engine_enabled_in_state(state: &mut PlaybackRuntimeLoopState, enabled:
     state.dj_lookahead = None;
     state.dj_lookahead_failure = None;
     state.prepared_dj_mixer = None;
+    state.prepared_drop_preview_mixer = None;
     state.last_dj_renderer_failure = None;
     if let Some(engine) = state.next_engine.as_mut() {
         engine.job.prepared_transition = None;
+    }
+    if let Some(mut engine) = state.drop_preview_engine.take() {
+        engine.stop();
     }
 }
 
@@ -1455,6 +1638,7 @@ fn run_runtime_loop(
         exclusive_sink: ExclusiveRuntimeSink::new(),
         engine: None,
         next_engine: None,
+        drop_preview_engine: None,
         fading_out_engine: None,
         current_exclusive: false,
         current_sample_rate_follow: false,
@@ -1466,6 +1650,7 @@ fn run_runtime_loop(
         dj_lookahead: None,
         dj_lookahead_failure: None,
         prepared_dj_mixer: None,
+        prepared_drop_preview_mixer: None,
         last_dj_renderer_failure: None,
     };
 
@@ -1743,6 +1928,82 @@ fn run_runtime_loop(
                         }
                     }
                 }
+                PlaybackRuntimeCommand::PrepareDropPreview(job) => {
+                    if !state.dj_engine_enabled {
+                        state.prepared_drop_preview_mixer = None;
+                        if let Some(mut stale) = state.drop_preview_engine.take() {
+                            stale.stop();
+                        }
+                        return std::ops::ControlFlow::Continue(());
+                    }
+                    let has_drop_preview_program = job
+                        .prepared_transition
+                        .as_ref()
+                        .is_some_and(|transition| transition.program.template == "DropPreview16");
+                    if !has_drop_preview_program {
+                        state.prepared_drop_preview_mixer = None;
+                        if let Some(mut stale) = state.drop_preview_engine.take() {
+                            stale.stop();
+                        }
+                        return std::ops::ControlFlow::Continue(());
+                    }
+                    let already_pending = state
+                        .drop_preview_engine
+                        .as_ref()
+                        .map(|engine| {
+                            engine.track_id == job.track.id && engine.generation == job.generation
+                        })
+                        .unwrap_or(false);
+                    if !already_pending {
+                        if let Some(mut stale) = state.drop_preview_engine.take() {
+                            state.prepared_drop_preview_mixer = None;
+                            stale.stop();
+                        }
+                        let pending_position = Arc::new(AtomicU64::new(0));
+                        let engine_result = if state.current_exclusive {
+                            PlaybackEngine::start_decoder_only(
+                                &config,
+                                &command_tx,
+                                job,
+                                state.device_sample_rate,
+                                state.device_channels,
+                                Arc::clone(&volume_ctl),
+                                pending_position,
+                            )
+                        } else {
+                            PlaybackEngine::start(
+                                &config,
+                                &command_tx,
+                                &device,
+                                &output_config,
+                                output_sample_format,
+                                job,
+                                event_tx.clone(),
+                                state.device_sample_rate,
+                                state.device_channels,
+                                Arc::clone(&volume_ctl),
+                                pending_position,
+                            )
+                        };
+                        match engine_result {
+                            Ok(engine) => {
+                                engine.shared.paused.store(true, Ordering::SeqCst);
+                                state.drop_preview_engine = Some(engine);
+                                let _ = prepare_drop_preview_mixer(
+                                    &mut state,
+                                    dj_mixer_max_block_samples(&output_config),
+                                );
+                                #[cfg(target_os = "windows")]
+                                if state.current_exclusive {
+                                    refresh_exclusive_sources(&state);
+                                }
+                            }
+                            Err(err) => {
+                                warn!("Failed to pre-buffer drop preview: {err:?}");
+                            }
+                        }
+                    }
+                }
                 PlaybackRuntimeCommand::SetDjEngineEnabled { enabled } => {
                     config.dj_engine_enabled = enabled;
                     set_dj_engine_enabled_in_state(&mut state, enabled);
@@ -1845,6 +2106,51 @@ fn run_runtime_loop(
                         // If not ready yet, NextDecodeComplete handles the late path.
                     }
                 }
+                PlaybackRuntimeCommand::ArmDropPreview {
+                    track_id,
+                    generation,
+                    trigger_position_samples,
+                } => {
+                    arm_drop_preview_in_state(
+                        &state,
+                        track_id,
+                        generation,
+                        trigger_position_samples,
+                    );
+                }
+                PlaybackRuntimeCommand::DropPreviewStart {
+                    track_id,
+                    generation,
+                    trigger_position_samples,
+                } => {
+                    if state
+                        .engine
+                        .as_ref()
+                        .map(|engine| (engine.track_id, engine.generation))
+                        == Some((track_id, generation))
+                    {
+                        let _ = prepare_drop_preview_mixer(
+                            &mut state,
+                            dj_mixer_max_block_samples(&output_config),
+                        );
+                        let actual_start_ms = samples_to_ms(
+                            trigger_position_samples,
+                            state.device_sample_rate,
+                            state.device_channels,
+                        );
+                        if let Err(reason) = start_prepared_drop_preview_overlay(
+                            &mut state,
+                            &event_tx,
+                            actual_start_ms,
+                        ) {
+                            debug!("Drop preview start skipped: {}", reason.as_str());
+                            state.prepared_drop_preview_mixer = None;
+                            if let Some(mut engine) = state.drop_preview_engine.take() {
+                                engine.stop();
+                            }
+                        }
+                    }
+                }
                 PlaybackRuntimeCommand::NextDecodeComplete {
                     track_id,
                     generation,
@@ -1937,6 +2243,11 @@ fn run_runtime_loop(
                         }
                     }
                     if let Some(engine) = state.fading_out_engine.as_mut() {
+                        if let Err(error) = engine.pause() {
+                            report_runtime_command_error(&event_tx, "Pause", error);
+                        }
+                    }
+                    if let Some(engine) = state.drop_preview_engine.as_mut() {
                         if let Err(error) = engine.pause() {
                             report_runtime_command_error(&event_tx, "Pause", error);
                         }
@@ -2038,6 +2349,15 @@ fn run_runtime_loop(
                             report_runtime_command_error(&event_tx, "Resume", error);
                         }
                     }
+                    if let Some(engine) = state
+                        .drop_preview_engine
+                        .as_mut()
+                        .filter(|engine| !engine.shared.paused.load(Ordering::SeqCst))
+                    {
+                        if let Err(error) = engine.resume() {
+                            report_runtime_command_error(&event_tx, "Resume", error);
+                        }
+                    }
                 }
                 PlaybackRuntimeCommand::Stop => {
                     stop_all_engines(&mut state);
@@ -2057,6 +2377,10 @@ fn run_runtime_loop(
                         .fading_out_engine
                         .as_ref()
                         .map(|e| (e.track_id, e.generation));
+                    let drop_preview = state
+                        .drop_preview_engine
+                        .as_ref()
+                        .map(|engine| (engine.track_id, engine.generation));
                     let next = state
                         .next_engine
                         .as_ref()
@@ -2066,7 +2390,14 @@ fn run_runtime_loop(
                         .as_ref()
                         .map(|engine| (engine.track_id, engine.generation));
 
-                    match terminal_engine_slot(active, next, fading, track_id, generation) {
+                    match terminal_engine_slot(
+                        active,
+                        next,
+                        fading,
+                        drop_preview,
+                        track_id,
+                        generation,
+                    ) {
                         Some(TerminalEngineSlot::FadingOut) => {
                             debug!(
                                 "Playback terminal ignored for fading engine: track_id={}, generation={}, outcome={:?}",
@@ -2085,6 +2416,16 @@ fn run_runtime_loop(
                                 emit_prepared_track_failure(&event_tx, track_id, message);
                             }
                             if let Some(mut engine) = state.next_engine.take() {
+                                engine.stop();
+                            }
+                        }
+                        Some(TerminalEngineSlot::DropPreview) => {
+                            debug!(
+                                "Playback terminal ignored for drop preview engine: track_id={}, generation={}, outcome={:?}",
+                                track_id, generation, outcome
+                            );
+                            state.prepared_drop_preview_mixer = None;
+                            if let Some(mut engine) = state.drop_preview_engine.take() {
                                 engine.stop();
                             }
                         }
@@ -2197,7 +2538,8 @@ fn run_runtime_loop(
 
                     let has_live_engines = state.engine.is_some()
                         || state.next_engine.is_some()
-                        || state.fading_out_engine.is_some();
+                        || state.fading_out_engine.is_some()
+                        || state.drop_preview_engine.is_some();
                     let desired_rate = device_swap_target_sample_rate(
                         desired_sample_rate,
                         sample_rate_follow,
@@ -2232,6 +2574,7 @@ fn run_runtime_loop(
                                 state.engine.as_mut(),
                                 state.next_engine.as_mut(),
                                 state.fading_out_engine.as_mut(),
+                                state.drop_preview_engine.as_mut(),
                             ]
                             .into_iter()
                             .flatten()
@@ -2268,6 +2611,7 @@ fn run_runtime_loop(
                                         state.engine.as_mut(),
                                         state.next_engine.as_mut(),
                                         state.fading_out_engine.as_mut(),
+                                        state.drop_preview_engine.as_mut(),
                                     ]
                                     .into_iter()
                                     .flatten()
@@ -2304,6 +2648,7 @@ fn run_runtime_loop(
                             state.engine.as_mut(),
                             state.next_engine.as_mut(),
                             state.fading_out_engine.as_mut(),
+                            state.drop_preview_engine.as_mut(),
                         ]
                         .into_iter()
                         .flatten()
@@ -2596,6 +2941,7 @@ fn switch_is_noop_for_active_job(
 
 fn stop_current_engine(state: &mut PlaybackRuntimeLoopState) {
     state.prepared_dj_mixer = None;
+    state.prepared_drop_preview_mixer = None;
     if let Some(mut engine) = state.engine.take() {
         engine.stop();
     }
@@ -2607,6 +2953,9 @@ fn stop_all_engines(state: &mut PlaybackRuntimeLoopState) {
         engine.stop();
     }
     if let Some(mut engine) = state.fading_out_engine.take() {
+        engine.stop();
+    }
+    if let Some(mut engine) = state.drop_preview_engine.take() {
         engine.stop();
     }
 }
@@ -2691,6 +3040,7 @@ fn exclusive_render_sources(
     active: Option<&PlaybackEngine>,
     prepared: Option<&PlaybackEngine>,
     fading: Option<&PlaybackEngine>,
+    drop_preview: Option<&PlaybackEngine>,
 ) -> Vec<ExclusiveRenderSource> {
     let mut sources = Vec::new();
     if let Some(engine) = active {
@@ -2711,6 +3061,12 @@ fn exclusive_render_sources(
             shared: Arc::clone(&engine.shared),
         });
     }
+    if let Some(engine) = drop_preview {
+        sources.push(ExclusiveRenderSource {
+            role: ExclusiveRenderRole::Prepared,
+            shared: Arc::clone(&engine.shared),
+        });
+    }
     sources
 }
 
@@ -2723,6 +3079,7 @@ fn refresh_exclusive_sources(state: &PlaybackRuntimeLoopState) {
             state.engine.as_ref(),
             state.next_engine.as_ref(),
             state.fading_out_engine.as_ref(),
+            state.drop_preview_engine.as_ref(),
         ));
 }
 
@@ -3049,18 +3406,22 @@ enum TerminalEngineSlot {
     Active,
     Next,
     FadingOut,
+    DropPreview,
 }
 
 fn terminal_engine_slot(
     active: Option<(i64, u64)>,
     next: Option<(i64, u64)>,
     fading: Option<(i64, u64)>,
+    drop_preview: Option<(i64, u64)>,
     track_id: i64,
     generation: u64,
 ) -> Option<TerminalEngineSlot> {
     let target = Some((track_id, generation));
     if fading == target {
         Some(TerminalEngineSlot::FadingOut)
+    } else if drop_preview == target {
+        Some(TerminalEngineSlot::DropPreview)
     } else if next == target {
         Some(TerminalEngineSlot::Next)
     } else if active == target {
@@ -4054,6 +4415,128 @@ mod tests {
     }
 
     #[test]
+    fn drop_preview_overlay_starts_without_promotion_or_crossfade_window() {
+        let mut state = test_runtime_loop_state();
+        start_dj_lookahead_in_state(
+            &mut state,
+            Some(DjMediaRef::LibraryTrack { track_id: 1 }),
+            Some(DjMediaRef::LibraryTrack { track_id: 2 }),
+            Some(11),
+            Some(12),
+            20,
+            48_000,
+        );
+
+        let active = test_engine_with_shared(1, 20);
+        active
+            .shared
+            .position_samples
+            .store(96_000, Ordering::Relaxed);
+        finish_engine_buffer(&active, &[0.1, 0.1, 0.2, 0.2]);
+
+        let mut real_next = test_engine_with_shared(2, 21);
+        real_next.shared.paused.store(true, Ordering::SeqCst);
+        real_next.job = PreparedPlaybackJob::test_fixture(2, 21)
+            .with_prepared_transition(test_prepared_transition_program(20, Some(11), Some(12)));
+        finish_engine_buffer(&real_next, &[0.3, 0.3, 0.4, 0.4]);
+
+        let mut transition = test_prepared_transition_program(20, Some(11), Some(12));
+        transition.program.template = "DropPreview16".to_string();
+        transition.program.automation = vec![
+            noor_mix::AutomationEvent {
+                param: noor_mix::Param::DeckGain(noor_mix::DeckId::A),
+                start_sample: 0,
+                end_sample: transition.program.resolve_at,
+                from: 0.0,
+                to: 0.0,
+                curve: noor_mix::Curve::Linear,
+            },
+            noor_mix::AutomationEvent {
+                param: noor_mix::Param::DeckGain(noor_mix::DeckId::B),
+                start_sample: 0,
+                end_sample: transition.program.resolve_at,
+                from: 0.65,
+                to: 0.65,
+                curve: noor_mix::Curve::Linear,
+            },
+        ];
+        let mut preview = test_engine_with_shared(2, 21);
+        preview.shared.paused.store(true, Ordering::SeqCst);
+        preview.job = PreparedPlaybackJob::test_fixture(2, 21).with_prepared_transition(transition);
+        finish_engine_buffer(&preview, &[0.0, 0.0, 0.4, 0.4]);
+
+        state.engine = Some(active);
+        state.next_engine = Some(real_next);
+        state.drop_preview_engine = Some(preview);
+
+        assert!(prepare_drop_preview_mixer(&mut state, 64).is_ok());
+        let (event_tx, mut event_rx) = tokio::sync::broadcast::channel(8);
+        assert!(start_prepared_drop_preview_overlay(&mut state, &event_tx, 120_000).is_ok());
+
+        assert!(state.prepared_drop_preview_mixer.is_none());
+        assert_eq!(state.engine.as_ref().map(|engine| engine.track_id), Some(1));
+        assert_eq!(
+            state.next_engine.as_ref().map(|engine| engine.track_id),
+            Some(2)
+        );
+        assert!(
+            state
+                .next_engine
+                .as_ref()
+                .expect("real next engine")
+                .shared
+                .paused
+                .load(Ordering::SeqCst)
+        );
+        let active = state.engine.as_ref().expect("active engine");
+        assert_eq!(active.shared.crossfade_samples.load(Ordering::Relaxed), 0);
+        let preview = state.drop_preview_engine.as_ref().expect("preview engine");
+        assert!(!preview.shared.paused.load(Ordering::SeqCst));
+        let buffer = preview.shared.buffer.lock().expect("preview buffer");
+        assert_samples_close(&buffer.samples, &[0.0, 0.0, 0.26, 0.26]);
+        match event_rx.try_recv().expect("preview event") {
+            PlaybackRuntimeEvent::DropPreviewStarted {
+                track_id,
+                generation,
+                actual_start_ms,
+            } => {
+                assert_eq!(track_id, 1);
+                assert_eq!(generation, 20);
+                assert_eq!(actual_start_ms, 120_000);
+            }
+            other => panic!("expected preview event, got {other:?}"),
+        }
+        assert!(
+            event_rx.try_recv().is_err(),
+            "preview must not finish outgoing"
+        );
+    }
+
+    #[test]
+    fn arming_drop_preview_sets_absolute_trigger_without_crossfade_samples() {
+        let mut state = test_runtime_loop_state();
+        let active = test_engine_with_shared(1, 20);
+        active.shared.crossfade_samples.store(0, Ordering::Relaxed);
+        state.engine = Some(active);
+
+        assert!(arm_drop_preview_in_state(&state, 1, 20, 144_000));
+
+        assert_eq!(
+            state.next_engine.as_ref().map(|engine| engine.track_id),
+            None
+        );
+        let active = state.engine.as_ref().expect("active engine");
+        assert_eq!(active.shared.crossfade_samples.load(Ordering::Relaxed), 0);
+        assert_eq!(
+            active
+                .shared
+                .drop_preview_trigger_samples
+                .load(Ordering::Relaxed),
+            144_000
+        );
+    }
+
+    #[test]
     fn mixer_promotion_stops_outgoing_without_legacy_fade() {
         let mut state = test_runtime_loop_state();
         start_dj_lookahead_in_state(
@@ -4832,15 +5315,19 @@ mod tests {
     #[test]
     fn terminal_engine_slot_identifies_prebuffered_track() {
         assert_eq!(
-            terminal_engine_slot(Some((1, 1)), Some((2, 1)), None, 2, 1),
+            terminal_engine_slot(Some((1, 1)), Some((2, 1)), None, None, 2, 1),
             Some(TerminalEngineSlot::Next)
         );
         assert_eq!(
-            terminal_engine_slot(Some((1, 1)), Some((2, 1)), Some((3, 1)), 3, 1),
+            terminal_engine_slot(Some((1, 1)), Some((2, 1)), Some((3, 1)), None, 3, 1),
             Some(TerminalEngineSlot::FadingOut)
         );
         assert_eq!(
-            terminal_engine_slot(Some((1, 1)), Some((2, 1)), Some((3, 1)), 4, 1),
+            terminal_engine_slot(Some((1, 1)), Some((2, 1)), Some((3, 1)), Some((4, 1)), 4, 1),
+            Some(TerminalEngineSlot::DropPreview)
+        );
+        assert_eq!(
+            terminal_engine_slot(Some((1, 1)), Some((2, 1)), Some((3, 1)), None, 4, 1),
             None
         );
     }
@@ -4971,13 +5458,20 @@ mod tests {
         let active = test_engine_with_shared(10, 1);
         let prepared = test_engine_with_shared(11, 1);
         let fading = test_engine_with_shared(9, 1);
+        let drop_preview = test_engine_with_shared(12, 1);
 
-        let sources = exclusive_render_sources(Some(&active), Some(&prepared), Some(&fading));
+        let sources = exclusive_render_sources(
+            Some(&active),
+            Some(&prepared),
+            Some(&fading),
+            Some(&drop_preview),
+        );
 
-        assert_eq!(sources.len(), 3);
+        assert_eq!(sources.len(), 4);
         assert_eq!(sources[0].role, ExclusiveRenderRole::Active);
         assert_eq!(sources[1].role, ExclusiveRenderRole::Prepared);
         assert_eq!(sources[2].role, ExclusiveRenderRole::Fading);
+        assert_eq!(sources[3].role, ExclusiveRenderRole::Prepared);
     }
 
     #[test]
@@ -5133,6 +5627,7 @@ mod tests {
             exclusive_sink: ExclusiveRuntimeSink::new(),
             engine: None,
             next_engine: None,
+            drop_preview_engine: None,
             fading_out_engine: None,
             current_exclusive: false,
             current_sample_rate_follow: false,
@@ -5144,6 +5639,7 @@ mod tests {
             dj_lookahead: None,
             dj_lookahead_failure: None,
             prepared_dj_mixer: None,
+            prepared_drop_preview_mixer: None,
             last_dj_renderer_failure: None,
         }
     }

--- a/noor-server/src/playback/runtime/shared.rs
+++ b/noor-server/src/playback/runtime/shared.rs
@@ -279,6 +279,23 @@ fn write_output_buffer<T>(
             }
         }
     }
+
+    if !shared.drop_preview_start_signaled.load(Ordering::Relaxed) {
+        let trigger = shared.drop_preview_trigger_samples.load(Ordering::Relaxed);
+        if trigger != u64::MAX {
+            let pos = shared.position_samples.load(Ordering::Relaxed);
+            if pos >= trigger {
+                shared
+                    .drop_preview_start_signaled
+                    .store(true, Ordering::Relaxed);
+                let _ = command_tx.send(PlaybackRuntimeCommand::DropPreviewStart {
+                    track_id: shared.track_id,
+                    generation: shared.generation,
+                    trigger_position_samples: pos,
+                });
+            }
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -326,6 +343,8 @@ pub(crate) struct PlaybackSharedState {
     pub(crate) crossfade_samples: AtomicU64,
     pub(crate) crossfade_start_signaled: AtomicBool,
     pub(crate) suppress_crossfade_after_seek: AtomicBool,
+    pub(crate) drop_preview_trigger_samples: AtomicU64,
+    pub(crate) drop_preview_start_signaled: AtomicBool,
     pub(crate) fadein_start_samples: AtomicU64,
     pub(crate) device_sample_rate: u32,
     pub(crate) device_channels: u16,
@@ -378,6 +397,8 @@ impl PlaybackSharedState {
             crossfade_samples: AtomicU64::new(crossfade_samples),
             crossfade_start_signaled: AtomicBool::new(false),
             suppress_crossfade_after_seek: AtomicBool::new(false),
+            drop_preview_trigger_samples: AtomicU64::new(u64::MAX),
+            drop_preview_start_signaled: AtomicBool::new(false),
             fadein_start_samples: AtomicU64::new(u64::MAX),
             device_sample_rate,
             device_channels,
@@ -872,6 +893,42 @@ mod tests {
                 assert_eq!(trigger_position_samples, 9_604);
             }
             other => panic!("expected CrossfadeStart, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn drop_preview_start_command_uses_absolute_trigger_without_crossfade() {
+        let shared = test_shared_state();
+        shared.total_samples.store(100_000, Ordering::Relaxed);
+        shared.position_samples.store(48_000, Ordering::Relaxed);
+        shared
+            .drop_preview_trigger_samples
+            .store(48_000, Ordering::Relaxed);
+        shared
+            .drop_preview_start_signaled
+            .store(false, Ordering::Relaxed);
+        {
+            let mut buffer = shared.buffer.lock().expect("buffer lock");
+            buffer.samples.extend_from_slice(&[0.5, 0.5, 0.5, 0.5]);
+        }
+
+        let (command_tx, command_rx) = mpsc::channel();
+        let (event_tx, _) = tokio::sync::broadcast::channel(8);
+        let mut out = [0.0_f32; 4];
+        write_output_f32(&mut out, &shared, &command_tx, &event_tx);
+
+        assert_eq!(shared.crossfade_samples.load(Ordering::Relaxed), 0);
+        match command_rx.try_recv().expect("drop preview command") {
+            PlaybackRuntimeCommand::DropPreviewStart {
+                track_id,
+                generation,
+                trigger_position_samples,
+            } => {
+                assert_eq!(track_id, shared.track_id);
+                assert_eq!(generation, shared.generation);
+                assert_eq!(trigger_position_samples, 48_004);
+            }
+            other => panic!("expected DropPreviewStart, got {other:?}"),
         }
     }
 

--- a/noor-server/src/playback/runtime/shared.rs
+++ b/noor-server/src/playback/runtime/shared.rs
@@ -273,6 +273,7 @@ fn write_output_buffer<T>(
                     let _ = command_tx.send(PlaybackRuntimeCommand::CrossfadeStart {
                         track_id: shared.track_id,
                         generation: shared.generation,
+                        trigger_position_samples: pos,
                     });
                 }
             }
@@ -842,6 +843,36 @@ mod tests {
             command_rx.try_recv().is_err(),
             "no CrossfadeStart command should be queued yet"
         );
+    }
+
+    #[test]
+    fn crossfade_start_command_captures_callback_position() {
+        let shared = test_shared_state();
+        shared.total_samples.store(10_000, Ordering::Relaxed);
+        shared.position_samples.store(9_600, Ordering::Relaxed);
+        shared.crossfade_samples.store(500, Ordering::Relaxed);
+        {
+            let mut buffer = shared.buffer.lock().expect("buffer lock");
+            buffer.samples.extend_from_slice(&[0.5, 0.5, 0.5, 0.5]);
+        }
+
+        let (command_tx, command_rx) = mpsc::channel();
+        let (event_tx, _) = tokio::sync::broadcast::channel(8);
+        let mut out = [0.0_f32; 4];
+        write_output_f32(&mut out, &shared, &command_tx, &event_tx);
+
+        match command_rx.try_recv().expect("crossfade command") {
+            PlaybackRuntimeCommand::CrossfadeStart {
+                track_id,
+                generation,
+                trigger_position_samples,
+            } => {
+                assert_eq!(track_id, shared.track_id);
+                assert_eq!(generation, shared.generation);
+                assert_eq!(trigger_position_samples, 9_604);
+            }
+            other => panic!("expected CrossfadeStart, got {other:?}"),
+        }
     }
 
     #[test]

--- a/noor-server/src/server/radio_pipeline.rs
+++ b/noor-server/src/server/radio_pipeline.rs
@@ -167,6 +167,7 @@ fn rank_radio_candidates(
             track_id: (candidate.is_in_library && candidate.track_id > 0)
                 .then_some(candidate.track_id),
             tidal_id: candidate.tidal_track_id,
+            policy: Default::default(),
             item: candidate,
         })
         .collect::<Vec<_>>();

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -1058,6 +1058,19 @@ pub fn api_routes(state: SharedState) -> Router {
         // Trending / charts (Phase 5)
         .route("/api/charts", get(chart_routes::get_charts))
         .route(
+            "/api/charts/snapshots",
+            get(chart_routes::get_chart_snapshots),
+        )
+        .route(
+            "/api/charts/spotify/daily/import",
+            post(chart_routes::import_spotify_daily_snapshot),
+        )
+        .route("/api/charts/matrix", get(chart_routes::get_chart_matrix))
+        .route(
+            "/api/charts/matrix/refresh",
+            post(chart_routes::refresh_chart_matrix),
+        )
+        .route(
             "/api/charts/lastfm/genres",
             get(chart_routes::list_lastfm_genres),
         )
@@ -14581,6 +14594,236 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn chart_snapshots_return_latest_ranked_entries_without_zero_tidal_id() {
+        let (db, db_path) = fresh_migrated_db();
+        db.with_conn(|conn| {
+            conn.execute(
+                "INSERT INTO chart_snapshots
+                    (id, source_key, region, period, chart_date, fetched_at, status)
+                 VALUES
+                    (1, 'spotify_daily', 'AU', 'daily', '2026-05-27', 100, 'ok'),
+                    (2, 'spotify_daily', 'AU', 'daily', '2026-05-28', 200, 'ok')",
+                [],
+            )?;
+            conn.execute(
+                "INSERT INTO chart_entries
+                    (id, snapshot_id, rank, rank_delta, artist, title, entity_type, streams)
+                 VALUES
+                    (10, 1, 1, 0, 'Old Artist', 'Old Track', 'track', 10),
+                    (20, 2, 2, -1, 'Second Artist', 'Second Track', 'track', 200),
+                    (21, 2, 1, 1, 'Top Artist', 'Top Track', 'track', 300)",
+                [],
+            )?;
+            conn.execute(
+                "INSERT INTO chart_entry_resolutions
+                    (entry_id, status, tidal_id)
+                 VALUES
+                    (20, 'unresolved', NULL),
+                    (21, 'tidal', 4242)",
+                [],
+            )?;
+            Ok(())
+        })
+        .expect("seed chart snapshots");
+
+        let response = json_request(
+            app_for_db(db),
+            "GET",
+            "/api/charts/snapshots?source=spotify_daily&period=daily&region=AU&limit=2",
+            "",
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await;
+
+        assert_eq!(body["snapshot"]["chart_date"], "2026-05-28");
+        assert_eq!(body["entries"].as_array().unwrap().len(), 2);
+        assert_eq!(body["entries"][0]["rank"], 1);
+        assert_eq!(body["entries"][0]["title"], "Top Track");
+        assert_eq!(body["entries"][0]["resolution_status"], "tidal");
+        assert_eq!(body["entries"][0]["tidal_id"], 4242);
+        assert_eq!(body["entries"][1]["rank"], 2);
+        assert_eq!(body["entries"][1]["title"], "Second Track");
+        assert_eq!(body["entries"][1]["resolution_status"], "unresolved");
+        assert!(body["entries"][1]["tidal_id"].is_null());
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[tokio::test]
+    async fn chart_matrix_returns_provider_cells_and_explicit_missing_cells() {
+        let (db, db_path) = fresh_migrated_db();
+        db.with_conn(|conn| {
+            queries::upsert_chart_snapshot(
+                conn,
+                &queries::ChartSnapshotSeed {
+                    source_key: "spotify_daily",
+                    region: "global",
+                    period: "daily",
+                    chart_date: "2026-05-27",
+                    fetched_at: 100,
+                    etag: None,
+                    content_hash: None,
+                    status: "ok",
+                },
+                &[queries::ChartEntrySeed {
+                    streams: Some(10),
+                    ..queries::ChartEntrySeed::track(1, "Old Artist", "Old Song")
+                }],
+            )?;
+            queries::upsert_chart_snapshot(
+                conn,
+                &queries::ChartSnapshotSeed {
+                    source_key: "spotify_daily",
+                    region: "global",
+                    period: "daily",
+                    chart_date: "2026-05-28",
+                    fetched_at: 200,
+                    etag: None,
+                    content_hash: None,
+                    status: "ok",
+                },
+                &[
+                    queries::ChartEntrySeed {
+                        streams: Some(500),
+                        tidal_id: Some(5001),
+                        resolution_status: Some("tidal"),
+                        ..queries::ChartEntrySeed::track(1, "Top Artist", "Top Song")
+                    },
+                    queries::ChartEntrySeed {
+                        streams: Some(400),
+                        ..queries::ChartEntrySeed::track(2, "Ignored Artist", "Ignored Song")
+                    },
+                ],
+            )?;
+            queries::upsert_chart_snapshot(
+                conn,
+                &queries::ChartSnapshotSeed {
+                    source_key: "spotify_daily",
+                    region: "global",
+                    period: "daily",
+                    chart_date: "2026-05-28",
+                    fetched_at: 205,
+                    etag: None,
+                    content_hash: Some("same-day-refresh"),
+                    status: "ok",
+                },
+                &[queries::ChartEntrySeed {
+                    streams: Some(550),
+                    tidal_id: Some(5001),
+                    resolution_status: Some("tidal"),
+                    ..queries::ChartEntrySeed::track(1, "Top Artist", "Top Song")
+                }],
+            )?;
+            queries::upsert_chart_snapshot(
+                conn,
+                &queries::ChartSnapshotSeed {
+                    source_key: "youtube_daily",
+                    region: "global",
+                    period: "daily",
+                    chart_date: "2026-05-28",
+                    fetched_at: 210,
+                    etag: None,
+                    content_hash: None,
+                    status: "ok",
+                },
+                &[queries::ChartEntrySeed {
+                    entity_type: "video",
+                    views: Some(900),
+                    resolution_status: Some("not_playable"),
+                    ..queries::ChartEntrySeed::track(1, "Video Artist", "Top Video")
+                }],
+            )?;
+            queries::upsert_chart_snapshot(
+                conn,
+                &queries::ChartSnapshotSeed {
+                    source_key: "shazam_daily",
+                    region: "AU",
+                    period: "daily",
+                    chart_date: "2026-05-28",
+                    fetched_at: 220,
+                    etag: None,
+                    content_hash: None,
+                    status: "ok",
+                },
+                &[queries::ChartEntrySeed::track(1, "AU Artist", "AU Shazam")],
+            )?;
+            Ok(())
+        })
+        .expect("seed chart matrix");
+
+        let response = json_request(app_for_db(db), "GET", "/api/charts/matrix", "").await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await;
+
+        let providers = body["providers"].as_array().expect("providers");
+        assert_eq!(providers.len(), 6);
+        assert_eq!(providers[0]["source_key"], "itunes_daily");
+        assert_eq!(providers[1]["source_key"], "spotify_daily");
+        assert_eq!(providers[2]["source_key"], "apple_music_daily");
+        assert_eq!(providers[3]["source_key"], "youtube_daily");
+        assert_eq!(providers[4]["source_key"], "shazam_daily");
+        assert_eq!(providers[5]["source_key"], "deezer_daily");
+
+        let rows = body["rows"].as_array().expect("rows");
+        let global = rows
+            .iter()
+            .find(|row| row["region"] == "global")
+            .expect("global row");
+        assert_eq!(global["cells"]["spotify_daily"]["title"], "Top Song");
+        assert_eq!(global["cells"]["spotify_daily"]["tidal_id"], 5001);
+        assert_eq!(global["cells"]["spotify_daily"]["streams"], 550);
+        assert_eq!(global["cells"]["spotify_daily"]["chart_date"], "2026-05-28");
+        assert_eq!(global["cells"]["youtube_daily"]["title"], "Top Video");
+        assert!(global["cells"]["itunes_daily"].is_null());
+        assert!(global["cells"]["deezer_daily"].is_null());
+
+        let au = rows
+            .iter()
+            .find(|row| row["region"] == "AU")
+            .expect("AU row");
+        assert_eq!(au["cells"]["shazam_daily"]["title"], "AU Shazam");
+        assert!(au["cells"]["shazam_daily"]["tidal_id"].is_null());
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[tokio::test]
+    async fn spotify_daily_import_endpoint_persists_snapshot_for_matrix() {
+        let (db, db_path) = fresh_migrated_db();
+        let csv = r#"rank,uri,artist_names,track_name,peak_rank,previous_rank,days_on_chart,streams
+1,spotify:track:imported,"Import Artist","Import Track",1,2,3,12345
+"#;
+
+        let response = json_request(
+            app_for_db(db.clone()),
+            "POST",
+            "/api/charts/spotify/daily/import?region=AU&date=2026-05-28",
+            csv,
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await;
+        assert_eq!(body["source"], "spotify_daily");
+        assert_eq!(body["region"], "AU");
+        assert_eq!(body["chart_date"], "2026-05-28");
+
+        let response = json_request(app_for_db(db), "GET", "/api/charts/matrix", "").await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await;
+        let au = body["rows"]
+            .as_array()
+            .expect("rows")
+            .iter()
+            .find(|row| row["region"] == "AU")
+            .expect("AU row");
+        assert_eq!(au["cells"]["spotify_daily"]["title"], "Import Track");
+        assert_eq!(au["cells"]["spotify_daily"]["streams"], 12345);
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[tokio::test]
     async fn dj_enabled_true_starts_current_pair_lookahead() {
         let (db, db_path) = fresh_migrated_db();
         let (_current, next) = seed_dj_queue_pair(&db);
@@ -16999,6 +17242,10 @@ mod tests {
             ("GET", "/api/tidal/moods"),
             ("GET", "/api/tidal/mood-page/mood_party"),
             ("GET", "/api/charts"),
+            ("GET", "/api/charts/snapshots"),
+            ("POST", "/api/charts/spotify/daily/import"),
+            ("GET", "/api/charts/matrix"),
+            ("POST", "/api/charts/matrix/refresh"),
             ("GET", "/api/charts/lastfm/genres"),
             ("GET", "/api/charts/lastfm/countries"),
             ("GET", "/api/server/token"),

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -11658,8 +11658,20 @@ fn spawn_playback_runtime_listener(
                 }
                 Ok(playback_runtime::PlaybackRuntimeEvent::Paused { .. })
                 | Ok(playback_runtime::PlaybackRuntimeEvent::Resumed { .. })
-                | Ok(playback_runtime::PlaybackRuntimeEvent::Preparing { .. })
-                | Ok(playback_runtime::PlaybackRuntimeEvent::DropPreviewStarted { .. }) => {}
+                | Ok(playback_runtime::PlaybackRuntimeEvent::Preparing { .. }) => {}
+                Ok(playback_runtime::PlaybackRuntimeEvent::DropPreviewStarted {
+                    track_id,
+                    generation,
+                    actual_start_ms,
+                }) => {
+                    let mut state_guard = state.write().await;
+                    state_guard.last_drop_preview = Some(crate::DropPreviewRuntimeState {
+                        track_id,
+                        generation,
+                        actual_fire_ms: actual_start_ms,
+                    });
+                    let _ = state_guard.event_tx.send(AppEvent::PlaybackStateChanged);
+                }
                 Ok(playback_runtime::PlaybackRuntimeEvent::Stopped) => {
                     let mut state_guard = state.write().await;
                     state_guard
@@ -11674,6 +11686,7 @@ fn spawn_playback_runtime_listener(
                     state_guard.current_stream_display = None;
                     state_guard.pending_stream_display = None;
                     state_guard.next_prebuffer_inflight = None;
+                    state_guard.last_drop_preview = None;
                 }
                 Ok(playback_runtime::PlaybackRuntimeEvent::NearEnd {
                     track_id,
@@ -14401,6 +14414,7 @@ mod tests {
             current_stream_display: None,
             pending_stream_display: None,
             next_prebuffer_inflight: None,
+            last_drop_preview: None,
             active_listen_session: None,
             live_listen_session: None,
             external_playback_track: None,

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -11437,7 +11437,8 @@ fn spawn_playback_runtime_listener(
                 }
                 Ok(playback_runtime::PlaybackRuntimeEvent::Paused { .. })
                 | Ok(playback_runtime::PlaybackRuntimeEvent::Resumed { .. })
-                | Ok(playback_runtime::PlaybackRuntimeEvent::Preparing { .. }) => {}
+                | Ok(playback_runtime::PlaybackRuntimeEvent::Preparing { .. })
+                | Ok(playback_runtime::PlaybackRuntimeEvent::DropPreviewStarted { .. }) => {}
                 Ok(playback_runtime::PlaybackRuntimeEvent::Stopped) => {
                     let mut state_guard = state.write().await;
                     state_guard

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -75,19 +75,20 @@ async fn queue_missing_dj_profiles_after_pair_change(state: SharedState, context
 fn active_dj_lookahead_start_for_state(
     state: &crate::AppState,
 ) -> Option<player::DjLookaheadStart> {
-    active_ephemeral_tidal_mix_dj_pair(state)
-        .and_then(|pair| {
-            player::dj_lookahead_start_from_pair(pair, EPHEMERAL_DJ_LOOKAHEAD_DEADLINE_SAMPLES)
+    state
+        .db
+        .with_conn(|conn| {
+            if !queries::is_dj_engine_enabled(conn)? {
+                return Ok(None);
+            }
+            let pair = active_dj_pair_for_state_and_conn(state, conn)?;
+            Ok(player::dj_lookahead_start_from_pair(
+                pair,
+                EPHEMERAL_DJ_LOOKAHEAD_DEADLINE_SAMPLES,
+            ))
         })
-        .or_else(|| {
-            state
-                .db
-                .with_conn(|conn| {
-                    player::build_dj_lookahead_start(conn, EPHEMERAL_DJ_LOOKAHEAD_DEADLINE_SAMPLES)
-                })
-                .ok()
-                .flatten()
-        })
+        .ok()
+        .flatten()
 }
 
 async fn start_dj_lookahead_and_queue_profiles_after_pair_change(
@@ -7003,6 +7004,28 @@ pub(crate) fn active_ephemeral_tidal_mix_dj_labels(
     labels
 }
 
+pub(crate) fn active_dj_pair_for_state_and_conn(
+    state: &crate::AppState,
+    conn: &rusqlite::Connection,
+) -> anyhow::Result<crate::playback::dj_lookahead::DjLookaheadPair> {
+    if let Some(pair) = active_ephemeral_tidal_mix_dj_pair(state)
+        && pair.next.is_some()
+    {
+        return Ok(pair);
+    }
+    let external_current = state
+        .ephemeral_tidal_track
+        .as_ref()
+        .or(state.external_playback_track.as_ref());
+    if let Some(current) = external_current
+        && let Some(pair) =
+            crate::playback::dj_lookahead::build_external_current_queue_pair(conn, current)?
+    {
+        return Ok(pair);
+    }
+    crate::playback::dj_lookahead::load_dj_lookahead_pair(conn)
+}
+
 async fn overlay_snapshot_with_external_track(
     state: &SharedState,
     snapshot: player::PlaybackSnapshot,
@@ -11153,9 +11176,7 @@ async fn start_ephemeral_tidal_playback(
     if dj_engine_enabled {
         let lookahead = {
             let state_guard = state.read().await;
-            active_ephemeral_tidal_mix_dj_pair(&state_guard).and_then(|pair| {
-                player::dj_lookahead_start_from_pair(pair, EPHEMERAL_DJ_LOOKAHEAD_DEADLINE_SAMPLES)
-            })
+            active_dj_lookahead_start_for_state(&state_guard)
         };
         if let Some(lookahead) = lookahead {
             let _ = lookahead.dispatch(&runtime_handle);
@@ -11833,7 +11854,7 @@ async fn handle_ephemeral_tidal_near_end(
             .cloned()
             .collect::<Vec<_>>();
         let Some(pending_track) = pending_tracks.first().cloned() else {
-            return Ok(true);
+            return Ok(false);
         };
         let Some(handle) = state_guard
             .playback_runtime
@@ -12157,6 +12178,11 @@ async fn handle_near_end_prebuffer_next(
             .db
             .with_conn(player::current_track_id)
             .unwrap_or(None);
+        let external_current = state_guard
+            .ephemeral_tidal_track
+            .as_ref()
+            .or(state_guard.external_playback_track.as_ref())
+            .map(|track| track.id);
         let cleared = recently_cleared(&state_guard);
         let still_next = state_guard
             .db
@@ -12165,7 +12191,7 @@ async fn handle_near_end_prebuffer_next(
             .flatten()
             .map(|track| track.id);
         if active_id != Some(current_track_id)
-            || db_current != Some(current_track_id)
+            || (db_current != Some(current_track_id) && external_current != Some(current_track_id))
             || current_playback_generation(&state_guard) != generation
             || still_next != Some(next.id)
         {
@@ -12261,9 +12287,14 @@ async fn handle_near_end_prebuffer_next(
             .as_ref()
             .map(|info| info.channels)
             .unwrap_or(2);
-        let job = player::attach_dj_transition_plan(
-            &state_guard.db,
+        let pair = state_guard
+            .db
+            .with_conn(|conn| active_dj_pair_for_state_and_conn(&state_guard, conn))?;
+        let engine = crate::playback::dj_engine::DjEngine::new(state_guard.db.clone());
+        let job = player::attach_dj_transition_plan_for_pair(
+            &engine,
             job,
+            pair,
             stream_info
                 .as_ref()
                 .and_then(|info| info.sample_rate_hz())
@@ -12271,9 +12302,7 @@ async fn handle_near_end_prebuffer_next(
             channels,
         )?;
         let lookahead_start = if job.prepared_transition.is_some() {
-            state_guard.db.with_conn(|conn| {
-                player::build_dj_lookahead_start(conn, EPHEMERAL_DJ_LOOKAHEAD_DEADLINE_SAMPLES)
-            })?
+            active_dj_lookahead_start_for_state(&state_guard)
         } else {
             None
         };
@@ -12290,7 +12319,14 @@ async fn handle_near_end_prebuffer_next(
             .db
             .with_conn(player::current_track_id)
             .unwrap_or(None);
-        if active_id != Some(current_track_id) || db_current != Some(current_track_id) {
+        let external_current = state_guard
+            .ephemeral_tidal_track
+            .as_ref()
+            .or(state_guard.external_playback_track.as_ref())
+            .map(|track| track.id);
+        if active_id != Some(current_track_id)
+            || (db_current != Some(current_track_id) && external_current != Some(current_track_id))
+        {
             return Ok(());
         }
         if current_playback_generation(&state_guard) != generation {
@@ -12445,6 +12481,95 @@ async fn try_adopt_prepared_ephemeral_tidal_next(
     Ok(true)
 }
 
+async fn switch_runtime_to_snapshot_current(
+    state: &SharedState,
+    snapshot: &player::PlaybackSnapshot,
+    generation: u64,
+) -> anyhow::Result<()> {
+    {
+        let mut state_guard = state.write().await;
+        if let Some(info) = state_guard.playback_runtime_info.as_mut() {
+            info.active_track_id = snapshot.state.current_track.as_ref().map(|track| track.id);
+        }
+    }
+
+    if let Some(track) = snapshot.state.current_track.as_ref() {
+        let user_quality = current_user_audio_quality(state).await;
+        let runtime_handle = ensure_playback_runtime_for_track(state, track)
+            .await
+            .map_err(|(status, body)| {
+                anyhow::anyhow!("playback runtime unavailable ({status}): {}", body.0)
+            })?;
+        let prepared_status = runtime_handle.track_status(track.id, generation);
+        if matches!(
+            prepared_status,
+            playback_runtime::PlaybackTrackStatus::Active
+                | playback_runtime::PlaybackTrackStatus::Prepared
+        ) {
+            let job = player::build_playback_preparation(
+                track,
+                None,
+                effective_crossfade_ms(state, snapshot.state.crossfade_ms).await,
+                user_quality,
+            )
+            .with_generation(generation);
+            runtime_handle.switch_to(job)?;
+            {
+                let mut state_guard = state.write().await;
+                if let Some(pending) = state_guard.pending_stream_display.take() {
+                    state_guard.current_stream_display = Some(pending);
+                }
+            }
+        } else {
+            let Some(stream_request) =
+                player::build_tidal_stream_request(track, user_quality.clone())
+            else {
+                handle_runtime_error(
+                    state.clone(),
+                    "Local library playback is not wired into the host audio runtime yet.",
+                )
+                .await;
+                return Ok(());
+            };
+            let stream_info = resolve_tidal_playback_stream(state, track, &stream_request)
+                .await
+                .map_err(|error| {
+                    anyhow::anyhow!(
+                        "playback stream resolve failed: {}",
+                        describe_tidal_playback_error(&error)
+                    )
+                })?;
+            let job = player::build_playback_preparation(
+                track,
+                Some(&stream_info),
+                effective_crossfade_ms(state, snapshot.state.crossfade_ms).await,
+                user_quality,
+            )
+            .with_generation(generation);
+            runtime_handle.switch_to(job)?;
+            {
+                let mut state_guard = state.write().await;
+                state_guard.current_stream_display = Some(crate::StreamDisplayInfo {
+                    audio_quality: stream_info.audio_quality.clone(),
+                    sample_rate: stream_info.sample_rate,
+                    bit_depth: stream_info.bit_depth,
+                });
+                state_guard.pending_stream_display = None;
+            }
+        }
+    }
+
+    let state_guard = state.read().await;
+    if let Some(track) = snapshot.state.current_track.as_ref() {
+        let _ = state_guard
+            .event_tx
+            .send(AppEvent::TrackChanged { track_id: track.id });
+    }
+    let _ = state_guard.event_tx.send(AppEvent::PlaybackStateChanged);
+    let _ = state_guard.event_tx.send(AppEvent::QueueUpdated);
+    Ok(())
+}
+
 async fn handle_runtime_finished(
     state: SharedState,
     finished_track_id: i64,
@@ -12556,6 +12681,30 @@ async fn handle_runtime_finished(
             // Fall through to teardown so the UI doesn't get stuck on a
             // ghost track.
         }
+        let persisted_snapshot = {
+            let state_guard = state.read().await;
+            let cleared = recently_cleared(&state_guard);
+            state_guard
+                .db
+                .with_conn(|conn| player::next_track(conn, cleared))?
+        };
+        if persisted_snapshot.state.current_track.is_some() {
+            {
+                let mut state_guard = state.write().await;
+                state_guard.external_playback_track = None;
+                state_guard.ephemeral_tidal_track = None;
+                state_guard.prepared_ephemeral_tidal_next = None;
+                state_guard.pending_stream_display = None;
+            }
+            sync_session_after_snapshot(
+                &state,
+                &persisted_snapshot,
+                Some(player::ListenSessionEndReason::Replaced),
+            )
+            .await;
+            switch_runtime_to_snapshot_current(&state, &persisted_snapshot, generation).await?;
+            return Ok(());
+        }
         {
             let mut state_guard = state.write().await;
             // Flush any in-flight listen session before tearing down so the
@@ -12644,101 +12793,15 @@ async fn handle_runtime_finished(
         Some(player::ListenSessionEndReason::QueueEnded)
     };
     sync_session_after_snapshot(&state, &snapshot, end_reason).await;
-
-    {
-        let mut state_guard = state.write().await;
-        if let Some(info) = state_guard.playback_runtime_info.as_mut() {
-            info.active_track_id = snapshot.state.current_track.as_ref().map(|track| track.id);
-        }
-    }
-
-    if let Some(track) = snapshot.state.current_track.as_ref() {
-        let user_quality = current_user_audio_quality(&state).await;
-        let runtime_handle = ensure_playback_runtime_for_track(&state, track)
-            .await
-            .map_err(|(status, body)| {
-                anyhow::anyhow!("playback runtime unavailable ({status}): {}", body.0)
-            })?;
-        let prepared_status = runtime_handle.track_status(track.id, generation);
-        if matches!(
-            prepared_status,
-            playback_runtime::PlaybackTrackStatus::Active
-                | playback_runtime::PlaybackTrackStatus::Prepared
-        ) {
-            let job = player::build_playback_preparation(
-                track,
-                None,
-                effective_crossfade_ms(&state, snapshot.state.crossfade_ms).await,
-                user_quality,
-            )
-            .with_generation(generation);
-            runtime_handle.switch_to(job)?;
-            {
-                let mut state_guard = state.write().await;
-                if let Some(pending) = state_guard.pending_stream_display.take() {
-                    state_guard.current_stream_display = Some(pending);
-                }
-            }
-        } else {
-            let Some(stream_request) =
-                player::build_tidal_stream_request(track, user_quality.clone())
-            else {
-                handle_runtime_error(
-                    state.clone(),
-                    "Local library playback is not wired into the host audio runtime yet.",
-                )
-                .await;
-                return Ok(());
-            };
-            let stream_info = resolve_tidal_playback_stream(&state, track, &stream_request)
-                .await
-                .map_err(|error| {
-                    anyhow::anyhow!(
-                        "playback stream resolve failed: {}",
-                        describe_tidal_playback_error(&error)
-                    )
-                })?;
-            let job = player::build_playback_preparation(
-                track,
-                Some(&stream_info),
-                effective_crossfade_ms(&state, snapshot.state.crossfade_ms).await,
-                user_quality,
-            )
-            .with_generation(generation);
-            runtime_handle.switch_to(job)?;
-            {
-                let mut state_guard = state.write().await;
-                state_guard.current_stream_display = Some(crate::StreamDisplayInfo {
-                    audio_quality: stream_info.audio_quality.clone(),
-                    sample_rate: stream_info.sample_rate,
-                    bit_depth: stream_info.bit_depth,
-                });
-                state_guard.pending_stream_display = None;
-            }
-        }
-    }
-
-    let state_guard = state.read().await;
-    if let Some(track) = snapshot.state.current_track.as_ref() {
-        let _ = state_guard
-            .event_tx
-            .send(AppEvent::TrackChanged { track_id: track.id });
-    }
-    let _ = state_guard.event_tx.send(AppEvent::PlaybackStateChanged);
-    let _ = state_guard.event_tx.send(AppEvent::QueueUpdated);
-    Ok(())
+    switch_runtime_to_snapshot_current(&state, &snapshot, generation).await
 }
 
 async fn mark_armed_dj_transition_missed_if_needed(state: &SharedState) -> anyhow::Result<()> {
     let pair = {
         let state_guard = state.read().await;
-        if let Some(pair) = active_ephemeral_tidal_mix_dj_pair(&state_guard) {
-            pair
-        } else {
-            state_guard
-                .db
-                .with_conn(crate::playback::dj_lookahead::load_dj_lookahead_pair)?
-        }
+        state_guard
+            .db
+            .with_conn(|conn| active_dj_pair_for_state_and_conn(&state_guard, conn))?
     };
     let (Some(current), Some(next)) = (pair.current.as_ref(), pair.next.as_ref()) else {
         return Ok(());
@@ -12770,13 +12833,9 @@ async fn mark_armed_dj_transition_manual_seek_suppressed_if_needed(
 ) -> anyhow::Result<()> {
     let pair = {
         let state_guard = state.read().await;
-        if let Some(pair) = active_ephemeral_tidal_mix_dj_pair(&state_guard) {
-            pair
-        } else {
-            state_guard
-                .db
-                .with_conn(crate::playback::dj_lookahead::load_dj_lookahead_pair)?
-        }
+        state_guard
+            .db
+            .with_conn(|conn| active_dj_pair_for_state_and_conn(&state_guard, conn))?
     };
     let (Some(current), Some(next)) = (pair.current.as_ref(), pair.next.as_ref()) else {
         return Ok(());
@@ -14864,6 +14923,72 @@ mod tests {
             Some(crate::playback::dj_lookahead::DjMediaRef::TidalTrack {
                 tidal_id: 77002,
                 track_id: Some(7002),
+            })
+        );
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[tokio::test]
+    async fn dj_lookahead_pairs_ephemeral_current_with_persisted_queue() {
+        let (db, db_path) = fresh_migrated_db();
+        db.with_conn(|conn| {
+            conn.execute(
+                "INSERT INTO artists (id, name) VALUES (7101, 'Queue Artist')",
+                [],
+            )?;
+            conn.execute(
+                "INSERT INTO tracks (id, title, artist_id, duration_ms, tidal_id)
+                 VALUES (7102, 'Queued Next', 7101, 180000, 88002)",
+                [],
+            )?;
+            conn.execute(
+                "INSERT INTO queue (track_id, position, source) VALUES (7102, 0, 'user_queue')",
+                [],
+            )?;
+            queries::set_dj_engine_enabled(conn, true)?;
+            Ok(())
+        })
+        .expect("seed queue");
+        let mut state = fresh_test_state(db);
+        state.ephemeral_tidal_track = Some(crate::db::models::Track {
+            id: -88001,
+            title: "Direct Current".to_string(),
+            artist_id: 0,
+            artist_name: Some("Direct Artist".to_string()),
+            album_id: None,
+            album_title: None,
+            disc_number: None,
+            track_number: None,
+            duration_ms: Some(180_000),
+            isrc: None,
+            tidal_id: Some(88001),
+            ytmusic_id: None,
+            soundcloud_id: None,
+            best_quality: Some("LOSSLESS".to_string()),
+            best_source: Some("tidal".to_string()),
+            fidelity_score: 0,
+            is_favorite: false,
+            play_count: 0,
+            last_played_at: None,
+            date_added: None,
+            source: "tidal_ephemeral".to_string(),
+            artwork_url: None,
+        });
+
+        let start = active_dj_lookahead_start_for_state(&state).expect("lookahead start");
+
+        assert_eq!(
+            start.current,
+            Some(crate::playback::dj_lookahead::DjMediaRef::TidalTrack {
+                tidal_id: 88001,
+                track_id: None,
+            })
+        );
+        assert_eq!(
+            start.next,
+            Some(crate::playback::dj_lookahead::DjMediaRef::TidalTrack {
+                tidal_id: 88002,
+                track_id: Some(7102),
             })
         );
         let _ = std::fs::remove_file(db_path);

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -31,7 +31,7 @@ use rusqlite::{OptionalExtension, params};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 use tracing::{error, info, warn};
 
@@ -51,11 +51,17 @@ mod tidal_sync_routes;
 pub use tidal_sync_routes::trigger_auto_sync;
 
 type TidalPlaylistTracksCache = Arc<Mutex<HashMap<String, (Instant, Vec<TidalTrack>)>>>;
+type DropPreviewArmKey = (i64, i64, u64);
 
 const TIDAL_PLAYLIST_TRACKS_CACHE_TTL: Duration = Duration::from_secs(60 * 60);
 const EPHEMERAL_DJ_LOOKAHEAD_DEADLINE_SAMPLES: u64 = 48_000 * 30;
+const DROP_PREVIEW_DURATION_MS: u32 = 16_000;
+const DROP_PREVIEW_ARM_RETRY_SECS: u64 = 60 * 60;
 const PLAYBACK_FINISH_DB_LOCK_RETRY_LIMIT: usize = 60;
 const PLAYBACK_FINISH_DB_LOCK_RETRY_DELAY_SECS: u64 = 2;
+
+static DROP_PREVIEW_ARM_ATTEMPTS: OnceLock<Mutex<HashMap<DropPreviewArmKey, Instant>>> =
+    OnceLock::new();
 
 async fn queue_missing_dj_profiles_after_pair_change(state: SharedState, context: &'static str) {
     if let Err(status) = dj_routes::queue_missing_dj_profiles_for_current_pair(state).await {
@@ -95,8 +101,223 @@ async fn start_dj_lookahead_and_queue_profiles_after_pair_change(
     };
     if let Some(lookahead) = lookahead {
         let _ = lookahead.dispatch(&handle);
+        spawn_drop_preview_scheduler(state.clone(), handle, lookahead);
     }
     queue_missing_dj_profiles_after_pair_change(state, context).await;
+}
+
+fn spawn_drop_preview_scheduler(
+    state: SharedState,
+    handle: playback_runtime::PlaybackRuntimeHandle,
+    lookahead: player::DjLookaheadStart,
+) {
+    tokio::spawn(async move {
+        if let Err(error) = schedule_drop_preview_for_pair(state, handle, lookahead).await {
+            warn!("Drop preview scheduling skipped: {error:?}");
+        }
+    });
+}
+
+async fn schedule_drop_preview_for_pair(
+    state: SharedState,
+    handle: playback_runtime::PlaybackRuntimeHandle,
+    lookahead: player::DjLookaheadStart,
+) -> anyhow::Result<()> {
+    let Some(current_ref) = lookahead.current.clone() else {
+        return Ok(());
+    };
+    let Some(next_ref) = lookahead.next.clone() else {
+        return Ok(());
+    };
+    let (Some(current_track_id), Some(next_track_id)) =
+        (current_ref.track_id(), next_ref.track_id())
+    else {
+        return Ok(());
+    };
+    if !claim_drop_preview_arm(current_track_id, next_track_id, lookahead.queue_generation) {
+        return Ok(());
+    }
+
+    let (next, runtime_info, user_quality) = {
+        let state_guard = state.read().await;
+        let active_id = state_guard
+            .playback_runtime_info
+            .as_ref()
+            .and_then(|info| info.active_track_id);
+        if active_id != Some(current_track_id)
+            || current_playback_generation(&state_guard) != lookahead.queue_generation
+        {
+            return Ok(());
+        }
+        let current = state_guard
+            .db
+            .with_conn(|conn| queue::get_track_by_id(conn, current_track_id))?
+            .context("drop preview current track missing")?;
+        let next = state_guard
+            .db
+            .with_conn(|conn| queue::get_track_by_id(conn, next_track_id))?
+            .context("drop preview next track missing")?;
+        let plan = state_guard.db.with_conn(|conn| {
+            dj_routes::drop_preview_plan_for_pair(
+                conn,
+                &current_ref,
+                &next_ref,
+                current.duration_ms,
+            )
+        })?;
+        let Some(plan) = plan else {
+            return Ok(());
+        };
+        let info = state_guard
+            .playback_runtime_info
+            .clone()
+            .context("playback runtime info missing")?;
+        let position_ms = handle.get_position_ms(info.sample_rate, info.channels);
+        if position_ms >= plan.planned_fire_ms {
+            return Ok(());
+        }
+        (
+            next,
+            (info.sample_rate, info.channels, plan),
+            current_user_audio_quality_locked(&state_guard),
+        )
+    };
+
+    let stream_request = match player::build_tidal_stream_request(&next, user_quality.clone()) {
+        Some(request) => request,
+        None => return Ok(()),
+    };
+    let stream_info = match resolve_tidal_playback_stream(&state, &next, &stream_request).await {
+        Ok(info) => Some(info),
+        Err(error) => {
+            warn!(
+                "Skipping drop preview for next track {}: {}",
+                next.id,
+                describe_tidal_playback_error(&error)
+            );
+            return Ok(());
+        }
+    };
+
+    let (sample_rate, channels, plan) = runtime_info;
+    let engine = {
+        let state_guard = state.read().await;
+        crate::playback::dj_engine::DjEngine::new(state_guard.db.clone())
+    };
+    let Some(program) = engine.plan_drop_preview(
+        &current_ref,
+        &next_ref,
+        stream_info
+            .as_ref()
+            .and_then(|info| info.sample_rate_hz())
+            .unwrap_or(sample_rate),
+        channels,
+        DROP_PREVIEW_DURATION_MS,
+    )?
+    else {
+        return Ok(());
+    };
+
+    let mut job = player::build_playback_preparation(&next, stream_info.as_ref(), 0, user_quality)
+        .with_generation(lookahead.queue_generation)
+        .with_dj_media_ref(next_ref.clone())
+        .with_prepared_transition(player::PreparedTransitionProgram {
+            program,
+            transition_event_id: None,
+            fire_ahead_ms: 0,
+            queue_generation: lookahead.queue_generation,
+            current_queue_item_id: lookahead.current_queue_item_id,
+            next_queue_item_id: lookahead.next_queue_item_id,
+        });
+    job.gapless = crate::playback::gapless::GaplessPlan::disabled();
+
+    {
+        let state_guard = state.read().await;
+        let active_id = state_guard
+            .playback_runtime_info
+            .as_ref()
+            .and_then(|info| info.active_track_id);
+        if active_id != Some(current_track_id)
+            || current_playback_generation(&state_guard) != lookahead.queue_generation
+        {
+            return Ok(());
+        }
+        let info = state_guard
+            .playback_runtime_info
+            .as_ref()
+            .context("playback runtime info missing")?;
+        let position_ms = handle.get_position_ms(info.sample_rate, info.channels);
+        if position_ms >= plan.planned_fire_ms {
+            return Ok(());
+        }
+    }
+
+    let trigger_position_samples =
+        samples_from_ms_for_runtime(plan.planned_fire_ms, sample_rate, channels);
+    handle.prepare_drop_preview(job)?;
+    handle.arm_drop_preview(
+        current_track_id,
+        lookahead.queue_generation,
+        trigger_position_samples,
+    )?;
+    info!(
+        current_track_id,
+        next_track_id = next.id,
+        planned_fire_ms = plan.planned_fire_ms,
+        incoming_drop_ms = plan.incoming_drop_ms,
+        source = %plan.source,
+        "Drop preview armed"
+    );
+    Ok(())
+}
+
+fn current_user_audio_quality_locked(
+    state: &crate::AppState,
+) -> Option<crate::db::audio_settings::AudioQuality> {
+    state
+        .db
+        .with_conn(|conn| crate::db::audio_settings::load(conn).map_err(anyhow::Error::from))
+        .ok()
+        .map(|settings| settings.quality)
+}
+
+fn samples_from_ms_for_runtime(ms: i64, sample_rate: u32, channels: u16) -> u64 {
+    let ms = ms.max(0) as u64;
+    ms.saturating_mul(sample_rate.max(1) as u64)
+        .saturating_mul(channels.max(1) as u64)
+        / 1000
+}
+
+fn claim_drop_preview_arm(current_track_id: i64, next_track_id: i64, generation: u64) -> bool {
+    let attempts = DROP_PREVIEW_ARM_ATTEMPTS.get_or_init(|| Mutex::new(HashMap::new()));
+    let now = Instant::now();
+    let mut attempts = attempts.lock().unwrap_or_else(|error| error.into_inner());
+    claim_drop_preview_arm_at(
+        &mut attempts,
+        current_track_id,
+        next_track_id,
+        generation,
+        now,
+    )
+}
+
+fn claim_drop_preview_arm_at(
+    attempts: &mut HashMap<DropPreviewArmKey, Instant>,
+    current_track_id: i64,
+    next_track_id: i64,
+    generation: u64,
+    now: Instant,
+) -> bool {
+    let retry_after = Duration::from_secs(DROP_PREVIEW_ARM_RETRY_SECS);
+    attempts.retain(|_, last_attempt| now.duration_since(*last_attempt) < retry_after);
+    let key = (current_track_id, next_track_id, generation);
+    if let Some(last_attempt) = attempts.get(&key)
+        && now.duration_since(*last_attempt) < retry_after
+    {
+        return false;
+    }
+    attempts.insert(key, now);
+    true
 }
 
 async fn refresh_dj_after_queue_change(state: SharedState, context: &'static str) {

--- a/noor-server/src/server/routes/chart_routes.rs
+++ b/noor-server/src/server/routes/chart_routes.rs
@@ -30,6 +30,20 @@ pub(super) struct ChartParams {
     tag: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+pub(super) struct ChartSnapshotParams {
+    source: Option<String>,
+    period: Option<String>,
+    region: Option<String>,
+    limit: Option<u32>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct SpotifyDailyImportParams {
+    region: Option<String>,
+    date: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize)]
 struct ChartTidalPlayable {
     tidal_id: i64,
@@ -119,6 +133,17 @@ struct ChartCacheEntry {
     inserted_at: Instant,
     payload: serde_json::Value,
 }
+
+const MATRIX_PROVIDERS: [(&str, &str); 6] = [
+    ("itunes_daily", "iTunes"),
+    ("spotify_daily", "Spotify"),
+    ("apple_music_daily", "Apple Music"),
+    ("youtube_daily", "YouTube"),
+    ("shazam_daily", "Shazam"),
+    ("deezer_daily", "Deezer"),
+];
+
+const MAIN_MATRIX_REGIONS: [&str; 6] = ["global", "US", "UK", "AU", "CA", "NZ"];
 
 fn chart_cache() -> &'static StdMutex<HashMap<String, ChartCacheEntry>> {
     static CACHE: OnceLock<StdMutex<HashMap<String, ChartCacheEntry>>> = OnceLock::new();
@@ -267,6 +292,220 @@ pub(super) async fn get_charts(
     });
     chart_cache_put(cache_key, payload.clone());
     Ok(Json(payload))
+}
+
+pub(super) async fn get_chart_snapshots(
+    State(state): State<SharedState>,
+    Query(params): Query<ChartSnapshotParams>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    let source_key = params
+        .source
+        .as_deref()
+        .map(|s| s.trim().to_ascii_lowercase())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "spotify_daily".to_string());
+    let period = params
+        .period
+        .as_deref()
+        .map(|s| s.trim().to_ascii_lowercase())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "daily".to_string());
+    let region = params
+        .region
+        .as_deref()
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .map(|s| {
+            if s.eq_ignore_ascii_case("global") {
+                "global".to_string()
+            } else {
+                s.to_ascii_uppercase()
+            }
+        })
+        .unwrap_or_else(|| "global".to_string());
+    let limit = params.limit.unwrap_or(50).clamp(1, 200);
+
+    let db = {
+        let s = state.read().await;
+        s.db.clone()
+    };
+    let snapshot = db
+        .with_conn(|conn| {
+            queries::get_latest_chart_snapshot(conn, &source_key, &region, &period, limit)
+        })
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": format!("chart snapshots: {e}") })),
+            )
+        })?;
+
+    match snapshot {
+        Some(snapshot) => Ok(Json(json!({
+            "source": source_key,
+            "period": period,
+            "region": region,
+            "limit": limit,
+            "snapshot": snapshot.snapshot,
+            "entries": snapshot.entries,
+        }))),
+        None => Ok(Json(json!({
+            "source": source_key,
+            "period": period,
+            "region": region,
+            "limit": limit,
+            "snapshot": Value::Null,
+            "entries": [],
+        }))),
+    }
+}
+
+pub(super) async fn import_spotify_daily_snapshot(
+    State(state): State<SharedState>,
+    Query(params): Query<SpotifyDailyImportParams>,
+    body: String,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    let region = normalize_chart_region(params.region.as_deref());
+    let now = chrono::Utc::now();
+    let chart_date = params
+        .date
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| now.date_naive().to_string());
+    let fetched_at = now.timestamp();
+    let db = {
+        let s = state.read().await;
+        s.db.clone()
+    };
+    let snapshot_id = db
+        .with_conn(|conn| {
+            crate::services::charts::spotify_daily::ingest_spotify_daily_csv(
+                conn,
+                &region,
+                &chart_date,
+                fetched_at,
+                &body,
+            )
+        })
+        .map_err(|e| {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": format!("spotify daily import: {e}") })),
+            )
+        })?;
+
+    Ok(Json(json!({
+        "source": "spotify_daily",
+        "period": "daily",
+        "region": region,
+        "chart_date": chart_date,
+        "snapshot_id": snapshot_id,
+    })))
+}
+
+pub(super) async fn get_chart_matrix(
+    State(state): State<SharedState>,
+    Query(params): Query<HashMap<String, String>>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    let region_group = params
+        .get("region_group")
+        .map(|s| s.trim().to_ascii_lowercase())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "main".to_string());
+
+    if region_group != "main" {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "unknown_region_group" })),
+        ));
+    }
+
+    let provider_keys: Vec<&str> = MATRIX_PROVIDERS.iter().map(|(key, _)| *key).collect();
+    let providers: Vec<_> = MATRIX_PROVIDERS
+        .iter()
+        .map(|(source_key, label)| json!({ "source_key": source_key, "label": label }))
+        .collect();
+
+    let db = {
+        let s = state.read().await;
+        s.db.clone()
+    };
+    let rows = db
+        .with_conn(|conn| {
+            queries::get_chart_matrix(conn, &MAIN_MATRIX_REGIONS, &provider_keys, "daily")
+        })
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": format!("chart matrix: {e}") })),
+            )
+        })?;
+
+    Ok(Json(json!({
+        "region_group": region_group,
+        "period": "daily",
+        "providers": providers,
+        "rows": rows,
+    })))
+}
+
+pub(super) async fn refresh_chart_matrix(
+    State(state): State<SharedState>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    let (http, db) = {
+        let s = state.read().await;
+        (s.http_client.clone(), s.db.clone())
+    };
+
+    let html = crate::services::charts::kworb_matrix::fetch_kworb_matrix_html(&http)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::BAD_GATEWAY,
+                Json(json!({ "error": format!("kworb matrix fetch: {e}") })),
+            )
+        })?;
+    let now = chrono::Utc::now();
+    let chart_date = now.date_naive().to_string();
+    let fetched_at = now.timestamp();
+    let report = db
+        .with_conn(|conn| {
+            crate::services::charts::kworb_matrix::ingest_kworb_matrix_html(
+                conn,
+                &chart_date,
+                fetched_at,
+                &html,
+            )
+        })
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": format!("kworb matrix ingest: {e}") })),
+            )
+        })?;
+
+    Ok(Json(json!({
+        "source": "kworb",
+        "chart_date": chart_date,
+        "fetched_at": fetched_at,
+        "report": report,
+    })))
+}
+
+fn normalize_chart_region(value: Option<&str>) -> String {
+    value
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| {
+            if s.eq_ignore_ascii_case("global") {
+                "global".to_string()
+            } else {
+                s.to_ascii_uppercase()
+            }
+        })
+        .unwrap_or_else(|| "global".to_string())
 }
 
 pub(super) async fn list_lastfm_genres() -> Json<Value> {

--- a/noor-server/src/server/routes/chart_routes.rs
+++ b/noor-server/src/server/routes/chart_routes.rs
@@ -69,116 +69,6 @@ const CHART_TRACK_SELECT_COLUMNS: &str =
     LEFT JOIN artists a ON t.artist_id = a.id
     LEFT JOIN albums al ON t.album_id = al.id";
 
-/// Fill in missing artwork for chart entries by searching Tidal for the
-/// (artist, title) pair. Updates `image_url` (top-level fallback) and the
-/// nested `tidal_playable.artwork_url` so the frontend's preference chain
-/// always lands on something usable.
-async fn enrich_chart_artwork(state: &SharedState, entries: &mut Vec<ChartEntryDto>) {
-    use futures::stream::{FuturesUnordered, StreamExt};
-
-    /// Last.fm's blank-star fallback. We never want to surface this: both the
-    /// usable-art check below and the replace-on-enrich path treat it as empty.
-    const LASTFM_PLACEHOLDER: &str = "2a96cbd8b46e442fc41c2b86b821562f";
-
-    fn is_unusable(url: Option<&str>) -> bool {
-        let Some(url) = url else { return true };
-        let trimmed = url.trim();
-        trimmed.is_empty() || trimmed.contains(LASTFM_PLACEHOLDER)
-    }
-
-    fn has_usable_art(e: &ChartEntryDto) -> bool {
-        let local_ok = !is_unusable(
-            e.local_track
-                .as_ref()
-                .and_then(|t| t.artwork_url.as_deref()),
-        );
-        let tp_ok = !is_unusable(
-            e.tidal_playable
-                .as_ref()
-                .and_then(|tp| tp.artwork_url.as_deref()),
-        );
-        let img_ok = !is_unusable(e.image_url.as_deref());
-        local_ok || tp_ok || img_ok
-    }
-
-    let needs: Vec<(usize, String, String)> = entries
-        .iter()
-        .enumerate()
-        .filter_map(|(idx, e)| {
-            if has_usable_art(e) {
-                return None;
-            }
-            let title = e
-                .local_track
-                .as_ref()
-                .map(|t| t.title.clone())
-                .or_else(|| e.tidal_playable.as_ref().map(|tp| tp.title.clone()))?;
-            let artist = e
-                .local_track
-                .as_ref()
-                .and_then(|t| t.artist_name.clone())
-                .or_else(|| {
-                    e.tidal_playable
-                        .as_ref()
-                        .and_then(|tp| tp.artist_name.clone())
-                })?;
-            Some((idx, artist, title))
-        })
-        .collect();
-
-    if needs.is_empty() {
-        return;
-    }
-
-    let (tokens, tidal_http_client) = {
-        let s = state.read().await;
-        (s.tidal_tokens.clone(), s.tidal_http_client.clone())
-    };
-    let tokens = match tokens {
-        Some(t) => Some(t),
-        None => super::load_persisted_tidal_tokens(state)
-            .await
-            .ok()
-            .flatten(),
-    };
-    let Some(tokens) = tokens else {
-        return;
-    };
-
-    let client = TidalClient::with_http(
-        tidal_http_client,
-        tokens.access_token.clone(),
-        tokens.country_code.clone(),
-    );
-
-    let mut tasks = FuturesUnordered::new();
-    for (idx, artist, title) in needs {
-        let client = client.clone();
-        tasks.push(async move {
-            let q = format!("{artist} {title}");
-            let result = client.search(&q, 1).await.ok();
-            let url = result
-                .and_then(|r| r.into_iter().next())
-                .and_then(|t| t.artwork_url);
-            (idx, url)
-        });
-    }
-
-    while let Some((idx, url)) = tasks.next().await {
-        let Some(url) = url else { continue };
-        if let Some(entry) = entries.get_mut(idx) {
-            if is_unusable(entry.image_url.as_deref()) {
-                entry.image_url = Some(url.clone());
-            }
-            if let Some(tp) = entry.tidal_playable.as_mut()
-                && is_unusable(tp.artwork_url.as_deref())
-            {
-                tp.artwork_url = Some(url);
-            }
-        }
-    }
-}
-
 /// Look up the most-confident genre name for each track id in a single query.
 /// Returns a map keyed by track_id; tracks with no genre rows are absent.
 fn fetch_top_genres_for_tracks(
@@ -351,7 +241,7 @@ pub(super) async fn get_charts(
         return Ok(Json(cached));
     }
 
-    let mut entries: Vec<ChartEntryDto> = match source.as_str() {
+    let entries: Vec<ChartEntryDto> = match source.as_str() {
         "tidal" => fetch_tidal_chart(&state, limit as i32).await.map_err(|e| {
             (
                 StatusCode::BAD_GATEWAY,
@@ -367,12 +257,6 @@ pub(super) async fn get_charts(
                 )
             })?,
     };
-
-    // Backfill missing artwork via Tidal search. Last.fm's chart.getTopTracks
-    // mostly returns a generic placeholder image, and many older library albums
-    // have NULL artwork_url, so this is the difference between blank tiles and
-    // real covers on the trending shelf.
-    enrich_chart_artwork(&state, &mut entries).await;
 
     let payload = json!({
         "source": source,

--- a/noor-server/src/server/routes/chart_routes.rs
+++ b/noor-server/src/server/routes/chart_routes.rs
@@ -459,7 +459,7 @@ pub(super) async fn refresh_chart_matrix(
         (s.http_client.clone(), s.db.clone())
     };
 
-    let html = crate::services::charts::kworb_matrix::fetch_kworb_matrix_html(&http)
+    let pages = crate::services::charts::kworb_matrix::fetch_kworb_chart_pages(&http)
         .await
         .map_err(|e| {
             (
@@ -472,11 +472,11 @@ pub(super) async fn refresh_chart_matrix(
     let fetched_at = now.timestamp();
     let report = db
         .with_conn(|conn| {
-            crate::services::charts::kworb_matrix::ingest_kworb_matrix_html(
+            crate::services::charts::kworb_matrix::ingest_kworb_chart_pages(
                 conn,
                 &chart_date,
                 fetched_at,
-                &html,
+                &pages,
             )
         })
         .map_err(|e| {

--- a/noor-server/src/server/routes/dj_routes.rs
+++ b/noor-server/src/server/routes/dj_routes.rs
@@ -217,6 +217,13 @@ struct DjDropPreviewStatus {
     reason: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DropPreviewPlan {
+    pub(crate) planned_fire_ms: i64,
+    pub(crate) incoming_drop_ms: i64,
+    pub(crate) source: String,
+}
+
 #[derive(Debug, Serialize)]
 struct DjSafeSuggestion {
     media_ref_kind: String,
@@ -1697,6 +1704,43 @@ fn drop_preview_status(
         source: Some(source.to_string()),
         reason: None,
     })
+}
+
+pub(crate) fn drop_preview_plan_for_pair(
+    conn: &rusqlite::Connection,
+    current_ref: &DjMediaRef,
+    next_ref: &DjMediaRef,
+    current_duration_ms: Option<i64>,
+) -> anyhow::Result<Option<DropPreviewPlan>> {
+    let enabled = queries::is_dj_engine_enabled(conn)?;
+    let current = deck_status(conn, current_ref, None, false)?;
+    let next = deck_status(conn, next_ref, None, false)?;
+    let status = drop_preview_status(
+        conn,
+        enabled,
+        Some(current_ref),
+        Some(next_ref),
+        Some(&current),
+        Some(&next),
+        current_duration_ms,
+    )?;
+    Ok(
+        match (
+            status.status.as_str(),
+            status.planned_fire_ms,
+            status.incoming_drop_ms,
+            status.source,
+        ) {
+            ("armed", Some(planned_fire_ms), Some(incoming_drop_ms), Some(source)) => {
+                Some(DropPreviewPlan {
+                    planned_fire_ms,
+                    incoming_drop_ms,
+                    source,
+                })
+            }
+            _ => None,
+        },
+    )
 }
 
 fn incoming_drop_marker(next: Option<&DjDeckStatus>) -> Option<(i64, &'static str)> {

--- a/noor-server/src/server/routes/dj_routes.rs
+++ b/noor-server/src/server/routes/dj_routes.rs
@@ -26,7 +26,7 @@ use crate::playback::runtime::PlaybackRuntimeConfig;
 use crate::playback::runtime::commands::PlaybackRuntimeCommand;
 use crate::playback::runtime::shared::PlaybackSharedState;
 use crate::services::audio_analysis::dj_profile::{
-    DJ_PROFILE_VERSION, DJ_WAVEFORM_PEAK_COUNT, decode_f32_blob, decode_u32_blob,
+    DJ_WAVEFORM_PEAK_COUNT, decode_f32_blob, decode_u32_blob, dj_profile_row_is_current,
 };
 use crate::services::tidal::stream as tidal_stream;
 
@@ -571,6 +571,10 @@ pub(super) async fn queue_missing_dj_profiles_for_current_pair(
                 if !queries::is_dj_engine_enabled(conn)? {
                     return Ok(Vec::new());
                 }
+                if foreground_playback_is_buffering(conn, &state_guard)? {
+                    tracing::debug!("Deferring DJ profile rebuilds while playback is buffering");
+                    return Ok(Vec::new());
+                }
                 let pair = match ephemeral_pair {
                     Some(pair) => pair,
                     None => crate::playback::dj_lookahead::load_dj_lookahead_pair(conn)?,
@@ -946,7 +950,6 @@ async fn queue_tidal_profile_rebuild(
             }
             tracing::warn!(tidal_id, error = %message, "DJ profile rebuild decode failed");
         } else {
-            clear_dj_profile_inflight(&inflight_for_decode, &inflight_key_for_decode);
             clear_dj_profile_rebuild_failure(&failure_key);
             tracing::info!(tidal_id, "DJ profile rebuild decode queued analysis");
         }
@@ -998,8 +1001,23 @@ fn dj_profile_inflight_key(key: &AudioDjProfileKey) -> String {
     format!("{}:{}", key.media_ref_kind, key.media_ref_id)
 }
 
+fn foreground_playback_is_buffering(
+    conn: &rusqlite::Connection,
+    state: &crate::AppState,
+) -> anyhow::Result<bool> {
+    if state
+        .audio_active
+        .load(std::sync::atomic::Ordering::Relaxed)
+        || state.playback_runtime.is_none()
+    {
+        return Ok(false);
+    }
+    Ok(player::load_state(conn)?.is_playing)
+}
+
 fn deck_needs_profile_rebuild(deck: &DjDeckStatus) -> bool {
-    !deck.profile_ready && matches!(deck.profile_status.as_str(), "missing" | "retrying")
+    (!deck.profile_ready && matches!(deck.profile_status.as_str(), "missing" | "retrying"))
+        || (deck.profile_ready && deck.waveform_status == "missing")
 }
 
 #[cfg(test)]
@@ -1415,8 +1433,10 @@ fn dj_profile_is_current_version(
     conn: &rusqlite::Connection,
     key: &AudioDjProfileKey,
 ) -> anyhow::Result<bool> {
-    Ok(queries::get_audio_dj_profile(conn, key)?
-        .is_some_and(|row| row.profile_version == DJ_PROFILE_VERSION))
+    Ok(
+        queries::get_audio_dj_profile(conn, key)?
+            .is_some_and(|row| dj_profile_row_is_current(&row)),
+    )
 }
 
 fn correction_response(row: AudioDjProfileCorrectionRow) -> DjProfileCorrectionResponse {
@@ -2175,7 +2195,7 @@ fn feedback_rating(value: &str) -> Option<i64> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::services::audio_analysis::dj_profile::encode_f32_blob;
+    use crate::services::audio_analysis::dj_profile::{DJ_PROFILE_VERSION, encode_f32_blob};
 
     fn test_profile_row(key: &AudioDjProfileKey, version: &str) -> AudioDjProfileRow {
         AudioDjProfileRow {
@@ -2257,6 +2277,11 @@ mod tests {
             .expect("current profile");
 
         assert!(dj_profile_is_current_version(&conn, &key).expect("current"));
+        let mut current_without_waveform = test_profile_row(&key, DJ_PROFILE_VERSION);
+        current_without_waveform.waveform_peaks_blob = encode_f32_blob(&[]);
+        queries::upsert_audio_dj_profile(&conn, &current_without_waveform)
+            .expect("profile missing waveform");
+        assert!(!dj_profile_is_current_version(&conn, &key).expect("missing waveform"));
     }
 
     #[test]
@@ -2312,6 +2337,7 @@ mod tests {
 
         assert_eq!(deck.waveform_status, "missing");
         assert!(deck.waveform_peaks.is_empty());
+        assert!(deck_needs_profile_rebuild(&deck));
     }
 
     #[test]

--- a/noor-server/src/server/routes/dj_routes.rs
+++ b/noor-server/src/server/routes/dj_routes.rs
@@ -189,6 +189,8 @@ struct DjDeckStatus {
     profile_ready: bool,
     profile_status: String,
     profile_error: Option<String>,
+    profile_retry_after_ms: Option<i64>,
+    profile_retry_reason: Option<String>,
     profile_confidence: Option<f64>,
     beat_count: Option<usize>,
     downbeat_count: Option<usize>,
@@ -358,6 +360,8 @@ enum ProfileRebuildInflightDecision {
 struct DjProfileRebuildFailure {
     status: String,
     message: String,
+    retry_reason: Option<String>,
+    next_retry_at: Option<Instant>,
     recorded_at: Instant,
 }
 
@@ -981,13 +985,29 @@ async fn queue_tidal_profile_rebuild(
     let inflight_for_decode = inflight.clone();
     let inflight_key_for_decode = inflight_key.clone();
     let failure_key = inflight_key.clone();
+    let retry_state = state.clone();
+    let event_tx = {
+        let state_guard = state.read().await;
+        state_guard.event_tx.clone()
+    };
+    let runtime_handle = tokio::runtime::Handle::current();
     tokio::task::spawn_blocking(move || {
         if let Err(error) = decode_and_buffer_job(config, job, shared, 48_000, 2) {
             let status = profile_rebuild_failure_status(&error);
             let message = profile_rebuild_error_message(&error, status);
-            record_dj_profile_rebuild_failure(&failure_key, status, message.clone());
-            if status != "retrying" {
-                clear_dj_profile_inflight(&inflight_for_decode, &inflight_key_for_decode);
+            finish_dj_profile_rebuild_failure(
+                &inflight_for_decode,
+                &inflight_key_for_decode,
+                status,
+                message.clone(),
+            );
+            let _ = event_tx.send(crate::AppEvent::PlaybackStateChanged);
+            if status == "retrying" {
+                schedule_dj_profile_retry(
+                    &runtime_handle,
+                    retry_state,
+                    Duration::from_secs(DJ_PROFILE_AUTO_REBUILD_RETRY_SECS),
+                );
             }
             tracing::warn!(tidal_id, error = %message, "DJ profile rebuild decode failed");
         } else {
@@ -1057,7 +1077,10 @@ fn foreground_playback_is_buffering(
 }
 
 fn deck_needs_profile_rebuild(deck: &DjDeckStatus) -> bool {
-    (!deck.profile_ready && matches!(deck.profile_status.as_str(), "missing" | "retrying"))
+    (!deck.profile_ready
+        && (deck.profile_status == "missing"
+            || (deck.profile_status == "retrying"
+                && deck.profile_retry_after_ms.unwrap_or(0) <= 0)))
         || (deck.profile_ready && deck.waveform_status == "missing")
 }
 
@@ -1094,17 +1117,49 @@ fn clear_dj_profile_inflight(
     }
 }
 
+fn finish_dj_profile_rebuild_failure(
+    inflight: &Arc<std::sync::Mutex<std::collections::HashMap<String, std::time::Instant>>>,
+    key: &str,
+    status: &str,
+    message: String,
+) {
+    record_dj_profile_rebuild_failure(key, status, message);
+    clear_dj_profile_inflight(inflight, key);
+}
+
+fn schedule_dj_profile_retry(
+    runtime: &tokio::runtime::Handle,
+    state: SharedState,
+    delay: Duration,
+) {
+    runtime.spawn(async move {
+        tokio::time::sleep(delay).await;
+        if let Err(status) = queue_missing_dj_profiles_for_current_pair(state).await {
+            tracing::warn!(
+                ?status,
+                "Scheduled DJ profile retry failed to queue current pair"
+            );
+        }
+    });
+}
+
 fn profile_rebuild_failures() -> &'static Mutex<HashMap<String, DjProfileRebuildFailure>> {
     DJ_PROFILE_REBUILD_FAILURES.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
 fn record_dj_profile_rebuild_failure(key: &str, status: &str, message: String) {
     if let Ok(mut guard) = profile_rebuild_failures().lock() {
+        let retry_reason = profile_rebuild_retry_reason(status, &message);
+        let next_retry_at = retry_reason
+            .as_ref()
+            .map(|_| Instant::now() + Duration::from_secs(DJ_PROFILE_AUTO_REBUILD_RETRY_SECS));
         guard.insert(
             key.to_string(),
             DjProfileRebuildFailure {
                 status: status.to_string(),
                 message,
+                retry_reason,
+                next_retry_at,
                 recorded_at: Instant::now(),
             },
         );
@@ -1153,6 +1208,37 @@ fn profile_rebuild_error_is_retryable(message: &str) -> bool {
         || lower.contains("request failed")
         || lower.contains("chunk error")
         || lower.contains("returned error status")
+}
+
+fn profile_rebuild_retry_reason(status: &str, message: &str) -> Option<String> {
+    if status != "retrying" {
+        return None;
+    }
+    let lower = message.to_ascii_lowercase();
+    let reason = if lower.contains("asset") || lower.contains("substatus") {
+        "asset_not_ready"
+    } else if lower.contains("dash") || lower.contains("prebuffer") {
+        "dash_prebuffer"
+    } else if lower.contains("timed out") || lower.contains("timeout") {
+        "timeout"
+    } else {
+        "transient_decode"
+    };
+    Some(reason.to_string())
+}
+
+fn profile_rebuild_retry_after_ms(failure: &DjProfileRebuildFailure) -> Option<i64> {
+    let next_retry_at = failure.next_retry_at?;
+    let now = Instant::now();
+    if next_retry_at <= now {
+        return Some(0);
+    }
+    Some(
+        next_retry_at
+            .duration_since(now)
+            .as_millis()
+            .min(i64::MAX as u128) as i64,
+    )
 }
 
 fn profile_rebuild_error_message(error: &anyhow::Error, status: &str) -> String {
@@ -1519,6 +1605,12 @@ fn deck_status(
     } else {
         "missing".to_string()
     };
+    let profile_retry_after_ms = rebuild_failure
+        .as_ref()
+        .and_then(profile_rebuild_retry_after_ms);
+    let profile_retry_reason = rebuild_failure
+        .as_ref()
+        .and_then(|failure| failure.retry_reason.clone());
     let profile_error = rebuild_failure.map(|failure| failure.message);
     let (title, artist) = match label_override {
         Some((title, artist)) => (title.clone(), artist.clone()),
@@ -1586,6 +1678,8 @@ fn deck_status(
         profile_ready: profile.is_some(),
         profile_status,
         profile_error,
+        profile_retry_after_ms,
+        profile_retry_reason,
         profile_confidence,
         beat_count,
         downbeat_count,
@@ -1655,7 +1749,7 @@ fn drop_preview_status(
     current_duration_ms: Option<i64>,
     actual_fire_ms: Option<i64>,
 ) -> anyhow::Result<DjDropPreviewStatus> {
-    let skipped = |reason: &'static str| DjDropPreviewStatus {
+    let skipped = |reason: &str| DjDropPreviewStatus {
         status: "skipped".to_string(),
         planned_fire_ms: None,
         actual_fire_ms: None,
@@ -1672,8 +1766,13 @@ fn drop_preview_status(
     else {
         return Ok(skipped("pair_missing"));
     };
-    if !current.profile_ready || !next.profile_ready {
-        return Ok(skipped("profiles_missing"));
+    if !current.profile_ready {
+        return Ok(skipped(&deck_profile_unavailable_reason(
+            "current", current,
+        )));
+    }
+    if !next.profile_ready {
+        return Ok(skipped(&deck_profile_unavailable_reason("next", next)));
     }
     if current.safe_crossfade_only || next.safe_crossfade_only {
         return Ok(skipped("safe_crossfade_only"));
@@ -1715,6 +1814,16 @@ fn drop_preview_status(
         source: Some(source.to_string()),
         reason: None,
     })
+}
+
+fn deck_profile_unavailable_reason(prefix: &str, deck: &DjDeckStatus) -> String {
+    if deck.profile_status == "retrying" {
+        if let Some(reason) = deck.profile_retry_reason.as_deref() {
+            return format!("{prefix}_profile_retrying_{reason}");
+        }
+        return format!("{prefix}_profile_retrying");
+    }
+    format!("{prefix}_profile_missing")
 }
 
 pub(crate) fn drop_preview_plan_for_pair(
@@ -2491,6 +2600,8 @@ mod tests {
             profile_ready,
             profile_status: profile_status.to_string(),
             profile_error: None,
+            profile_retry_after_ms: None,
+            profile_retry_reason: None,
             profile_confidence: profile_ready.then_some(0.85),
             beat_count: profile_ready.then_some(128),
             downbeat_count: profile_ready.then_some(32),
@@ -3640,6 +3751,42 @@ mod tests {
     }
 
     #[test]
+    fn drop_preview_status_reports_retrying_asset_unavailable() {
+        let conn = rusqlite::Connection::open_in_memory().expect("db");
+        crate::db::schema::run_migrations(&conn).expect("migrations");
+        let current_ref = DjMediaRef::TidalTrack {
+            tidal_id: 111,
+            track_id: Some(1),
+        };
+        let next_ref = DjMediaRef::TidalTrack {
+            tidal_id: 222,
+            track_id: Some(2),
+        };
+        let mut current = test_deck_status(true, "ready");
+        current.phrase_markers_ms = vec![128_000];
+        let mut next = test_deck_status(false, "retrying");
+        next.profile_retry_reason = Some("asset_not_ready".to_string());
+
+        let status = drop_preview_status(
+            &conn,
+            true,
+            Some(&current_ref),
+            Some(&next_ref),
+            Some(&current),
+            Some(&next),
+            Some(240_000),
+            None,
+        )
+        .expect("preview status");
+
+        assert_eq!(status.status, "skipped");
+        assert_eq!(
+            status.reason.as_deref(),
+            Some("next_profile_retrying_asset_not_ready")
+        );
+    }
+
+    #[test]
     fn ready_pair_transition_planning_cooldown_suppresses_same_generation() {
         let mut attempts = HashMap::new();
         let now = Instant::now();
@@ -3863,9 +4010,78 @@ mod tests {
             deck.profile_error.as_deref(),
             Some("DASH stream prebuffer failed. Retrying analysis.")
         );
-        assert!(deck_needs_profile_rebuild(&deck));
+        assert!(deck.profile_retry_after_ms.is_some_and(|ms| ms > 0));
+        assert_eq!(deck.profile_retry_reason.as_deref(), Some("dash_prebuffer"));
+        assert!(!deck_needs_profile_rebuild(&deck));
 
         clear_dj_profile_rebuild_failure(&rebuild_key);
+    }
+
+    #[test]
+    fn due_retrying_profile_failure_needs_rebuild() {
+        let mut deck = test_deck_status(false, "retrying");
+        deck.profile_retry_after_ms = Some(0);
+
+        assert!(deck_needs_profile_rebuild(&deck));
+    }
+
+    #[test]
+    fn asset_not_ready_retrying_profile_reports_retry_reason() {
+        let conn = rusqlite::Connection::open_in_memory().expect("db");
+        crate::db::schema::run_migrations(&conn).expect("migrations");
+        let media_ref = DjMediaRef::TidalTrack {
+            tidal_id: 12198476,
+            track_id: None,
+        };
+        let key = media_ref.profile_key();
+        let rebuild_key = dj_profile_inflight_key(&key);
+        clear_dj_profile_rebuild_failure(&rebuild_key);
+        record_dj_profile_rebuild_failure(
+            &rebuild_key,
+            "retrying",
+            "TIDAL asset is not ready. Retrying analysis.".to_string(),
+        );
+
+        let deck = deck_status(&conn, &media_ref, None, false).expect("deck status");
+
+        assert_eq!(deck.profile_status, "retrying");
+        assert_eq!(
+            deck.profile_retry_reason.as_deref(),
+            Some("asset_not_ready")
+        );
+        assert!(deck.profile_retry_after_ms.is_some_and(|ms| ms > 0));
+
+        clear_dj_profile_rebuild_failure(&rebuild_key);
+    }
+
+    #[test]
+    fn retryable_profile_rebuild_failure_clears_inflight() {
+        let inflight = Arc::new(std::sync::Mutex::new(std::collections::HashMap::new()));
+        let key = "tidal_track:250295729";
+        let first = mark_dj_profile_rebuild_inflight(
+            &inflight,
+            key,
+            std::time::Duration::from_secs(DJ_PROFILE_AUTO_REBUILD_RETRY_SECS),
+        )
+        .expect("first mark");
+
+        finish_dj_profile_rebuild_failure(
+            &inflight,
+            key,
+            "retrying",
+            "TIDAL asset is not ready. Retrying analysis.".to_string(),
+        );
+
+        let second = mark_dj_profile_rebuild_inflight(
+            &inflight,
+            key,
+            std::time::Duration::from_secs(DJ_PROFILE_AUTO_REBUILD_RETRY_SECS),
+        )
+        .expect("second mark");
+
+        assert_eq!(first, ProfileRebuildInflightDecision::Start);
+        assert_eq!(second, ProfileRebuildInflightDecision::Start);
+        clear_dj_profile_rebuild_failure(key);
     }
 
     #[test]

--- a/noor-server/src/server/routes/dj_routes.rs
+++ b/noor-server/src/server/routes/dj_routes.rs
@@ -36,6 +36,7 @@ const SAFE_SUGGESTION_BAD_COUNT: i64 = 3;
 const DJ_PROFILE_AUTO_REBUILD_RETRY_SECS: u64 = 300;
 const DJ_TIMING_HISTORY_LIMIT: i64 = 5;
 const DJ_READY_PAIR_TRANSITION_WINDOW_MS: i64 = 30_000;
+const DJ_TIMING_SANITY_MAX_DELTA_MS: i64 = 30_000;
 #[cfg(test)]
 const DJ_READY_PAIR_PLANNING_RETRY_SECS: u64 = 15;
 const DJ_PROFILE_REBUILD_FAILURE_TTL_SECS: u64 = 300;
@@ -1796,10 +1797,15 @@ fn latest_fired_dj_timing_deltas(
          FROM dj_transition_events
          WHERE timing_status = 'fired'
            AND timing_delta_ms IS NOT NULL
+           AND ABS(timing_delta_ms) <= ?2
+           AND template != 'DropPreview16'
          ORDER BY started_at DESC, id DESC
          LIMIT ?1",
     )?;
-    let rows = stmt.query_map([limit.max(0)], |row| row.get::<_, i64>(0))?;
+    let rows = stmt.query_map(
+        params![limit.max(0), DJ_TIMING_SANITY_MAX_DELTA_MS],
+        |row| row.get::<_, i64>(0),
+    )?;
     let mut deltas = Vec::new();
     for row in rows {
         deltas.push(row?);
@@ -1834,7 +1840,10 @@ fn summarize_timing_history(
         if event.timing_status.as_deref() == Some("missed") {
             missed_count += 1;
         }
-        if let Some(delta_ms) = event.timing_delta_ms {
+        if let Some(delta_ms) = event
+            .timing_delta_ms
+            .filter(|delta| timing_delta_is_sane(*delta))
+        {
             delta_sum += delta_ms;
             abs_delta_sum += delta_ms.abs();
             delta_count += 1;
@@ -1862,6 +1871,10 @@ fn summarize_timing_history(
         late_count,
         missed_count,
     }
+}
+
+fn timing_delta_is_sane(delta_ms: i64) -> bool {
+    delta_ms.abs() <= DJ_TIMING_SANITY_MAX_DELTA_MS
 }
 
 fn median_abs_delta(deltas: &[i64]) -> Option<i64> {
@@ -2894,6 +2907,40 @@ mod tests {
     }
 
     #[test]
+    fn latest_fired_timing_deltas_exclude_impossible_and_preview_rows() {
+        let conn = rusqlite::Connection::open_in_memory().expect("db");
+        crate::db::schema::run_migrations(&conn).expect("migrations");
+        conn.execute(
+            "INSERT INTO dj_transition_events (
+                from_media_ref_kind, from_media_ref_id, to_media_ref_kind, to_media_ref_id,
+                template, program_json, planner_version, planned_start_ms,
+                actual_start_ms, timing_delta_ms, timing_source, timing_status
+             ) VALUES
+             (
+                'tidal_track', '1', 'tidal_track', '2',
+                'SafeCrossfade', '{\"template\":\"SafeCrossfade\"}', 'dj-v1',
+                100000, 100120, 120, 'downbeat_sync', 'fired'
+             ),
+             (
+                'tidal_track', '2', 'tidal_track', '3',
+                'SafeCrossfade', '{\"template\":\"SafeCrossfade\"}', 'dj-v1',
+                100000, 140001, 40001, 'downbeat_sync', 'fired'
+             ),
+             (
+                'tidal_track', '3', 'tidal_track', '4',
+                'DropPreview16', '{\"template\":\"DropPreview16\"}', 'dj-v1',
+                100000, 100240, 240, 'drop_preview', 'fired'
+             )",
+            [],
+        )
+        .expect("insert timing rows");
+
+        let deltas = latest_fired_dj_timing_deltas(&conn, 20).expect("deltas");
+
+        assert_eq!(deltas, vec![120]);
+    }
+
+    #[test]
     fn timing_history_includes_track_pair_labels() {
         let conn = rusqlite::Connection::open_in_memory().expect("db");
         crate::db::schema::run_migrations(&conn).expect("migrations");
@@ -3081,6 +3128,64 @@ mod tests {
         assert_eq!(summary.bad_count, 1);
         assert_eq!(summary.late_count, 1);
         assert_eq!(summary.missed_count, 1);
+    }
+
+    #[test]
+    fn timing_history_summary_excludes_impossible_deltas_from_averages() {
+        let events = vec![
+            DjTimingHistoryEvent {
+                event_id: 1,
+                from_title: None,
+                from_artist: None,
+                to_title: None,
+                to_artist: None,
+                planned_template: "SafeCrossfade".to_string(),
+                renderer_template: Some("SafeCrossfade".to_string()),
+                planning_reason: None,
+                planned_start_ms: Some(10_000),
+                actual_start_ms: Some(10_100),
+                timing_delta_ms: Some(100),
+                timing_source: Some("downbeat_sync".to_string()),
+                timing_status: Some("fired".to_string()),
+                timing_quality: "tight".to_string(),
+                timing_direction: "on_time".to_string(),
+                runtime_rendered_dj_mixer: Some(true),
+                runtime_renderer_status: Some("rendered_handoff".to_string()),
+                runtime_renderer_reason: Some("none".to_string()),
+                started_at: "now".to_string(),
+                rejected_alternatives: Vec::new(),
+            },
+            DjTimingHistoryEvent {
+                event_id: 2,
+                from_title: None,
+                from_artist: None,
+                to_title: None,
+                to_artist: None,
+                planned_template: "SafeCrossfade".to_string(),
+                renderer_template: Some("SafeCrossfade".to_string()),
+                planning_reason: None,
+                planned_start_ms: Some(10_000),
+                actual_start_ms: Some(50_001),
+                timing_delta_ms: Some(40_001),
+                timing_source: Some("downbeat_sync".to_string()),
+                timing_status: Some("fired".to_string()),
+                timing_quality: "bad".to_string(),
+                timing_direction: "late".to_string(),
+                runtime_rendered_dj_mixer: Some(true),
+                runtime_renderer_status: Some("rendered_handoff".to_string()),
+                runtime_renderer_reason: Some("none".to_string()),
+                started_at: "now".to_string(),
+                rejected_alternatives: Vec::new(),
+            },
+        ];
+
+        let summary = summarize_timing_history(&events, &[100]);
+
+        assert_eq!(summary.event_count, 2);
+        assert_eq!(summary.average_delta_ms, Some(100));
+        assert_eq!(summary.average_abs_delta_ms, Some(100));
+        assert_eq!(summary.tight_count, 1);
+        assert_eq!(summary.bad_count, 1);
     }
 
     #[test]

--- a/noor-server/src/server/routes/dj_routes.rs
+++ b/noor-server/src/server/routes/dj_routes.rs
@@ -443,6 +443,11 @@ async fn get_status(
             .playback_runtime_info
             .as_ref()
             .and_then(|info| info.active_track_id);
+        let active_generation = super::current_playback_generation(&state);
+        let drop_preview_actual_fire_ms = state.last_drop_preview.and_then(|preview| {
+            (Some(preview.track_id) == active_track_id && preview.generation == active_generation)
+                .then_some(preview.actual_fire_ms)
+        });
         state
             .db
             .with_conn(|conn| {
@@ -550,6 +555,7 @@ async fn get_status(
                     active_track_id.and_then(|track_id| {
                         current_track_duration_ms(conn, track_id).ok().flatten()
                     }),
+                    drop_preview_actual_fire_ms,
                 )?;
                 Ok(DjStatusResponse {
                     enabled,
@@ -1647,6 +1653,7 @@ fn drop_preview_status(
     current: Option<&DjDeckStatus>,
     next: Option<&DjDeckStatus>,
     current_duration_ms: Option<i64>,
+    actual_fire_ms: Option<i64>,
 ) -> anyhow::Result<DjDropPreviewStatus> {
     let skipped = |reason: &'static str| DjDropPreviewStatus {
         status: "skipped".to_string(),
@@ -1697,9 +1704,13 @@ fn drop_preview_status(
         });
     };
     Ok(DjDropPreviewStatus {
-        status: "armed".to_string(),
+        status: if actual_fire_ms.is_some() {
+            "fired".to_string()
+        } else {
+            "armed".to_string()
+        },
         planned_fire_ms: Some(planned_fire_ms),
-        actual_fire_ms: None,
+        actual_fire_ms,
         incoming_drop_ms: Some(incoming_drop_ms),
         source: Some(source.to_string()),
         reason: None,
@@ -1723,6 +1734,7 @@ pub(crate) fn drop_preview_plan_for_pair(
         Some(&current),
         Some(&next),
         current_duration_ms,
+        None,
     )?;
     Ok(
         match (
@@ -3539,6 +3551,7 @@ mod tests {
             Some(&current),
             Some(&next),
             Some(240_000),
+            None,
         )
         .expect("preview status");
 
@@ -3553,6 +3566,42 @@ mod tests {
                 reason: None,
             }
         );
+    }
+
+    #[test]
+    fn drop_preview_status_reports_actual_fire() {
+        let conn = rusqlite::Connection::open_in_memory().expect("db");
+        crate::db::schema::run_migrations(&conn).expect("migrations");
+        seed_dsp_key(&conn, 1, "8A");
+        seed_dsp_key(&conn, 2, "8B");
+        let current_ref = DjMediaRef::TidalTrack {
+            tidal_id: 111,
+            track_id: Some(1),
+        };
+        let next_ref = DjMediaRef::TidalTrack {
+            tidal_id: 222,
+            track_id: Some(2),
+        };
+        let mut current = test_deck_status(true, "ready");
+        current.phrase_markers_ms = vec![128_000];
+        let mut next = test_deck_status(true, "ready");
+        next.drop_markers_ms = vec![32_000];
+
+        let status = drop_preview_status(
+            &conn,
+            true,
+            Some(&current_ref),
+            Some(&next_ref),
+            Some(&current),
+            Some(&next),
+            Some(240_000),
+            Some(128_008),
+        )
+        .expect("preview status");
+
+        assert_eq!(status.status, "fired");
+        assert_eq!(status.planned_fire_ms, Some(128_000));
+        assert_eq!(status.actual_fire_ms, Some(128_008));
     }
 
     #[test]
@@ -3582,6 +3631,7 @@ mod tests {
             Some(&current),
             Some(&next),
             Some(240_000),
+            None,
         )
         .expect("preview status");
 

--- a/noor-server/src/server/routes/dj_routes.rs
+++ b/noor-server/src/server/routes/dj_routes.rs
@@ -34,6 +34,7 @@ const DEFAULT_DJ_LOOKAHEAD_DEADLINE_SAMPLES: u64 = 48_000 * 30;
 const DJ_PROFILE_CONFIDENCE_FLOOR: f64 = 0.65;
 const SAFE_SUGGESTION_BAD_COUNT: i64 = 3;
 const DJ_PROFILE_AUTO_REBUILD_RETRY_SECS: u64 = 300;
+const DJ_PROFILE_TRANSIENT_RETRY_SECS: u64 = 25;
 const DJ_TIMING_HISTORY_LIMIT: i64 = 5;
 const DJ_READY_PAIR_TRANSITION_WINDOW_MS: i64 = 30_000;
 const DJ_TIMING_SANITY_MAX_DELTA_MS: i64 = 30_000;
@@ -1006,7 +1007,7 @@ async fn queue_tidal_profile_rebuild(
                 schedule_dj_profile_retry(
                     &runtime_handle,
                     retry_state,
-                    Duration::from_secs(DJ_PROFILE_AUTO_REBUILD_RETRY_SECS),
+                    Duration::from_secs(DJ_PROFILE_TRANSIENT_RETRY_SECS),
                 );
             }
             tracing::warn!(tidal_id, error = %message, "DJ profile rebuild decode failed");
@@ -1152,7 +1153,7 @@ fn record_dj_profile_rebuild_failure(key: &str, status: &str, message: String) {
         let retry_reason = profile_rebuild_retry_reason(status, &message);
         let next_retry_at = retry_reason
             .as_ref()
-            .map(|_| Instant::now() + Duration::from_secs(DJ_PROFILE_AUTO_REBUILD_RETRY_SECS));
+            .map(|_| Instant::now() + Duration::from_secs(DJ_PROFILE_TRANSIENT_RETRY_SECS));
         guard.insert(
             key.to_string(),
             DjProfileRebuildFailure {
@@ -4011,6 +4012,7 @@ mod tests {
             Some("DASH stream prebuffer failed. Retrying analysis.")
         );
         assert!(deck.profile_retry_after_ms.is_some_and(|ms| ms > 0));
+        assert!(deck.profile_retry_after_ms.is_some_and(|ms| ms <= 25_000));
         assert_eq!(deck.profile_retry_reason.as_deref(), Some("dash_prebuffer"));
         assert!(!deck_needs_profile_rebuild(&deck));
 
@@ -4050,6 +4052,7 @@ mod tests {
             Some("asset_not_ready")
         );
         assert!(deck.profile_retry_after_ms.is_some_and(|ms| ms > 0));
+        assert!(deck.profile_retry_after_ms.is_some_and(|ms| ms <= 25_000));
 
         clear_dj_profile_rebuild_failure(&rebuild_key);
     }

--- a/noor-server/src/server/routes/dj_routes.rs
+++ b/noor-server/src/server/routes/dj_routes.rs
@@ -390,25 +390,21 @@ async fn set_enabled(
 ) -> Result<Json<EnabledResponse>, StatusCode> {
     let (runtime, lookahead) = {
         let state_guard = state.write().await;
-        let ephemeral_lookahead = if payload.enabled {
-            super::active_ephemeral_tidal_mix_dj_pair(&state_guard).and_then(|pair| {
-                player::dj_lookahead_start_from_pair(pair, DEFAULT_DJ_LOOKAHEAD_DEADLINE_SAMPLES)
-            })
-        } else {
-            None
-        };
         let lookahead = state_guard
             .db
             .with_conn(|conn| {
                 queries::set_dj_engine_enabled(conn, payload.enabled)?;
                 if payload.enabled {
-                    player::build_dj_lookahead_start(conn, DEFAULT_DJ_LOOKAHEAD_DEADLINE_SAMPLES)
+                    let pair = super::active_dj_pair_for_state_and_conn(&state_guard, conn)?;
+                    Ok(player::dj_lookahead_start_from_pair(
+                        pair,
+                        DEFAULT_DJ_LOOKAHEAD_DEADLINE_SAMPLES,
+                    ))
                 } else {
                     Ok(None)
                 }
             })
             .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-        let lookahead = ephemeral_lookahead.or(lookahead);
         (
             state_guard
                 .playback_runtime
@@ -442,7 +438,6 @@ async fn get_status(
 ) -> Result<Json<DjStatusResponse>, StatusCode> {
     let response = {
         let state = state.read().await;
-        let ephemeral_pair = super::active_ephemeral_tidal_mix_dj_pair(&state);
         let ephemeral_labels = super::active_ephemeral_tidal_mix_dj_labels(&state);
         let active_track_id = state
             .playback_runtime_info
@@ -457,10 +452,7 @@ async fn get_status(
             .db
             .with_conn(|conn| {
                 let enabled = queries::is_dj_engine_enabled(conn)?;
-                let pair = match ephemeral_pair.clone() {
-                    Some(pair) => pair,
-                    None => crate::playback::dj_lookahead::load_dj_lookahead_pair(conn)?,
-                };
+                let pair = super::active_dj_pair_for_state_and_conn(&state, conn)?;
                 let current_ref = pair.current.clone();
                 let next_ref = pair.next.clone();
                 let current = match pair.current {
@@ -609,7 +601,6 @@ pub(super) async fn queue_missing_dj_profiles_for_current_pair(
 ) -> Result<(), StatusCode> {
     let missing_profile_refs = {
         let state_guard = state.read().await;
-        let ephemeral_pair = super::active_ephemeral_tidal_mix_dj_pair(&state_guard);
         let ephemeral_labels = super::active_ephemeral_tidal_mix_dj_labels(&state_guard);
         state_guard
             .db
@@ -621,10 +612,7 @@ pub(super) async fn queue_missing_dj_profiles_for_current_pair(
                     tracing::debug!("Deferring DJ profile rebuilds while playback is buffering");
                     return Ok(Vec::new());
                 }
-                let pair = match ephemeral_pair {
-                    Some(pair) => pair,
-                    None => crate::playback::dj_lookahead::load_dj_lookahead_pair(conn)?,
-                };
+                let pair = super::active_dj_pair_for_state_and_conn(&state_guard, conn)?;
                 let mut missing = Vec::new();
                 for media_ref in [pair.current, pair.next].into_iter().flatten() {
                     let key = media_ref.profile_key();

--- a/noor-server/src/server/routes/dj_routes.rs
+++ b/noor-server/src/server/routes/dj_routes.rs
@@ -37,6 +37,8 @@ const DJ_PROFILE_AUTO_REBUILD_RETRY_SECS: u64 = 300;
 const DJ_TIMING_HISTORY_LIMIT: i64 = 5;
 const DJ_READY_PAIR_TRANSITION_WINDOW_MS: i64 = 30_000;
 const DJ_TIMING_SANITY_MAX_DELTA_MS: i64 = 30_000;
+const DROP_PREVIEW_MIN_POSITION_MS: i64 = 60_000;
+const DROP_PREVIEW_FINAL_WINDOW_GUARD_MS: i64 = 45_000;
 #[cfg(test)]
 const DJ_READY_PAIR_PLANNING_RETRY_SECS: u64 = 15;
 const DJ_PROFILE_REBUILD_FAILURE_TTL_SECS: u64 = 300;
@@ -175,6 +177,7 @@ struct DjStatusResponse {
     recent_timing_events: Vec<DjTimingHistoryEvent>,
     timing_history_summary: DjTimingHistorySummary,
     safe_crossfade_suggestion: Option<DjSafeSuggestion>,
+    drop_preview: DjDropPreviewStatus,
 }
 
 #[derive(Debug, Serialize)]
@@ -197,9 +200,21 @@ struct DjDeckStatus {
     phrase_markers_ms: Vec<i64>,
     mix_in_markers_ms: Vec<i64>,
     mix_out_markers_ms: Vec<i64>,
+    drop_markers_ms: Vec<i64>,
+    manual_drop_markers_ms: Vec<i64>,
     passive_analysis_status: Option<String>,
     passive_analysis_reason: Option<String>,
     safe_crossfade_only: bool,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+struct DjDropPreviewStatus {
+    status: String,
+    planned_fire_ms: Option<i64>,
+    actual_fire_ms: Option<i64>,
+    incoming_drop_ms: Option<i64>,
+    source: Option<String>,
+    reason: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -518,6 +533,17 @@ async fn get_status(
                 let timing_history_summary =
                     summarize_timing_history(&recent_timing_events, &tuning_deltas);
                 let renderer_status = renderer_status_for_transition(latest_transition.as_ref());
+                let drop_preview = drop_preview_status(
+                    conn,
+                    enabled,
+                    current_ref.as_ref(),
+                    next_ref.as_ref(),
+                    current.as_ref(),
+                    next.as_ref(),
+                    active_track_id.and_then(|track_id| {
+                        current_track_duration_ms(conn, track_id).ok().flatten()
+                    }),
+                )?;
                 Ok(DjStatusResponse {
                     enabled,
                     current,
@@ -552,6 +578,7 @@ async fn get_status(
                     recent_timing_events,
                     timing_history_summary,
                     safe_crossfade_suggestion,
+                    drop_preview,
                 })
             })
             .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
@@ -1498,6 +1525,8 @@ fn deck_status(
         phrase_markers_ms,
         mix_in_markers_ms,
         mix_out_markers_ms,
+        drop_markers_ms,
+        manual_drop_markers_ms,
     ) = if let Some(profile) = profile.as_ref() {
         let beat_markers = decode_f32_blob(&profile.beat_grid_blob).unwrap_or_default();
         let downbeat_markers = decode_f32_blob(&profile.downbeats_blob).unwrap_or_default();
@@ -1516,6 +1545,8 @@ fn deck_status(
             phrase_markers,
             seconds_markers_ms(&decode_f32_blob(&profile.mix_in_blob).unwrap_or_default()),
             seconds_markers_ms(&decode_f32_blob(&profile.mix_out_blob).unwrap_or_default()),
+            seconds_markers_ms(&decode_f32_blob(&profile.drop_blob).unwrap_or_default()),
+            Vec::new(),
         )
     } else {
         (
@@ -1523,6 +1554,8 @@ fn deck_status(
             None,
             None,
             None,
+            Vec::new(),
+            Vec::new(),
             Vec::new(),
             Vec::new(),
             Vec::new(),
@@ -1551,6 +1584,8 @@ fn deck_status(
         phrase_markers_ms,
         mix_in_markers_ms,
         mix_out_markers_ms,
+        drop_markers_ms,
+        manual_drop_markers_ms,
         passive_analysis_status: passive_analysis
             .as_ref()
             .map(|snapshot| snapshot.status.to_string()),
@@ -1595,6 +1630,154 @@ fn phrase_markers_ms(phrases: &[u32], downbeats: &[f32]) -> Vec<i64> {
         .filter(|value| value.is_finite() && **value >= 0.0)
         .map(|value| (*value as f64 * 1000.0).round() as i64)
         .collect()
+}
+
+fn drop_preview_status(
+    conn: &rusqlite::Connection,
+    enabled: bool,
+    current_ref: Option<&DjMediaRef>,
+    next_ref: Option<&DjMediaRef>,
+    current: Option<&DjDeckStatus>,
+    next: Option<&DjDeckStatus>,
+    current_duration_ms: Option<i64>,
+) -> anyhow::Result<DjDropPreviewStatus> {
+    let skipped = |reason: &'static str| DjDropPreviewStatus {
+        status: "skipped".to_string(),
+        planned_fire_ms: None,
+        actual_fire_ms: None,
+        incoming_drop_ms: incoming_drop_marker(next).map(|marker| marker.0),
+        source: incoming_drop_marker(next).map(|marker| marker.1.to_string()),
+        reason: Some(reason.to_string()),
+    };
+
+    if !enabled {
+        return Ok(skipped("disabled"));
+    }
+    let (Some(current_ref), Some(next_ref), Some(current), Some(next)) =
+        (current_ref, next_ref, current, next)
+    else {
+        return Ok(skipped("pair_missing"));
+    };
+    if !current.profile_ready || !next.profile_ready {
+        return Ok(skipped("profiles_missing"));
+    }
+    if current.safe_crossfade_only || next.safe_crossfade_only {
+        return Ok(skipped("safe_crossfade_only"));
+    }
+    if current
+        .profile_confidence
+        .is_some_and(|value| value < DJ_PROFILE_CONFIDENCE_FLOOR)
+        || next
+            .profile_confidence
+            .is_some_and(|value| value < DJ_PROFILE_CONFIDENCE_FLOOR)
+    {
+        return Ok(skipped("profile_low_confidence"));
+    }
+    if !drop_preview_pair_harmonic_compatible(conn, current_ref, next_ref)? {
+        return Ok(skipped("harmonic_incompatible"));
+    }
+    let Some((incoming_drop_ms, source)) = incoming_drop_marker(Some(next)) else {
+        return Ok(skipped("missing_incoming_drop"));
+    };
+    let Some(planned_fire_ms) = select_drop_preview_fire_ms(current, current_duration_ms) else {
+        return Ok(DjDropPreviewStatus {
+            status: "skipped".to_string(),
+            planned_fire_ms: None,
+            actual_fire_ms: None,
+            incoming_drop_ms: Some(incoming_drop_ms),
+            source: Some(source.to_string()),
+            reason: Some("no_safe_mid_song_marker".to_string()),
+        });
+    };
+    Ok(DjDropPreviewStatus {
+        status: "armed".to_string(),
+        planned_fire_ms: Some(planned_fire_ms),
+        actual_fire_ms: None,
+        incoming_drop_ms: Some(incoming_drop_ms),
+        source: Some(source.to_string()),
+        reason: None,
+    })
+}
+
+fn incoming_drop_marker(next: Option<&DjDeckStatus>) -> Option<(i64, &'static str)> {
+    let next = next?;
+    next.manual_drop_markers_ms
+        .iter()
+        .copied()
+        .find(|marker| *marker >= 0)
+        .map(|marker| (marker, "manual"))
+        .or_else(|| {
+            next.drop_markers_ms
+                .iter()
+                .copied()
+                .find(|marker| *marker >= 0)
+                .map(|marker| (marker, "profile"))
+        })
+}
+
+fn select_drop_preview_fire_ms(current: &DjDeckStatus, duration_ms: Option<i64>) -> Option<i64> {
+    let duration_ms = duration_ms.filter(|duration| *duration > 0)?;
+    let min_ms = DROP_PREVIEW_MIN_POSITION_MS.max(duration_ms * 45 / 100);
+    let max_ms = (duration_ms * 65 / 100)
+        .min(duration_ms - DJ_READY_PAIR_TRANSITION_WINDOW_MS - DROP_PREVIEW_FINAL_WINDOW_GUARD_MS);
+    if max_ms < min_ms {
+        return None;
+    }
+    let target_ms = duration_ms * 55 / 100;
+    current
+        .phrase_markers_ms
+        .iter()
+        .chain(current.downbeat_markers_ms.iter())
+        .copied()
+        .filter(|marker| (min_ms..=max_ms).contains(marker))
+        .min_by_key(|marker| (*marker - target_ms).abs())
+}
+
+fn drop_preview_pair_harmonic_compatible(
+    conn: &rusqlite::Connection,
+    current_ref: &DjMediaRef,
+    next_ref: &DjMediaRef,
+) -> anyhow::Result<bool> {
+    let current_key = media_ref_camelot_key(conn, current_ref)?;
+    let next_key = media_ref_camelot_key(conn, next_ref)?;
+    Ok(match (current_key.as_deref(), next_key.as_deref()) {
+        (Some(current), Some(next)) => noor_mix::planner::scoring::camelot_distance(current, next)
+            .is_some_and(|distance| matches!(distance, 0 | 1 | 7)),
+        _ => false,
+    })
+}
+
+fn media_ref_camelot_key(
+    conn: &rusqlite::Connection,
+    media_ref: &DjMediaRef,
+) -> anyhow::Result<Option<String>> {
+    let key = media_ref.profile_key();
+    let profile = queries::get_audio_dj_profile(conn, &key)?;
+    let track_id = media_ref
+        .track_id()
+        .or_else(|| profile.as_ref().and_then(|profile| profile.track_id))
+        .or_else(|| {
+            media_ref
+                .tidal_id()
+                .and_then(|tidal_id| track_id_for_tidal_id(conn, tidal_id).ok().flatten())
+        });
+    let Some(track_id) = track_id else {
+        return Ok(None);
+    };
+    Ok(queries::get_audio_dsp_features(conn, track_id)?.and_then(|features| features.camelot_key))
+}
+
+fn track_id_for_tidal_id(
+    conn: &rusqlite::Connection,
+    tidal_id: i64,
+) -> anyhow::Result<Option<i64>> {
+    conn.query_row(
+        "SELECT id FROM tracks WHERE tidal_id = ?1 LIMIT 1",
+        [tidal_id],
+        |row| row.get::<_, i64>(0),
+    )
+    .optional()
+    .map_err(anyhow::Error::from)
 }
 
 fn latest_open_transition_for_pair(
@@ -2267,10 +2450,48 @@ mod tests {
             phrase_markers_ms: Vec::new(),
             mix_in_markers_ms: Vec::new(),
             mix_out_markers_ms: Vec::new(),
+            drop_markers_ms: Vec::new(),
+            manual_drop_markers_ms: Vec::new(),
             passive_analysis_status: None,
             passive_analysis_reason: None,
             safe_crossfade_only: false,
         }
+    }
+
+    fn seed_dsp_key(conn: &rusqlite::Connection, track_id: i64, camelot_key: &str) {
+        conn.execute(
+            "INSERT OR IGNORE INTO artists (id, name) VALUES (1, 'Test Artist')",
+            [],
+        )
+        .expect("artist");
+        conn.execute(
+            "INSERT OR IGNORE INTO tracks (id, title, artist_id, source)
+             VALUES (?1, ?2, 1, 'tidal')",
+            params![track_id, format!("Track {track_id}")],
+        )
+        .expect("track");
+        queries::upsert_audio_dsp_features(
+            conn,
+            &crate::db::models::AudioDspFeatures {
+                track_id,
+                bpm: Some(120.0),
+                key_signature: None,
+                camelot_key: Some(camelot_key.to_string()),
+                loudness_lufs: Some(-12.0),
+                energy: Some(0.7),
+                danceability: Some(0.7),
+                beat_strength: Some(0.7),
+                spectral_centroid: None,
+                stereo_width: None,
+                is_instrumental: false,
+                analysis_source: "test".to_string(),
+                analysis_offset_ms: 0,
+                samples_analyzed: None,
+                analyzed_at: "now".to_string(),
+                analysis_version: "test".to_string(),
+            },
+        )
+        .expect("dsp features");
     }
 
     #[test]
@@ -3215,6 +3436,113 @@ mod tests {
         assert!(ready_pair_transition_due(151_000, Some(180_000)));
         assert!(ready_pair_transition_due(180_000, Some(180_000)));
         assert!(!ready_pair_transition_due(151_000, None));
+    }
+
+    #[test]
+    fn drop_preview_selects_nearest_safe_mid_song_marker() {
+        let mut current = test_deck_status(true, "ready");
+        current.phrase_markers_ms = vec![40_000, 120_000];
+        current.downbeat_markers_ms = vec![132_000, 190_000];
+
+        assert_eq!(
+            select_drop_preview_fire_ms(&current, Some(240_000)),
+            Some(132_000)
+        );
+    }
+
+    #[test]
+    fn drop_preview_rejects_unsafe_mid_song_window() {
+        let mut current = test_deck_status(true, "ready");
+        current.phrase_markers_ms = vec![40_000, 190_000];
+        current.downbeat_markers_ms = vec![59_000];
+
+        assert_eq!(select_drop_preview_fire_ms(&current, Some(240_000)), None);
+    }
+
+    #[test]
+    fn drop_preview_prefers_manual_drop_marker() {
+        let mut next = test_deck_status(true, "ready");
+        next.drop_markers_ms = vec![32_000];
+        next.manual_drop_markers_ms = vec![24_000];
+
+        assert_eq!(incoming_drop_marker(Some(&next)), Some((24_000, "manual")));
+    }
+
+    #[test]
+    fn drop_preview_status_arms_compatible_ready_pair() {
+        let conn = rusqlite::Connection::open_in_memory().expect("db");
+        crate::db::schema::run_migrations(&conn).expect("migrations");
+        seed_dsp_key(&conn, 1, "8A");
+        seed_dsp_key(&conn, 2, "8B");
+        let current_ref = DjMediaRef::TidalTrack {
+            tidal_id: 111,
+            track_id: Some(1),
+        };
+        let next_ref = DjMediaRef::TidalTrack {
+            tidal_id: 222,
+            track_id: Some(2),
+        };
+        let mut current = test_deck_status(true, "ready");
+        current.phrase_markers_ms = vec![128_000];
+        let mut next = test_deck_status(true, "ready");
+        next.drop_markers_ms = vec![32_000];
+
+        let status = drop_preview_status(
+            &conn,
+            true,
+            Some(&current_ref),
+            Some(&next_ref),
+            Some(&current),
+            Some(&next),
+            Some(240_000),
+        )
+        .expect("preview status");
+
+        assert_eq!(
+            status,
+            DjDropPreviewStatus {
+                status: "armed".to_string(),
+                planned_fire_ms: Some(128_000),
+                actual_fire_ms: None,
+                incoming_drop_ms: Some(32_000),
+                source: Some("profile".to_string()),
+                reason: None,
+            }
+        );
+    }
+
+    #[test]
+    fn drop_preview_status_skips_harmonic_mismatch() {
+        let conn = rusqlite::Connection::open_in_memory().expect("db");
+        crate::db::schema::run_migrations(&conn).expect("migrations");
+        seed_dsp_key(&conn, 1, "8A");
+        seed_dsp_key(&conn, 2, "2B");
+        let current_ref = DjMediaRef::TidalTrack {
+            tidal_id: 111,
+            track_id: Some(1),
+        };
+        let next_ref = DjMediaRef::TidalTrack {
+            tidal_id: 222,
+            track_id: Some(2),
+        };
+        let mut current = test_deck_status(true, "ready");
+        current.phrase_markers_ms = vec![128_000];
+        let mut next = test_deck_status(true, "ready");
+        next.drop_markers_ms = vec![32_000];
+
+        let status = drop_preview_status(
+            &conn,
+            true,
+            Some(&current_ref),
+            Some(&next_ref),
+            Some(&current),
+            Some(&next),
+            Some(240_000),
+        )
+        .expect("preview status");
+
+        assert_eq!(status.status, "skipped");
+        assert_eq!(status.reason.as_deref(), Some("harmonic_incompatible"));
     }
 
     #[test]

--- a/noor-server/src/server/routes/search_routes.rs
+++ b/noor-server/src/server/routes/search_routes.rs
@@ -1,5 +1,6 @@
 use crate::SharedState;
 use crate::db::queries;
+use anyhow::Context;
 use axum::{
     extract::{Query, State},
     http::StatusCode,
@@ -119,7 +120,7 @@ async fn fetch_spotify_playlist_search_compact(
         return Ok(Vec::new());
     }
 
-    let results = cached_search(
+    let results = match cached_search(
         client,
         db,
         cfg,
@@ -128,7 +129,18 @@ async fn fetch_spotify_playlist_search_compact(
         limit,
         0,
     )
-    .await?;
+    .await
+    {
+        Ok(results) if !results.playlists.is_empty() => results,
+        Ok(results) => results,
+        Err(primary_error) => {
+            crate::services::spotify::catalog::search_playlists_from_saved_credentials(
+                db, query, limit, 0,
+            )
+            .await
+            .with_context(|| format!("sportify playlist search failed: {primary_error}"))?
+        }
+    };
 
     Ok(results
         .playlists

--- a/noor-server/src/server/routes/sportify_routes.rs
+++ b/noor-server/src/server/routes/sportify_routes.rs
@@ -69,19 +69,47 @@ pub(super) async fn sportify_discovery_search(
     let cached = db
         .with_conn(|conn| sp_cache::get_search(conn, &cache_cfg, q, kind, limit, offset))
         .map_err(super::internal)?;
+    let cached = cached.filter(|p| {
+        !(matches!(
+            kind,
+            crate::services::sportify::client::SportifySearchKind::Playlist
+        ) && p.playlists.is_empty())
+    });
 
     let payload = match cached {
         Some(p) => p,
         None => {
-            let fetched = sportify_client
-                .search(q, kind, limit, offset)
-                .await
-                .map_err(|e| {
-                    (
+            let primary = sportify_client.search(q, kind, limit, offset).await;
+            let fetched = match primary {
+                Ok(fetched) => fetched,
+                Err(primary_error)
+                    if matches!(
+                        kind,
+                        crate::services::sportify::client::SportifySearchKind::Playlist
+                    ) =>
+                {
+                    crate::services::spotify::catalog::search_playlists_from_saved_credentials(
+                        &db, q, limit, offset,
+                    )
+                    .await
+                    .map_err(|fallback_error| {
+                        (
+                            StatusCode::BAD_GATEWAY,
+                            Json(json!({
+                                "error": format!(
+                                    "sportify_search: {primary_error}; spotify_fallback: {fallback_error}"
+                                )
+                            })),
+                        )
+                    })?
+                }
+                Err(e) => {
+                    return Err((
                         StatusCode::BAD_GATEWAY,
                         Json(json!({ "error": format!("sportify_search: {e}") })),
-                    )
-                })?;
+                    ));
+                }
+            };
             db.with_conn(|conn| sp_cache::put_search(conn, q, kind, limit, offset, &fetched))
                 .map_err(super::internal)?;
             fetched
@@ -271,12 +299,23 @@ pub(super) async fn sportify_discovery_playlist(
     {
         Some(p) => p,
         None => {
-            let fetched = sportify_client.playlist(id).await.map_err(|e| {
-                (
-                    StatusCode::BAD_GATEWAY,
-                    Json(json!({ "error": format!("sportify_playlist_fetch: {e}") })),
-                )
-            })?;
+            let fetched = match sportify_client.playlist(id).await {
+                Ok(fetched) => fetched,
+                Err(primary_error) => {
+                    crate::services::spotify::catalog::playlist_from_saved_credentials(&db, id)
+                        .await
+                        .map_err(|fallback_error| {
+                            (
+                                StatusCode::BAD_GATEWAY,
+                                Json(json!({
+                                    "error": format!(
+                                        "sportify_playlist_fetch: {primary_error}; spotify_fallback: {fallback_error}"
+                                    )
+                                })),
+                            )
+                        })?
+                }
+            };
             db.with_conn(|conn| {
                 sp_cache::put_playlist_meta(conn, id, &fetched)?;
                 Ok::<_, anyhow::Error>(())

--- a/noor-server/src/server/routes/tidal_home_routes.rs
+++ b/noor-server/src/server/routes/tidal_home_routes.rs
@@ -19,6 +19,17 @@ const MOOD_THUMBNAIL_FETCH_CONCURRENCY: usize = 4;
 const MOOD_THUMBNAIL_PROBE_TIMEOUT: Duration = Duration::from_secs(4);
 const TIDAL_HOME_MODULES_PAGE_PATH: &str = "pages/home";
 const ROUTE_TIMING_INFO_THRESHOLD_MS: u128 = 500;
+const DEFAULT_TIDAL_MOOD_CATEGORIES: &[(&str, &str)] = &[
+    ("mood_party", "Party"),
+    ("mood_workout", "Workout"),
+    ("mood_focus", "Focus"),
+    ("mood_relax", "Relax"),
+    ("mood_sleep", "Sleep"),
+    ("mood_love", "Love"),
+    ("m_happy", "Happy"),
+    ("m_celebration", "Celebration"),
+    ("mood_djselector", "DJ Selector"),
+];
 
 enum MoodProbeOutcome {
     Modules {
@@ -446,7 +457,7 @@ fn resolve_page_path(section: &str, id: Option<&str>) -> Result<String, StatusCo
     // (verified live: all 404 with subStatus 2001 "Not found"). `moods` now
     // has its own dedicated route at /api/tidal/moods + /api/tidal/mood-page/{slug}
     // because its modules are PAGE_LINKS, not the usual TRACK_LIST/etc shape.
-    // Empty top-level whitelist for now — this generic route is kept for
+    // Empty top-level whitelist for now. This generic route is kept for
     // future slugs (pages/explore, pages/hires, pages/videos, etc).
     let allowed_top = matches!(section, "");
     let allowed_with_id = matches!(section, "mood" | "genre");
@@ -652,38 +663,32 @@ pub(super) async fn get_tidal_moods(
             json!({ "categories": cached, "source": "tidal", "cached": true }),
         ));
     }
-    let client = TidalClient::with_http(
-        tidal_http_client.clone(),
-        tokens.access_token.clone(),
-        tokens.country_code.clone(),
-    );
-    let raw = match client.get_page_raw("pages/moods").await {
-        Ok(r) => r,
-        Err(e) if super::error_looks_like_auth(&e) => {
-            let refreshed = super::recover_tidal_session(&state, &http_client, &tokens)
-                .await
-                .map_err(|_| StatusCode::BAD_GATEWAY)?;
-            let retry = TidalClient::with_http(
-                tidal_http_client.clone(),
-                refreshed.access_token.clone(),
-                refreshed.country_code.clone(),
-            );
-            retry.get_page_raw("pages/moods").await.map_err(|e| {
-                tracing::warn!("TIDAL get_tidal_moods failed after refresh: {e}");
-                StatusCode::BAD_GATEWAY
-            })?
-        }
-        Err(e) => {
-            tracing::warn!("TIDAL get_tidal_moods failed: {e}");
-            return Err(StatusCode::BAD_GATEWAY);
-        }
-    };
-    let categories = extract_page_links(&raw);
+    let categories = default_tidal_mood_categories();
     let (response_categories, pending_probe_slugs, cached_probe_hits) =
         apply_cached_mood_category_probes(categories, &tokens.country_code, &page_modules_cache);
     let pending_probe_count = pending_probe_slugs.len();
 
     put_cached_tidal_mood_categories(&mood_cache, response_categories.clone());
+
+    {
+        let state_bg = state.clone();
+        let mood_cache_bg = mood_cache.clone();
+        let page_modules_cache_bg = page_modules_cache.clone();
+        let tokens_bg = tokens.clone();
+        let http_client_bg = http_client;
+        let tidal_http_client_bg = tidal_http_client.clone();
+        tokio::spawn(async move {
+            refresh_tidal_moods_cache(
+                state_bg,
+                mood_cache_bg,
+                page_modules_cache_bg,
+                tokens_bg,
+                http_client_bg,
+                tidal_http_client_bg,
+            )
+            .await;
+        });
+    }
 
     if !pending_probe_slugs.is_empty() {
         let mood_cache_bg = mood_cache.clone();
@@ -731,8 +736,88 @@ pub(super) async fn get_tidal_moods(
         );
     }
     Ok(Json(
-        json!({ "categories": response_categories, "source": "tidal" }),
+        json!({ "categories": response_categories, "source": "tidal", "fallback": true }),
     ))
+}
+
+async fn refresh_tidal_moods_cache(
+    state: SharedState,
+    mood_cache: TidalMoodCategoriesCache,
+    page_modules_cache: TidalPageModulesCache,
+    tokens: crate::services::tidal::auth::TidalTokens,
+    http_client: reqwest::Client,
+    tidal_http_client: reqwest::Client,
+) {
+    let started_at = Instant::now();
+    let client = TidalClient::with_http(
+        tidal_http_client.clone(),
+        tokens.access_token.clone(),
+        tokens.country_code.clone(),
+    );
+    let raw = match client.get_page_raw("pages/moods").await {
+        Ok(r) => r,
+        Err(e) if super::error_looks_like_auth(&e) => {
+            let Ok(refreshed) = super::recover_tidal_session(&state, &http_client, &tokens).await
+            else {
+                tracing::warn!("TIDAL get_tidal_moods refresh failed");
+                return;
+            };
+            let retry = TidalClient::with_http(
+                tidal_http_client.clone(),
+                refreshed.access_token.clone(),
+                refreshed.country_code.clone(),
+            );
+            match retry.get_page_raw("pages/moods").await {
+                Ok(r) => r,
+                Err(e) => {
+                    tracing::warn!("TIDAL get_tidal_moods failed after refresh: {e}");
+                    return;
+                }
+            }
+        }
+        Err(e) => {
+            tracing::warn!("TIDAL get_tidal_moods failed: {e}");
+            return;
+        }
+    };
+    let live_categories = extract_page_links(&raw);
+    if live_categories.is_empty() {
+        tracing::warn!("TIDAL get_tidal_moods returned no PAGE_LINKS categories");
+        return;
+    }
+
+    let (response_categories, pending_probe_slugs, cached_probe_hits) =
+        apply_cached_mood_category_probes(
+            live_categories,
+            &tokens.country_code,
+            &page_modules_cache,
+        );
+    put_cached_tidal_mood_categories(&mood_cache, response_categories.clone());
+
+    if !pending_probe_slugs.is_empty() {
+        let probe_client = TidalClient::with_http(
+            tidal_http_client,
+            tokens.access_token.clone(),
+            tokens.country_code.clone(),
+        );
+        run_mood_thumbnail_probe_refresh(
+            mood_cache.clone(),
+            page_modules_cache,
+            probe_client,
+            tokens.country_code.clone(),
+            response_categories.clone(),
+            pending_probe_slugs,
+        )
+        .await;
+    }
+
+    tracing::info!(
+        route = "tidal_moods_refresh",
+        elapsed_ms = started_at.elapsed().as_millis(),
+        cached_probe_hits,
+        category_count = response_categories.len(),
+        "TIDAL moods background refresh complete"
+    );
 }
 
 fn apply_cached_mood_category_probes(
@@ -784,6 +869,21 @@ fn apply_mood_probe_results(
                 }
             }
             Some(category)
+        })
+        .collect()
+}
+
+fn default_tidal_mood_categories() -> Vec<Value> {
+    DEFAULT_TIDAL_MOOD_CATEGORIES
+        .iter()
+        .map(|(slug, title)| {
+            json!({
+                "slug": slug,
+                "title": title,
+                "icon": null,
+                "imageId": null,
+                "thumbnail": null,
+            })
         })
         .collect()
 }

--- a/noor-server/src/services/audio_analysis/dj_profile.rs
+++ b/noor-server/src/services/audio_analysis/dj_profile.rs
@@ -5,6 +5,7 @@ use anyhow::Result;
 use rusqlite::Connection;
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 use tokio::sync::mpsc;
 use tracing::{debug, info, warn};
 
@@ -13,6 +14,8 @@ use super::{onset, tempo};
 
 pub const DJ_PROFILE_VERSION: &str = "dj_profile_v2";
 pub const DJ_WAVEFORM_PEAK_COUNT: usize = 512;
+const DJ_PROFILE_DB_LOCK_RETRY_LIMIT: usize = 6;
+const DJ_PROFILE_DB_LOCK_RETRY_DELAY: Duration = Duration::from_secs(1);
 
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
@@ -102,7 +105,9 @@ fn persist_dj_analysis_job(
     analyzer: fn(&[f32], u32) -> Option<BeatGridAnalysis>,
 ) -> Result<()> {
     let key = job.media_ref.profile_key();
-    if db.with_conn(|conn| dj_analysis_skips_existing_profile_version(conn, &key))? {
+    if with_dj_profile_db_retry("check current DJ profile version", || {
+        db.with_conn(|conn| dj_analysis_skips_existing_profile_version(conn, &key))
+    })? {
         debug!(
             media_ref_kind = %key.media_ref_kind,
             media_ref_id = %key.media_ref_id,
@@ -133,8 +138,10 @@ fn persist_dj_analysis_job(
         return Ok(());
     };
 
-    db.with_conn(|conn| {
-        persist_dj_analysis_job_from_analysis(conn, &job, "dj_playback", &analysis)
+    with_dj_profile_db_retry("persist DJ profile", || {
+        db.with_conn(|conn| {
+            persist_dj_analysis_job_from_analysis(conn, &job, "dj_playback", &analysis)
+        })
     })?;
     info!(
         media_ref_kind = %key.media_ref_kind,
@@ -144,6 +151,59 @@ fn persist_dj_analysis_job(
         "DJ profile persisted"
     );
     Ok(())
+}
+
+fn with_dj_profile_db_retry<T, F>(operation: &'static str, f: F) -> Result<T>
+where
+    F: FnMut() -> Result<T>,
+{
+    with_dj_profile_db_retry_config(
+        operation,
+        DJ_PROFILE_DB_LOCK_RETRY_LIMIT,
+        DJ_PROFILE_DB_LOCK_RETRY_DELAY,
+        f,
+    )
+}
+
+fn with_dj_profile_db_retry_config<T, F>(
+    operation: &'static str,
+    retry_limit: usize,
+    retry_delay: Duration,
+    mut f: F,
+) -> Result<T>
+where
+    F: FnMut() -> Result<T>,
+{
+    for attempt in 0..=retry_limit {
+        match f() {
+            Ok(value) => return Ok(value),
+            Err(error) if sqlite_database_locked(&error) && attempt < retry_limit => {
+                let next_attempt = attempt + 1;
+                warn!(
+                    operation,
+                    next_attempt, retry_limit, "DJ profile database locked; retrying"
+                );
+                std::thread::sleep(retry_delay);
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    unreachable!("DJ profile retry loop always returns before exhausting attempts")
+}
+
+fn sqlite_database_locked(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        if let Some(rusqlite::Error::SqliteFailure(sqlite_error, _)) =
+            cause.downcast_ref::<rusqlite::Error>()
+        {
+            return matches!(
+                sqlite_error.code,
+                rusqlite::ErrorCode::DatabaseBusy | rusqlite::ErrorCode::DatabaseLocked
+            );
+        }
+        let message = cause.to_string();
+        message.contains("database is locked") || message.contains("database table is locked")
+    })
 }
 
 fn fallback_beat_grid_analysis(samples: &[f32], sample_rate: u32) -> Option<BeatGridAnalysis> {
@@ -266,9 +326,12 @@ pub fn dj_analysis_skips_existing_profile_version(
     key: &AudioDjProfileKey,
 ) -> Result<bool> {
     let existing = queries::get_audio_dj_profile(conn, key)?;
-    Ok(existing
-        .as_ref()
-        .is_some_and(|row| row.profile_version == DJ_PROFILE_VERSION))
+    Ok(existing.as_ref().is_some_and(dj_profile_row_is_current))
+}
+
+pub fn dj_profile_row_is_current(row: &AudioDjProfileRow) -> bool {
+    row.profile_version == DJ_PROFILE_VERSION
+        && decode_f32_blob(&row.waveform_peaks_blob).is_some_and(|peaks| !peaks.is_empty())
 }
 
 pub fn persist_dj_analysis_job_from_analysis(
@@ -837,6 +900,12 @@ mod tests {
                 conn,
                 &key("tidal_track", "1")
             )?);
+            row.waveform_peaks_blob = encode_f32_blob(&[]);
+            queries::upsert_audio_dj_profile(conn, &row)?;
+            assert!(!super::dj_analysis_skips_existing_profile_version(
+                conn,
+                &key("tidal_track", "1")
+            )?);
             Ok(())
         })
         .expect("check");
@@ -1255,6 +1324,34 @@ mod tests {
             .expect("get")
             .expect("profile");
         assert_eq!(loaded.tidal_id, Some(7));
+    }
+
+    #[test]
+    fn dj_profile_db_retry_retries_locked_database_errors() {
+        let attempts = std::cell::Cell::new(0);
+        let result = with_dj_profile_db_retry_config(
+            "test retry",
+            2,
+            Duration::ZERO,
+            || -> Result<&'static str> {
+                let attempt = attempts.get();
+                attempts.set(attempt + 1);
+                if attempt == 0 {
+                    return Err(rusqlite::Error::SqliteFailure(
+                        rusqlite::ffi::Error {
+                            code: rusqlite::ErrorCode::DatabaseBusy,
+                            extended_code: rusqlite::ffi::SQLITE_BUSY,
+                        },
+                        None,
+                    )
+                    .into());
+                }
+                Ok("ok")
+            },
+        );
+
+        assert_eq!(result.expect("retry result"), "ok");
+        assert_eq!(attempts.get(), 2);
     }
 
     #[test]

--- a/noor-server/src/services/audio_analysis/queue_prescanner.rs
+++ b/noor-server/src/services/audio_analysis/queue_prescanner.rs
@@ -555,13 +555,23 @@ async fn load_candidates(state: &SharedState) -> Result<(Vec<PrescanCandidate>, 
 
 async fn run_batch(state: &SharedState, event_rx: &mut broadcast::Receiver<AppEvent>) {
     // Respect the global passive-DSP toggle.
-    let passive_on = state
-        .read()
-        .await
-        .db
-        .with_conn(|conn| Ok::<_, anyhow::Error>(super::is_passive_enabled(conn)))
-        .unwrap_or(true);
+    let (passive_on, playback_buffering) = {
+        let state_guard = state.read().await;
+        state_guard
+            .db
+            .with_conn(|conn| {
+                Ok::<_, anyhow::Error>((
+                    super::is_passive_enabled(conn),
+                    foreground_playback_is_buffering(conn, &state_guard)?,
+                ))
+            })
+            .unwrap_or((true, false))
+    };
     if !passive_on {
+        return;
+    }
+    if playback_buffering {
+        tracing::debug!("queue prescanner deferred while playback is buffering");
         return;
     }
 
@@ -632,6 +642,20 @@ async fn run_batch(state: &SharedState, event_rx: &mut broadcast::Receiver<AppEv
         }
         tokio::time::sleep(INTER_TRACK_DELAY).await;
     }
+}
+
+fn foreground_playback_is_buffering(
+    conn: &rusqlite::Connection,
+    state: &crate::AppState,
+) -> anyhow::Result<bool> {
+    if state
+        .audio_active
+        .load(std::sync::atomic::Ordering::Relaxed)
+        || state.playback_runtime.is_none()
+    {
+        return Ok(false);
+    }
+    Ok(crate::playback::player::load_state(conn)?.is_playing)
 }
 
 /// Spawn the long-lived queue-lookahead actor. Subscribes to queue/track

--- a/noor-server/src/services/charts/kworb_matrix.rs
+++ b/noor-server/src/services/charts/kworb_matrix.rs
@@ -15,6 +15,7 @@ const KWORB_COUNTRY_INDEX_URLS: &[&str] = &[
     "https://kworb.net/charts/index_n.html",
     "https://kworb.net/charts/index_u.html",
 ];
+const MAX_KWORB_DETAIL_ROWS: usize = 200;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct KworbMatrixCell {
@@ -26,11 +27,33 @@ pub struct KworbMatrixCell {
     pub external_url: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KworbChartEntry {
+    pub rank: i64,
+    pub rank_delta: Option<i64>,
+    pub artist: String,
+    pub title: String,
+    pub external_url: Option<String>,
+    pub streams: Option<i64>,
+    pub views: Option<i64>,
+    pub points: Option<i64>,
+    pub seven_day_streams: Option<i64>,
+    pub total_streams: Option<i64>,
+    pub days_on_chart: Option<i64>,
+    pub peak_rank: Option<i64>,
+}
+
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct KworbMatrixIngestReport {
     pub rows_seen: usize,
     pub entries_written: usize,
     pub snapshots_written: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct KworbChartPages {
+    pub matrix_html: String,
+    pub detail_pages: BTreeMap<String, String>,
 }
 
 pub async fn fetch_kworb_matrix_html(client: &reqwest::Client) -> Result<String> {
@@ -45,6 +68,30 @@ pub async fn fetch_kworb_matrix_html(client: &reqwest::Client) -> Result<String>
         }
     }
     Ok(html)
+}
+
+pub async fn fetch_kworb_chart_pages(client: &reqwest::Client) -> Result<KworbChartPages> {
+    let matrix_html = fetch_kworb_matrix_html(client).await?;
+    let detail_urls = kworb_detail_urls_for_matrix_html(&matrix_html).unwrap_or_default();
+    let mut detail_pages = BTreeMap::new();
+    let detail_fetches = detail_urls.into_iter().map(|url| async move {
+        let result = fetch_kworb_page(client, &url).await;
+        (url, result)
+    });
+
+    for (url, result) in futures::future::join_all(detail_fetches).await {
+        match result {
+            Ok(page) => {
+                detail_pages.insert(url, page);
+            }
+            Err(err) => warn!(%url, error = %err, "kworb chart detail page fetch failed"),
+        }
+    }
+
+    Ok(KworbChartPages {
+        matrix_html,
+        detail_pages,
+    })
 }
 
 async fn fetch_kworb_page(client: &reqwest::Client, url: &str) -> Result<String> {
@@ -201,11 +248,147 @@ fn parse_kworb_line_cells(input: &str) -> Vec<KworbMatrixCell> {
     cells
 }
 
+pub fn parse_kworb_detail_html(source_key: &str, input: &str) -> Result<Vec<KworbChartEntry>> {
+    let mut entries = parse_kworb_detail_table_entries(source_key, input);
+
+    let mut seen = BTreeSet::new();
+    entries.retain(|entry| {
+        seen.insert((
+            entry.rank,
+            entry.artist.to_ascii_lowercase(),
+            entry.title.to_ascii_lowercase(),
+        ))
+    });
+    entries.sort_by_key(|entry| entry.rank);
+
+    if entries.is_empty() {
+        return Err(anyhow!("kworb chart detail rows not found"));
+    }
+
+    Ok(entries)
+}
+
+fn parse_kworb_detail_table_entries(source_key: &str, input: &str) -> Vec<KworbChartEntry> {
+    let mut entries = Vec::new();
+    let mut headers: Vec<String> = Vec::new();
+
+    for row in table_rows(input) {
+        let row_cells = table_cells(&row);
+        if row_cells.len() < 2 {
+            continue;
+        }
+
+        let values = row_cells
+            .iter()
+            .map(|cell| plain_text(&cell.html))
+            .collect::<Vec<_>>();
+        if values.iter().any(|value| {
+            let normalized = normalize_label(value);
+            normalized == "artistandtitle" || normalized == "artisttitle"
+        }) {
+            headers = values.iter().map(|value| normalize_label(value)).collect();
+            continue;
+        }
+
+        let Some((rank_index, rank)) = values
+            .iter()
+            .enumerate()
+            .find_map(|(index, value)| parse_rank(value).map(|rank| (index, rank)))
+        else {
+            continue;
+        };
+
+        let Some(title_index) = detail_title_cell_index(&values, rank_index) else {
+            continue;
+        };
+        let (artist, title) = split_artist_title(&values[title_index]);
+        if title.is_empty() {
+            continue;
+        }
+
+        let rank_delta = metric_by_header(&headers, &values, &["p"])
+            .and_then(|value| parse_rank_delta(&value))
+            .or_else(|| {
+                values
+                    .get(rank_index + 1)
+                    .and_then(|value| parse_rank_delta(value))
+            });
+        let streams = if source_key == "spotify_daily" {
+            metric_by_header(&headers, &values, &["streams"])
+                .and_then(|value| parse_integer_metric(&value))
+        } else {
+            None
+        };
+        let views = if source_key == "youtube_daily" {
+            metric_by_header(&headers, &values, &["views"])
+                .and_then(|value| parse_integer_metric(&value))
+        } else {
+            None
+        };
+        let points = if source_key != "spotify_daily" && source_key != "youtube_daily" {
+            metric_by_header(&headers, &values, &["points", "streams", "views"])
+                .and_then(|value| parse_integer_metric(&value))
+        } else {
+            None
+        };
+        let seven_day_streams = metric_by_header(&headers, &values, &["7day"])
+            .and_then(|value| parse_integer_metric(&value));
+        let total_streams = metric_by_header(&headers, &values, &["total"])
+            .and_then(|value| parse_integer_metric(&value));
+        let days_on_chart = metric_by_header(&headers, &values, &["days"])
+            .and_then(|value| parse_integer_metric(&value));
+        let peak_rank = metric_by_header(&headers, &values, &["pk", "peak"])
+            .and_then(|value| parse_rank(&value));
+
+        entries.push(KworbChartEntry {
+            rank,
+            rank_delta,
+            artist,
+            title,
+            external_url: first_href(&row_cells[title_index].html).or_else(|| first_href(&row)),
+            streams,
+            views,
+            points,
+            seven_day_streams,
+            total_streams,
+            days_on_chart,
+            peak_rank,
+        });
+    }
+
+    entries
+}
+
 pub fn ingest_kworb_matrix_html(
     conn: &Connection,
     chart_date: &str,
     fetched_at: i64,
     input: &str,
+) -> Result<KworbMatrixIngestReport> {
+    ingest_kworb_matrix_html_with_details(conn, chart_date, fetched_at, input, &BTreeMap::new())
+}
+
+pub fn ingest_kworb_chart_pages(
+    conn: &Connection,
+    chart_date: &str,
+    fetched_at: i64,
+    pages: &KworbChartPages,
+) -> Result<KworbMatrixIngestReport> {
+    ingest_kworb_matrix_html_with_details(
+        conn,
+        chart_date,
+        fetched_at,
+        &pages.matrix_html,
+        &pages.detail_pages,
+    )
+}
+
+pub fn ingest_kworb_matrix_html_with_details(
+    conn: &Connection,
+    chart_date: &str,
+    fetched_at: i64,
+    input: &str,
+    detail_pages: &BTreeMap<String, String>,
 ) -> Result<KworbMatrixIngestReport> {
     let cells = parse_kworb_matrix_html(input)?;
     let mut grouped: BTreeMap<(String, String), Vec<KworbMatrixCell>> = BTreeMap::new();
@@ -229,18 +412,50 @@ pub fn ingest_kworb_matrix_html(
             content_hash: None,
             status: "ok",
         };
-        let entries = cells
-            .iter()
-            .enumerate()
-            .map(|(index, cell)| ChartEntrySeed {
-                external_url: cell.external_url.as_deref(),
-                raw_json: Some(json!({
-                    "provider": cell.provider_label,
-                    "source": "kworb",
-                })),
-                ..ChartEntrySeed::track((index + 1) as i64, &cell.artist, &cell.title)
-            })
-            .collect::<Vec<_>>();
+        let detail_url = cells.iter().find_map(|cell| cell.external_url.as_deref());
+        let detail_entries = detail_url
+            .and_then(|url| detail_pages.get(url).map(|html| (url, html)))
+            .and_then(|(url, html)| {
+                parse_kworb_detail_html(source_key, html)
+                    .ok()
+                    .map(|rows| (url, rows))
+            });
+        let entries = match detail_entries.as_ref() {
+            Some((url, rows)) if !rows.is_empty() => rows
+                .iter()
+                .take(MAX_KWORB_DETAIL_ROWS)
+                .map(|entry| {
+                    let mut seed = ChartEntrySeed::track(entry.rank, &entry.artist, &entry.title);
+                    seed.rank_delta = entry.rank_delta;
+                    seed.external_url = entry.external_url.as_deref();
+                    seed.streams = entry.streams;
+                    seed.views = entry.views;
+                    seed.points = entry.points.map(|value| value as f64);
+                    seed.seven_day_streams = entry.seven_day_streams;
+                    seed.total_streams = entry.total_streams;
+                    seed.days_on_chart = entry.days_on_chart;
+                    seed.peak_rank = entry.peak_rank;
+                    seed.raw_json = Some(json!({
+                        "provider": cells[0].provider_label,
+                        "source": "kworb",
+                        "detail_url": *url,
+                    }));
+                    seed
+                })
+                .collect::<Vec<_>>(),
+            _ => cells
+                .iter()
+                .enumerate()
+                .map(|(index, cell)| ChartEntrySeed {
+                    external_url: cell.external_url.as_deref(),
+                    raw_json: Some(json!({
+                        "provider": cell.provider_label,
+                        "source": "kworb",
+                    })),
+                    ..ChartEntrySeed::track((index + 1) as i64, &cell.artist, &cell.title)
+                })
+                .collect::<Vec<_>>(),
+        };
         upsert_chart_snapshot(conn, &snapshot, &entries)?;
         entries_written += entries.len();
         snapshots_written += 1;
@@ -374,6 +589,15 @@ fn providers_from_header(line: &str) -> Option<Vec<(&'static str, &'static str)>
     }
 }
 
+fn kworb_detail_urls_for_matrix_html(input: &str) -> Result<BTreeSet<String>> {
+    let cells = parse_kworb_matrix_html(input)?;
+    Ok(cells
+        .into_iter()
+        .filter_map(|cell| cell.external_url)
+        .filter(|url| url.starts_with("https://kworb.net/"))
+        .collect())
+}
+
 fn region_for_country(label: &str) -> Option<&'static str> {
     match normalize_label(label).as_str() {
         "worldwide" | "global" => Some("global"),
@@ -399,6 +623,80 @@ fn split_artist_title(text: &str) -> (String, String) {
         return (artist.trim().to_string(), title.trim().to_string());
     }
     ("Unknown artist".to_string(), text.trim().to_string())
+}
+
+fn detail_title_cell_index(values: &[String], rank_index: usize) -> Option<usize> {
+    values
+        .iter()
+        .enumerate()
+        .skip(rank_index + 1)
+        .find(|(_, value)| value.contains(" - "))
+        .map(|(index, _)| index)
+        .or_else(|| {
+            values
+                .iter()
+                .enumerate()
+                .skip(rank_index + 1)
+                .find(|(_, value)| {
+                    let normalized = normalize_label(value);
+                    !value.is_empty()
+                        && !is_metric_like(value)
+                        && normalized != "re"
+                        && normalized != "new"
+                        && normalized != "steady"
+                })
+                .map(|(index, _)| index)
+        })
+}
+
+fn metric_by_header(headers: &[String], values: &[String], names: &[&str]) -> Option<String> {
+    headers
+        .iter()
+        .enumerate()
+        .find(|(_, header)| names.iter().any(|name| header == name))
+        .and_then(|(index, _)| values.get(index).cloned())
+}
+
+fn parse_rank(value: &str) -> Option<i64> {
+    let digits = value
+        .trim()
+        .chars()
+        .take_while(|ch| ch.is_ascii_digit())
+        .collect::<String>();
+    if digits.is_empty() {
+        None
+    } else {
+        digits.parse::<i64>().ok()
+    }
+}
+
+fn parse_rank_delta(value: &str) -> Option<i64> {
+    let trimmed = value.trim();
+    if trimmed == "=" {
+        return Some(0);
+    }
+    if trimmed.eq_ignore_ascii_case("RE") || trimmed.eq_ignore_ascii_case("NEW") {
+        return None;
+    }
+    let signed = trimmed.replace(',', "");
+    let parsed = signed.parse::<i64>().ok()?;
+    Some(-parsed)
+}
+
+fn parse_integer_metric(value: &str) -> Option<i64> {
+    let normalized = value.trim().trim_start_matches('+').replace(',', "");
+    normalized.parse::<i64>().ok()
+}
+
+fn is_metric_like(value: &str) -> bool {
+    let value = value.trim();
+    value == "="
+        || value.eq_ignore_ascii_case("RE")
+        || value.eq_ignore_ascii_case("NEW")
+        || value
+            .trim_start_matches(['+', '-'])
+            .chars()
+            .all(|ch| ch.is_ascii_digit() || ch == ',' || ch == '.')
 }
 
 fn tr_start_regex() -> &'static Regex {
@@ -432,6 +730,85 @@ fn line_break_regex() -> &'static Regex {
 mod tests {
     use super::*;
     use crate::db::{queries, schema};
+
+    #[test]
+    fn kworb_detail_parser_reads_ranked_track_rows() {
+        let html = r#"
+<table>
+  <tr><th>Pos</th><th>P+</th><th>Artist and Title</th><th>Days</th><th>Pk</th><th>Streams</th><th>7Day</th><th>Total</th></tr>
+  <tr><td>1</td><td>=</td><td><a href="/spotify/track/a.html">Justin Bieber - Beauty And A Beat (feat. Nicki Minaj)</a></td><td>24</td><td>1</td><td>1,234,567</td><td>7,654,321</td><td>45,000,000</td></tr>
+  <tr><td>2</td><td>+3</td><td><a href="/spotify/track/b.html">Drake - ICEMAN</a></td><td>3</td><td>2</td><td>999,999</td><td>2,000,000</td><td>3,000,000</td></tr>
+</table>
+"#;
+
+        let entries = parse_kworb_detail_html("spotify_daily", html).expect("parse detail rows");
+
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].rank, 1);
+        assert_eq!(entries[0].artist, "Justin Bieber");
+        assert_eq!(entries[0].title, "Beauty And A Beat (feat. Nicki Minaj)");
+        assert_eq!(entries[0].streams, Some(1_234_567));
+        assert_eq!(entries[0].seven_day_streams, Some(7_654_321));
+        assert_eq!(entries[0].total_streams, Some(45_000_000));
+        assert_eq!(entries[0].days_on_chart, Some(24));
+        assert_eq!(entries[0].peak_rank, Some(1));
+        assert_eq!(entries[0].rank_delta, Some(0));
+        assert_eq!(entries[1].rank_delta, Some(-3));
+        assert_eq!(
+            entries[1].external_url.as_deref(),
+            Some("https://kworb.net/spotify/track/b.html")
+        );
+    }
+
+    #[test]
+    fn kworb_matrix_ingest_prefers_detail_rows_for_chart_snapshots() {
+        let conn = Connection::open_in_memory().expect("open memory db");
+        schema::run_migrations(&conn).expect("run migrations");
+        let index_html = r#"
+<table>
+  <tr><th>Country</th><th>Spotify</th></tr>
+  <tr><td>Worldwide</td><td><a href="/spotify/country/global_daily.html">Justin Bieber - Beauty And A Beat (feat. Nicki Minaj)</a></td></tr>
+</table>
+"#;
+        let detail_html = r#"
+<table>
+  <tr><th>Pos</th><th>P+</th><th>Artist and Title</th><th>Streams</th></tr>
+  <tr><td>1</td><td>=</td><td><a href="/spotify/track/a.html">Justin Bieber - Beauty And A Beat (feat. Nicki Minaj)</a></td><td>1,234,567</td></tr>
+  <tr><td>2</td><td>-1</td><td><a href="/spotify/track/b.html">Drake - ICEMAN</a></td><td>999,999</td></tr>
+  <tr><td>3</td><td>+4</td><td><a href="/spotify/track/c.html">Olivia Rodrigo - the cure</a></td><td>888,888</td></tr>
+</table>
+"#;
+        let detail_pages = BTreeMap::from([(
+            "https://kworb.net/spotify/country/global_daily.html".to_string(),
+            detail_html.to_string(),
+        )]);
+
+        let report = ingest_kworb_matrix_html_with_details(
+            &conn,
+            "2026-05-29",
+            1234,
+            index_html,
+            &detail_pages,
+        )
+        .expect("ingest detail snapshot");
+
+        assert_eq!(report.entries_written, 3);
+        assert_eq!(report.snapshots_written, 1);
+        let snapshot =
+            queries::get_latest_chart_snapshot(&conn, "spotify_daily", "global", "daily", 20)
+                .expect("read snapshot")
+                .expect("snapshot exists");
+        assert_eq!(snapshot.entries.len(), 3);
+        assert_eq!(snapshot.entries[1].title, "ICEMAN");
+        assert_eq!(snapshot.entries[2].rank, 3);
+        assert_eq!(snapshot.entries[2].streams, Some(888_888));
+        let matrix = queries::get_chart_matrix(&conn, &["global"], &["spotify_daily"], "daily")
+            .expect("read matrix");
+        assert_eq!(
+            matrix[0].cells["spotify_daily"].as_ref().unwrap().title,
+            "Beauty And A Beat (feat. Nicki Minaj)"
+        );
+    }
 
     #[test]
     fn kworb_matrix_ingest_writes_provider_snapshots_for_supported_regions() {

--- a/noor-server/src/services/charts/kworb_matrix.rs
+++ b/noor-server/src/services/charts/kworb_matrix.rs
@@ -259,9 +259,17 @@ struct HtmlCell {
 }
 
 fn table_rows(input: &str) -> Vec<String> {
-    row_regex()
-        .captures_iter(input)
-        .filter_map(|capture| capture.get(1).map(|m| m.as_str().to_string()))
+    tr_start_regex()
+        .split(input)
+        .skip(1)
+        .filter_map(|part| {
+            let row = part.split("</tr>").next().unwrap_or(part);
+            if row.contains("<td") || row.contains("<th") {
+                Some(row.to_string())
+            } else {
+                None
+            }
+        })
         .collect()
 }
 
@@ -393,9 +401,9 @@ fn split_artist_title(text: &str) -> (String, String) {
     ("Unknown artist".to_string(), text.trim().to_string())
 }
 
-fn row_regex() -> &'static Regex {
+fn tr_start_regex() -> &'static Regex {
     static REGEX: OnceLock<Regex> = OnceLock::new();
-    REGEX.get_or_init(|| Regex::new(r#"(?is)<tr[^>]*>(.*?)</tr>"#).expect("row regex"))
+    REGEX.get_or_init(|| Regex::new(r#"(?is)<tr[^>]*>"#).expect("tr start regex"))
 }
 
 fn cell_regex() -> &'static Regex {
@@ -494,6 +502,45 @@ mod tests {
         assert_eq!(
             matrix[1].cells["youtube_daily"].as_ref().unwrap().title,
             "AU YouTube"
+        );
+    }
+
+    #[test]
+    fn kworb_matrix_ingest_handles_kworb_rows_without_closing_tr_tags() {
+        let conn = Connection::open_in_memory().expect("open memory db");
+        schema::run_migrations(&conn).expect("run migrations");
+        let html = r#"
+<table>
+<thead><tr><th>Country</th><th>iTunes</th><th>Spotify</th><th>Apple Music</th><th>YouTube</th><th>Shazam</th><th>Deezer</th></tr></thead><tbody>
+<tr><td><div>Worldwide</div></td><td><div><a href="/ww/index.html">The Chemical Brothers - Go</a></div></td><td><div><a href="/spotify/country/global_daily.html">Justin Bieber - Beauty And A Beat (feat. Nicki Minaj)</a></div></td><td><div><a href="/apple_songs/index.html">Justin Bieber - Beauty and a Beat</a></div></td><td><div><a href="/youtube/index.html">ALPHA DRIVE ONE 'OMG!' MV</a></div></td><td><div><a href="/charts/shazam/ww.html">The Chemical Brothers - Go</a></div></td><td><div><a href="/charts/deezer/ww.html">Ella Langley - Choosin' Texas</a></div></td>
+<tr><td><div>United States</div></td><td><div><a href="/charts/itunes/us.html">Ella Langley - Choosin' Texas</a></div></td><td><div><a href="/spotify/country/us_daily.html">Drake - Janice STFU</a></div></td><td><div><a href="/charts/apple_s/us.html">Drake - Janice STFU</a></div></td><td><div><a href="/youtube/insights/us_daily.html">Ella Langley - Choosin' Texas</a></div></td><td><div><a href="/charts/shazam/us.html">Drake - Janice STFU</a></div></td><td><div><a href="/charts/deezer/us.html">Ella Langley - Choosin' Texas</a></div></td>
+<tr><td><div>Australia</div></td><td><div><a href="/charts/itunes/au.html">Ella Langley - Choosin' Texas</a></div></td><td><div><a href="/spotify/country/au_daily.html">Olivia Rodrigo - the cure</a></div></td><td><div><a href="/charts/apple_s/au.html">Olivia Rodrigo - the cure</a></div></td><td><div><a href="/youtube/insights/au_daily.html">HUNTR/X - Golden</a></div></td><td><div><a href="/charts/shazam/au.html">Josh Fawaz - Like a Prayer</a></div></td><td><div><a href="/charts/deezer/au.html">Sabrina Carpenter - When Did You Get Hot?</a></div></td>
+</tbody></table>
+"#;
+
+        let report =
+            ingest_kworb_matrix_html(&conn, "2026-05-29", 1234, html).expect("ingest matrix");
+
+        assert_eq!(report.entries_written, 18);
+        assert_eq!(report.snapshots_written, 18);
+        let matrix = queries::get_chart_matrix(
+            &conn,
+            &["global", "US", "AU"],
+            &["spotify_daily", "youtube_daily", "deezer_daily"],
+            "daily",
+        )
+        .expect("read matrix");
+        assert_eq!(
+            matrix[1].cells["spotify_daily"].as_ref().unwrap().title,
+            "Janice STFU"
+        );
+        assert_eq!(
+            matrix[1].cells["youtube_daily"].as_ref().unwrap().artist,
+            "Ella Langley"
+        );
+        assert_eq!(
+            matrix[2].cells["deezer_daily"].as_ref().unwrap().title,
+            "When Did You Get Hot?"
         );
     }
 

--- a/noor-server/src/services/charts/kworb_matrix.rs
+++ b/noor-server/src/services/charts/kworb_matrix.rs
@@ -1,0 +1,542 @@
+use crate::db::queries::{ChartEntrySeed, ChartSnapshotSeed, upsert_chart_snapshot};
+use anyhow::{Context, Result, anyhow};
+use regex::Regex;
+use rusqlite::Connection;
+use serde::Serialize;
+use serde_json::json;
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::OnceLock;
+use tracing::warn;
+
+pub const KWORB_CHARTS_URL: &str = "https://kworb.net/charts";
+const KWORB_COUNTRY_INDEX_URLS: &[&str] = &[
+    "https://kworb.net/charts/index_a.html",
+    "https://kworb.net/charts/index_c.html",
+    "https://kworb.net/charts/index_n.html",
+    "https://kworb.net/charts/index_u.html",
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KworbMatrixCell {
+    pub region: String,
+    pub source_key: String,
+    pub provider_label: String,
+    pub artist: String,
+    pub title: String,
+    pub external_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct KworbMatrixIngestReport {
+    pub rows_seen: usize,
+    pub entries_written: usize,
+    pub snapshots_written: usize,
+}
+
+pub async fn fetch_kworb_matrix_html(client: &reqwest::Client) -> Result<String> {
+    let mut html = fetch_kworb_page(client, KWORB_CHARTS_URL).await?;
+    for url in KWORB_COUNTRY_INDEX_URLS {
+        match fetch_kworb_page(client, url).await {
+            Ok(page) => {
+                html.push('\n');
+                html.push_str(&page);
+            }
+            Err(err) => warn!(%url, error = %err, "kworb country chart page fetch failed"),
+        }
+    }
+    Ok(html)
+}
+
+async fn fetch_kworb_page(client: &reqwest::Client, url: &str) -> Result<String> {
+    let response = client
+        .get(url)
+        .send()
+        .await
+        .with_context(|| format!("fetch kworb chart page {url}"))?
+        .error_for_status()
+        .with_context(|| format!("kworb chart page status {url}"))?;
+    response
+        .text()
+        .await
+        .with_context(|| format!("read kworb chart page {url}"))
+}
+
+pub fn parse_kworb_matrix_html(input: &str) -> Result<Vec<KworbMatrixCell>> {
+    let mut cells = parse_kworb_table_cells(input).unwrap_or_default();
+    cells.extend(parse_kworb_line_cells(input));
+
+    let mut seen = BTreeSet::new();
+    cells.retain(|cell| {
+        seen.insert((
+            cell.region.clone(),
+            cell.source_key.clone(),
+            cell.artist.clone(),
+            cell.title.clone(),
+        ))
+    });
+
+    if cells.is_empty() {
+        return Err(anyhow!("kworb matrix rows not found"));
+    }
+
+    Ok(cells)
+}
+
+fn parse_kworb_table_cells(input: &str) -> Result<Vec<KworbMatrixCell>> {
+    let rows = table_rows(input);
+    let header_cells = rows
+        .iter()
+        .map(|row| table_cells(row))
+        .find(|cells| {
+            cells
+                .first()
+                .map(|cell| plain_text(&cell.html).eq_ignore_ascii_case("country"))
+                .unwrap_or(false)
+        })
+        .ok_or_else(|| anyhow!("kworb matrix country header not found"))?;
+
+    let providers = header_cells
+        .iter()
+        .enumerate()
+        .skip(1)
+        .filter_map(|(index, cell)| {
+            let label = plain_text(&cell.html);
+            source_key_for_provider(&label).map(|source_key| (index, source_key, label))
+        })
+        .collect::<Vec<_>>();
+
+    if providers.is_empty() {
+        return Err(anyhow!("kworb matrix provider columns not found"));
+    }
+
+    let mut cells = Vec::new();
+    for row in rows {
+        let row_cells = table_cells(&row);
+        if row_cells.len() < 2 {
+            continue;
+        }
+        let country = plain_text(&row_cells[0].html);
+        if country.eq_ignore_ascii_case("country") {
+            continue;
+        }
+        let Some(region) = region_for_country(&country) else {
+            continue;
+        };
+
+        for (index, source_key, provider_label) in &providers {
+            let Some(cell) = row_cells.get(*index) else {
+                continue;
+            };
+            let text = plain_text(&cell.html);
+            if text.is_empty() || text == "-" {
+                continue;
+            }
+            let (artist, title) = split_artist_title(&text);
+            cells.push(KworbMatrixCell {
+                region: region.to_string(),
+                source_key: (*source_key).to_string(),
+                provider_label: provider_label.clone(),
+                artist,
+                title,
+                external_url: first_href(&cell.html),
+            });
+        }
+    }
+
+    Ok(cells)
+}
+
+fn parse_kworb_line_cells(input: &str) -> Vec<KworbMatrixCell> {
+    let lines = html_lines(input);
+    let mut cells = Vec::new();
+    let mut index = 0usize;
+    while index < lines.len() {
+        let Some(providers) = providers_from_header(&lines[index]) else {
+            index += 1;
+            continue;
+        };
+        index += 1;
+
+        while index < lines.len() {
+            let line = &lines[index];
+            if providers_from_header(line).is_some() {
+                break;
+            }
+            if line.ends_with(':') {
+                index += 1;
+                continue;
+            }
+            let Some(region) = region_for_country(line) else {
+                index += 1;
+                continue;
+            };
+            index += 1;
+
+            for (source_key, provider_label) in &providers {
+                while index < lines.len() && lines[index].ends_with(':') {
+                    index += 1;
+                }
+                if index >= lines.len()
+                    || providers_from_header(&lines[index]).is_some()
+                    || region_for_country(&lines[index]).is_some()
+                {
+                    break;
+                }
+                let text = &lines[index];
+                if !text.is_empty() && text != "-" {
+                    let (artist, title) = split_artist_title(text);
+                    cells.push(KworbMatrixCell {
+                        region: region.to_string(),
+                        source_key: (*source_key).to_string(),
+                        provider_label: (*provider_label).to_string(),
+                        artist,
+                        title,
+                        external_url: None,
+                    });
+                }
+                index += 1;
+            }
+        }
+    }
+    cells
+}
+
+pub fn ingest_kworb_matrix_html(
+    conn: &Connection,
+    chart_date: &str,
+    fetched_at: i64,
+    input: &str,
+) -> Result<KworbMatrixIngestReport> {
+    let cells = parse_kworb_matrix_html(input)?;
+    let mut grouped: BTreeMap<(String, String), Vec<KworbMatrixCell>> = BTreeMap::new();
+    for cell in cells {
+        grouped
+            .entry((cell.source_key.clone(), cell.region.clone()))
+            .or_default()
+            .push(cell);
+    }
+
+    let mut entries_written = 0usize;
+    let mut snapshots_written = 0usize;
+    for ((source_key, region), cells) in &grouped {
+        let snapshot = ChartSnapshotSeed {
+            source_key,
+            region,
+            period: "daily",
+            chart_date,
+            fetched_at,
+            etag: None,
+            content_hash: None,
+            status: "ok",
+        };
+        let entries = cells
+            .iter()
+            .enumerate()
+            .map(|(index, cell)| ChartEntrySeed {
+                external_url: cell.external_url.as_deref(),
+                raw_json: Some(json!({
+                    "provider": cell.provider_label,
+                    "source": "kworb",
+                })),
+                ..ChartEntrySeed::track((index + 1) as i64, &cell.artist, &cell.title)
+            })
+            .collect::<Vec<_>>();
+        upsert_chart_snapshot(conn, &snapshot, &entries)?;
+        entries_written += entries.len();
+        snapshots_written += 1;
+    }
+
+    Ok(KworbMatrixIngestReport {
+        rows_seen: grouped.len(),
+        entries_written,
+        snapshots_written,
+    })
+}
+
+#[derive(Debug)]
+struct HtmlCell {
+    html: String,
+}
+
+fn table_rows(input: &str) -> Vec<String> {
+    row_regex()
+        .captures_iter(input)
+        .filter_map(|capture| capture.get(1).map(|m| m.as_str().to_string()))
+        .collect()
+}
+
+fn table_cells(row: &str) -> Vec<HtmlCell> {
+    cell_regex()
+        .captures_iter(row)
+        .filter_map(|capture| {
+            capture.get(1).map(|m| HtmlCell {
+                html: m.as_str().to_string(),
+            })
+        })
+        .collect()
+}
+
+fn plain_text(input: &str) -> String {
+    let without_tags = tag_regex().replace_all(input, " ");
+    decode_entities(&without_tags)
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn html_lines(input: &str) -> Vec<String> {
+    let with_breaks = line_break_regex().replace_all(input, "\n");
+    let without_tags = tag_regex().replace_all(&with_breaks, " ");
+    decode_entities(&without_tags)
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(|line| line.split_whitespace().collect::<Vec<_>>().join(" "))
+        .collect()
+}
+
+fn decode_entities(input: &str) -> String {
+    input
+        .replace("&amp;", "&")
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+        .replace("&apos;", "'")
+        .replace("&nbsp;", " ")
+        .replace("&ndash;", "-")
+        .replace("&mdash;", "-")
+}
+
+fn first_href(input: &str) -> Option<String> {
+    href_regex()
+        .captures(input)
+        .and_then(|capture| capture.get(1).map(|m| decode_entities(m.as_str())))
+        .map(|href| {
+            if href.starts_with("http://") || href.starts_with("https://") {
+                href
+            } else {
+                format!("https://kworb.net/{}", href.trim_start_matches('/'))
+            }
+        })
+}
+
+fn source_key_for_provider(label: &str) -> Option<&'static str> {
+    match normalize_label(label).as_str() {
+        "itunes" => Some("itunes_daily"),
+        "spotify" => Some("spotify_daily"),
+        "applemusic" => Some("apple_music_daily"),
+        "youtube" => Some("youtube_daily"),
+        "shazam" => Some("shazam_daily"),
+        "deezer" => Some("deezer_daily"),
+        _ => None,
+    }
+}
+
+fn providers_from_header(line: &str) -> Option<Vec<(&'static str, &'static str)>> {
+    let normalized = normalize_label(line);
+    if !normalized.starts_with("country") {
+        return None;
+    }
+
+    let mut providers = [
+        ("itunes", "itunes_daily", "iTunes"),
+        ("spotify", "spotify_daily", "Spotify"),
+        ("applemusic", "apple_music_daily", "Apple Music"),
+        ("youtube", "youtube_daily", "YouTube"),
+        ("shazam", "shazam_daily", "Shazam"),
+        ("deezer", "deezer_daily", "Deezer"),
+    ]
+    .into_iter()
+    .filter_map(|(needle, source_key, label)| {
+        normalized
+            .find(needle)
+            .map(|position| (position, source_key, label))
+    })
+    .collect::<Vec<_>>();
+
+    providers.sort_by_key(|(position, _, _)| *position);
+    if providers.is_empty() {
+        None
+    } else {
+        Some(
+            providers
+                .into_iter()
+                .map(|(_, source_key, label)| (source_key, label))
+                .collect(),
+        )
+    }
+}
+
+fn region_for_country(label: &str) -> Option<&'static str> {
+    match normalize_label(label).as_str() {
+        "worldwide" | "global" => Some("global"),
+        "unitedstates" | "usa" | "us" => Some("US"),
+        "unitedkingdom" | "uk" => Some("UK"),
+        "australia" | "au" => Some("AU"),
+        "canada" | "ca" => Some("CA"),
+        "newzealand" | "nz" => Some("NZ"),
+        _ => None,
+    }
+}
+
+fn normalize_label(label: &str) -> String {
+    label
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric())
+        .collect::<String>()
+        .to_ascii_lowercase()
+}
+
+fn split_artist_title(text: &str) -> (String, String) {
+    if let Some((artist, title)) = text.split_once(" - ") {
+        return (artist.trim().to_string(), title.trim().to_string());
+    }
+    ("Unknown artist".to_string(), text.trim().to_string())
+}
+
+fn row_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| Regex::new(r#"(?is)<tr[^>]*>(.*?)</tr>"#).expect("row regex"))
+}
+
+fn cell_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| Regex::new(r#"(?is)<t[dh][^>]*>(.*?)</t[dh]>"#).expect("cell regex"))
+}
+
+fn tag_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| Regex::new(r#"(?is)<[^>]+>"#).expect("tag regex"))
+}
+
+fn href_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| Regex::new(r#"(?is)<a\s+[^>]*href=["']([^"']+)["']"#).expect("href regex"))
+}
+
+fn line_break_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| {
+        Regex::new(r#"(?is)</(?:a|td|th|tr|p|div|li|h[1-6])>|<br\s*/?>"#).expect("line break regex")
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::{queries, schema};
+
+    #[test]
+    fn kworb_matrix_ingest_writes_provider_snapshots_for_supported_regions() {
+        let conn = Connection::open_in_memory().expect("open memory db");
+        schema::run_migrations(&conn).expect("run migrations");
+        let html = r#"
+<table>
+  <tr><th>Country</th><th>iTunes</th><th>Spotify</th><th>Apple Music</th><th>YouTube</th><th>Shazam</th><th>Deezer</th></tr>
+  <tr>
+    <td>Worldwide</td>
+    <td><a href="/itunes/song/a.html">Artist A - Song A</a></td>
+    <td><a href="/spotify/track/b.html">Artist B - Song B</a></td>
+    <td>Artist C - Song C</td>
+    <td>Artist D - Song D</td>
+    <td>Artist E - Song E</td>
+    <td>Artist F - Song F</td>
+  </tr>
+  <tr>
+    <td>Australia</td>
+    <td>AU Artist - AU iTunes</td>
+    <td>AU Artist - AU Spotify</td>
+    <td>-</td>
+    <td>AU Video - AU YouTube</td>
+    <td>AU Shazam - AU Song</td>
+    <td>AU Deezer - AU Song</td>
+  </tr>
+</table>
+"#;
+
+        let report =
+            ingest_kworb_matrix_html(&conn, "2026-05-28", 1234, html).expect("ingest matrix");
+
+        assert_eq!(report.entries_written, 11);
+        assert_eq!(report.snapshots_written, 11);
+        let matrix = queries::get_chart_matrix(
+            &conn,
+            &["global", "AU"],
+            &[
+                "itunes_daily",
+                "spotify_daily",
+                "apple_music_daily",
+                "youtube_daily",
+            ],
+            "daily",
+        )
+        .expect("read matrix");
+        assert_eq!(
+            matrix[0].cells["itunes_daily"].as_ref().unwrap().title,
+            "Song A"
+        );
+        assert_eq!(
+            matrix[0].cells["itunes_daily"]
+                .as_ref()
+                .unwrap()
+                .external_url
+                .as_deref(),
+            Some("https://kworb.net/itunes/song/a.html")
+        );
+        assert_eq!(
+            matrix[0].cells["spotify_daily"].as_ref().unwrap().artist,
+            "Artist B"
+        );
+        assert_eq!(
+            matrix[1].cells["spotify_daily"].as_ref().unwrap().title,
+            "AU Spotify"
+        );
+        assert!(matrix[1].cells["apple_music_daily"].is_none());
+        assert_eq!(
+            matrix[1].cells["youtube_daily"].as_ref().unwrap().title,
+            "AU YouTube"
+        );
+    }
+
+    #[test]
+    fn kworb_line_matrix_parser_handles_rendered_country_sequences() {
+        let text = r#"
+Country iTunes Spotify Apple Music YouTube Shazam Deezer
+Worldwide
+Muse - Hexagons
+Michael Jackson - Billie Jean
+Drake - Janice STFU
+ZEROBASEONE - TOP 5
+The Chemical Brothers - Go
+Ella Langley - Choosin' Texas
+United States
+Ella Langley - Choosin' Texas
+Drake - Janice STFU
+Drake - Janice STFU
+Drake - Janice STFU
+Ella Langley - Choosin' Texas
+Ella Langley - Choosin' Texas
+Australia
+The Chemical Brothers - Go
+Ella Langley - Choosin' Texas
+Drake - Janice STFU
+HUNTR/X - Golden
+The Chemical Brothers - Go
+Olivia Rodrigo - drop dead
+"#;
+
+        let cells = parse_kworb_matrix_html(text).expect("parse rendered text");
+
+        let au_spotify = cells
+            .iter()
+            .find(|cell| cell.region == "AU" && cell.source_key == "spotify_daily")
+            .expect("AU Spotify");
+        assert_eq!(au_spotify.artist, "Ella Langley");
+        assert_eq!(au_spotify.title, "Choosin' Texas");
+        let us_youtube = cells
+            .iter()
+            .find(|cell| cell.region == "US" && cell.source_key == "youtube_daily")
+            .expect("US YouTube");
+        assert_eq!(us_youtube.artist, "Drake");
+        assert_eq!(us_youtube.title, "Janice STFU");
+    }
+}

--- a/noor-server/src/services/charts/mod.rs
+++ b/noor-server/src/services/charts/mod.rs
@@ -1,1 +1,3 @@
 pub mod curated;
+pub mod kworb_matrix;
+pub mod spotify_daily;

--- a/noor-server/src/services/charts/spotify_daily.rs
+++ b/noor-server/src/services/charts/spotify_daily.rs
@@ -1,0 +1,302 @@
+use crate::db::queries::{ChartEntrySeed, ChartSnapshotSeed, upsert_chart_snapshot};
+use anyhow::{Context, Result, anyhow};
+use rusqlite::Connection;
+use serde_json::json;
+use sha2::{Digest, Sha256};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpotifyDailyChartRow {
+    pub rank: i64,
+    pub rank_delta: Option<i64>,
+    pub artist: String,
+    pub title: String,
+    pub spotify_track_id: Option<String>,
+    pub external_url: Option<String>,
+    pub streams: Option<i64>,
+    pub peak_rank: Option<i64>,
+    pub days_on_chart: Option<i64>,
+}
+
+impl SpotifyDailyChartRow {
+    pub fn as_entry_seed(&self) -> ChartEntrySeed<'_> {
+        ChartEntrySeed {
+            rank: self.rank,
+            rank_delta: self.rank_delta,
+            artist: &self.artist,
+            title: &self.title,
+            entity_type: "track",
+            external_track_id: self.spotify_track_id.as_deref(),
+            external_url: self.external_url.as_deref(),
+            streams: self.streams,
+            peak_rank: self.peak_rank,
+            days_on_chart: self.days_on_chart,
+            raw_json: Some(json!({
+                "provider": "spotify",
+                "spotify_track_id": self.spotify_track_id,
+                "streams": self.streams,
+            })),
+            ..ChartEntrySeed::track(self.rank, &self.artist, &self.title)
+        }
+    }
+}
+
+pub fn parse_spotify_daily_csv(input: &str) -> Result<Vec<SpotifyDailyChartRow>> {
+    let mut lines = input.lines().filter(|line| !line.trim().is_empty());
+    let header_line = lines
+        .next()
+        .ok_or_else(|| anyhow!("spotify chart csv is empty"))?;
+    let headers = parse_csv_line(header_line)
+        .into_iter()
+        .map(|header| normalize_header(&header))
+        .collect::<Vec<_>>();
+
+    let mut rows = Vec::new();
+    for (index, line) in lines.enumerate() {
+        let fields = parse_csv_line(line);
+        if fields.iter().all(|field| field.trim().is_empty()) {
+            continue;
+        }
+        let field = |name: &str| -> Option<&str> {
+            headers
+                .iter()
+                .position(|header| header == name)
+                .and_then(|idx| fields.get(idx))
+                .map(String::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+        };
+
+        let rank = field("rank")
+            .ok_or_else(|| anyhow!("missing rank at row {}", index + 2))?
+            .parse::<i64>()
+            .with_context(|| format!("invalid rank at row {}", index + 2))?;
+        let artist = field("artist_names")
+            .or_else(|| field("artist"))
+            .ok_or_else(|| anyhow!("missing artist at row {}", index + 2))?
+            .to_string();
+        let title = field("track_name")
+            .or_else(|| field("title"))
+            .ok_or_else(|| anyhow!("missing title at row {}", index + 2))?
+            .to_string();
+        let previous_rank = field("previous_rank").and_then(parse_optional_i64);
+        let peak_rank = field("peak_rank").and_then(parse_optional_i64);
+        let days_on_chart = field("days_on_chart")
+            .and_then(parse_optional_i64)
+            .or_else(|| {
+                field("weeks_on_chart")
+                    .and_then(parse_optional_i64)
+                    .map(|weeks| weeks * 7)
+            });
+        let streams = field("streams").and_then(parse_optional_i64);
+        let spotify_track_id = field("uri")
+            .or_else(|| field("spotify_url"))
+            .or_else(|| field("track_url"))
+            .and_then(extract_spotify_track_id);
+        let external_url = spotify_track_id
+            .as_ref()
+            .map(|id| format!("https://open.spotify.com/track/{id}"));
+
+        rows.push(SpotifyDailyChartRow {
+            rank,
+            rank_delta: previous_rank.map(|prev| prev - rank),
+            artist,
+            title,
+            spotify_track_id,
+            external_url,
+            streams,
+            peak_rank,
+            days_on_chart,
+        });
+    }
+
+    Ok(rows)
+}
+
+pub fn ingest_spotify_daily_csv(
+    conn: &Connection,
+    region: &str,
+    chart_date: &str,
+    fetched_at: i64,
+    input: &str,
+) -> Result<i64> {
+    let rows = parse_spotify_daily_csv(input)?;
+    let content_hash = content_sha256(input);
+    let snapshot = ChartSnapshotSeed {
+        source_key: "spotify_daily",
+        region,
+        period: "daily",
+        chart_date,
+        fetched_at,
+        etag: None,
+        content_hash: Some(&content_hash),
+        status: "ok",
+    };
+    let entries = rows
+        .iter()
+        .map(SpotifyDailyChartRow::as_entry_seed)
+        .collect::<Vec<_>>();
+
+    upsert_chart_snapshot(conn, &snapshot, &entries)
+}
+
+fn content_sha256(input: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(input.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+fn normalize_header(value: &str) -> String {
+    value
+        .trim()
+        .trim_matches('\u{feff}')
+        .to_ascii_lowercase()
+        .replace([' ', '-'], "_")
+}
+
+fn parse_optional_i64(value: &str) -> Option<i64> {
+    let cleaned = value.trim().replace(',', "");
+    if cleaned.is_empty() || cleaned == "-" {
+        return None;
+    }
+    cleaned.parse::<i64>().ok()
+}
+
+fn extract_spotify_track_id(value: &str) -> Option<String> {
+    let value = value.trim();
+    if value.is_empty() {
+        return None;
+    }
+    if let Some(id) = value.strip_prefix("spotify:track:") {
+        return non_empty_id(id);
+    }
+    if let Some((_, tail)) = value.split_once("/track/") {
+        let id = tail.split(['?', '&', '/']).next().unwrap_or("").trim();
+        return non_empty_id(id);
+    }
+    non_empty_id(value)
+}
+
+fn non_empty_id(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn parse_csv_line(line: &str) -> Vec<String> {
+    let mut fields = Vec::new();
+    let mut current = String::new();
+    let mut chars = line.chars().peekable();
+    let mut in_quotes = false;
+
+    while let Some(ch) = chars.next() {
+        match ch {
+            '"' if in_quotes && chars.peek() == Some(&'"') => {
+                current.push('"');
+                let _ = chars.next();
+            }
+            '"' => in_quotes = !in_quotes,
+            ',' if !in_quotes => {
+                fields.push(current.trim().to_string());
+                current.clear();
+            }
+            _ => current.push(ch),
+        }
+    }
+    fields.push(current.trim().to_string());
+    fields
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::{queries, schema};
+    use rusqlite::Connection;
+
+    #[test]
+    fn spotify_daily_csv_rows_normalize_to_chart_entry_seeds() {
+        let csv = r#"rank,uri,artist_names,track_name,peak_rank,previous_rank,weeks_on_chart,streams
+1,spotify:track:abc123,"Sabrina Carpenter","Espresso",1,2,12,"1,234,567"
+2,https://open.spotify.com/track/def456?si=share,"Kendrick Lamar, SZA","Luther",1,,5,987654
+3,,PinkPantheress,"Stateside + Zara Larsson",3,-,1,-
+"#;
+
+        let rows = parse_spotify_daily_csv(csv).expect("parse csv");
+
+        assert_eq!(rows.len(), 3);
+        assert_eq!(rows[0].rank, 1);
+        assert_eq!(rows[0].rank_delta, Some(1));
+        assert_eq!(rows[0].artist, "Sabrina Carpenter");
+        assert_eq!(rows[0].title, "Espresso");
+        assert_eq!(rows[0].spotify_track_id.as_deref(), Some("abc123"));
+        assert_eq!(
+            rows[0].external_url.as_deref(),
+            Some("https://open.spotify.com/track/abc123")
+        );
+        assert_eq!(rows[0].streams, Some(1_234_567));
+        assert_eq!(rows[0].days_on_chart, Some(84));
+
+        assert_eq!(rows[1].artist, "Kendrick Lamar, SZA");
+        assert_eq!(rows[1].spotify_track_id.as_deref(), Some("def456"));
+        assert_eq!(rows[1].rank_delta, None);
+
+        let seed = rows[2].as_entry_seed();
+        assert_eq!(seed.rank, 3);
+        assert_eq!(seed.artist, "PinkPantheress");
+        assert_eq!(seed.title, "Stateside + Zara Larsson");
+        assert_eq!(seed.entity_type, "track");
+        assert_eq!(seed.streams, None);
+        assert_eq!(seed.resolution_status, None);
+    }
+
+    #[test]
+    fn spotify_daily_ingest_replaces_daily_snapshot_and_feeds_matrix() {
+        let conn = Connection::open_in_memory().expect("open memory db");
+        schema::run_migrations(&conn).expect("run migrations");
+        let first_csv = r#"rank,uri,artist_names,track_name,peak_rank,previous_rank,days_on_chart,streams
+1,spotify:track:first,"First Artist","First Track",1,2,8,1000
+2,spotify:track:second,"Second Artist","Second Track",2,3,4,900
+"#;
+        let refresh_csv = r#"rank,uri,artist_names,track_name,peak_rank,previous_rank,days_on_chart,streams
+1,spotify:track:updated,"Updated Artist","Updated Track",1,4,9,1200
+"#;
+
+        ingest_spotify_daily_csv(&conn, "global", "2026-05-28", 100, first_csv)
+            .expect("ingest first snapshot");
+        ingest_spotify_daily_csv(&conn, "global", "2026-05-28", 200, refresh_csv)
+            .expect("ingest refresh snapshot");
+
+        let latest =
+            queries::get_latest_chart_snapshot(&conn, "spotify_daily", "global", "daily", 10)
+                .expect("read latest snapshot")
+                .expect("latest snapshot");
+        assert_eq!(latest.snapshot.chart_date, "2026-05-28");
+        assert_eq!(latest.snapshot.fetched_at, 200);
+        assert_eq!(latest.entries.len(), 1);
+        assert_eq!(latest.entries[0].rank, 1);
+        assert_eq!(latest.entries[0].artist, "Updated Artist");
+        assert_eq!(latest.entries[0].title, "Updated Track");
+        assert_eq!(
+            latest.entries[0].external_url.as_deref(),
+            Some("https://open.spotify.com/track/updated")
+        );
+        assert_eq!(latest.entries[0].streams, Some(1200));
+        assert!(latest.entries[0].tidal_id.is_none());
+        assert_eq!(latest.entries[0].resolution_status, "unresolved");
+
+        let matrix = queries::get_chart_matrix(
+            &conn,
+            &["global"],
+            &["spotify_daily", "youtube_daily"],
+            "daily",
+        )
+        .expect("read matrix");
+        assert_eq!(
+            matrix[0].cells["spotify_daily"].as_ref().unwrap().title,
+            "Updated Track"
+        );
+        assert!(matrix[0].cells["youtube_daily"].is_none());
+    }
+}

--- a/noor-server/src/services/discovery_trainer.rs
+++ b/noor-server/src/services/discovery_trainer.rs
@@ -62,6 +62,8 @@ pub enum EvidenceKind {
     ArtistAffinity,
     GenreAffinity,
     FavoriteAffinity,
+    LastfmDirectSimilarity,
+    LastfmBranchSimilarity,
 }
 
 #[derive(Debug, Clone, Copy, Default, Serialize)]
@@ -70,6 +72,8 @@ pub struct SupportBreakdown {
     pub colisten: f64,
     pub structure: f64,
     pub metadata: f64,
+    pub lastfm_direct: f64,
+    pub lastfm_branch: f64,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -531,7 +535,12 @@ fn build_behavioral_embeddings(
                 edge.evidence_kind,
                 weighted,
             );
-            if edge.evidence_kind != EvidenceKind::DirectTransition {
+            if !matches!(
+                edge.evidence_kind,
+                EvidenceKind::DirectTransition
+                    | EvidenceKind::LastfmDirectSimilarity
+                    | EvidenceKind::LastfmBranchSimilarity
+            ) {
                 *co.entry(edge.to_track_id)
                     .or_default()
                     .entry(edge.from_track_id)
@@ -630,6 +639,8 @@ fn add_support_bucket(
         | EvidenceKind::ArtistAffinity
         | EvidenceKind::GenreAffinity
         | EvidenceKind::FavoriteAffinity => bucket.structure += weight,
+        EvidenceKind::LastfmDirectSimilarity => bucket.lastfm_direct += weight,
+        EvidenceKind::LastfmBranchSimilarity => bucket.lastfm_branch += weight,
     }
 }
 
@@ -1031,6 +1042,18 @@ fn similarity_neighbors(
                     reason_tags.push("direct_transition".to_string());
                     contributions.push(("direct_transition", directional_behavior_bonus));
                 }
+                let lastfm_direct_bonus = (support_breakdown.lastfm_direct * 0.06).clamp(0.0, 0.12);
+                if lastfm_direct_bonus > 0.0 {
+                    metadata_score += lastfm_direct_bonus;
+                    reason_tags.push("lastfm_direct".to_string());
+                    contributions.push(("lastfm_direct", lastfm_direct_bonus));
+                }
+                let lastfm_branch_bonus = (support_breakdown.lastfm_branch * 0.04).clamp(0.0, 0.08);
+                if lastfm_branch_bonus > 0.0 {
+                    metadata_score += lastfm_branch_bonus;
+                    reason_tags.push("lastfm_branch".to_string());
+                    contributions.push(("lastfm_branch", lastfm_branch_bonus));
+                }
 
                 let total_score = score + metadata_score + directional_behavior_bonus;
                 reason_tags.sort();
@@ -1276,6 +1299,8 @@ fn heldout_metric_label(kind: EvidenceKind) -> &'static str {
         EvidenceKind::ArtistAffinity => "artist",
         EvidenceKind::GenreAffinity => "genre",
         EvidenceKind::FavoriteAffinity => "favorite",
+        EvidenceKind::LastfmDirectSimilarity => "lastfm_direct",
+        EvidenceKind::LastfmBranchSimilarity => "lastfm_branch",
     }
 }
 
@@ -1825,6 +1850,47 @@ mod tests {
         assert!(tokens.iter().any(|token| token == "dance_8"));
         assert!(tokens.iter().any(|token| token == "beat_4"));
         assert!(tokens.iter().any(|token| token == "lufs_-12"));
+    }
+
+    #[test]
+    fn lastfm_evidence_tags_are_directional() {
+        let (tracks, behavioral, audio, fusion) = make_test_input(2, 32);
+        let co_score = HashMap::new();
+        let co_count = HashMap::new();
+        let mut support_buckets: HashMap<i64, HashMap<i64, SupportBreakdown>> = HashMap::new();
+        support_buckets.entry(0).or_default().insert(
+            1,
+            SupportBreakdown {
+                lastfm_direct: 0.44,
+                ..Default::default()
+            },
+        );
+        let play_counts = HashMap::new();
+
+        let result = similarity_neighbors(
+            &tracks,
+            &behavioral,
+            &audio,
+            &fusion,
+            &co_score,
+            &co_count,
+            &support_buckets,
+            &play_counts,
+            1,
+            None,
+            None,
+        );
+
+        let forward = result
+            .iter()
+            .find(|row| row.track_id == 0 && row.neighbor_track_id == 1)
+            .expect("forward neighbor");
+        let reverse = result
+            .iter()
+            .find(|row| row.track_id == 1 && row.neighbor_track_id == 0)
+            .expect("reverse neighbor");
+        assert!(forward.reason_tags.iter().any(|tag| tag == "lastfm_direct"));
+        assert!(!reverse.reason_tags.iter().any(|tag| tag == "lastfm_direct"));
     }
 
     #[test]

--- a/noor-server/src/services/learning.rs
+++ b/noor-server/src/services/learning.rs
@@ -27,8 +27,16 @@ use tokio::sync::mpsc;
 
 const MODEL_FAMILY: &str = queries::DISCOVERY_ENGINE_V2_FAMILY;
 const EXTERNAL_TRAINING_CANDIDATE_LIMIT: i64 = 1_000;
+const EXTERNAL_TRAINING_RESOLVED_LASTFM_LIMIT: i64 = 5_000;
+const LASTFM_DIRECT_EDGE_WEIGHT: f64 = 0.55;
+const LASTFM_BRANCH_EDGE_WEIGHT: f64 = 0.35;
 const EXTERNAL_REFRESH_MAX_SEED_TRACKS: usize = 100;
 const EXTERNAL_REFRESH_LASTFM_ROWS_PER_SEED: usize = 20;
+const EXTERNAL_REFRESH_LASTFM_BRANCH_SEED_TRACKS: usize = 25;
+const EXTERNAL_REFRESH_LASTFM_BRANCHES_PER_SEED: usize = 2;
+const EXTERNAL_REFRESH_LASTFM_BRANCH_ROWS: usize = 5;
+const EXTERNAL_REFRESH_LASTFM_BRANCH_ATTENUATION: f64 = 0.65;
+const EXTERNAL_REFRESH_LASTFM_BRANCH_MIN_PARENT_MATCH: f64 = 0.50;
 const EXTERNAL_REFRESH_TIDAL_NEW_RELEASE_ROWS: usize = 500;
 const EXTERNAL_REFRESH_TIDAL_SIMILAR_SEED_TRACKS: usize = 10;
 const EXTERNAL_REFRESH_TIDAL_SIMILAR_ARTISTS_PER_SEED: i32 = 2;
@@ -67,6 +75,7 @@ pub struct ExternalLastfmCandidate {
     pub title: String,
     pub mbid: Option<String>,
     pub match_score: f64,
+    pub branch_from: Option<String>,
 }
 
 impl From<LastFmSimilarTrack> for ExternalLastfmCandidate {
@@ -76,6 +85,22 @@ impl From<LastFmSimilarTrack> for ExternalLastfmCandidate {
             title: value.title,
             mbid: value.mbid,
             match_score: value.match_score,
+            branch_from: None,
+        }
+    }
+}
+
+impl ExternalLastfmCandidate {
+    fn branch_from(value: LastFmSimilarTrack, parent: &ExternalLastfmCandidate) -> Self {
+        Self {
+            artist: value.artist,
+            title: value.title,
+            mbid: value.mbid,
+            match_score: (parent.match_score
+                * value.match_score
+                * EXTERNAL_REFRESH_LASTFM_BRANCH_ATTENUATION)
+                .clamp(0.0, 1.0),
+            branch_from: Some(format!("{} - {}", parent.artist, parent.title)),
         }
     }
 }
@@ -294,13 +319,19 @@ pub async fn refresh_external_provider_candidates(
                 .await
             {
                 Ok(rows) => {
-                    lastfm_rows.insert(
-                        seed.track_id,
-                        rows.into_iter()
-                            .take(budget.lastfm_rows_per_seed)
-                            .map(ExternalLastfmCandidate::from)
-                            .collect(),
-                    );
+                    let direct_rows = rows
+                        .into_iter()
+                        .take(budget.lastfm_rows_per_seed)
+                        .map(ExternalLastfmCandidate::from)
+                        .collect::<Vec<_>>();
+                    let branch_rows = if index < EXTERNAL_REFRESH_LASTFM_BRANCH_SEED_TRACKS {
+                        refresh_lastfm_branch_rows(lastfm, seed.track_id, &direct_rows).await
+                    } else {
+                        Vec::new()
+                    };
+                    let mut rows = direct_rows;
+                    rows.extend(branch_rows);
+                    lastfm_rows.insert(seed.track_id, rows);
                 }
                 Err(error) => {
                     if is_provider_rate_limit_error(&error) {
@@ -455,6 +486,64 @@ pub async fn refresh_external_provider_candidates(
     })?;
     report.tidal_similar_provider_errors = tidal_similar_provider_errors;
     Ok(report)
+}
+
+async fn refresh_lastfm_branch_rows(
+    lastfm: &LastFmClient,
+    seed_track_id: i64,
+    direct_rows: &[ExternalLastfmCandidate],
+) -> Vec<ExternalLastfmCandidate> {
+    let mut branch_rows = Vec::new();
+    let mut branch_seen = direct_rows
+        .iter()
+        .map(|row| lastfm_candidate_key(&row.artist, &row.title))
+        .collect::<HashSet<_>>();
+    for parent in direct_rows
+        .iter()
+        .filter(|row| row.match_score >= EXTERNAL_REFRESH_LASTFM_BRANCH_MIN_PARENT_MATCH)
+        .take(EXTERNAL_REFRESH_LASTFM_BRANCHES_PER_SEED)
+    {
+        tokio::time::sleep(std::time::Duration::from_millis(
+            EXTERNAL_REFRESH_LASTFM_DELAY_MS,
+        ))
+        .await;
+        let rows = match lastfm
+            .track_get_similar(
+                &parent.artist,
+                &parent.title,
+                EXTERNAL_REFRESH_LASTFM_BRANCH_ROWS,
+            )
+            .await
+        {
+            Ok(rows) => rows,
+            Err(error) => {
+                tracing::warn!(
+                    target: "noor.discovery.external",
+                    seed_track_id,
+                    parent_artist = %parent.artist,
+                    parent_title = %parent.title,
+                    error = %error,
+                    "Last.fm branch refresh failed"
+                );
+                continue;
+            }
+        };
+        for row in rows.into_iter().take(EXTERNAL_REFRESH_LASTFM_BRANCH_ROWS) {
+            let key = lastfm_candidate_key(&row.artist, &row.title);
+            if branch_seen.insert(key) {
+                branch_rows.push(ExternalLastfmCandidate::branch_from(row, parent));
+            }
+        }
+    }
+    branch_rows
+}
+
+fn lastfm_candidate_key(artist: &str, title: &str) -> String {
+    format!(
+        "{}\u{1f}{}",
+        artist.trim().to_ascii_lowercase(),
+        title.trim().to_ascii_lowercase()
+    )
 }
 
 pub async fn resolve_external_tidal_candidates(
@@ -675,6 +764,7 @@ pub fn persist_external_provider_refresh(
                         serde_json::json!({
                             "match_score": row.match_score,
                             "mbid": row.mbid,
+                            "branch_from": row.branch_from,
                         })
                         .to_string(),
                     ),
@@ -2063,6 +2153,76 @@ fn trainer_external_candidates_from_rows(
         .collect()
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum LastfmRecallKind {
+    Direct,
+    Branch,
+}
+
+fn lastfm_recall_kind(source_payload_json: Option<&str>) -> LastfmRecallKind {
+    let has_branch_parent = source_payload_json
+        .and_then(|raw| serde_json::from_str::<serde_json::Value>(raw).ok())
+        .and_then(|value| {
+            value
+                .get("branch_from")
+                .and_then(|branch| branch.as_str())
+                .map(str::trim)
+                .map(str::is_empty)
+        })
+        .is_some_and(|empty| !empty);
+    if has_branch_parent {
+        LastfmRecallKind::Branch
+    } else {
+        LastfmRecallKind::Direct
+    }
+}
+
+fn lastfm_resolved_edges_from_rows(
+    rows: Vec<queries::ResolvedLastfmExternalSightingRow>,
+) -> Vec<TrainerEdge> {
+    let mut grouped: HashMap<(i64, i64, LastfmRecallKind), f64> = HashMap::new();
+    for row in rows {
+        let kind = lastfm_recall_kind(row.source_payload_json.as_deref());
+        let weight = row.similarity.clamp(0.0, 1.0)
+            * match kind {
+                LastfmRecallKind::Direct => LASTFM_DIRECT_EDGE_WEIGHT,
+                LastfmRecallKind::Branch => LASTFM_BRANCH_EDGE_WEIGHT,
+            };
+        grouped
+            .entry((row.seed_track_id, row.resolved_track_id, kind))
+            .and_modify(|existing| {
+                if weight > *existing {
+                    *existing = weight;
+                }
+            })
+            .or_insert(weight);
+    }
+
+    grouped
+        .into_iter()
+        .map(
+            |((seed_track_id, resolved_track_id, kind), weight)| TrainerEdge {
+                event_id: format!(
+                    "lastfm-resolved:{}:{}:{}",
+                    seed_track_id,
+                    resolved_track_id,
+                    match kind {
+                        LastfmRecallKind::Direct => "direct",
+                        LastfmRecallKind::Branch => "branch",
+                    }
+                ),
+                from_track_id: seed_track_id,
+                to_track_id: resolved_track_id,
+                weight,
+                evidence_kind: match kind {
+                    LastfmRecallKind::Direct => EvidenceKind::LastfmDirectSimilarity,
+                    LastfmRecallKind::Branch => EvidenceKind::LastfmBranchSimilarity,
+                },
+            },
+        )
+        .collect()
+}
+
 fn external_freshness_bucket(updated_at: &str) -> Option<String> {
     let updated = chrono::NaiveDateTime::parse_from_str(updated_at, "%Y-%m-%d %H:%M:%S").ok()?;
     let now = chrono::Utc::now().naive_utc();
@@ -2131,6 +2291,13 @@ fn build_trainer_input(
     let playback_transition_rows = queries::get_playback_transition_edges(conn)?;
     let listen_transition_rows = queries::get_listen_history_transition_edges(conn)?;
     let listen_colisten_rows = queries::get_completion_weighted_listen_edges(conn, 45)?;
+    let lastfm_resolved_edges = lastfm_resolved_edges_from_rows(
+        queries::get_resolved_lastfm_external_sightings_for_training(
+            conn,
+            &chrono::Utc::now().format("%Y-%m-%d %H:%M:%S").to_string(),
+            EXTERNAL_TRAINING_RESOLVED_LASTFM_LIMIT,
+        )?,
+    );
     let playlist_sequences = queries::get_playlist_sequences(conn)?;
     let album_sequences = queries::get_album_sequences(conn)?;
     let artist_sequences = queries::get_artist_sequences(conn)?;
@@ -2273,6 +2440,11 @@ fn build_trainer_input(
                 label: "listen_history".to_string(),
                 base_weight: 1.3,
                 edges: listen_colisten_edges,
+            },
+            TrainerEvidenceGroup {
+                label: "lastfm_resolved".to_string(),
+                base_weight: 1.0,
+                edges: lastfm_resolved_edges,
             },
         ],
         heldout_pairs,
@@ -2964,6 +3136,7 @@ mod tests {
                 title: "Similar Track".to_string(),
                 mbid: Some("mbid-1".to_string()),
                 match_score: 0.91,
+                branch_from: Some("Branch Artist - Branch Track".to_string()),
             }],
         );
         let tidal = vec![ExternalTidalCandidate {
@@ -3024,6 +3197,88 @@ mod tests {
             )
             .unwrap();
         assert_eq!(refresh_at, "2026-02-02 12:00:00");
+    }
+
+    #[test]
+    fn lastfm_branch_candidate_attenuates_parent_and_child_match() {
+        let parent = ExternalLastfmCandidate {
+            artist: "Parent Artist".to_string(),
+            title: "Parent Track".to_string(),
+            mbid: None,
+            match_score: 0.8,
+            branch_from: None,
+        };
+        let child = LastFmSimilarTrack {
+            artist: "Child Artist".to_string(),
+            title: "Child Track".to_string(),
+            mbid: Some("child-mbid".to_string()),
+            match_score: 0.5,
+        };
+
+        let branched = ExternalLastfmCandidate::branch_from(child, &parent);
+
+        assert_eq!(branched.artist, "Child Artist");
+        assert_eq!(branched.title, "Child Track");
+        assert_eq!(branched.mbid.as_deref(), Some("child-mbid"));
+        assert_eq!(
+            branched.branch_from.as_deref(),
+            Some("Parent Artist - Parent Track")
+        );
+        assert!((branched.match_score - 0.26).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn lastfm_resolved_edges_weight_direct_above_branch() {
+        let edges = lastfm_resolved_edges_from_rows(vec![
+            queries::ResolvedLastfmExternalSightingRow {
+                seed_track_id: 1,
+                resolved_track_id: 2,
+                similarity: 0.8,
+                source_payload_json: Some(r#"{"match":0.8}"#.to_string()),
+            },
+            queries::ResolvedLastfmExternalSightingRow {
+                seed_track_id: 1,
+                resolved_track_id: 3,
+                similarity: 0.8,
+                source_payload_json: Some(
+                    r#"{"match":0.8,"branch_from":"Parent - Track"}"#.to_string(),
+                ),
+            },
+        ]);
+
+        let direct = edges
+            .iter()
+            .find(|edge| edge.evidence_kind == EvidenceKind::LastfmDirectSimilarity)
+            .expect("direct edge");
+        let branch = edges
+            .iter()
+            .find(|edge| edge.evidence_kind == EvidenceKind::LastfmBranchSimilarity)
+            .expect("branch edge");
+        assert_eq!(edges.len(), 2);
+        assert!(direct.weight > branch.weight);
+        assert_eq!(direct.from_track_id, 1);
+        assert_eq!(direct.to_track_id, 2);
+    }
+
+    #[test]
+    fn lastfm_resolved_edges_dedupe_same_seed_and_track_by_kind() {
+        let edges = lastfm_resolved_edges_from_rows(vec![
+            queries::ResolvedLastfmExternalSightingRow {
+                seed_track_id: 1,
+                resolved_track_id: 2,
+                similarity: 0.4,
+                source_payload_json: Some(r#"{"match":0.4}"#.to_string()),
+            },
+            queries::ResolvedLastfmExternalSightingRow {
+                seed_track_id: 1,
+                resolved_track_id: 2,
+                similarity: 0.9,
+                source_payload_json: Some(r#"{"match":0.9}"#.to_string()),
+            },
+        ]);
+
+        assert_eq!(edges.len(), 1);
+        assert!((edges[0].weight - (0.9 * LASTFM_DIRECT_EDGE_WEIGHT)).abs() < f64::EPSILON);
     }
 
     fn tidal_search_track(
@@ -3189,6 +3444,8 @@ fn reason_label(key: &str) -> &'static str {
         "album_context" => "album-adjacent",
         "artist_affinity" => "session neighbor",
         "genre_branch" => "genre branch",
+        "lastfm_direct" => "Last.fm direct",
+        "lastfm_branch" => "Last.fm branch",
         _ => "learned signal",
     }
 }

--- a/noor-server/src/services/sportify/client.rs
+++ b/noor-server/src/services/sportify/client.rs
@@ -23,6 +23,7 @@ use super::models::{
 #[derive(Debug, Clone)]
 pub struct SportifyClientConfig {
     pub base_url: String,
+    pub fallback_base_urls: Vec<String>,
     pub user_agent: String,
 }
 
@@ -70,12 +71,34 @@ mod tests {
         assert_eq!(items.as_array().unwrap().len(), 1);
         assert_eq!(items[0]["id"], "spotify-playlist-3");
     }
+
+    #[test]
+    fn client_config_collects_fallback_base_urls() {
+        let client = SportifyClient::new(SportifyClientConfig {
+            base_url: "https://primary.example/".to_string(),
+            fallback_base_urls: vec![
+                "https://fallback.example/".to_string(),
+                "https://primary.example".to_string(),
+            ],
+            user_agent: "noor-test".to_string(),
+        })
+        .expect("client");
+
+        assert_eq!(
+            client.base_urls,
+            vec![
+                "https://primary.example".to_string(),
+                "https://fallback.example".to_string()
+            ]
+        );
+    }
 }
 
 impl Default for SportifyClientConfig {
     fn default() -> Self {
         Self {
             base_url: "https://sportify.xcasper.space".to_string(),
+            fallback_base_urls: Vec::new(),
             user_agent: "noor-server/sportify".to_string(),
         }
     }
@@ -112,7 +135,7 @@ impl SportifySearchKind {
 #[derive(Clone)]
 pub struct SportifyClient {
     http: reqwest::Client,
-    base_url: String,
+    base_urls: Vec<String>,
 }
 
 impl SportifyClient {
@@ -128,16 +151,47 @@ impl SportifyClient {
             .timeout(std::time::Duration::from_secs(10))
             .build()
             .context("build sportify reqwest client")?;
-        Ok(Self {
-            http,
-            base_url: config.base_url.trim_end_matches('/').to_string(),
-        })
+        let mut base_urls = Vec::new();
+        for raw in std::iter::once(config.base_url).chain(config.fallback_base_urls) {
+            let normalized = raw.trim().trim_end_matches('/').to_string();
+            if !normalized.is_empty() && !base_urls.iter().any(|u| u == &normalized) {
+                base_urls.push(normalized);
+            }
+        }
+        if base_urls.is_empty() {
+            return Err(anyhow!("no sportify base URL configured"));
+        }
+        Ok(Self { http, base_urls })
     }
 
     /// Issue a GET, validate the standard envelope, and return the raw body
     /// JSON (envelope fields included). Callers extract the resource field.
     async fn fetch_raw(&self, path: &str, query: &[(&str, String)]) -> Result<Value> {
-        let url = format!("{}{}", self.base_url, path);
+        let mut errors = Vec::new();
+        for base_url in &self.base_urls {
+            match self.fetch_raw_from_base(base_url, path, query).await {
+                Ok(value) => return Ok(value),
+                Err(e) => {
+                    tracing::debug!("sportify {} via {} failed: {}", path, base_url, e);
+                    errors.push(format!("{}: {}", base_url, e));
+                }
+            }
+        }
+
+        Err(anyhow!(
+            "all sportify proxies failed for {}: {}",
+            path,
+            errors.join("; ")
+        ))
+    }
+
+    async fn fetch_raw_from_base(
+        &self,
+        base_url: &str,
+        path: &str,
+        query: &[(&str, String)],
+    ) -> Result<Value> {
+        let url = format!("{}{}", base_url, path);
         let resp = self
             .http
             .get(&url)
@@ -196,39 +250,43 @@ impl SportifyClient {
         offset: u32,
     ) -> Result<SportifySearchResults> {
         let limit = limit.clamp(1, 50);
-        let value = self
-            .fetch_raw(
-                "/api/search",
-                &[
-                    ("q", query.to_string()),
-                    ("type", kind.as_str().to_string()),
-                    ("limit", limit.to_string()),
-                    ("offset", offset.to_string()),
-                ],
-            )
-            .await?;
-
-        // Sportify search usually returns `{ results: [...] }`, but has also
-        // shipped nested `{ results: { items: [...] } }` and typed buckets.
-        // Normalize all of those into the requested result bucket.
-        let mut out = SportifySearchResults::default();
-        let array = extract_search_items(&value, kind);
-
-        match kind {
-            SportifySearchKind::Track => {
-                out.tracks = serde_json::from_value(array).unwrap_or_default();
-            }
-            SportifySearchKind::Album => {
-                out.albums = serde_json::from_value(array).unwrap_or_default();
-            }
-            SportifySearchKind::Artist => {
-                out.artists = serde_json::from_value(array).unwrap_or_default();
-            }
-            SportifySearchKind::Playlist => {
-                out.playlists = serde_json::from_value(array).unwrap_or_default();
+        let query_params = [
+            ("q", query.to_string()),
+            ("type", kind.as_str().to_string()),
+            ("limit", limit.to_string()),
+            ("offset", offset.to_string()),
+        ];
+        let mut errors = Vec::new();
+        for (idx, base_url) in self.base_urls.iter().enumerate() {
+            match self
+                .fetch_raw_from_base(base_url, "/api/search", &query_params)
+                .await
+            {
+                Ok(value) => {
+                    let out = search_results_from_value(&value, kind);
+                    if matches!(kind, SportifySearchKind::Playlist)
+                        && out.playlists.is_empty()
+                        && idx + 1 < self.base_urls.len()
+                    {
+                        tracing::debug!(
+                            "sportify playlist search via {} returned no playlist rows",
+                            base_url
+                        );
+                        continue;
+                    }
+                    return Ok(out);
+                }
+                Err(e) => {
+                    tracing::debug!("sportify /api/search via {} failed: {}", base_url, e);
+                    errors.push(format!("{}: {}", base_url, e));
+                }
             }
         }
-        Ok(out)
+
+        Err(anyhow!(
+            "all sportify proxies failed for /api/search: {}",
+            errors.join("; ")
+        ))
     }
 
     pub async fn track(&self, spotify_id: &str) -> Result<SportifyTrack> {
@@ -296,6 +354,30 @@ fn extract_search_items(value: &Value, kind: SportifySearchKind) -> Value {
                 .and_then(|v| unwrap_items(v, kind))
         })
         .unwrap_or_else(|| Value::Array(Vec::new()))
+}
+
+fn search_results_from_value(value: &Value, kind: SportifySearchKind) -> SportifySearchResults {
+    // Sportify search usually returns `{ results: [...] }`, but has also
+    // shipped nested `{ results: { items: [...] } }` and typed buckets.
+    // Normalize all of those into the requested result bucket.
+    let mut out = SportifySearchResults::default();
+    let array = extract_search_items(value, kind);
+
+    match kind {
+        SportifySearchKind::Track => {
+            out.tracks = serde_json::from_value(array).unwrap_or_default();
+        }
+        SportifySearchKind::Album => {
+            out.albums = serde_json::from_value(array).unwrap_or_default();
+        }
+        SportifySearchKind::Artist => {
+            out.artists = serde_json::from_value(array).unwrap_or_default();
+        }
+        SportifySearchKind::Playlist => {
+            out.playlists = serde_json::from_value(array).unwrap_or_default();
+        }
+    }
+    out
 }
 
 fn truncate_for_log(s: &str) -> String {

--- a/noor-server/src/services/sportify/recommend.rs
+++ b/noor-server/src/services/sportify/recommend.rs
@@ -182,7 +182,9 @@ pub async fn cached_search(
     offset: u32,
 ) -> Result<SportifySearchResults> {
     if let Some(s) = db.with_conn(|conn| sp_cache::get_search(conn, cfg, q, kind, limit, offset))? {
-        return Ok(s);
+        if !(matches!(kind, SportifySearchKind::Playlist) && s.playlists.is_empty()) {
+            return Ok(s);
+        }
     }
     let fetched = client.search(q, kind, limit, offset).await?;
     db.with_conn(|conn| sp_cache::put_search(conn, q, kind, limit, offset, &fetched))?;
@@ -446,6 +448,7 @@ mod tests {
     fn test_client() -> SportifyClient {
         SportifyClient::new(SportifyClientConfig {
             base_url: "http://127.0.0.1:9".to_string(),
+            fallback_base_urls: Vec::new(),
             user_agent: "noor-test".to_string(),
         })
         .expect("sportify client")

--- a/noor-server/src/services/spotify/catalog.rs
+++ b/noor-server/src/services/spotify/catalog.rs
@@ -1,0 +1,530 @@
+use anyhow::{Context, Result};
+use reqwest::Client;
+use serde::Deserialize;
+use std::collections::HashMap;
+
+use crate::db::Database;
+use crate::services::sportify::models::{
+    SportifyAlbumRef, SportifyArtistRef, SportifyExternalIds, SportifyImage, SportifyPlaylist,
+    SportifyPlaylistOwner, SportifySearchResults, SportifyTrack,
+};
+
+use super::auth;
+
+const SPOTIFY_API_BASE: &str = "https://api.spotify.com/v1";
+
+#[derive(Debug, Deserialize, Default)]
+struct SpotifyImageDto {
+    #[serde(default)]
+    url: Option<String>,
+    #[serde(default)]
+    width: Option<i32>,
+    #[serde(default)]
+    height: Option<i32>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct SpotifyOwnerDto {
+    #[serde(default, alias = "displayName")]
+    display_name: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct SpotifyFollowersDto {
+    #[serde(default)]
+    total: Option<i64>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct SpotifyTracksSummaryDto {
+    #[serde(default)]
+    total: Option<i32>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct SpotifyPlaylistSearchDto {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    images: Vec<SpotifyImageDto>,
+    #[serde(default)]
+    owner: Option<SpotifyOwnerDto>,
+    #[serde(default)]
+    followers: Option<SpotifyFollowersDto>,
+    #[serde(default)]
+    tracks: Option<SpotifyTracksSummaryDto>,
+    #[serde(default)]
+    external_urls: HashMap<String, String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct SpotifySearchResponse {
+    #[serde(default)]
+    playlists: Option<SpotifyPaging<SpotifyPlaylistSearchDto>>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct SpotifyPaging<T> {
+    #[serde(default)]
+    items: Vec<Option<T>>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct SpotifyArtistDto {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct SpotifyAlbumDto {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    images: Vec<SpotifyImageDto>,
+    #[serde(default)]
+    release_date: Option<String>,
+    #[serde(default)]
+    total_tracks: Option<i32>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct SpotifyExternalIdsDto {
+    #[serde(default)]
+    isrc: Option<String>,
+    #[serde(default)]
+    ean: Option<String>,
+    #[serde(default)]
+    upc: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct SpotifyTrackDto {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    artists: Vec<SpotifyArtistDto>,
+    #[serde(default)]
+    album: Option<SpotifyAlbumDto>,
+    #[serde(default)]
+    duration_ms: Option<i64>,
+    #[serde(default)]
+    explicit: Option<bool>,
+    #[serde(default)]
+    track_number: Option<i32>,
+    #[serde(default)]
+    disc_number: Option<i32>,
+    #[serde(default)]
+    preview_url: Option<String>,
+    #[serde(default)]
+    popularity: Option<i32>,
+    #[serde(default)]
+    external_ids: Option<SpotifyExternalIdsDto>,
+    #[serde(default)]
+    external_urls: HashMap<String, String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct SpotifyPlaylistTrackItemDto {
+    #[serde(default)]
+    track: Option<SpotifyTrackDto>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct SpotifyPlaylistTracksDto {
+    #[serde(default)]
+    total: Option<i32>,
+    #[serde(default)]
+    items: Vec<SpotifyPlaylistTrackItemDto>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct SpotifyPlaylistDetailDto {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    images: Vec<SpotifyImageDto>,
+    #[serde(default)]
+    owner: Option<SpotifyOwnerDto>,
+    #[serde(default)]
+    followers: Option<SpotifyFollowersDto>,
+    #[serde(default)]
+    tracks: Option<SpotifyPlaylistTracksDto>,
+    #[serde(default)]
+    external_urls: HashMap<String, String>,
+}
+
+struct SpotifyCatalogClient {
+    http: Client,
+    token: String,
+}
+
+impl SpotifyCatalogClient {
+    fn new(http: Client, token: String) -> Self {
+        Self { http, token }
+    }
+
+    async fn get_json<T: for<'de> Deserialize<'de>>(
+        &self,
+        path: &str,
+        query: &[(&str, String)],
+    ) -> Result<T> {
+        let response = self
+            .http
+            .get(format!("{}{}", SPOTIFY_API_BASE, path))
+            .bearer_auth(&self.token)
+            .query(query)
+            .send()
+            .await
+            .with_context(|| format!("spotify catalog request failed: {}", path))?;
+
+        let status = response.status();
+        let body = response.text().await.context("read spotify catalog body")?;
+        if !status.is_success() {
+            anyhow::bail!(
+                "spotify catalog {} returned HTTP {}: {}",
+                path,
+                status,
+                truncate_for_log(&body)
+            );
+        }
+
+        serde_json::from_str(&body).with_context(|| format!("parse spotify catalog {}", path))
+    }
+
+    async fn search_playlists(
+        &self,
+        query: &str,
+        limit: u32,
+        offset: u32,
+    ) -> Result<SportifySearchResults> {
+        let payload: SpotifySearchResponse = self
+            .get_json(
+                "/search",
+                &[
+                    ("q", query.to_string()),
+                    ("type", "playlist".to_string()),
+                    ("limit", limit.clamp(1, 50).to_string()),
+                    ("offset", offset.to_string()),
+                ],
+            )
+            .await?;
+
+        Ok(SportifySearchResults {
+            playlists: payload
+                .playlists
+                .map(|page| {
+                    page.items
+                        .into_iter()
+                        .flatten()
+                        .map(playlist_from_search)
+                        .collect()
+                })
+                .unwrap_or_default(),
+            ..SportifySearchResults::default()
+        })
+    }
+
+    async fn playlist(&self, spotify_id: &str) -> Result<SportifyPlaylist> {
+        let payload: SpotifyPlaylistDetailDto = self
+            .get_json(
+                &format!("/playlists/{}", spotify_id),
+                &[(
+                    "fields",
+                    [
+                        "id,name,description,images,owner(display_name),followers(total)",
+                        "tracks(total,items(track(id,name,artists(id,name),album(id,name,images,release_date,total_tracks),duration_ms,explicit,track_number,disc_number,preview_url,popularity,external_ids,external_urls)))",
+                    ]
+                    .join(","),
+                )],
+            )
+            .await?;
+
+        Ok(playlist_from_detail(payload))
+    }
+}
+
+pub async fn search_playlists_from_saved_credentials(
+    db: &Database,
+    query: &str,
+    limit: u32,
+    offset: u32,
+) -> Result<SportifySearchResults> {
+    let client = catalog_client_from_saved_credentials(db).await?;
+    client.search_playlists(query, limit, offset).await
+}
+
+pub async fn playlist_from_saved_credentials(
+    db: &Database,
+    spotify_id: &str,
+) -> Result<SportifyPlaylist> {
+    let client = catalog_client_from_saved_credentials(db).await?;
+    client.playlist(spotify_id).await
+}
+
+async fn catalog_client_from_saved_credentials(db: &Database) -> Result<SpotifyCatalogClient> {
+    let creds = db
+        .with_conn(|conn| Ok(auth::load_credentials(conn).ok().flatten()))?
+        .context("spotify credentials not configured")?;
+    let http = Client::new();
+    let token = auth::fetch_app_token(&http, &creds)
+        .await
+        .context("fetch spotify catalog token")?;
+    Ok(SpotifyCatalogClient::new(http, token.access_token))
+}
+
+fn playlist_from_search(dto: SpotifyPlaylistSearchDto) -> SportifyPlaylist {
+    let total_tracks = dto.tracks.and_then(|tracks| tracks.total);
+    let owner = dto.owner.and_then(|owner| {
+        owner
+            .display_name
+            .map(|name| SportifyPlaylistOwner::Object {
+                id: None,
+                name: Some(name),
+            })
+    });
+    SportifyPlaylist {
+        id: dto.id,
+        name: dto.name,
+        description: dto.description,
+        images: dto.images.into_iter().map(image_from_dto).collect(),
+        owner,
+        followers: dto.followers.and_then(|followers| followers.total),
+        total_tracks,
+        url: dto.external_urls.get("spotify").cloned(),
+        ..SportifyPlaylist::default()
+    }
+}
+
+fn playlist_from_detail(dto: SpotifyPlaylistDetailDto) -> SportifyPlaylist {
+    let (total_tracks, tracks) = dto
+        .tracks
+        .map(|tracks| {
+            (
+                tracks.total,
+                tracks
+                    .items
+                    .into_iter()
+                    .filter_map(|item| item.track)
+                    .map(track_from_dto)
+                    .collect(),
+            )
+        })
+        .unwrap_or((None, Vec::new()));
+    let owner = dto.owner.and_then(|owner| {
+        owner
+            .display_name
+            .map(|name| SportifyPlaylistOwner::Object {
+                id: None,
+                name: Some(name),
+            })
+    });
+
+    SportifyPlaylist {
+        id: dto.id,
+        name: dto.name,
+        description: dto.description,
+        images: dto.images.into_iter().map(image_from_dto).collect(),
+        owner,
+        followers: dto.followers.and_then(|followers| followers.total),
+        total_tracks,
+        url: dto.external_urls.get("spotify").cloned(),
+        tracks,
+        ..SportifyPlaylist::default()
+    }
+}
+
+fn track_from_dto(dto: SpotifyTrackDto) -> SportifyTrack {
+    let album = dto.album.map(|album| SportifyAlbumRef {
+        id: album.id,
+        name: album.name,
+        images: album.images.into_iter().map(image_from_dto).collect(),
+        release_date: album.release_date,
+        total_tracks: album.total_tracks,
+    });
+
+    SportifyTrack {
+        id: dto.id,
+        name: dto.name,
+        artists: dto
+            .artists
+            .into_iter()
+            .map(|artist| SportifyArtistRef {
+                id: artist.id,
+                name: artist.name,
+                uri: None,
+            })
+            .collect(),
+        thumbnail: album
+            .as_ref()
+            .and_then(|album| {
+                album
+                    .images
+                    .iter()
+                    .max_by_key(|image| image.width.unwrap_or(0))
+            })
+            .and_then(|image| image.url.clone()),
+        album,
+        duration_ms: dto.duration_ms,
+        explicit: dto.explicit,
+        track_number: dto.track_number,
+        disc_number: dto.disc_number,
+        preview_url: dto.preview_url,
+        popularity: dto.popularity,
+        external_ids: dto.external_ids.map(|ids| SportifyExternalIds {
+            isrc: ids.isrc,
+            ean: ids.ean,
+            upc: ids.upc,
+        }),
+        external_urls: dto.external_urls,
+        ..SportifyTrack::default()
+    }
+}
+
+fn image_from_dto(dto: SpotifyImageDto) -> SportifyImage {
+    SportifyImage {
+        url: dto.url,
+        width: dto.width,
+        height: dto.height,
+    }
+}
+
+fn truncate_for_log(s: &str) -> String {
+    if s.len() > 256 {
+        format!("{}...", &s[..256])
+    } else {
+        s.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_search_playlist_total_from_nested_tracks() {
+        let payload = SpotifyPlaylistSearchDto {
+            id: Some("playlist-1".to_string()),
+            name: Some("Lofi".to_string()),
+            tracks: Some(SpotifyTracksSummaryDto { total: Some(42) }),
+            owner: Some(SpotifyOwnerDto {
+                display_name: Some("Spotify".to_string()),
+            }),
+            ..SpotifyPlaylistSearchDto::default()
+        };
+
+        let playlist = playlist_from_search(payload);
+
+        assert_eq!(playlist.spotify_id().as_deref(), Some("playlist-1"));
+        assert_eq!(playlist.title().as_deref(), Some("Lofi"));
+        assert_eq!(playlist.total_track_count(), Some(42));
+        assert_eq!(
+            playlist
+                .owner
+                .as_ref()
+                .and_then(|owner| owner.display_name()),
+            Some("Spotify")
+        );
+    }
+
+    #[test]
+    fn maps_search_response_skips_null_playlist_rows() {
+        let payload = SpotifySearchResponse {
+            playlists: Some(SpotifyPaging {
+                items: vec![
+                    None,
+                    Some(SpotifyPlaylistSearchDto {
+                        id: Some("playlist-1".to_string()),
+                        name: Some("Lofi".to_string()),
+                        ..SpotifyPlaylistSearchDto::default()
+                    }),
+                ],
+            }),
+        };
+
+        let playlists: Vec<SportifyPlaylist> = payload
+            .playlists
+            .map(|page| {
+                page.items
+                    .into_iter()
+                    .flatten()
+                    .map(playlist_from_search)
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        assert_eq!(playlists.len(), 1);
+        assert_eq!(playlists[0].spotify_id().as_deref(), Some("playlist-1"));
+    }
+
+    #[test]
+    fn maps_playlist_detail_tracks_for_tidal_resolution() {
+        let payload = SpotifyPlaylistDetailDto {
+            id: Some("playlist-1".to_string()),
+            tracks: Some(SpotifyPlaylistTracksDto {
+                total: Some(1),
+                items: vec![SpotifyPlaylistTrackItemDto {
+                    track: Some(SpotifyTrackDto {
+                        id: Some("track-1".to_string()),
+                        name: Some("Song".to_string()),
+                        artists: vec![SpotifyArtistDto {
+                            id: Some("artist-1".to_string()),
+                            name: Some("Artist".to_string()),
+                        }],
+                        album: Some(SpotifyAlbumDto {
+                            id: Some("album-1".to_string()),
+                            name: Some("Album".to_string()),
+                            images: vec![SpotifyImageDto {
+                                url: Some("https://i.scdn.co/image/test".to_string()),
+                                width: Some(640),
+                                height: Some(640),
+                            }],
+                            ..SpotifyAlbumDto::default()
+                        }),
+                        external_ids: Some(SpotifyExternalIdsDto {
+                            isrc: Some("USABC1234567".to_string()),
+                            ..SpotifyExternalIdsDto::default()
+                        }),
+                        ..SpotifyTrackDto::default()
+                    }),
+                }],
+            }),
+            ..SpotifyPlaylistDetailDto::default()
+        };
+
+        let playlist = playlist_from_detail(payload);
+        let track = playlist.tracks.first().expect("track");
+
+        assert_eq!(playlist.total_track_count(), Some(1));
+        assert_eq!(track.id.as_deref(), Some("track-1"));
+        assert_eq!(track.primary_artist(), Some("Artist"));
+        assert_eq!(
+            track.album.as_ref().and_then(|album| album.name.as_deref()),
+            Some("Album")
+        );
+        assert_eq!(
+            track
+                .external_ids
+                .as_ref()
+                .and_then(|ids| ids.isrc.as_deref()),
+            Some("USABC1234567")
+        );
+        assert_eq!(
+            track.best_thumbnail().as_deref(),
+            Some("https://i.scdn.co/image/test")
+        );
+    }
+}

--- a/noor-server/src/services/spotify/mod.rs
+++ b/noor-server/src/services/spotify/mod.rs
@@ -1,2 +1,3 @@
 pub mod auth;
+pub mod catalog;
 pub mod enrichment;


### PR DESCRIPTION
Summary:
- Add opt-in editorial and charts variants to shared page and section headers.
- Extract Last.fm and Market pulse mural rendering into a shared ChartMural component.
- Refactor /charts shelves and playlist artwork to use shared layout, neutral titles, and existing artwork fallback behavior.

Verification:
- pnpm test -- trending_shelf_contract.test.ts daily_chart_shelf_contract.test.ts
- pnpm lint
- pnpm check
- pnpm run build
- /charts HTTP smoke check on existing dev server

Notes:
- Existing unrelated scrobbling, backend, onboarding, and recommendation working tree changes were left unstaged.