### PR TITLE
Add chart ingestion provider matrix

### DIFF
--- a/docs/plans/2026-05-29-daily-chart-ingestion.md
+++ b/docs/plans/2026-05-29-daily-chart-ingestion.md
@@ -1,0 +1,488 @@
+# Daily Chart Ingestion Plan
+
+## Goal
+
+Build a daily chart ingestion pipeline that gives `/charts` richer, Kworb-style market views while preserving NOORwave's playback contract: every chart row should resolve to local library data when possible, then to a playable TIDAL candidate, then to a pending external row if unresolved.
+
+Kworb is useful as a product reference because it shows a country by service matrix and per-service daily chart pages. It should not be the default production dependency unless source permission is confirmed. Prefer official or already-integrated APIs first, then treat third-party HTML as an optional, rate-limited fallback.
+
+## Observed Reference Shape
+
+Kworb is not one chart. It is a broad music data site with several useful shapes:
+
+- Home overview and navigation across iTunes, worldwide, artists, charts, radio, Spotify, YouTube, and trending.
+- Current cross-provider country matrix.
+- Global artist ranking that combines Apple Music, Spotify, iTunes, YouTube, Shazam, and Deezer signals.
+- Spotify daily and weekly country charts with totals and track history links.
+- Worldwide and European iTunes and Apple Music song and album charts.
+- YouTube video rankings, language filters, artist pages, country pages, and top lists.
+- Radio estimates with audience, audience delta, formats, peak audience, and cross-provider positions.
+- Artist detail pages showing where a track or artist is charting across services and countries.
+
+Kworb `/charts` shows a matrix by country and source:
+
+- Country
+- iTunes top song
+- Spotify top song
+- Apple Music top song
+- YouTube top video
+- Shazam top song
+- Deezer top song
+
+Kworb Spotify country pages expose richer daily rows:
+
+- Rank and rank movement
+- Artist and title
+- Days on chart
+- Peak position
+- Daily streams and stream delta
+- Seven-day streams and delta
+- Total streams
+- Spotify track id embedded in the track-history URL
+
+## Source Catalog
+
+Model chart ingestion as a source catalog, not a one-off Spotify feature. Each source has a stable key, parser, resolver policy, retention policy, and UI capability flag.
+
+Initial source families:
+
+- `charts_matrix`: current top item by country and provider. Good for a fast "what is number one everywhere" view.
+- `spotify_daily`: daily track charts by region. Best first playable source because Spotify rows carry strong identifiers.
+- `spotify_weekly`: weekly track charts by region. Same resolver path as daily.
+- `spotify_totals`: accumulated Spotify totals and historical track stats. Useful for context, not urgent for playback.
+- `global_artist`: combined artist points by provider and top country. Good for artist discovery and "global heat".
+- `itunes_worldwide`: worldwide and European song or album points. Mostly display plus TIDAL resolve by artist and title.
+- `apple_music_worldwide`: worldwide and European song or album points. Mostly display plus TIDAL resolve by artist and title.
+- `youtube_daily`: 24-hour video views and likes. Should route through video surfaces, not normal track playback.
+- `radio_estimates`: audience and format estimates. Good for trend context and cross-provider comparison.
+- `artist_positions`: per-artist cross-service positions. Better as an artist detail enhancement than the first `/charts` page.
+
+Each source family can support several regions, periods, and entity types:
+
+- `entity_type`: `track`, `album`, `artist`, `video`
+- `period`: `live`, `daily`, `weekly`, `totals`
+- `region`: `global`, ISO country code, or provider-specific region key
+
+## Source Strategy
+
+### Phase 0: Catalog and Snapshot Shell
+
+Add the shared schema, source registry, snapshot read API, and resolver queue without enabling every provider. This keeps the first backend change small and gives `/charts` a stable local data contract.
+
+The first UI can read local snapshots even before all sources exist.
+
+### Phase 1: Charts Matrix and Spotify Daily Charts
+
+Use the country matrix as the browse model and Spotify daily as the first detailed playable source. The `/charts` page should not read as "Spotify charts". It should read as a market pulse surface with provider columns for iTunes, Spotify, Apple Music, YouTube, Shazam, and Deezer.
+
+Provider priority for detailed playable rows:
+
+1. Official Spotify Charts daily CSV or page data where accessible.
+2. Existing Sportify playlist/detail endpoints for metadata enrichment only.
+3. Kworb Spotify daily pages only if allowed, behind a feature flag.
+
+Do not block UI requests on external fetches. Ingestion runs in the background and `/charts` reads local snapshots.
+
+### Phase 2: Weekly, Totals, and Artist Heat
+
+Add weekly Spotify snapshots, Spotify totals, and global artist rankings. These are useful for trend context but do not need to resolve every row to playback before they can be displayed.
+
+### Phase 3: Last.fm Continuity
+
+Keep the existing Last.fm trending shelf as a live fallback and comparison source. Last.fm remains useful for broad "now moving" trends but should not be the only charts data source.
+
+### Phase 4: Extra Sources
+
+Add providers only when we can resolve rows reliably:
+
+- Apple Music: display-only until we have a resolver path.
+- iTunes: display-only or TIDAL resolve by artist and title.
+- YouTube: video route integration, not normal track playback.
+- Shazam and Deezer: display and TIDAL resolve by artist and title.
+
+## Backend Data Model
+
+Add new append-only migrations:
+
+### `chart_sources`
+
+- `id INTEGER PRIMARY KEY`
+- `source_key TEXT UNIQUE NOT NULL`
+- `display_name TEXT NOT NULL`
+- `provider TEXT NOT NULL`
+- `enabled INTEGER NOT NULL DEFAULT 1`
+- `default_region TEXT`
+- `refresh_interval_hours INTEGER NOT NULL DEFAULT 24`
+- `last_success_at INTEGER`
+- `last_error TEXT`
+
+Example `source_key` values:
+
+- `charts_matrix`
+- `spotify_daily`
+- `spotify_weekly`
+- `spotify_totals`
+- `lastfm_worldwide`
+- `global_artist`
+- `apple_music_daily`
+- `itunes_daily`
+- `youtube_daily`
+- `radio_estimates`
+- `artist_positions`
+
+### `chart_snapshots`
+
+- `id INTEGER PRIMARY KEY`
+- `source_key TEXT NOT NULL`
+- `region TEXT NOT NULL`
+- `period TEXT NOT NULL`
+- `chart_date TEXT NOT NULL`
+- `fetched_at INTEGER NOT NULL`
+- `etag TEXT`
+- `content_hash TEXT`
+- `status TEXT NOT NULL`
+- unique `(source_key, region, period, chart_date)`
+
+`period` starts with `daily` and `weekly`.
+
+### `chart_entries`
+
+- `id INTEGER PRIMARY KEY`
+- `snapshot_id INTEGER NOT NULL`
+- `rank INTEGER NOT NULL`
+- `rank_delta INTEGER`
+- `artist TEXT NOT NULL`
+- `title TEXT NOT NULL`
+- `entity_type TEXT NOT NULL DEFAULT 'track'`
+- `album TEXT`
+- `external_track_id TEXT`
+- `external_artist_id TEXT`
+- `external_video_id TEXT`
+- `external_url TEXT`
+- `streams INTEGER`
+- `stream_delta INTEGER`
+- `views INTEGER`
+- `likes INTEGER`
+- `audience REAL`
+- `audience_delta REAL`
+- `points REAL`
+- `points_delta REAL`
+- `seven_day_streams INTEGER`
+- `total_streams INTEGER`
+- `days_on_chart INTEGER`
+- `peak_rank INTEGER`
+- `provider_positions_json TEXT`
+- `raw_json TEXT`
+- unique `(snapshot_id, rank)`
+
+### `chart_entry_resolutions`
+
+- `entry_id INTEGER PRIMARY KEY`
+- `external_candidate_id INTEGER`
+- `local_track_id INTEGER`
+- `tidal_id INTEGER`
+- `status TEXT NOT NULL`
+- `score REAL`
+- `resolved_at INTEGER`
+- `attempts INTEGER NOT NULL DEFAULT 0`
+- `last_error TEXT`
+
+`status` values:
+
+- `local`
+- `tidal`
+- `pending`
+- `unresolved`
+- `not_playable`
+
+Use `external_candidate_id` to point at the existing `external_track_candidates` table when a row is not already a local track. Do not create a parallel candidate system for chart rows. The chart resolution table should store chart-specific state and rank context, not duplicate the long-lived external candidate resolver.
+
+## Ingestion Flow
+
+1. Scheduler picks due `(source_key, region, period)` jobs once per day.
+2. Provider fetches raw data with timeout, user-agent, and rate limit.
+3. Parser normalizes rows into `ChartEntrySeed`.
+4. Snapshot transaction inserts `chart_snapshots` and `chart_entries`.
+5. Resolver job starts after insert and processes entries in bounded batches.
+6. Resolution order:
+   - Match local by external id where available.
+   - Match local by ISRC where available.
+   - Match local by normalized artist and title.
+   - Resolve to TIDAL using existing search or direct id path.
+   - Leave as pending external when unresolved.
+7. UI reads snapshot immediately, then receives updated resolution state via polling or WebSocket event.
+
+## Daily Scheduling
+
+Start simple:
+
+- On server startup, enqueue any chart source whose latest successful snapshot is older than 20 hours.
+- Run an hourly lightweight scheduler tick inside `noor-server`.
+- Fetch daily charts at most once per source and region per day.
+- Provide `POST /api/charts/refresh` for manual refresh in dev only or admin-only later.
+
+No OS scheduler is required. This keeps portable and installed Windows behavior identical.
+
+## API Contract
+
+Add:
+
+- `GET /api/charts/sources`
+- `GET /api/charts/snapshots?source=spotify_daily&period=daily&region=AU&limit=50`
+- `GET /api/charts/snapshot/{id}`
+- `GET /api/charts/matrix?region_group=main`
+- `GET /api/charts/artists?source=global_artist&limit=100`
+- `POST /api/charts/refresh`
+
+Keep existing `GET /api/charts` as compatibility. It can map to the latest Last.fm snapshot or live Last.fm fallback until the new UI is ready.
+
+`ChartEntry` should gain:
+
+- `rank`
+- `rank_delta`
+- `period`
+- `region`
+- `chart_date`
+- `source_key`
+- `source_label`
+- `streams`
+- `stream_delta`
+- `resolution_status`
+
+## Frontend Plan
+
+Change `/charts` from two unrelated blocks into three sections:
+
+1. `Now moving`: existing Last.fm trending shelf.
+2. `Market pulse`: Kworb-style country/provider matrix backed by local snapshots.
+3. `Chart playlists`: existing Spotify editorial playlist cards.
+
+The first backend slice remains the additive snapshot endpoint because it is the safest TDD target. The first product UI should still show the market-pulse shape, even when data is empty, so it is clear that Spotify is only one provider.
+
+First visible `Market pulse` shell:
+
+- Rows: `Global`, `US`, `UK`, `AU`, `CA`, and `NZ` first
+- Columns: `iTunes`, `Spotify`, `Apple Music`, `YouTube`, `Shazam`, `Deezer`
+- Cell state: top item, loading, unavailable, unresolved, or source not enabled
+- Click behavior: open the provider and region drilldown when a detailed snapshot exists
+
+First detailed `Daily charts` drilldown:
+
+- Source: `Spotify`
+- Period: `Daily`
+- Region: selected from the matrix or quick switches
+- Layout: compact ranked list, not playlist cards
+
+Daily row shape:
+
+- Rank and movement
+- Artwork thumbnail when available
+- Title and artist
+- Source metric, starting with streams
+- Resolution state: in library, playable, resolving, or unresolved
+- Play and context menu actions only when the row is resolved enough
+
+The Kworb-style matrix should become the default mode after the matrix snapshot endpoint exists:
+
+- Rows are countries.
+- Columns are providers.
+- Cells show the current top track, artist, or video.
+- Clicking a cell opens the detailed snapshot for that provider and region.
+- Resolved cells play or queue directly.
+- Unresolved cells offer search, TIDAL resolve, or external open actions.
+
+Daily chart cards should:
+
+- Render immediately from local snapshots.
+- Show rank and movement.
+- Show streams when present.
+- Show views, likes, audience, or points when the selected source provides them.
+- Use existing `TrendingCard` playback behavior.
+- Show `Resolving...` only for pending rows, not for the whole grid.
+
+## Resolver Rules
+
+Reuse existing helpers where possible:
+
+- `buildTrackMenu`
+- `buildTidalTrackMenu`
+- pending external queue behavior
+- TIDAL search and import paths
+
+Never insert `tidal_id = 0` into durable storage. `0` can remain a frontend placeholder only.
+
+For daily snapshots, resolution is best-effort and incremental. A failed TIDAL lookup should not poison the chart row forever. Retry unresolved rows daily with capped attempts.
+
+## Rollout Steps
+
+1. Add schema and models.
+2. Add `ChartProvider` trait and provider capability flags.
+3. Add `ChartsMatrixProvider` and `SpotifyDailyProvider`.
+4. Add parser tests using saved fixture HTML or CSV.
+5. Add snapshot insert and stale-source scheduler.
+6. Add resolver job with bounded concurrency.
+7. Add `/api/charts/snapshots` and `/api/charts/matrix` read endpoints.
+8. Update `/charts` UI to read latest daily snapshot and matrix data.
+9. Add manual refresh and diagnostics.
+10. Add weekly, totals, artist heat, YouTube, radio, and iTunes/Apple Music in separate PR-sized steps.
+11. Consider optional Kworb provider behind `NOOR_CHARTS_KWORB=1` only after source permission and robots review.
+
+## TDD Tracer Bullets
+
+Use vertical slices. Do not write all tests first.
+
+### Slice 1: Latest Snapshot Read
+
+Public behavior: `GET /api/charts/snapshots?source=spotify_daily&period=daily&region=AU&limit=2` returns the latest local snapshot, sorted by rank, without network access.
+
+Red:
+
+- Add a backend route test that seeds two `chart_snapshots` for the same source and region, then asserts the endpoint returns only the newest `chart_date`.
+- Assert rank order and `resolution_status`.
+- Assert unresolved rows do not expose `tidal_id = 0`.
+
+Green:
+
+- Add append-only schema.
+- Add minimal insert helpers for test setup.
+- Add the read endpoint and DTO.
+
+Refactor:
+
+- Keep the existing `GET /api/charts` route unchanged.
+- Extract DTO conversion only after the route passes.
+
+### Slice 2: Provider Matrix Read
+
+Public behavior: `GET /api/charts/matrix?region_group=main` returns the latest top cell for each configured region and provider without network access.
+
+Red:
+
+- Add a backend route test that seeds latest snapshots for `itunes_daily`, `spotify_daily`, `apple_music_daily`, `youtube_daily`, `shazam_daily`, and `deezer_daily`.
+- Assert response rows are countries and columns are providers.
+- Assert missing providers return an explicit empty cell, not a route failure.
+
+Green:
+
+- Add a matrix read query over existing snapshot tables.
+- Add `/api/charts/matrix`.
+- Keep provider availability and source freshness in the response.
+
+### Slice 3: Idempotent Daily Upsert
+
+Public behavior: ingesting the same source, region, period, and chart date twice does not duplicate rows.
+
+Red:
+
+- Add a backend test that calls the snapshot upsert API twice with changed stream counts.
+- Assert there is one snapshot and one row per rank.
+- Assert updated metric values are visible through the read endpoint.
+
+Green:
+
+- Add transactional snapshot upsert.
+- Replace entries for the snapshot or upsert by rank, but keep the external contract stable.
+
+### Slice 4: Spotify Daily Parser
+
+Public behavior: a saved Spotify daily fixture becomes normalized chart rows with rank, title, artist, streams, external id, and date.
+
+Red:
+
+- Add a parser fixture test using saved HTML or CSV.
+- Assert the parser handles rank movement and missing optional metrics.
+
+Green:
+
+- Add `SpotifyDailyProvider` parser only.
+- Keep fetcher separate so parser tests never hit the network.
+
+### Slice 5: Resolver Candidate Link
+
+Public behavior: an unresolved chart row is linked to `external_track_candidates`, and a later TIDAL resolution updates the chart row without rewriting chart history.
+
+Red:
+
+- Add a backend test that ingests an unresolved row.
+- Assert an external candidate exists with the normalized artist and title.
+- Assert `chart_entry_resolutions.external_candidate_id` points at it.
+- Resolve the candidate, then assert the chart endpoint reports `resolution_status = tidal`.
+
+Green:
+
+- Reuse `upsert_external_track_candidate`.
+- Add the smallest chart-specific resolution update path.
+
+### Slice 6: Frontend Matrix and Snapshot Rendering
+
+Public behavior: `/charts` renders the provider matrix shell immediately, then renders a daily chart snapshot drilldown when a provider and region have data. Pending rows do not block resolved rows.
+
+Red:
+
+- Add a Svelte/Vitest test around the market pulse component with mocked matrix and snapshot payloads.
+- Assert provider columns include iTunes, Spotify, Apple Music, YouTube, Shazam, and Deezer.
+- Assert rank, title, source label, and pending state render in the drilldown.
+- Assert the existing Spotify playlist metadata cache test still passes.
+
+Green:
+
+- Add a small `MarketPulseShelf` component.
+- Wire it below the existing Last.fm shelf only after the component test passes.
+
+## Grill Findings
+
+### 1. The plan was too broad for a first implementation.
+
+Recommended answer: ship only the snapshot shell plus `spotify_daily` first. The Kworb-style matrix can be the second UI once the read contract exists.
+
+### 2. A generic metrics table can become a junk drawer.
+
+Recommended answer: keep common columns for rank, movement, streams, views, audience, points, and provider positions, but preserve provider-specific leftovers in `raw_json`. Do not add a new column for every provider quirk until the UI needs it.
+
+### 3. Chart resolution must not duplicate existing external candidate logic.
+
+Recommended answer: chart rows should link to `external_track_candidates`. The chart table owns chart context. The external candidate table owns dedupe and long-lived resolution.
+
+### 4. Scraping Kworb directly is a product and legal risk.
+
+Recommended answer: use Kworb to define the product shape. Enable a Kworb provider only behind `NOOR_CHARTS_KWORB=1` after source permission and robots review. First production source should be official Spotify chart data where accessible.
+
+### 5. The existing `/api/charts` contract is live data, not daily snapshots.
+
+Recommended answer: do not mutate it first. Add `/api/charts/snapshots` and `/api/charts/matrix`, then later decide whether `/api/charts` should alias the new default.
+
+### 6. The current `tidal_id = 0` placeholder is frontend-only and dangerous if persisted.
+
+Recommended answer: tests must assert no durable chart row stores `tidal_id = 0`. Unresolved means `tidal_id NULL`, `external_candidate_id` set, and `status = pending` or `unresolved`.
+
+### 7. Scheduler behavior can hide failures.
+
+Recommended answer: ingestion should be callable through a normal Rust service API first, with scheduler as a thin caller. Test ingestion directly before testing hourly ticks.
+
+### 8. The first UI must not wait for resolution.
+
+Recommended answer: render chart rows from snapshots immediately. Resolution should enrich rows incrementally, never gate first paint.
+
+## Test Plan
+
+Backend:
+
+- Parser fixtures for Spotify daily rows.
+- Snapshot upsert idempotency.
+- Resolver local match by external id, ISRC, and normalized artist/title.
+- Retry behavior for unresolved rows.
+- API contract tests for latest snapshot and empty source.
+
+Frontend:
+
+- Daily charts render from a cached snapshot payload.
+- Pending rows do not block resolved rows.
+- Source and region selection persists.
+- Existing Spotify playlist cards still use their metadata cache.
+
+## Open Decisions
+
+- Whether to include third-party HTML ingestion at all, or only official sources.
+- Which regions to enable by default: likely Global, US, UK, AU, CA, NZ, Germany, France, Japan.
+- How much history to retain locally: recommended 90 daily snapshots per source and region.
+- Whether chart data should influence automix/discovery scoring or stay display-only.

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -697,6 +697,107 @@ export interface ChartEntry {
 
 export type TrendingSource = 'lastfm' | 'tidal';
 
+export interface ChartSnapshotSummary {
+	id: number;
+	source_key: string;
+	region: string;
+	period: string;
+	chart_date: string;
+	fetched_at: number;
+	status: string;
+}
+
+export interface ChartSnapshotEntry {
+	id: number;
+	rank: number;
+	rank_delta: number | null;
+	artist: string;
+	title: string;
+	entity_type: 'track' | 'album' | 'artist' | 'video' | string;
+	album: string | null;
+	artwork_url: string | null;
+	external_track_id: string | null;
+	external_artist_id: string | null;
+	external_video_id: string | null;
+	external_url: string | null;
+	streams: number | null;
+	stream_delta: number | null;
+	views: number | null;
+	likes: number | null;
+	audience: number | null;
+	audience_delta: number | null;
+	points: number | null;
+	points_delta: number | null;
+	seven_day_streams: number | null;
+	total_streams: number | null;
+	days_on_chart: number | null;
+	peak_rank: number | null;
+	provider_positions_json: unknown | null;
+	raw_json: unknown | null;
+	external_candidate_id: number | null;
+	local_track_id: number | null;
+	tidal_id: number | null;
+	resolution_status: 'local' | 'tidal' | 'pending' | 'unresolved' | 'not_playable' | string;
+	resolution_score: number | null;
+}
+
+export interface ChartSnapshotResponse {
+	source: string;
+	period: string;
+	region: string;
+	limit: number;
+	snapshot: ChartSnapshotSummary | null;
+	entries: ChartSnapshotEntry[];
+}
+
+export interface ChartMatrixProvider {
+	source_key: string;
+	label: string;
+}
+
+export interface ChartMatrixCell {
+	snapshot_id: number;
+	entry_id: number;
+	source_key: string;
+	region: string;
+	chart_date: string;
+	rank: number;
+	rank_delta: number | null;
+	artist: string;
+	title: string;
+	entity_type: string;
+	artwork_url: string | null;
+	streams: number | null;
+	views: number | null;
+	points: number | null;
+	external_url: string | null;
+	tidal_id: number | null;
+	resolution_status: string;
+}
+
+export interface ChartMatrixRow {
+	region: string;
+	cells: Record<string, ChartMatrixCell | null>;
+}
+
+export interface ChartMatrixResponse {
+	region_group: string;
+	period: string;
+	providers: ChartMatrixProvider[];
+	rows: ChartMatrixRow[];
+}
+
+export interface ChartMatrixRefreshResponse {
+	source: string;
+	chart_date: string;
+	fetched_at: number;
+	report: {
+		rows_seen: number;
+		entries_written: number;
+		snapshots_written: number;
+	};
+}
+
 export interface LastfmGenre {
 	key: string;
 	label: string;
@@ -2509,6 +2610,33 @@ export const api = {
 			tag: string | null;
 			tracks: ChartEntry[];
 		}>('/api/charts', params);
+	},
+
+	getChartSnapshot(opts: {
+		source?: string;
+		period?: string;
+		region?: string;
+		limit?: number;
+	} = {}) {
+		const params: Record<string, string> = {};
+		if (opts.source) params.source = opts.source;
+		if (opts.period) params.period = opts.period;
+		if (opts.region) params.region = opts.region;
+		if (opts.limit != null) params.limit = String(opts.limit);
+		return fetchApi<ChartSnapshotResponse>('/api/charts/snapshots', params);
+	},
+
+	getChartMatrix(opts: { regionGroup?: string } = {}) {
+		const params: Record<string, string> = {};
+		if (opts.regionGroup) params.region_group = opts.regionGroup;
+		return fetchApi<ChartMatrixResponse>('/api/charts/matrix', params);
+	},
+
+	refreshChartMatrix() {
+		return fetchApi<ChartMatrixRefreshResponse>('/api/charts/matrix/refresh', undefined, {
+			method: 'POST',
+			body: JSON.stringify({}),
+		});
 	},
 
 	getLastfmGenres() {

--- a/frontend/src/lib/components/charts/DailyChartShelf.svelte
+++ b/frontend/src/lib/components/charts/DailyChartShelf.svelte
@@ -23,6 +23,7 @@
 
 	const PERIOD = 'daily';
 	const LIMIT = 20;
+	const ROTATE_MS = 8000;
 
 	let selectedRegion = $state('global');
 	let selectedSource = $state('spotify_daily');
@@ -30,13 +31,20 @@
 	let data = $state<ChartSnapshotResponse | null>(null);
 	let resolvedTracks = $state<Record<number, TidalSearchTrack | null>>({});
 	let resolvingEntries = $state<Record<number, boolean>>({});
-	let loading = $state(true);
 	let matrixLoading = $state(true);
+	let loading = $state(true);
 	let refreshingMatrix = $state(false);
-	let error = $state(false);
 	let matrixError = $state(false);
+	let error = $state(false);
 	let requestToken = 0;
 	let refreshAttempted = false;
+	let snapshotRefreshAttempted = false;
+	let currentEntryIndex = $state(0);
+	let carouselPaused = $state(false);
+	let carouselTimer: ReturnType<typeof setInterval> | undefined;
+
+	let chartEntries = $derived(data?.entries ?? []);
+	let currentEntry = $derived(chartEntries[currentEntryIndex] ?? chartEntries[0] ?? null);
 
 	onMount(() => {
 		void loadMatrix();
@@ -44,15 +52,21 @@
 	});
 
 	$effect(() => {
-		const cells = selectedRegionCells();
-		if (cells.length === 0) return;
-		void resolveVisibleCells(cells);
+		if (chartEntries.length === 0) return;
+		void resolveVisibleEntries(chartEntries);
 	});
 
 	$effect(() => {
-		const entries = data?.entries ?? [];
-		if (entries.length === 0) return;
-		void resolveVisibleEntries(entries);
+		if (currentEntryIndex >= chartEntries.length) currentEntryIndex = 0;
+	});
+
+	$effect(() => {
+		stopCarousel();
+		if (chartEntries.length <= 1) return;
+		carouselTimer = setInterval(() => {
+			if (!carouselPaused) jumpEntry(1);
+		}, ROTATE_MS);
+		return stopCarousel;
 	});
 
 	async function loadMatrix() {
@@ -100,6 +114,16 @@
 			});
 			if (token !== requestToken) return;
 			data = next;
+			currentEntryIndex = 0;
+			if (
+				!snapshotRefreshAttempted &&
+				!refreshingMatrix &&
+				next.entries.length > 0 &&
+				next.entries.length < Math.min(10, LIMIT)
+			) {
+				snapshotRefreshAttempted = true;
+				void refreshMatrix();
+			}
 		} catch (e) {
 			console.error('[daily-charts] snapshot fetch failed', e);
 			if (token !== requestToken) return;
@@ -120,18 +144,6 @@
 		selectedRegion = region;
 		selectedSource = source;
 		void loadSnapshot(region, source);
-	}
-
-	function rankDeltaLabel(delta: number | null): string {
-		if (delta == null || delta === 0) return 'steady';
-		return delta > 0 ? `up ${delta}` : `down ${Math.abs(delta)}`;
-	}
-
-	function formatMetric(entry: ChartSnapshotEntry): string {
-		if (entry.streams != null) return `${entry.streams.toLocaleString()} streams`;
-		if (entry.views != null) return `${entry.views.toLocaleString()} views`;
-		if (entry.points != null) return `${entry.points.toLocaleString()} pts`;
-		return entryStatusLabel(entry);
 	}
 
 	function cellMetric(cell: ChartMatrixCell): string {
@@ -161,14 +173,6 @@
 		return REGIONS.find((region) => region.code === selectedRegion)?.label ?? selectedRegion;
 	}
 
-	function selectedRegionCells(): ChartMatrixCell[] {
-		const row = matrix?.rows.find((item) => item.region === selectedRegion);
-		if (!row || !matrix) return [];
-		return matrix.providers
-			.map((provider) => row.cells[provider.source_key])
-			.filter((cell): cell is ChartMatrixCell => Boolean(cell));
-	}
-
 	function selectedProviderLabel(): string {
 		return (
 			matrix?.providers.find((provider) => provider.source_key === selectedSource)?.label ??
@@ -176,16 +180,29 @@
 		);
 	}
 
-	async function resolveVisibleCells(cells: ChartMatrixCell[]) {
-		await Promise.all(cells.slice(0, 6).map((cell) => resolveCell(cell)));
+	function stopCarousel() {
+		if (carouselTimer) clearInterval(carouselTimer);
+		carouselTimer = undefined;
+	}
+
+	function selectEntry(entryId: number) {
+		const nextIndex = chartEntries.findIndex((entry) => entry.id === entryId);
+		if (nextIndex >= 0) currentEntryIndex = nextIndex;
+	}
+
+	function jumpEntry(delta: number) {
+		if (chartEntries.length === 0) return;
+		currentEntryIndex = (currentEntryIndex + delta + chartEntries.length) % chartEntries.length;
+	}
+
+	function rankDeltaLabel(delta: number | null): string {
+		if (delta == null || delta === 0) return 'Steady';
+		if (delta < 0) return `Up ${Math.abs(delta)}`;
+		return `Down ${delta}`;
 	}
 
 	async function resolveVisibleEntries(entries: ChartSnapshotEntry[]) {
-		await Promise.all(entries.slice(0, 12).map((entry) => resolveEntry(entry)));
-	}
-
-	async function resolveCell(cell: ChartMatrixCell): Promise<TidalSearchTrack | null> {
-		return resolveChartItem(cell.entry_id, cell.artist, cell.title, cell.entity_type, cell.tidal_id);
+		await Promise.all(entries.slice(0, LIMIT).map((entry) => resolveEntry(entry)));
 	}
 
 	async function resolveEntry(entry: ChartSnapshotEntry): Promise<TidalSearchTrack | null> {
@@ -220,8 +237,8 @@
 		}
 	}
 
-	async function playCell(cell: ChartMatrixCell) {
-		const hit = resolvedTracks[cell.entry_id] ?? (await resolveCell(cell));
+	async function playEntry(entry: ChartSnapshotEntry) {
+		const hit = resolvedTracks[entry.id] ?? (await resolveEntry(entry));
 		if (!hit) {
 			playerError.set({ message: "Couldn't find that chart entry on TIDAL." });
 			return;
@@ -231,19 +248,19 @@
 			title: hit.title,
 			artist_name: hit.artist_name,
 			album_title: hit.album_title,
-			artwork_url: hit.artwork_url ?? cell.artwork_url,
+			artwork_url: hit.artwork_url ?? entry.artwork_url,
 			duration_ms: hit.duration_ms,
 			artist_tidal_id: hit.artist_id,
 			album_tidal_id: hit.album_tidal_id,
 		});
 	}
 
-	function cellArtwork(cell: ChartMatrixCell): string | null {
-		return resolvedTracks[cell.entry_id]?.artwork_url ?? cell.artwork_url;
-	}
-
 	function entryArtwork(entry: ChartSnapshotEntry): string | null {
 		return resolvedTracks[entry.id]?.artwork_url ?? entry.artwork_url;
+	}
+
+	function entryFallbackText(entry: ChartSnapshotEntry): string {
+		return (entry.title.trim()[0] ?? 'N').toUpperCase();
 	}
 
 	function entryStatusLabel(entry: ChartSnapshotEntry): string {
@@ -254,19 +271,22 @@
 		return entry.resolution_status;
 	}
 
-	function cellFallbackText(cell: ChartMatrixCell): string {
-		return (cell.title.trim()[0] ?? 'N').toUpperCase();
+	function entryMetric(entry: ChartSnapshotEntry): string {
+		if (entry.streams != null) return `${entry.streams.toLocaleString()} streams`;
+		if (entry.views != null) return `${entry.views.toLocaleString()} views`;
+		if (entry.points != null) return `${entry.points.toLocaleString()} pts`;
+		return entryStatusLabel(entry);
 	}
 
-	function fallbackText(entry: ChartSnapshotEntry): string {
-		return (entry.title.trim()[0] ?? 'N').toUpperCase();
+	function entrySubtitle(entry: ChartSnapshotEntry): string {
+		return `#${entry.rank} ${rankDeltaLabel(entry.rank_delta)} - ${entry.artist}`;
 	}
 </script>
 
 <section class="daily-chart-shelf">
 	<div class="section-header">
 		<div class="section-title-group">
-			<p class="eyebrow">Charts · Provider matrix</p>
+			<p class="eyebrow">Charts - Provider matrix</p>
 			<h2>Market pulse</h2>
 		</div>
 		<div class="region-tabs" role="tablist" aria-label="Daily chart region">
@@ -286,54 +306,97 @@
 	</div>
 
 	{#if matrix?.providers.length}
-		<div class="region-pulse" aria-label={`${selectedRegionLabel()} provider leaders`}>
-			<div class="region-pulse-copy">
-				<p>{selectedRegionLabel()} chart leaders</p>
-				<h3>{selectedProviderLabel()}</h3>
-			</div>
-			<div class="provider-card-row">
-				{#each matrix.providers as provider (provider.source_key)}
-					{@const row = matrix.rows.find((item) => item.region === selectedRegion)}
-					{@const cell = row?.cells[provider.source_key] ?? null}
+		<div class="source-tabs" role="tablist" aria-label="Daily chart provider">
+			{#each matrix.providers as provider (provider.source_key)}
+				<button
+					type="button"
+					class="source-chip"
+					class:active={provider.source_key === selectedSource}
+					role="tab"
+					aria-selected={provider.source_key === selectedSource}
+					onclick={() => pickProvider(selectedRegion, provider.source_key)}
+				>
+					{provider.label}
+				</button>
+			{/each}
+		</div>
+	{/if}
+
+	{#if chartEntries.length > 0 && currentEntry}
+		<div
+			class="chart-mural-card"
+			onmouseenter={() => carouselPaused = true}
+			onmouseleave={() => carouselPaused = false}
+			role="region"
+			aria-label={`${selectedProviderLabel()} ${selectedRegionLabel()} top ${chartEntries.length}`}
+		>
+			<div class="chart-mural-bg" aria-hidden="true">
+				{#each chartEntries as entry (entry.id)}
 					<button
+						class="chart-mural-tile"
+						class:chart-mural-tile--featured={currentEntry.id === entry.id}
 						type="button"
-						class="provider-card"
-						class:active={selectedSource === provider.source_key}
-						class:empty={!cell}
-						onclick={() => {
-							if (cell) {
-								pickProvider(selectedRegion, provider.source_key);
-								void playCell(cell);
-							}
-						}}
-						aria-label={`${provider.label} ${selectedRegionLabel()} leader`}
+						onclick={() => selectEntry(entry.id)}
+						aria-label={`Select ${entry.title}`}
+						title={`${entry.rank}. ${entry.title} - ${entry.artist}`}
 					>
-						<span class="provider-name">{provider.label}</span>
-						{#if cell}
-							<div class="provider-art">
-								<ArtworkImage
-									src={cellArtwork(cell)}
-									size={320}
-									className="provider-card-art"
-									fallbackText={cellFallbackText(cell)}
-									decorative
-								/>
-							</div>
-							<strong>{cell.title}</strong>
-							<span>{cell.artist}</span>
-							<small>{cellMetric(cell)}</small>
-						{:else}
-							<div class="provider-art empty-art"></div>
-							<strong>No data</strong>
-							<span>{selectedRegionLabel()}</span>
-							<small>Provider missing</small>
-						{/if}
+						<ArtworkImage
+							src={entryArtwork(entry)}
+							size={320}
+							className="chart-mural-art"
+							fallbackText={entryFallbackText(entry)}
+							decorative
+						/>
 					</button>
 				{/each}
 			</div>
+			<div class="chart-mural-shade"></div>
+			<div class="chart-mural-content">
+				<div class="chart-mural-meta">
+					<span class="chart-mural-kind">
+						{selectedProviderLabel()} top {chartEntries.length} - {selectedRegionLabel()}
+					</span>
+					<h3 class="chart-mural-title">{currentEntry.title}</h3>
+					<p class="chart-mural-sub">{entrySubtitle(currentEntry)}</p>
+					<div class="chart-mural-actions">
+						<button class="btn btn-primary chart-mural-play" type="button" onclick={() => void playEntry(currentEntry)}>
+							<svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor" aria-hidden="true">
+								<path d="M3 2.5l10 5.5-10 5.5V2.5z"/>
+							</svg>
+							Play
+						</button>
+						<span>{entryMetric(currentEntry)}</span>
+					</div>
+				</div>
+			</div>
+			{#if chartEntries.length > 1}
+				<button class="chart-nav chart-nav--prev" type="button" onclick={() => jumpEntry(-1)} aria-label="Previous chart entry">&lsaquo;</button>
+				<button class="chart-nav chart-nav--next" type="button" onclick={() => jumpEntry(1)} aria-label="Next chart entry">&rsaquo;</button>
+			{/if}
 		</div>
+	{:else if loading}
+		<div class="chart-mural-loading">Loading chart mural</div>
+	{:else if error}
+		<EmptyState
+			title="Daily chart unavailable"
+			copy="Restart the NOOR server if this update just landed."
+		/>
+	{:else if !matrixLoading}
+		<EmptyState
+			title={`No ${selectedProviderLabel()} top list for ${selectedRegionLabel()}`}
+			copy="Try another provider or region."
+		/>
+	{/if}
 
+	{#if matrix?.providers.length}
 		<div class="matrix-shell" aria-label="Market pulse provider matrix">
+			<div class="matrix-heading">
+				<div>
+					<p>Provider comparison</p>
+					<h3>All markets</h3>
+				</div>
+				<span>{selectedRegionLabel()} focus</span>
+			</div>
 			<div class="matrix-grid">
 				<div class="matrix-head region-head">Region</div>
 				{#each matrix.providers as provider (provider.source_key)}
@@ -386,58 +449,13 @@
 		/>
 	{/if}
 
-	{#if data?.snapshot && data.entries.length > 0}
-		<div class="chart-list" aria-label="Daily chart entries">
-			<div class="list-heading">
-				<p>{selectedRegionLabel()} · {selectedProviderLabel()}</p>
-				<h3>Provider snapshot</h3>
-			</div>
-			{#each data.entries as entry (entry.id)}
-				<div class="chart-row">
-					<div class="rank">
-						<span>{entry.rank}</span>
-						<small>{rankDeltaLabel(entry.rank_delta)}</small>
-					</div>
-					<div class="art-cell">
-						<ArtworkImage
-							src={entryArtwork(entry)}
-							size={320}
-							className="daily-chart-art"
-							fallbackText={fallbackText(entry)}
-							decorative
-						/>
-					</div>
-					<div class="track-meta">
-						<strong>{entry.title}</strong>
-						<span>{entry.artist}</span>
-					</div>
-					<div class="metric">{formatMetric(entry)}</div>
-					<div class="status" data-status={entry.resolution_status}>
-						{entryStatusLabel(entry)}
-					</div>
-				</div>
-			{/each}
-		</div>
-	{:else if loading}
-		<div class="chart-list" aria-label="Loading daily chart">
-			{#each Array.from({ length: 6 }) as _, i (i)}
-				<div class="chart-row skeleton" aria-hidden="true"></div>
-			{/each}
-		</div>
-	{:else if error}
-		<EmptyState
-			title="Daily snapshots unavailable"
-			copy="Restart the NOOR server if this update just landed."
-		/>
-	{:else}
+	{#if !matrixLoading && !matrixError && !regionHasMatrixData(selectedRegion)}
 		<EmptyState
 			title={matrixHasData(matrix)
-				? `No Spotify daily list for ${selectedRegionLabel()}`
+				? `No provider leaders for ${selectedRegionLabel()}`
 				: 'No market snapshot yet'}
 			copy={matrixHasData(matrix)
-				? regionHasMatrixData(selectedRegion)
-					? `This region has provider leaders, but no ${selectedProviderLabel()} detail list yet.`
-					: 'This region has no provider snapshot yet. Global data is available above.'
+				? 'This region has no provider leaders yet. Global data is available above.'
 				: 'NOOR tried to refresh the provider matrix, but there is no stored chart data yet.'}
 		/>
 	{/if}
@@ -515,140 +533,299 @@
 		opacity: 0.55;
 	}
 
-	.region-pulse {
-		display: grid;
-		gap: var(--space-3);
-	}
-
-	.region-pulse-copy {
+	.source-tabs {
 		display: flex;
-		align-items: end;
-		justify-content: space-between;
-		gap: var(--gap-sm);
-	}
-
-	.region-pulse-copy p,
-	.region-pulse-copy h3 {
-		margin: 0;
-	}
-
-	.region-pulse-copy p {
-		font-size: var(--font-size-xs);
-		font-weight: var(--font-weight-semibold);
-		color: var(--text-secondary);
-		text-transform: uppercase;
-		letter-spacing: 0;
-	}
-
-	.region-pulse-copy h3 {
-		font-size: var(--font-size-xl);
-		font-weight: var(--font-weight-bold);
-		line-height: var(--line-height-tight);
-	}
-
-	.provider-card-row {
-		display: grid;
-		grid-template-columns: repeat(6, minmax(132px, 1fr));
-		gap: var(--space-2);
+		align-items: center;
+		gap: var(--space-1);
 		overflow-x: auto;
 		padding-bottom: var(--space-1);
 	}
 
-	.provider-card {
-		position: relative;
-		display: grid;
-		grid-template-rows: auto auto auto auto auto;
-		align-content: start;
-		gap: var(--space-1);
-		min-width: 132px;
-		min-height: clamp(210px, 19vw, 260px);
-		padding: var(--space-2);
+	.source-chip {
 		border: 1px solid var(--panel-border);
-		border-radius: var(--radius-sm);
+		border-radius: 999px;
 		background: var(--panel-bg);
-		color: var(--text-secondary);
-		text-align: left;
+		color: var(--text-muted);
 		cursor: pointer;
+		font-size: var(--font-size-xs);
+		font-weight: var(--font-weight-semibold);
+		line-height: 1;
+		padding: var(--space-2) var(--space-3);
+		white-space: nowrap;
 		transition: background var(--motion-base), border-color var(--motion-base), color var(--motion-base);
 	}
 
-	.provider-card:hover,
-	.provider-card:focus-visible,
-	.provider-card.active {
-		border-color: var(--accent-line);
+	.source-chip:hover,
+	.source-chip:focus-visible,
+	.source-chip.active {
 		background: var(--bg-hover);
+		border-color: var(--accent-line);
 		color: var(--text-primary);
 		outline: none;
 	}
 
-	.provider-card.empty {
-		cursor: default;
-		opacity: 0.62;
-	}
-
-	.provider-name {
-		font-size: var(--font-size-2xs);
-		font-weight: var(--font-weight-bold);
-		color: var(--service-spotify);
-		text-transform: uppercase;
-		letter-spacing: 0;
-	}
-
-	.provider-art {
-		width: 100%;
-		aspect-ratio: 1 / 1;
-		border-radius: var(--radius-xs);
+	.chart-mural-card {
+		position: relative;
+		min-height: clamp(220px, 24vw, 360px);
+		border: 1px solid var(--panel-border);
+		border-radius: var(--radius-md);
 		overflow: hidden;
-		background: var(--bg-raised);
+		background: var(--panel-bg);
 	}
 
-	:global(.provider-card-art) {
+	.chart-mural-bg {
+		position: absolute;
+		inset: -7%;
+		z-index: 0;
+		display: grid;
+		grid-template-columns: repeat(10, minmax(0, 1fr));
+		grid-template-rows: repeat(2, minmax(0, 1fr));
+		background: linear-gradient(120deg, var(--panel-bg), color-mix(in srgb, var(--accent-soft) 24%, transparent));
+	}
+
+	.chart-mural-bg::after {
+		content: '';
+		position: absolute;
+		inset: 0;
+		background:
+			radial-gradient(circle at 78% 42%, rgba(255,255,255,0.2), transparent 30%),
+			linear-gradient(90deg, rgba(0,0,0,0.06), transparent 42%, rgba(0,0,0,0.02));
+		pointer-events: none;
+	}
+
+	.chart-mural-tile {
+		appearance: none;
+		position: relative;
+		min-width: 0;
+		min-height: 0;
+		padding: 0;
+		border: 0;
+		background: var(--bg-raised);
+		color: var(--text-primary);
+		cursor: pointer;
+		overflow: hidden;
+		opacity: 0.96;
+		filter: saturate(1.18) brightness(1.16);
+		transform: skewX(-7deg) scaleX(1.08);
+		transform-origin: center;
+		transition:
+			filter var(--motion-fast),
+			opacity var(--motion-fast),
+			transform var(--motion-base),
+			box-shadow var(--motion-base);
+	}
+
+	.chart-mural-tile::after {
+		content: '';
+		position: absolute;
+		inset: 0;
+		background: linear-gradient(90deg, rgba(0,0,0,0.18), transparent 48%, rgba(0,0,0,0.2));
+		opacity: 0.18;
+		pointer-events: none;
+	}
+
+	.chart-mural-tile:hover,
+	.chart-mural-tile:focus-visible,
+	.chart-mural-tile--featured {
+		z-index: var(--z-raised);
+		opacity: 1;
+		filter: saturate(1.8) brightness(1.42);
+		transform: skewX(-7deg) scaleX(1.08) scale(1.045);
+		box-shadow:
+			0 0 0 1px rgba(255,255,255,0.32),
+			0 14px 30px rgba(0,0,0,0.32),
+			0 0 24px color-mix(in srgb, var(--accent) 38%, transparent);
+		outline: none;
+	}
+
+	:global(.chart-mural-art),
+	:global(.chart-mural-art.fallback) {
+		display: block;
 		width: 100%;
 		height: 100%;
-		object-fit: cover;
-		display: block;
 	}
 
-	:global(.provider-card-art.fallback),
-	.empty-art {
+	:global(.chart-mural-art) {
+		object-fit: cover;
+		transform: skewX(7deg) scale(1.24);
+		transition: transform var(--motion-base);
+	}
+
+	.chart-mural-tile:hover :global(.chart-mural-art),
+	.chart-mural-tile:focus-visible :global(.chart-mural-art),
+	.chart-mural-tile--featured :global(.chart-mural-art) {
+		transform: skewX(7deg) scale(1.34);
+	}
+
+	:global(.chart-mural-art.fallback) {
 		display: grid;
 		place-items: center;
-		background: linear-gradient(135deg, var(--bg-raised), var(--panel-bg));
-		color: var(--text-muted);
-		font-size: var(--font-size-2xl);
+		background: linear-gradient(135deg, var(--bg-raised), color-mix(in srgb, var(--accent-soft) 28%, var(--bg-surface)));
+		color: rgba(255,255,255,0.78);
+		font-size: var(--font-size-xl);
 		font-weight: var(--font-weight-bold);
 	}
 
-	.provider-card strong,
-	.provider-card span,
-	.provider-card small {
-		min-width: 0;
-		max-width: 100%;
+	.chart-mural-shade {
+		position: absolute;
+		inset: 0;
+		z-index: var(--z-base);
+		background: linear-gradient(90deg, rgba(0,0,0,0.7) 0%, rgba(0,0,0,0.34) 42%, rgba(0,0,0,0.06) 78%, transparent 100%);
+		pointer-events: none;
+	}
+
+	.chart-mural-content {
+		position: relative;
+		z-index: calc(var(--z-base) + 1);
+		display: grid;
+		align-items: center;
+		min-height: inherit;
+		padding: var(--space-5);
+		pointer-events: none;
+	}
+
+	.chart-mural-meta {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-1);
+		max-width: min(42rem, 58vw);
+		text-shadow: 0 2px 18px rgba(0,0,0,0.62);
+	}
+
+	.chart-mural-kind {
+		color: var(--accent);
+		font-size: var(--font-size-2xs);
+		font-weight: var(--font-weight-semibold);
+		letter-spacing: 0;
+		text-transform: uppercase;
+	}
+
+	.chart-mural-title {
+		margin: 0;
+		color: var(--text-primary);
+		font-size: var(--font-size-4xl);
+		font-weight: var(--font-weight-bold);
+		line-height: var(--line-height-tight);
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
 	}
 
-	.provider-card strong {
-		color: var(--text-primary);
+	.chart-mural-sub {
+		margin: 0 0 var(--space-2);
+		color: var(--text-secondary);
+		font-size: var(--font-size-sm);
+	}
+
+	.chart-mural-actions {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		pointer-events: auto;
+	}
+
+	.chart-mural-actions span {
+		color: var(--text-secondary);
+		font-size: var(--font-size-xs);
+		font-weight: var(--font-weight-semibold);
+	}
+
+	.chart-mural-play {
+		display: flex;
+		align-items: center;
+		gap: var(--space-1);
 		font-size: var(--font-size-sm);
 		font-weight: var(--font-weight-semibold);
-		line-height: var(--line-height-snug);
 	}
 
-	.provider-card span:not(.provider-name) {
-		font-size: var(--font-size-xs);
+	.chart-nav {
+		position: absolute;
+		top: 50%;
+		z-index: var(--z-raised);
+		display: grid;
+		place-items: center;
+		width: clamp(32px, 3vw, 40px);
+		aspect-ratio: 1 / 1;
+		border: 1px solid var(--panel-border);
+		border-radius: 50%;
+		background: rgba(0,0,0,0.5);
+		color: var(--text-primary);
+		cursor: pointer;
+		font-size: var(--font-size-xl);
+		line-height: 1;
+		opacity: 0;
+		transform: translateY(-50%);
+		transition: opacity var(--motion-fast), background var(--motion-fast);
+	}
+
+	.chart-mural-card:hover .chart-nav,
+	.chart-nav:focus-visible {
+		opacity: 1;
+		outline: none;
+	}
+
+	.chart-nav:hover {
+		background: rgba(0,0,0,0.75);
+	}
+
+	.chart-nav--prev {
+		left: var(--space-3);
+	}
+
+	.chart-nav--next {
+		right: var(--space-3);
+	}
+
+	.chart-mural-loading {
+		display: grid;
+		place-items: center;
+		min-height: clamp(180px, 20vw, 280px);
+		border: 1px solid var(--panel-border);
+		border-radius: var(--radius-md);
+		background: var(--panel-bg);
 		color: var(--text-secondary);
-	}
-
-	.provider-card small {
-		font-size: var(--font-size-2xs);
-		color: var(--text-muted);
+		font-size: var(--font-size-sm);
+		font-weight: var(--font-weight-semibold);
 	}
 
 	.matrix-shell {
+		display: grid;
+		gap: var(--space-2);
 		overflow-x: auto;
 		padding-bottom: var(--space-1);
+	}
+
+	.matrix-heading {
+		display: flex;
+		align-items: end;
+		justify-content: space-between;
+		gap: var(--gap-sm);
+		min-width: 920px;
+	}
+
+	.matrix-heading p,
+	.matrix-heading h3 {
+		margin: 0;
+	}
+
+	.matrix-heading p {
+		font-size: var(--font-size-xs);
+		font-weight: var(--font-weight-semibold);
+		color: var(--text-muted);
+		text-transform: uppercase;
+		letter-spacing: 0;
+	}
+
+	.matrix-heading h3 {
+		font-size: var(--font-size-lg);
+		font-weight: var(--font-weight-bold);
+		line-height: var(--line-height-tight);
+	}
+
+	.matrix-heading span {
+		color: var(--text-secondary);
+		font-size: var(--font-size-xs);
+		font-weight: var(--font-weight-semibold);
 	}
 
 	.matrix-grid {
@@ -772,162 +949,22 @@
 		color: var(--text-primary);
 	}
 
-	.chart-list {
-		display: grid;
-		gap: var(--space-1);
-	}
-
-	.list-heading {
-		display: flex;
-		align-items: baseline;
-		justify-content: space-between;
-		gap: var(--gap-sm);
-		padding-top: var(--space-1);
-	}
-
-	.list-heading p,
-	.list-heading h3 {
-		margin: 0;
-	}
-
-	.list-heading p {
-		font-size: var(--font-size-xs);
-		font-weight: var(--font-weight-semibold);
-		color: var(--text-muted);
-		text-transform: uppercase;
-		letter-spacing: 0;
-	}
-
-	.list-heading h3 {
-		font-size: var(--font-size-md);
-		font-weight: var(--font-weight-bold);
-		line-height: var(--line-height-tight);
-	}
-
-	.chart-row {
-		display: grid;
-		grid-template-columns: clamp(44px, 5vw, 64px) clamp(42px, 4vw, 52px) minmax(0, 1fr) auto auto;
-		align-items: center;
-		gap: var(--space-3);
-		min-height: clamp(56px, 6vw, 68px);
-		padding: var(--space-2) var(--space-3);
-		border: 1px solid var(--panel-border);
-		border-radius: var(--radius-sm);
-		background: var(--panel-bg);
-	}
-
-	.rank {
-		display: flex;
-		flex-direction: column;
-		gap: var(--space-1);
-		line-height: var(--line-height-tight);
-	}
-
-	.rank span {
-		font-size: var(--font-size-lg);
-		font-weight: var(--font-weight-bold);
-	}
-
-	.rank small {
-		font-size: var(--font-size-2xs);
-		color: var(--text-muted);
-		text-transform: uppercase;
-		letter-spacing: 0;
-	}
-
-	.art-cell {
-		width: clamp(42px, 4vw, 52px);
-		aspect-ratio: 1 / 1;
-		border-radius: var(--radius-xs);
-		overflow: hidden;
-		background: var(--bg-raised);
-	}
-
-	:global(.daily-chart-art) {
-		width: 100%;
-		height: 100%;
-		object-fit: cover;
-		display: block;
-	}
-
-	:global(.daily-chart-art.fallback) {
-		display: grid;
-		place-items: center;
-		color: var(--text-muted);
-		font-size: var(--font-size-sm);
-		font-weight: var(--font-weight-semibold);
-	}
-
-	.track-meta {
-		min-width: 0;
-		display: flex;
-		flex-direction: column;
-		gap: var(--space-1);
-	}
-
-	.track-meta strong,
-	.track-meta span {
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-	}
-
-	.track-meta strong {
-		font-size: var(--font-size-sm);
-		font-weight: var(--font-weight-semibold);
-		line-height: var(--line-height-snug);
-	}
-
-	.track-meta span {
-		font-size: var(--font-size-xs);
-		color: var(--text-secondary);
-	}
-
-	.metric,
-	.status {
-		font-size: var(--font-size-xs);
-		font-weight: var(--font-weight-semibold);
-		color: var(--text-secondary);
-		white-space: nowrap;
-	}
-
-	.status {
-		border-radius: 999px;
-		padding: var(--space-1) var(--space-2);
-		background: var(--bg-hover);
-		color: var(--text-muted);
-		text-transform: capitalize;
-	}
-
-	.status[data-status='local'],
-	.status[data-status='tidal'] {
-		color: var(--text-primary);
-	}
-
-	.skeleton {
-		min-height: clamp(56px, 6vw, 68px);
-		background: linear-gradient(90deg, var(--panel-bg), var(--bg-hover), var(--panel-bg));
-		background-size: 200% 100%;
-		animation: pulse 1.2s linear infinite;
-	}
-
-	@keyframes pulse {
-		from { background-position: 200% 0; }
-		to { background-position: -200% 0; }
-	}
-
 	@media (max-width: 760px) {
-		.provider-card-row {
-			grid-template-columns: repeat(6, minmax(118px, 38vw));
+		.chart-mural-bg {
+			grid-template-columns: repeat(5, minmax(0, 1fr));
+			grid-template-rows: repeat(4, minmax(0, 1fr));
 		}
 
-		.chart-row {
-			grid-template-columns: clamp(36px, 10vw, 48px) clamp(42px, 12vw, 52px) minmax(0, 1fr);
+		.chart-mural-content {
+			padding: var(--space-4);
 		}
 
-		.metric,
-		.status {
-			grid-column: 3;
+		.chart-mural-meta {
+			max-width: 100%;
+		}
+
+		.chart-mural-title {
+			font-size: var(--font-size-3xl);
 		}
 	}
 </style>

--- a/frontend/src/lib/components/charts/DailyChartShelf.svelte
+++ b/frontend/src/lib/components/charts/DailyChartShelf.svelte
@@ -6,9 +6,11 @@
 		type ChartMatrixResponse,
 		type ChartSnapshotEntry,
 		type ChartSnapshotResponse,
+		type TidalSearchTrack,
 	} from '$lib/api/client';
 	import EmptyState from '$lib/components/ui/EmptyState.svelte';
 	import ArtworkImage from '$lib/components/ui/ArtworkImage.svelte';
+	import { playTidalTrackNow, playerError } from '$lib/stores/player';
 
 	const REGIONS = [
 		{ code: 'global', label: 'Global' },
@@ -19,13 +21,15 @@
 		{ code: 'NZ', label: 'NZ' },
 	];
 
-	const SOURCE = 'spotify_daily';
 	const PERIOD = 'daily';
 	const LIMIT = 20;
 
 	let selectedRegion = $state('global');
+	let selectedSource = $state('spotify_daily');
 	let matrix = $state<ChartMatrixResponse | null>(null);
 	let data = $state<ChartSnapshotResponse | null>(null);
+	let resolvedTracks = $state<Record<number, TidalSearchTrack | null>>({});
+	let resolvingEntries = $state<Record<number, boolean>>({});
 	let loading = $state(true);
 	let matrixLoading = $state(true);
 	let refreshingMatrix = $state(false);
@@ -36,7 +40,19 @@
 
 	onMount(() => {
 		void loadMatrix();
-		void loadSnapshot(selectedRegion);
+		void loadSnapshot(selectedRegion, selectedSource);
+	});
+
+	$effect(() => {
+		const cells = selectedRegionCells();
+		if (cells.length === 0) return;
+		void resolveVisibleCells(cells);
+	});
+
+	$effect(() => {
+		const entries = data?.entries ?? [];
+		if (entries.length === 0) return;
+		void resolveVisibleEntries(entries);
 	});
 
 	async function loadMatrix() {
@@ -63,7 +79,7 @@
 		try {
 			await api.refreshChartMatrix();
 			matrix = await api.getChartMatrix();
-			void loadSnapshot(selectedRegion);
+			void loadSnapshot(selectedRegion, selectedSource);
 		} catch (e) {
 			console.error('[daily-charts] matrix refresh failed', e);
 		} finally {
@@ -71,13 +87,13 @@
 		}
 	}
 
-	async function loadSnapshot(region: string) {
+	async function loadSnapshot(region: string, source: string) {
 		const token = ++requestToken;
 		loading = true;
 		error = false;
 		try {
 			const next = await api.getChartSnapshot({
-				source: SOURCE,
+				source,
 				period: PERIOD,
 				region,
 				limit: LIMIT,
@@ -97,7 +113,13 @@
 	function pickRegion(region: string) {
 		if (region === selectedRegion) return;
 		selectedRegion = region;
-		void loadSnapshot(region);
+		void loadSnapshot(region, selectedSource);
+	}
+
+	function pickProvider(region: string, source: string) {
+		selectedRegion = region;
+		selectedSource = source;
+		void loadSnapshot(region, source);
 	}
 
 	function rankDeltaLabel(delta: number | null): string {
@@ -109,14 +131,17 @@
 		if (entry.streams != null) return `${entry.streams.toLocaleString()} streams`;
 		if (entry.views != null) return `${entry.views.toLocaleString()} views`;
 		if (entry.points != null) return `${entry.points.toLocaleString()} pts`;
-		return entry.resolution_status;
+		return entryStatusLabel(entry);
 	}
 
 	function cellMetric(cell: ChartMatrixCell): string {
 		if (cell.streams != null) return `${cell.streams.toLocaleString()} streams`;
 		if (cell.views != null) return `${cell.views.toLocaleString()} views`;
 		if (cell.points != null) return `${cell.points.toLocaleString()} pts`;
-		return cell.resolution_status;
+		if (resolvedTracks[cell.entry_id]?.in_library) return 'In library';
+		if (resolvedTracks[cell.entry_id]) return 'TIDAL ready';
+		if (resolvingEntries[cell.entry_id]) return 'Resolving';
+		return 'Tap to resolve';
 	}
 
 	function matrixHasData(next: ChartMatrixResponse | null): boolean {
@@ -134,6 +159,103 @@
 
 	function selectedRegionLabel(): string {
 		return REGIONS.find((region) => region.code === selectedRegion)?.label ?? selectedRegion;
+	}
+
+	function selectedRegionCells(): ChartMatrixCell[] {
+		const row = matrix?.rows.find((item) => item.region === selectedRegion);
+		if (!row || !matrix) return [];
+		return matrix.providers
+			.map((provider) => row.cells[provider.source_key])
+			.filter((cell): cell is ChartMatrixCell => Boolean(cell));
+	}
+
+	function selectedProviderLabel(): string {
+		return (
+			matrix?.providers.find((provider) => provider.source_key === selectedSource)?.label ??
+			'Spotify'
+		);
+	}
+
+	async function resolveVisibleCells(cells: ChartMatrixCell[]) {
+		await Promise.all(cells.slice(0, 6).map((cell) => resolveCell(cell)));
+	}
+
+	async function resolveVisibleEntries(entries: ChartSnapshotEntry[]) {
+		await Promise.all(entries.slice(0, 12).map((entry) => resolveEntry(entry)));
+	}
+
+	async function resolveCell(cell: ChartMatrixCell): Promise<TidalSearchTrack | null> {
+		return resolveChartItem(cell.entry_id, cell.artist, cell.title, cell.entity_type, cell.tidal_id);
+	}
+
+	async function resolveEntry(entry: ChartSnapshotEntry): Promise<TidalSearchTrack | null> {
+		return resolveChartItem(entry.id, entry.artist, entry.title, entry.entity_type, entry.tidal_id);
+	}
+
+	async function resolveChartItem(
+		entryId: number,
+		artist: string,
+		title: string,
+		entityType: string,
+		tidalId: number | null,
+	): Promise<TidalSearchTrack | null> {
+		if (tidalId || entityType === 'video') return null;
+		if (entryId in resolvedTracks || resolvingEntries[entryId]) {
+			return resolvedTracks[entryId] ?? null;
+		}
+
+		resolvingEntries = { ...resolvingEntries, [entryId]: true };
+		try {
+			const query = [artist, title].filter(Boolean).join(' ');
+			const results = await api.searchTidal(query, 1);
+			const hit = results.tracks[0] ?? null;
+			resolvedTracks = { ...resolvedTracks, [entryId]: hit };
+			return hit;
+		} catch (e) {
+			console.error('[daily-charts] tidal resolve failed', e);
+			resolvedTracks = { ...resolvedTracks, [entryId]: null };
+			return null;
+		} finally {
+			resolvingEntries = { ...resolvingEntries, [entryId]: false };
+		}
+	}
+
+	async function playCell(cell: ChartMatrixCell) {
+		const hit = resolvedTracks[cell.entry_id] ?? (await resolveCell(cell));
+		if (!hit) {
+			playerError.set({ message: "Couldn't find that chart entry on TIDAL." });
+			return;
+		}
+		await playTidalTrackNow({
+			tidal_id: hit.tidal_id,
+			title: hit.title,
+			artist_name: hit.artist_name,
+			album_title: hit.album_title,
+			artwork_url: hit.artwork_url ?? cell.artwork_url,
+			duration_ms: hit.duration_ms,
+			artist_tidal_id: hit.artist_id,
+			album_tidal_id: hit.album_tidal_id,
+		});
+	}
+
+	function cellArtwork(cell: ChartMatrixCell): string | null {
+		return resolvedTracks[cell.entry_id]?.artwork_url ?? cell.artwork_url;
+	}
+
+	function entryArtwork(entry: ChartSnapshotEntry): string | null {
+		return resolvedTracks[entry.id]?.artwork_url ?? entry.artwork_url;
+	}
+
+	function entryStatusLabel(entry: ChartSnapshotEntry): string {
+		if (entry.tidal_id || entry.resolution_status === 'tidal') return 'TIDAL ready';
+		if (resolvedTracks[entry.id]?.in_library) return 'In library';
+		if (resolvedTracks[entry.id]) return 'TIDAL ready';
+		if (resolvingEntries[entry.id]) return 'Resolving';
+		return entry.resolution_status;
+	}
+
+	function cellFallbackText(cell: ChartMatrixCell): string {
+		return (cell.title.trim()[0] ?? 'N').toUpperCase();
 	}
 
 	function fallbackText(entry: ChartSnapshotEntry): string {
@@ -164,6 +286,53 @@
 	</div>
 
 	{#if matrix?.providers.length}
+		<div class="region-pulse" aria-label={`${selectedRegionLabel()} provider leaders`}>
+			<div class="region-pulse-copy">
+				<p>{selectedRegionLabel()} chart leaders</p>
+				<h3>{selectedProviderLabel()}</h3>
+			</div>
+			<div class="provider-card-row">
+				{#each matrix.providers as provider (provider.source_key)}
+					{@const row = matrix.rows.find((item) => item.region === selectedRegion)}
+					{@const cell = row?.cells[provider.source_key] ?? null}
+					<button
+						type="button"
+						class="provider-card"
+						class:active={selectedSource === provider.source_key}
+						class:empty={!cell}
+						onclick={() => {
+							if (cell) {
+								pickProvider(selectedRegion, provider.source_key);
+								void playCell(cell);
+							}
+						}}
+						aria-label={`${provider.label} ${selectedRegionLabel()} leader`}
+					>
+						<span class="provider-name">{provider.label}</span>
+						{#if cell}
+							<div class="provider-art">
+								<ArtworkImage
+									src={cellArtwork(cell)}
+									size={320}
+									className="provider-card-art"
+									fallbackText={cellFallbackText(cell)}
+									decorative
+								/>
+							</div>
+							<strong>{cell.title}</strong>
+							<span>{cell.artist}</span>
+							<small>{cellMetric(cell)}</small>
+						{:else}
+							<div class="provider-art empty-art"></div>
+							<strong>No data</strong>
+							<span>{selectedRegionLabel()}</span>
+							<small>Provider missing</small>
+						{/if}
+					</button>
+				{/each}
+			</div>
+		</div>
+
 		<div class="matrix-shell" aria-label="Market pulse provider matrix">
 			<div class="matrix-grid">
 				<div class="matrix-head region-head">Region</div>
@@ -185,7 +354,11 @@
 							type="button"
 							class="matrix-cell"
 							class:filled={Boolean(cell)}
-							onclick={() => pickRegion(row.region)}
+							class:active={Boolean(cell) && row.region === selectedRegion && provider.source_key === selectedSource}
+							onclick={() => {
+								if (cell) pickProvider(row.region, provider.source_key);
+								else pickRegion(row.region);
+							}}
 							aria-label={`${provider.label} ${row.region}`}
 						>
 							{#if cell}
@@ -215,6 +388,10 @@
 
 	{#if data?.snapshot && data.entries.length > 0}
 		<div class="chart-list" aria-label="Daily chart entries">
+			<div class="list-heading">
+				<p>{selectedRegionLabel()} · {selectedProviderLabel()}</p>
+				<h3>Provider snapshot</h3>
+			</div>
 			{#each data.entries as entry (entry.id)}
 				<div class="chart-row">
 					<div class="rank">
@@ -223,7 +400,7 @@
 					</div>
 					<div class="art-cell">
 						<ArtworkImage
-							src={entry.artwork_url}
+							src={entryArtwork(entry)}
 							size={320}
 							className="daily-chart-art"
 							fallbackText={fallbackText(entry)}
@@ -236,7 +413,7 @@
 					</div>
 					<div class="metric">{formatMetric(entry)}</div>
 					<div class="status" data-status={entry.resolution_status}>
-						{entry.resolution_status}
+						{entryStatusLabel(entry)}
 					</div>
 				</div>
 			{/each}
@@ -259,7 +436,7 @@
 				: 'No market snapshot yet'}
 			copy={matrixHasData(matrix)
 				? regionHasMatrixData(selectedRegion)
-					? 'This region has provider leaders, but no Spotify daily detail list yet.'
+					? `This region has provider leaders, but no ${selectedProviderLabel()} detail list yet.`
 					: 'This region has no provider snapshot yet. Global data is available above.'
 				: 'NOOR tried to refresh the provider matrix, but there is no stored chart data yet.'}
 		/>
@@ -338,6 +515,137 @@
 		opacity: 0.55;
 	}
 
+	.region-pulse {
+		display: grid;
+		gap: var(--space-3);
+	}
+
+	.region-pulse-copy {
+		display: flex;
+		align-items: end;
+		justify-content: space-between;
+		gap: var(--gap-sm);
+	}
+
+	.region-pulse-copy p,
+	.region-pulse-copy h3 {
+		margin: 0;
+	}
+
+	.region-pulse-copy p {
+		font-size: var(--font-size-xs);
+		font-weight: var(--font-weight-semibold);
+		color: var(--text-secondary);
+		text-transform: uppercase;
+		letter-spacing: 0;
+	}
+
+	.region-pulse-copy h3 {
+		font-size: var(--font-size-xl);
+		font-weight: var(--font-weight-bold);
+		line-height: var(--line-height-tight);
+	}
+
+	.provider-card-row {
+		display: grid;
+		grid-template-columns: repeat(6, minmax(132px, 1fr));
+		gap: var(--space-2);
+		overflow-x: auto;
+		padding-bottom: var(--space-1);
+	}
+
+	.provider-card {
+		position: relative;
+		display: grid;
+		grid-template-rows: auto auto auto auto auto;
+		align-content: start;
+		gap: var(--space-1);
+		min-width: 132px;
+		min-height: clamp(210px, 19vw, 260px);
+		padding: var(--space-2);
+		border: 1px solid var(--panel-border);
+		border-radius: var(--radius-sm);
+		background: var(--panel-bg);
+		color: var(--text-secondary);
+		text-align: left;
+		cursor: pointer;
+		transition: background var(--motion-base), border-color var(--motion-base), color var(--motion-base);
+	}
+
+	.provider-card:hover,
+	.provider-card:focus-visible,
+	.provider-card.active {
+		border-color: var(--accent-line);
+		background: var(--bg-hover);
+		color: var(--text-primary);
+		outline: none;
+	}
+
+	.provider-card.empty {
+		cursor: default;
+		opacity: 0.62;
+	}
+
+	.provider-name {
+		font-size: var(--font-size-2xs);
+		font-weight: var(--font-weight-bold);
+		color: var(--service-spotify);
+		text-transform: uppercase;
+		letter-spacing: 0;
+	}
+
+	.provider-art {
+		width: 100%;
+		aspect-ratio: 1 / 1;
+		border-radius: var(--radius-xs);
+		overflow: hidden;
+		background: var(--bg-raised);
+	}
+
+	:global(.provider-card-art) {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		display: block;
+	}
+
+	:global(.provider-card-art.fallback),
+	.empty-art {
+		display: grid;
+		place-items: center;
+		background: linear-gradient(135deg, var(--bg-raised), var(--panel-bg));
+		color: var(--text-muted);
+		font-size: var(--font-size-2xl);
+		font-weight: var(--font-weight-bold);
+	}
+
+	.provider-card strong,
+	.provider-card span,
+	.provider-card small {
+		min-width: 0;
+		max-width: 100%;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.provider-card strong {
+		color: var(--text-primary);
+		font-size: var(--font-size-sm);
+		font-weight: var(--font-weight-semibold);
+		line-height: var(--line-height-snug);
+	}
+
+	.provider-card span:not(.provider-name) {
+		font-size: var(--font-size-xs);
+		color: var(--text-secondary);
+	}
+
+	.provider-card small {
+		font-size: var(--font-size-2xs);
+		color: var(--text-muted);
+	}
+
 	.matrix-shell {
 		overflow-x: auto;
 		padding-bottom: var(--space-1);
@@ -389,7 +697,8 @@
 	.matrix-region:hover,
 	.matrix-cell:hover,
 	.matrix-cell:focus-visible,
-	.matrix-region:focus-visible {
+	.matrix-region:focus-visible,
+	.matrix-cell.active {
 		background: var(--bg-hover);
 		border-color: var(--accent-line);
 		color: var(--text-primary);
@@ -466,6 +775,33 @@
 	.chart-list {
 		display: grid;
 		gap: var(--space-1);
+	}
+
+	.list-heading {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: var(--gap-sm);
+		padding-top: var(--space-1);
+	}
+
+	.list-heading p,
+	.list-heading h3 {
+		margin: 0;
+	}
+
+	.list-heading p {
+		font-size: var(--font-size-xs);
+		font-weight: var(--font-weight-semibold);
+		color: var(--text-muted);
+		text-transform: uppercase;
+		letter-spacing: 0;
+	}
+
+	.list-heading h3 {
+		font-size: var(--font-size-md);
+		font-weight: var(--font-weight-bold);
+		line-height: var(--line-height-tight);
 	}
 
 	.chart-row {
@@ -581,6 +917,10 @@
 	}
 
 	@media (max-width: 760px) {
+		.provider-card-row {
+			grid-template-columns: repeat(6, minmax(118px, 38vw));
+		}
+
 		.chart-row {
 			grid-template-columns: clamp(36px, 10vw, 48px) clamp(42px, 12vw, 52px) minmax(0, 1fr);
 		}

--- a/frontend/src/lib/components/charts/DailyChartShelf.svelte
+++ b/frontend/src/lib/components/charts/DailyChartShelf.svelte
@@ -119,10 +119,21 @@
 		return cell.resolution_status;
 	}
 
-	function matrixHasData(next: ChartMatrixResponse): boolean {
-		return next.rows.some((row) =>
+	function matrixHasData(next: ChartMatrixResponse | null): boolean {
+		return Boolean(next?.rows.some((row) =>
 			next.providers.some((provider) => Boolean(row.cells[provider.source_key])),
+		));
+	}
+
+	function regionHasMatrixData(region: string): boolean {
+		const row = matrix?.rows.find((item) => item.region === region);
+		return Boolean(
+			row && matrix?.providers.some((provider) => Boolean(row.cells[provider.source_key])),
 		);
+	}
+
+	function selectedRegionLabel(): string {
+		return REGIONS.find((region) => region.code === selectedRegion)?.label ?? selectedRegion;
 	}
 
 	function fallbackText(entry: ChartSnapshotEntry): string {
@@ -243,8 +254,14 @@
 		/>
 	{:else}
 		<EmptyState
-			title="No market snapshot yet"
-			copy="NOOR tried to refresh the provider matrix, but there is no stored chart data yet."
+			title={matrixHasData(matrix)
+				? `No Spotify daily list for ${selectedRegionLabel()}`
+				: 'No market snapshot yet'}
+			copy={matrixHasData(matrix)
+				? regionHasMatrixData(selectedRegion)
+					? 'This region has provider leaders, but no Spotify daily detail list yet.'
+					: 'This region has no provider snapshot yet. Global data is available above.'
+				: 'NOOR tried to refresh the provider matrix, but there is no stored chart data yet.'}
 		/>
 	{/if}
 </section>

--- a/frontend/src/lib/components/charts/DailyChartShelf.svelte
+++ b/frontend/src/lib/components/charts/DailyChartShelf.svelte
@@ -1,0 +1,576 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import {
+		api,
+		type ChartMatrixCell,
+		type ChartMatrixResponse,
+		type ChartSnapshotEntry,
+		type ChartSnapshotResponse,
+	} from '$lib/api/client';
+	import EmptyState from '$lib/components/ui/EmptyState.svelte';
+	import ArtworkImage from '$lib/components/ui/ArtworkImage.svelte';
+
+	const REGIONS = [
+		{ code: 'global', label: 'Global' },
+		{ code: 'US', label: 'US' },
+		{ code: 'UK', label: 'UK' },
+		{ code: 'AU', label: 'AU' },
+		{ code: 'CA', label: 'CA' },
+		{ code: 'NZ', label: 'NZ' },
+	];
+
+	const SOURCE = 'spotify_daily';
+	const PERIOD = 'daily';
+	const LIMIT = 20;
+
+	let selectedRegion = $state('global');
+	let matrix = $state<ChartMatrixResponse | null>(null);
+	let data = $state<ChartSnapshotResponse | null>(null);
+	let loading = $state(true);
+	let matrixLoading = $state(true);
+	let refreshingMatrix = $state(false);
+	let error = $state(false);
+	let matrixError = $state(false);
+	let requestToken = 0;
+	let refreshAttempted = false;
+
+	onMount(() => {
+		void loadMatrix();
+		void loadSnapshot(selectedRegion);
+	});
+
+	async function loadMatrix() {
+		matrixLoading = true;
+		matrixError = false;
+		try {
+			const next = await api.getChartMatrix();
+			matrix = next;
+			if (!refreshAttempted && !matrixHasData(next)) {
+				refreshAttempted = true;
+				await refreshMatrix();
+			}
+		} catch (e) {
+			console.error('[daily-charts] matrix fetch failed', e);
+			matrix = null;
+			matrixError = true;
+		} finally {
+			matrixLoading = false;
+		}
+	}
+
+	async function refreshMatrix() {
+		refreshingMatrix = true;
+		try {
+			await api.refreshChartMatrix();
+			matrix = await api.getChartMatrix();
+			void loadSnapshot(selectedRegion);
+		} catch (e) {
+			console.error('[daily-charts] matrix refresh failed', e);
+		} finally {
+			refreshingMatrix = false;
+		}
+	}
+
+	async function loadSnapshot(region: string) {
+		const token = ++requestToken;
+		loading = true;
+		error = false;
+		try {
+			const next = await api.getChartSnapshot({
+				source: SOURCE,
+				period: PERIOD,
+				region,
+				limit: LIMIT,
+			});
+			if (token !== requestToken) return;
+			data = next;
+		} catch (e) {
+			console.error('[daily-charts] snapshot fetch failed', e);
+			if (token !== requestToken) return;
+			data = null;
+			error = true;
+		} finally {
+			if (token === requestToken) loading = false;
+		}
+	}
+
+	function pickRegion(region: string) {
+		if (region === selectedRegion) return;
+		selectedRegion = region;
+		void loadSnapshot(region);
+	}
+
+	function rankDeltaLabel(delta: number | null): string {
+		if (delta == null || delta === 0) return 'steady';
+		return delta > 0 ? `up ${delta}` : `down ${Math.abs(delta)}`;
+	}
+
+	function formatMetric(entry: ChartSnapshotEntry): string {
+		if (entry.streams != null) return `${entry.streams.toLocaleString()} streams`;
+		if (entry.views != null) return `${entry.views.toLocaleString()} views`;
+		if (entry.points != null) return `${entry.points.toLocaleString()} pts`;
+		return entry.resolution_status;
+	}
+
+	function cellMetric(cell: ChartMatrixCell): string {
+		if (cell.streams != null) return `${cell.streams.toLocaleString()} streams`;
+		if (cell.views != null) return `${cell.views.toLocaleString()} views`;
+		if (cell.points != null) return `${cell.points.toLocaleString()} pts`;
+		return cell.resolution_status;
+	}
+
+	function matrixHasData(next: ChartMatrixResponse): boolean {
+		return next.rows.some((row) =>
+			next.providers.some((provider) => Boolean(row.cells[provider.source_key])),
+		);
+	}
+
+	function fallbackText(entry: ChartSnapshotEntry): string {
+		return (entry.title.trim()[0] ?? 'N').toUpperCase();
+	}
+</script>
+
+<section class="daily-chart-shelf">
+	<div class="section-header">
+		<div class="section-title-group">
+			<p class="eyebrow">Charts · Provider matrix</p>
+			<h2>Market pulse</h2>
+		</div>
+		<div class="region-tabs" role="tablist" aria-label="Daily chart region">
+			{#each REGIONS as region (region.code)}
+				<button
+					type="button"
+					class="chip"
+					class:active={region.code === selectedRegion}
+					role="tab"
+					aria-selected={region.code === selectedRegion}
+					onclick={() => pickRegion(region.code)}
+				>
+					{region.label}
+				</button>
+			{/each}
+		</div>
+	</div>
+
+	{#if matrix?.providers.length}
+		<div class="matrix-shell" aria-label="Market pulse provider matrix">
+			<div class="matrix-grid">
+				<div class="matrix-head region-head">Region</div>
+				{#each matrix.providers as provider (provider.source_key)}
+					<div class="matrix-head">{provider.label}</div>
+				{/each}
+				{#each matrix.rows as row (row.region)}
+					<button
+						type="button"
+						class="matrix-region"
+						class:active={row.region === selectedRegion}
+						onclick={() => pickRegion(row.region)}
+					>
+						{row.region === 'global' ? 'Global' : row.region}
+					</button>
+					{#each matrix.providers as provider (provider.source_key)}
+						{@const cell = row.cells[provider.source_key]}
+						<button
+							type="button"
+							class="matrix-cell"
+							class:filled={Boolean(cell)}
+							onclick={() => pickRegion(row.region)}
+							aria-label={`${provider.label} ${row.region}`}
+						>
+							{#if cell}
+								<strong>{cell.title}</strong>
+								<span>{cell.artist}</span>
+								<small>{cellMetric(cell)}</small>
+							{:else}
+								<span>No data</span>
+							{/if}
+						</button>
+					{/each}
+				{/each}
+			</div>
+		</div>
+	{:else if matrixLoading}
+		<div class="provider-strip" aria-label="Loading chart providers">
+			{#each Array.from({ length: 6 }) as _, i (i)}
+				<span class="provider-skeleton">{refreshingMatrix ? 'Refreshing' : 'Loading'}</span>
+			{/each}
+		</div>
+	{:else if matrixError}
+		<EmptyState
+			title="Market matrix unavailable"
+			copy="Restart the NOOR server if this update just landed."
+		/>
+	{/if}
+
+	{#if data?.snapshot && data.entries.length > 0}
+		<div class="chart-list" aria-label="Daily chart entries">
+			{#each data.entries as entry (entry.id)}
+				<div class="chart-row">
+					<div class="rank">
+						<span>{entry.rank}</span>
+						<small>{rankDeltaLabel(entry.rank_delta)}</small>
+					</div>
+					<div class="art-cell">
+						<ArtworkImage
+							src={entry.artwork_url}
+							size={320}
+							className="daily-chart-art"
+							fallbackText={fallbackText(entry)}
+							decorative
+						/>
+					</div>
+					<div class="track-meta">
+						<strong>{entry.title}</strong>
+						<span>{entry.artist}</span>
+					</div>
+					<div class="metric">{formatMetric(entry)}</div>
+					<div class="status" data-status={entry.resolution_status}>
+						{entry.resolution_status}
+					</div>
+				</div>
+			{/each}
+		</div>
+	{:else if loading}
+		<div class="chart-list" aria-label="Loading daily chart">
+			{#each Array.from({ length: 6 }) as _, i (i)}
+				<div class="chart-row skeleton" aria-hidden="true"></div>
+			{/each}
+		</div>
+	{:else if error}
+		<EmptyState
+			title="Daily snapshots unavailable"
+			copy="Restart the NOOR server if this update just landed."
+		/>
+	{:else}
+		<EmptyState
+			title="No market snapshot yet"
+			copy="NOOR tried to refresh the provider matrix, but there is no stored chart data yet."
+		/>
+	{/if}
+</section>
+
+<style>
+	.daily-chart-shelf {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-3);
+	}
+
+	.section-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: var(--gap-sm);
+		flex-wrap: wrap;
+	}
+
+	.section-title-group {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-1);
+	}
+
+	.eyebrow {
+		margin: 0;
+		font-size: var(--font-size-xs);
+		font-weight: var(--font-weight-semibold);
+		text-transform: uppercase;
+		letter-spacing: 0;
+		color: var(--service-spotify);
+	}
+
+	h2 {
+		margin: 0;
+		font-size: var(--font-size-lg);
+		font-weight: var(--font-weight-bold);
+		line-height: var(--line-height-tight);
+	}
+
+	.region-tabs {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--space-1);
+		padding: var(--space-1);
+		border: 1px solid var(--panel-border);
+		border-radius: 999px;
+		background: var(--panel-bg);
+		overflow-x: auto;
+		max-width: 100%;
+	}
+
+	.provider-strip {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(min(112px, 100%), 1fr));
+		gap: var(--space-1);
+	}
+
+	.provider-strip span {
+		border: 1px solid var(--panel-border);
+		border-radius: 999px;
+		background: var(--panel-bg);
+		color: var(--text-secondary);
+		font-size: var(--font-size-xs);
+		font-weight: var(--font-weight-semibold);
+		line-height: 1;
+		padding: var(--space-2) var(--space-3);
+		text-align: center;
+		white-space: nowrap;
+	}
+
+	.provider-skeleton {
+		opacity: 0.55;
+	}
+
+	.matrix-shell {
+		overflow-x: auto;
+		padding-bottom: var(--space-1);
+	}
+
+	.matrix-grid {
+		display: grid;
+		grid-template-columns: clamp(72px, 8vw, 96px) repeat(6, minmax(136px, 1fr));
+		gap: var(--space-1);
+		min-width: 920px;
+	}
+
+	.matrix-head,
+	.matrix-region,
+	.matrix-cell {
+		border: 1px solid var(--panel-border);
+		background: var(--panel-bg);
+		color: var(--text-secondary);
+		border-radius: var(--radius-xs);
+	}
+
+	.matrix-head {
+		padding: var(--space-2) var(--space-3);
+		font-size: var(--font-size-xs);
+		font-weight: var(--font-weight-bold);
+		line-height: 1;
+		text-align: left;
+	}
+
+	.region-head {
+		color: var(--text-muted);
+	}
+
+	.matrix-region,
+	.matrix-cell {
+		min-height: clamp(58px, 6vw, 74px);
+		padding: var(--space-2) var(--space-3);
+		cursor: pointer;
+		transition: background var(--motion-base), border-color var(--motion-base), color var(--motion-base);
+	}
+
+	.matrix-region {
+		font-size: var(--font-size-sm);
+		font-weight: var(--font-weight-bold);
+		text-align: left;
+	}
+
+	.matrix-region.active,
+	.matrix-region:hover,
+	.matrix-cell:hover,
+	.matrix-cell:focus-visible,
+	.matrix-region:focus-visible {
+		background: var(--bg-hover);
+		border-color: var(--accent-line);
+		color: var(--text-primary);
+		outline: none;
+	}
+
+	.matrix-cell {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+		justify-content: center;
+		gap: var(--space-1);
+		text-align: left;
+		min-width: 0;
+	}
+
+	.matrix-cell strong,
+	.matrix-cell span,
+	.matrix-cell small {
+		max-width: 100%;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.matrix-cell strong {
+		color: var(--text-primary);
+		font-size: var(--font-size-xs);
+		font-weight: var(--font-weight-semibold);
+		line-height: var(--line-height-snug);
+	}
+
+	.matrix-cell span {
+		font-size: var(--font-size-xs);
+		color: var(--text-secondary);
+	}
+
+	.matrix-cell small {
+		font-size: var(--font-size-2xs);
+		color: var(--text-muted);
+		line-height: 1;
+	}
+
+	.matrix-cell:not(.filled) {
+		color: var(--text-muted);
+		opacity: 0.72;
+	}
+
+	.chip {
+		border: 0;
+		border-radius: 999px;
+		background: transparent;
+		color: var(--text-muted);
+		font-size: var(--font-size-xs);
+		font-weight: var(--font-weight-semibold);
+		line-height: 1;
+		padding: var(--space-2) var(--space-3);
+		cursor: pointer;
+		white-space: nowrap;
+		transition: background var(--motion-base), color var(--motion-base);
+	}
+
+	.chip:hover,
+	.chip:focus-visible {
+		color: var(--text-primary);
+		outline: none;
+	}
+
+	.chip.active {
+		background: var(--bg-hover);
+		color: var(--text-primary);
+	}
+
+	.chart-list {
+		display: grid;
+		gap: var(--space-1);
+	}
+
+	.chart-row {
+		display: grid;
+		grid-template-columns: clamp(44px, 5vw, 64px) clamp(42px, 4vw, 52px) minmax(0, 1fr) auto auto;
+		align-items: center;
+		gap: var(--space-3);
+		min-height: clamp(56px, 6vw, 68px);
+		padding: var(--space-2) var(--space-3);
+		border: 1px solid var(--panel-border);
+		border-radius: var(--radius-sm);
+		background: var(--panel-bg);
+	}
+
+	.rank {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-1);
+		line-height: var(--line-height-tight);
+	}
+
+	.rank span {
+		font-size: var(--font-size-lg);
+		font-weight: var(--font-weight-bold);
+	}
+
+	.rank small {
+		font-size: var(--font-size-2xs);
+		color: var(--text-muted);
+		text-transform: uppercase;
+		letter-spacing: 0;
+	}
+
+	.art-cell {
+		width: clamp(42px, 4vw, 52px);
+		aspect-ratio: 1 / 1;
+		border-radius: var(--radius-xs);
+		overflow: hidden;
+		background: var(--bg-raised);
+	}
+
+	:global(.daily-chart-art) {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		display: block;
+	}
+
+	:global(.daily-chart-art.fallback) {
+		display: grid;
+		place-items: center;
+		color: var(--text-muted);
+		font-size: var(--font-size-sm);
+		font-weight: var(--font-weight-semibold);
+	}
+
+	.track-meta {
+		min-width: 0;
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-1);
+	}
+
+	.track-meta strong,
+	.track-meta span {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.track-meta strong {
+		font-size: var(--font-size-sm);
+		font-weight: var(--font-weight-semibold);
+		line-height: var(--line-height-snug);
+	}
+
+	.track-meta span {
+		font-size: var(--font-size-xs);
+		color: var(--text-secondary);
+	}
+
+	.metric,
+	.status {
+		font-size: var(--font-size-xs);
+		font-weight: var(--font-weight-semibold);
+		color: var(--text-secondary);
+		white-space: nowrap;
+	}
+
+	.status {
+		border-radius: 999px;
+		padding: var(--space-1) var(--space-2);
+		background: var(--bg-hover);
+		color: var(--text-muted);
+		text-transform: capitalize;
+	}
+
+	.status[data-status='local'],
+	.status[data-status='tidal'] {
+		color: var(--text-primary);
+	}
+
+	.skeleton {
+		min-height: clamp(56px, 6vw, 68px);
+		background: linear-gradient(90deg, var(--panel-bg), var(--bg-hover), var(--panel-bg));
+		background-size: 200% 100%;
+		animation: pulse 1.2s linear infinite;
+	}
+
+	@keyframes pulse {
+		from { background-position: 200% 0; }
+		to { background-position: -200% 0; }
+	}
+
+	@media (max-width: 760px) {
+		.chart-row {
+			grid-template-columns: clamp(36px, 10vw, 48px) clamp(42px, 12vw, 52px) minmax(0, 1fr);
+		}
+
+		.metric,
+		.status {
+			grid-column: 3;
+		}
+	}
+</style>

--- a/frontend/src/lib/components/charts/daily_chart_shelf_contract.test.ts
+++ b/frontend/src/lib/components/charts/daily_chart_shelf_contract.test.ts
@@ -11,11 +11,14 @@ const chartsPage = readFileSync(
 );
 
 describe('daily chart shelf contract', () => {
-	test('loads the additive snapshot endpoint without replacing trending or playlists', () => {
+	test('loads chart snapshots and the provider matrix without replacing trending or playlists', () => {
 		expect(source).toContain('api.getChartSnapshot');
 		expect(source).toContain('api.getChartMatrix');
 		expect(source).toContain('api.refreshChartMatrix');
 		expect(source).toContain("let selectedSource = $state('spotify_daily')");
+		expect(source).toContain('const LIMIT = 20');
+		expect(source).toContain('snapshotRefreshAttempted');
+		expect(source).toContain('next.entries.length < Math.min(10, LIMIT)');
 
 		const trendingIndex = chartsPage.indexOf('<TrendingShelf limit={12} />');
 		const dailyIndex = chartsPage.indexOf('<DailyChartShelf />');
@@ -28,10 +31,9 @@ describe('daily chart shelf contract', () => {
 
 	test('keeps empty and restart states visible when refresh cannot populate data', () => {
 		expect(source).toContain('No market snapshot yet');
-		expect(source).toContain('No Spotify daily list for');
+		expect(source).toContain('No provider leaders for');
 		expect(source).toContain('Global data is available above');
 		expect(source).toContain('NOOR tried to refresh the provider matrix');
-		expect(source).toContain('Daily snapshots unavailable');
 		expect(source).toContain('Restart the NOOR server');
 	});
 
@@ -43,20 +45,23 @@ describe('daily chart shelf contract', () => {
 		expect(source).toContain('regionHasMatrixData(selectedRegion)');
 	});
 
-	test('makes region tabs and provider cards change the active provider snapshot', () => {
-		expect(source).toContain('selectedRegionCells()');
+	test('uses provider chips and a top 20 mural instead of duplicate leader cards', () => {
+		expect(source).toContain('source-tabs');
+		expect(source).toContain('chart-mural-card');
+		expect(source).toContain('chartEntries as entry');
+		expect(source).toContain('currentEntry');
 		expect(source).toContain('pickProvider(selectedRegion, provider.source_key)');
-		expect(source).toContain('loadSnapshot(region, source)');
-		expect(source).toContain('Provider snapshot');
+		expect(source).not.toContain('provider-card');
+		expect(source).not.toContain('Provider snapshot');
 	});
 
-	test('resolves visible provider leaders against TIDAL for artwork and playback', () => {
+	test('resolves visible chart entries against TIDAL for artwork and playback', () => {
 		expect(source).toContain('api.searchTidal(query, 1)');
 		expect(source).toContain('resolvedTracks');
 		expect(source).toContain('playTidalTrackNow');
 		expect(source).toContain('TIDAL ready');
-		expect(source).toContain('provider-card-art');
-		expect(source).toContain('resolveVisibleEntries(entries)');
-		expect(source).toContain('entryStatusLabel(entry)');
+		expect(source).toContain('chart-mural-art');
+		expect(source).toContain('async function resolveVisibleEntries(entries');
+		expect(source).toContain('async function playEntry(entry');
 	});
 });

--- a/frontend/src/lib/components/charts/daily_chart_shelf_contract.test.ts
+++ b/frontend/src/lib/components/charts/daily_chart_shelf_contract.test.ts
@@ -28,6 +28,8 @@ describe('daily chart shelf contract', () => {
 
 	test('keeps empty and restart states visible when refresh cannot populate data', () => {
 		expect(source).toContain('No market snapshot yet');
+		expect(source).toContain('No Spotify daily list for');
+		expect(source).toContain('Global data is available above');
 		expect(source).toContain('NOOR tried to refresh the provider matrix');
 		expect(source).toContain('Daily snapshots unavailable');
 		expect(source).toContain('Restart the NOOR server');
@@ -38,5 +40,6 @@ describe('daily chart shelf contract', () => {
 		expect(source).toContain('{provider.label}');
 		expect(source).toContain('row.cells[provider.source_key]');
 		expect(source).toContain('matrixHasData(next)');
+		expect(source).toContain('regionHasMatrixData(selectedRegion)');
 	});
 });

--- a/frontend/src/lib/components/charts/daily_chart_shelf_contract.test.ts
+++ b/frontend/src/lib/components/charts/daily_chart_shelf_contract.test.ts
@@ -15,7 +15,7 @@ describe('daily chart shelf contract', () => {
 		expect(source).toContain('api.getChartSnapshot');
 		expect(source).toContain('api.getChartMatrix');
 		expect(source).toContain('api.refreshChartMatrix');
-		expect(source).toContain("const SOURCE = 'spotify_daily'");
+		expect(source).toContain("let selectedSource = $state('spotify_daily')");
 
 		const trendingIndex = chartsPage.indexOf('<TrendingShelf limit={12} />');
 		const dailyIndex = chartsPage.indexOf('<DailyChartShelf />');
@@ -41,5 +41,22 @@ describe('daily chart shelf contract', () => {
 		expect(source).toContain('row.cells[provider.source_key]');
 		expect(source).toContain('matrixHasData(next)');
 		expect(source).toContain('regionHasMatrixData(selectedRegion)');
+	});
+
+	test('makes region tabs and provider cards change the active provider snapshot', () => {
+		expect(source).toContain('selectedRegionCells()');
+		expect(source).toContain('pickProvider(selectedRegion, provider.source_key)');
+		expect(source).toContain('loadSnapshot(region, source)');
+		expect(source).toContain('Provider snapshot');
+	});
+
+	test('resolves visible provider leaders against TIDAL for artwork and playback', () => {
+		expect(source).toContain('api.searchTidal(query, 1)');
+		expect(source).toContain('resolvedTracks');
+		expect(source).toContain('playTidalTrackNow');
+		expect(source).toContain('TIDAL ready');
+		expect(source).toContain('provider-card-art');
+		expect(source).toContain('resolveVisibleEntries(entries)');
+		expect(source).toContain('entryStatusLabel(entry)');
 	});
 });

--- a/frontend/src/lib/components/charts/daily_chart_shelf_contract.test.ts
+++ b/frontend/src/lib/components/charts/daily_chart_shelf_contract.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, test } from 'vitest';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(join(here, 'DailyChartShelf.svelte'), 'utf8');
+const chartsPage = readFileSync(
+	join(here, '..', '..', '..', 'routes', 'charts', '+page.svelte'),
+	'utf8',
+);
+
+describe('daily chart shelf contract', () => {
+	test('loads the additive snapshot endpoint without replacing trending or playlists', () => {
+		expect(source).toContain('api.getChartSnapshot');
+		expect(source).toContain('api.getChartMatrix');
+		expect(source).toContain('api.refreshChartMatrix');
+		expect(source).toContain("const SOURCE = 'spotify_daily'");
+
+		const trendingIndex = chartsPage.indexOf('<TrendingShelf limit={12} />');
+		const dailyIndex = chartsPage.indexOf('<DailyChartShelf />');
+		const playlistsIndex = chartsPage.indexOf('<h2 class="block-title">Spotify chart playlists</h2>');
+
+		expect(trendingIndex).toBeGreaterThan(-1);
+		expect(dailyIndex).toBeGreaterThan(trendingIndex);
+		expect(playlistsIndex).toBeGreaterThan(dailyIndex);
+	});
+
+	test('keeps empty and restart states visible when refresh cannot populate data', () => {
+		expect(source).toContain('No market snapshot yet');
+		expect(source).toContain('NOOR tried to refresh the provider matrix');
+		expect(source).toContain('Daily snapshots unavailable');
+		expect(source).toContain('Restart the NOOR server');
+	});
+
+	test('shows the full provider matrix target, not just Spotify', () => {
+		expect(source).toContain('matrix.providers as provider');
+		expect(source).toContain('{provider.label}');
+		expect(source).toContain('row.cells[provider.source_key]');
+		expect(source).toContain('matrixHasData(next)');
+	});
+});

--- a/frontend/src/lib/stores/spotify-chart-meta-cache.test.ts
+++ b/frontend/src/lib/stores/spotify-chart-meta-cache.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
+import type { SpotifyPlaylistDetail } from '$lib/api/client';
+import {
+	clearSpotifyChartMetaCache,
+	getCachedSpotifyChartMeta,
+	getCachedSpotifyChartMetaMap,
+	putCachedSpotifyChartMeta,
+} from './spotify-chart-meta-cache';
+
+function playlist(title: string, thumbnail: string | null): SpotifyPlaylistDetail {
+	return {
+		source: 'spotify',
+		spotifyId: 'spotify-id',
+		type: 'playlist',
+		title,
+		description: null,
+		thumbnail,
+		owner: null,
+		followers: null,
+		totalTracks: null,
+		snapshotId: null,
+		tracks: [],
+	};
+}
+
+describe('Spotify chart metadata cache', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-05-29T00:00:00Z'));
+		clearSpotifyChartMetaCache();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	test('returns cached playlist title and artwork without refetching', () => {
+		putCachedSpotifyChartMeta('chart-1', playlist('Top 50', 'https://img.example/top.jpg'));
+
+		expect(getCachedSpotifyChartMeta('chart-1')).toEqual({
+			title: 'Top 50',
+			thumbnail: 'https://img.example/top.jpg',
+		});
+		expect(getCachedSpotifyChartMetaMap(['chart-1', 'missing'])).toEqual({
+			'chart-1': {
+				title: 'Top 50',
+				thumbnail: 'https://img.example/top.jpg',
+			},
+		});
+	});
+
+	test('expires playlist metadata after six hours', () => {
+		putCachedSpotifyChartMeta('chart-1', playlist('Top 50', null));
+
+		vi.setSystemTime(new Date('2026-05-29T07:00:00Z'));
+
+		expect(getCachedSpotifyChartMeta('chart-1')).toBeNull();
+	});
+});

--- a/frontend/src/lib/stores/spotify-chart-meta-cache.ts
+++ b/frontend/src/lib/stores/spotify-chart-meta-cache.ts
@@ -1,0 +1,82 @@
+import type { SpotifyPlaylistDetail } from '$lib/api/client';
+
+const STORAGE_KEY = 'noor:spotify-chart-meta:v1';
+const TTL_MS = 6 * 60 * 60 * 1000;
+
+export type SpotifyChartMeta = {
+	thumbnail: string | null;
+	title: string | null;
+};
+
+type CacheEntry = SpotifyChartMeta & {
+	insertedAt: number;
+};
+
+let cache: Record<string, CacheEntry> = {};
+let hydrated = false;
+
+function hydrate(): void {
+	if (hydrated || typeof localStorage === 'undefined') return;
+	hydrated = true;
+	try {
+		const raw = localStorage.getItem(STORAGE_KEY);
+		if (!raw) return;
+		const parsed = JSON.parse(raw);
+		if (parsed && typeof parsed === 'object') cache = parsed;
+	} catch {
+		cache = {};
+	}
+}
+
+function persist(): void {
+	if (typeof localStorage === 'undefined') return;
+	try {
+		localStorage.setItem(STORAGE_KEY, JSON.stringify(cache));
+	} catch {
+		// Storage can be disabled or full. The in-memory cache still helps.
+	}
+}
+
+export function getCachedSpotifyChartMeta(id: string): SpotifyChartMeta | null {
+	hydrate();
+	const entry = cache[id];
+	if (!entry) return null;
+	if (Date.now() - entry.insertedAt > TTL_MS) {
+		delete cache[id];
+		persist();
+		return null;
+	}
+	return { thumbnail: entry.thumbnail, title: entry.title };
+}
+
+export function getCachedSpotifyChartMetaMap(ids: string[]): Record<string, SpotifyChartMeta> {
+	hydrate();
+	const out: Record<string, SpotifyChartMeta> = {};
+	for (const id of ids) {
+		const entry = getCachedSpotifyChartMeta(id);
+		if (entry) out[id] = entry;
+	}
+	return out;
+}
+
+export function putCachedSpotifyChartMeta(id: string, playlist: SpotifyPlaylistDetail): void {
+	hydrate();
+	cache[id] = {
+		thumbnail: playlist.thumbnail,
+		title: playlist.title,
+		insertedAt: Date.now(),
+	};
+	persist();
+}
+
+export function clearSpotifyChartMetaCache(): void {
+	cache = {};
+	hydrated = true;
+	if (typeof localStorage !== 'undefined') {
+		try {
+			localStorage.removeItem(STORAGE_KEY);
+		} catch {
+			/* ignore */
+		}
+	}
+}

--- a/frontend/src/routes/charts/+page.svelte
+++ b/frontend/src/routes/charts/+page.svelte
@@ -4,6 +4,12 @@
   import { openContextMenu } from '$lib/stores/context_menu';
   import { goto } from '$app/navigation';
   import TrendingShelf from '$lib/components/charts/TrendingShelf.svelte';
+  import DailyChartShelf from '$lib/components/charts/DailyChartShelf.svelte';
+  import {
+    getCachedSpotifyChartMetaMap,
+    putCachedSpotifyChartMeta,
+    type SpotifyChartMeta,
+  } from '$lib/stores/spotify-chart-meta-cache';
 
   // Editorial Spotify chart playlists. Stable IDs that change daily/weekly
   // server-side but the playlist identity is fixed. Click navigates to the
@@ -27,14 +33,19 @@
 
   // Best-effort cover fetch. The playlist endpoint also returns tracks and
   // TIDAL resolution state, so keep these requests away from first paint.
-  let meta = $state<Record<string, { thumbnail: string | null; title: string | null }>>({});
+  let meta = $state<Record<string, SpotifyChartMeta>>({});
   let metaTimer: ReturnType<typeof setTimeout> | null = null;
   let metaAbort: AbortController | null = null;
 
   onMount(() => {
+    const cached = getCachedSpotifyChartMetaMap(CHARTS.map((chart) => chart.id));
+    meta = cached;
+    const missing = CHARTS.filter((chart) => !cached[chart.id]);
+    if (missing.length === 0) return;
+
     metaAbort = new AbortController();
     metaTimer = setTimeout(() => {
-      void loadPlaylistMeta(metaAbort?.signal);
+      void loadPlaylistMeta(missing, metaAbort?.signal);
     }, 1600);
   });
 
@@ -43,14 +54,15 @@
     metaAbort?.abort();
   });
 
-  async function loadPlaylistMeta(signal: AbortSignal | undefined) {
-    const queue = [...CHARTS];
+  async function loadPlaylistMeta(charts: typeof CHARTS, signal: AbortSignal | undefined) {
+    const queue = [...charts];
     const workers = Array.from({ length: 2 }, async () => {
       while (queue.length > 0 && !signal?.aborted) {
         const c = queue.shift();
         if (!c) return;
         try {
           const { playlist } = await api.getSpotifyPlaylist(c.id, signal);
+          putCachedSpotifyChartMeta(c.id, playlist);
           meta[c.id] = { thumbnail: playlist.thumbnail, title: playlist.title };
         } catch {
           // Quiet: proxy outage just keeps the fallback glyph + hardcoded title.
@@ -78,6 +90,10 @@
 
   <section class="trending-block">
     <TrendingShelf limit={12} />
+  </section>
+
+  <section class="daily-block">
+    <DailyChartShelf />
   </section>
 
   <section>

--- a/frontend/src/routes/charts/+page.svelte
+++ b/frontend/src/routes/charts/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { onDestroy, onMount } from 'svelte';
   import { api } from '$lib/api/client';
   import { openContextMenu } from '$lib/stores/context_menu';
   import { goto } from '$app/navigation';
@@ -25,24 +25,40 @@
     { id: '37i9dQZF1DX4dyzvuaRJ0n', title: 'mint', sub: 'Editorial' },
   ];
 
-  // Best-effort cover fetch. The existing playlist endpoint also returns
-  // tracks + does TIDAL resolution server-side, so this is heavier than it
-  // needs to be -- see FOLLOWUPS for a lightweight metadata endpoint. When
-  // the sportify proxy is slow or down, cards just fall back to the glyph.
+  // Best-effort cover fetch. The playlist endpoint also returns tracks and
+  // TIDAL resolution state, so keep these requests away from first paint.
   let meta = $state<Record<string, { thumbnail: string | null; title: string | null }>>({});
+  let metaTimer: ReturnType<typeof setTimeout> | null = null;
+  let metaAbort: AbortController | null = null;
 
   onMount(() => {
-    void Promise.allSettled(
-      CHARTS.map(async (c) => {
+    metaAbort = new AbortController();
+    metaTimer = setTimeout(() => {
+      void loadPlaylistMeta(metaAbort?.signal);
+    }, 1600);
+  });
+
+  onDestroy(() => {
+    if (metaTimer) clearTimeout(metaTimer);
+    metaAbort?.abort();
+  });
+
+  async function loadPlaylistMeta(signal: AbortSignal | undefined) {
+    const queue = [...CHARTS];
+    const workers = Array.from({ length: 2 }, async () => {
+      while (queue.length > 0 && !signal?.aborted) {
+        const c = queue.shift();
+        if (!c) return;
         try {
-          const { playlist } = await api.getSpotifyPlaylist(c.id);
+          const { playlist } = await api.getSpotifyPlaylist(c.id, signal);
           meta[c.id] = { thumbnail: playlist.thumbnail, title: playlist.title };
         } catch {
           // Quiet: proxy outage just keeps the fallback glyph + hardcoded title.
         }
-      }),
-    );
-  });
+      }
+    });
+    await Promise.allSettled(workers);
+  }
 
   function chartMenu(id: string, title: string) {
     return [

--- a/noor-server/src/db/queries.rs
+++ b/noor-server/src/db/queries.rs
@@ -4,12 +4,426 @@ use anyhow::{Result, bail};
 use rusqlite::{Connection, OptionalExtension, Row, params, params_from_iter};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 pub const DISCOVERY_ENGINE_V2: &str = "v2";
 pub const DISCOVERY_ENGINE_V1: &str = "v1";
 pub const DISCOVERY_ENGINE_V2_FAMILY: &str = "discovery-fusion-v2";
 pub const DISCOVERY_ENGINE_V1_FAMILY: &str = "discovery-fusion";
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ChartSnapshotSummary {
+    pub id: i64,
+    pub source_key: String,
+    pub region: String,
+    pub period: String,
+    pub chart_date: String,
+    pub fetched_at: i64,
+    pub status: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ChartSnapshotEntryRow {
+    pub id: i64,
+    pub rank: i64,
+    pub rank_delta: Option<i64>,
+    pub artist: String,
+    pub title: String,
+    pub entity_type: String,
+    pub album: Option<String>,
+    pub artwork_url: Option<String>,
+    pub external_track_id: Option<String>,
+    pub external_artist_id: Option<String>,
+    pub external_video_id: Option<String>,
+    pub external_url: Option<String>,
+    pub streams: Option<i64>,
+    pub stream_delta: Option<i64>,
+    pub views: Option<i64>,
+    pub likes: Option<i64>,
+    pub audience: Option<f64>,
+    pub audience_delta: Option<f64>,
+    pub points: Option<f64>,
+    pub points_delta: Option<f64>,
+    pub seven_day_streams: Option<i64>,
+    pub total_streams: Option<i64>,
+    pub days_on_chart: Option<i64>,
+    pub peak_rank: Option<i64>,
+    pub provider_positions_json: Option<Value>,
+    pub raw_json: Option<Value>,
+    pub external_candidate_id: Option<i64>,
+    pub local_track_id: Option<i64>,
+    pub tidal_id: Option<i64>,
+    pub resolution_status: String,
+    pub resolution_score: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct LatestChartSnapshot {
+    pub snapshot: ChartSnapshotSummary,
+    pub entries: Vec<ChartSnapshotEntryRow>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ChartMatrixCell {
+    pub snapshot_id: i64,
+    pub entry_id: i64,
+    pub source_key: String,
+    pub region: String,
+    pub chart_date: String,
+    pub rank: i64,
+    pub rank_delta: Option<i64>,
+    pub artist: String,
+    pub title: String,
+    pub entity_type: String,
+    pub artwork_url: Option<String>,
+    pub streams: Option<i64>,
+    pub views: Option<i64>,
+    pub points: Option<f64>,
+    pub external_url: Option<String>,
+    pub tidal_id: Option<i64>,
+    pub resolution_status: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ChartMatrixRow {
+    pub region: String,
+    pub cells: BTreeMap<String, Option<ChartMatrixCell>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ChartSnapshotSeed<'a> {
+    pub source_key: &'a str,
+    pub region: &'a str,
+    pub period: &'a str,
+    pub chart_date: &'a str,
+    pub fetched_at: i64,
+    pub etag: Option<&'a str>,
+    pub content_hash: Option<&'a str>,
+    pub status: &'a str,
+}
+
+#[derive(Debug, Clone)]
+pub struct ChartEntrySeed<'a> {
+    pub rank: i64,
+    pub rank_delta: Option<i64>,
+    pub artist: &'a str,
+    pub title: &'a str,
+    pub entity_type: &'a str,
+    pub album: Option<&'a str>,
+    pub artwork_url: Option<&'a str>,
+    pub external_track_id: Option<&'a str>,
+    pub external_artist_id: Option<&'a str>,
+    pub external_video_id: Option<&'a str>,
+    pub external_url: Option<&'a str>,
+    pub streams: Option<i64>,
+    pub stream_delta: Option<i64>,
+    pub views: Option<i64>,
+    pub likes: Option<i64>,
+    pub audience: Option<f64>,
+    pub audience_delta: Option<f64>,
+    pub points: Option<f64>,
+    pub points_delta: Option<f64>,
+    pub seven_day_streams: Option<i64>,
+    pub total_streams: Option<i64>,
+    pub days_on_chart: Option<i64>,
+    pub peak_rank: Option<i64>,
+    pub provider_positions_json: Option<Value>,
+    pub raw_json: Option<Value>,
+    pub resolution_status: Option<&'a str>,
+    pub tidal_id: Option<i64>,
+    pub local_track_id: Option<i64>,
+    pub external_candidate_id: Option<i64>,
+    pub resolution_score: Option<f64>,
+}
+
+impl<'a> ChartEntrySeed<'a> {
+    pub fn track(rank: i64, artist: &'a str, title: &'a str) -> Self {
+        Self {
+            rank,
+            rank_delta: None,
+            artist,
+            title,
+            entity_type: "track",
+            album: None,
+            artwork_url: None,
+            external_track_id: None,
+            external_artist_id: None,
+            external_video_id: None,
+            external_url: None,
+            streams: None,
+            stream_delta: None,
+            views: None,
+            likes: None,
+            audience: None,
+            audience_delta: None,
+            points: None,
+            points_delta: None,
+            seven_day_streams: None,
+            total_streams: None,
+            days_on_chart: None,
+            peak_rank: None,
+            provider_positions_json: None,
+            raw_json: None,
+            resolution_status: None,
+            tidal_id: None,
+            local_track_id: None,
+            external_candidate_id: None,
+            resolution_score: None,
+        }
+    }
+}
+
+pub fn upsert_chart_snapshot(
+    conn: &Connection,
+    snapshot: &ChartSnapshotSeed<'_>,
+    entries: &[ChartEntrySeed<'_>],
+) -> Result<i64> {
+    let tx = conn.unchecked_transaction()?;
+    tx.execute(
+        "INSERT INTO chart_snapshots
+            (source_key, region, period, chart_date, fetched_at, etag, content_hash, status)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+         ON CONFLICT(source_key, region, period, chart_date)
+         DO UPDATE SET
+            fetched_at = excluded.fetched_at,
+            etag = excluded.etag,
+            content_hash = excluded.content_hash,
+            status = excluded.status",
+        params![
+            snapshot.source_key,
+            snapshot.region,
+            snapshot.period,
+            snapshot.chart_date,
+            snapshot.fetched_at,
+            snapshot.etag,
+            snapshot.content_hash,
+            snapshot.status,
+        ],
+    )?;
+    let snapshot_id: i64 = tx.query_row(
+        "SELECT id FROM chart_snapshots
+         WHERE source_key = ?1 AND region = ?2 AND period = ?3 AND chart_date = ?4",
+        params![
+            snapshot.source_key,
+            snapshot.region,
+            snapshot.period,
+            snapshot.chart_date,
+        ],
+        |row| row.get(0),
+    )?;
+    tx.execute(
+        "DELETE FROM chart_entries WHERE snapshot_id = ?1",
+        params![snapshot_id],
+    )?;
+
+    for entry in entries {
+        tx.execute(
+            "INSERT INTO chart_entries
+                (snapshot_id, rank, rank_delta, artist, title, entity_type, album, artwork_url,
+                 external_track_id, external_artist_id, external_video_id, external_url,
+                 streams, stream_delta, views, likes, audience, audience_delta, points,
+                 points_delta, seven_day_streams, total_streams, days_on_chart, peak_rank,
+                 provider_positions_json, raw_json)
+             VALUES
+                (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14,
+                 ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26)",
+            params![
+                snapshot_id,
+                entry.rank,
+                entry.rank_delta,
+                entry.artist,
+                entry.title,
+                entry.entity_type,
+                entry.album,
+                entry.artwork_url,
+                entry.external_track_id,
+                entry.external_artist_id,
+                entry.external_video_id,
+                entry.external_url,
+                entry.streams,
+                entry.stream_delta,
+                entry.views,
+                entry.likes,
+                entry.audience,
+                entry.audience_delta,
+                entry.points,
+                entry.points_delta,
+                entry.seven_day_streams,
+                entry.total_streams,
+                entry.days_on_chart,
+                entry.peak_rank,
+                entry.provider_positions_json,
+                entry.raw_json,
+            ],
+        )?;
+        let entry_id = tx.last_insert_rowid();
+        tx.execute(
+            "INSERT INTO chart_entry_resolutions
+                (entry_id, external_candidate_id, local_track_id, tidal_id, status, score)
+             VALUES (?1, ?2, ?3, NULLIF(?4, 0), ?5, ?6)",
+            params![
+                entry_id,
+                entry.external_candidate_id,
+                entry.local_track_id,
+                entry.tidal_id,
+                entry.resolution_status.unwrap_or("unresolved"),
+                entry.resolution_score,
+            ],
+        )?;
+    }
+
+    tx.commit()?;
+    Ok(snapshot_id)
+}
+
+pub fn get_latest_chart_snapshot(
+    conn: &Connection,
+    source_key: &str,
+    region: &str,
+    period: &str,
+    limit: u32,
+) -> Result<Option<LatestChartSnapshot>> {
+    let snapshot = conn
+        .query_row(
+            "SELECT id, source_key, region, period, chart_date, fetched_at, status
+             FROM chart_snapshots
+             WHERE source_key = ?1 AND region = ?2 AND period = ?3
+             ORDER BY chart_date DESC, fetched_at DESC, id DESC
+             LIMIT 1",
+            params![source_key, region, period],
+            |row| {
+                Ok(ChartSnapshotSummary {
+                    id: row.get(0)?,
+                    source_key: row.get(1)?,
+                    region: row.get(2)?,
+                    period: row.get(3)?,
+                    chart_date: row.get(4)?,
+                    fetched_at: row.get(5)?,
+                    status: row.get(6)?,
+                })
+            },
+        )
+        .optional()?;
+
+    let Some(snapshot) = snapshot else {
+        return Ok(None);
+    };
+
+    let mut stmt = conn.prepare(
+        "SELECT
+            e.id, e.rank, e.rank_delta, e.artist, e.title, e.entity_type,
+            e.album, e.artwork_url, e.external_track_id, e.external_artist_id,
+            e.external_video_id, e.external_url, e.streams, e.stream_delta,
+            e.views, e.likes, e.audience, e.audience_delta, e.points,
+            e.points_delta, e.seven_day_streams, e.total_streams,
+            e.days_on_chart, e.peak_rank, e.provider_positions_json, e.raw_json,
+            r.external_candidate_id, r.local_track_id, NULLIF(r.tidal_id, 0),
+            COALESCE(r.status, 'unresolved'), r.score
+         FROM chart_entries e
+         LEFT JOIN chart_entry_resolutions r ON r.entry_id = e.id
+         WHERE e.snapshot_id = ?1
+         ORDER BY e.rank ASC
+         LIMIT ?2",
+    )?;
+
+    let entries = stmt
+        .query_map(params![snapshot.id, limit], |row| {
+            Ok(ChartSnapshotEntryRow {
+                id: row.get(0)?,
+                rank: row.get(1)?,
+                rank_delta: row.get(2)?,
+                artist: row.get(3)?,
+                title: row.get(4)?,
+                entity_type: row.get(5)?,
+                album: row.get(6)?,
+                artwork_url: row.get(7)?,
+                external_track_id: row.get(8)?,
+                external_artist_id: row.get(9)?,
+                external_video_id: row.get(10)?,
+                external_url: row.get(11)?,
+                streams: row.get(12)?,
+                stream_delta: row.get(13)?,
+                views: row.get(14)?,
+                likes: row.get(15)?,
+                audience: row.get(16)?,
+                audience_delta: row.get(17)?,
+                points: row.get(18)?,
+                points_delta: row.get(19)?,
+                seven_day_streams: row.get(20)?,
+                total_streams: row.get(21)?,
+                days_on_chart: row.get(22)?,
+                peak_rank: row.get(23)?,
+                provider_positions_json: row.get(24)?,
+                raw_json: row.get(25)?,
+                external_candidate_id: row.get(26)?,
+                local_track_id: row.get(27)?,
+                tidal_id: row.get(28)?,
+                resolution_status: row.get(29)?,
+                resolution_score: row.get(30)?,
+            })
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+
+    Ok(Some(LatestChartSnapshot { snapshot, entries }))
+}
+
+pub fn get_chart_matrix(
+    conn: &Connection,
+    regions: &[&str],
+    source_keys: &[&str],
+    period: &str,
+) -> Result<Vec<ChartMatrixRow>> {
+    let mut stmt = conn.prepare(
+        "SELECT
+            s.id, e.id, s.source_key, s.region, s.chart_date,
+            e.rank, e.rank_delta, e.artist, e.title, e.entity_type,
+            e.artwork_url, e.streams, e.views, e.points, e.external_url,
+            NULLIF(r.tidal_id, 0), COALESCE(r.status, 'unresolved')
+         FROM chart_snapshots s
+         JOIN chart_entries e ON e.snapshot_id = s.id AND e.rank = 1
+         LEFT JOIN chart_entry_resolutions r ON r.entry_id = e.id
+         WHERE s.source_key = ?1 AND s.region = ?2 AND s.period = ?3
+         ORDER BY s.chart_date DESC, s.fetched_at DESC, s.id DESC
+         LIMIT 1",
+    )?;
+
+    let mut rows = Vec::with_capacity(regions.len());
+    for region in regions {
+        let mut cells = BTreeMap::new();
+        for source_key in source_keys {
+            let cell = stmt
+                .query_row(params![source_key, region, period], |row| {
+                    Ok(ChartMatrixCell {
+                        snapshot_id: row.get(0)?,
+                        entry_id: row.get(1)?,
+                        source_key: row.get(2)?,
+                        region: row.get(3)?,
+                        chart_date: row.get(4)?,
+                        rank: row.get(5)?,
+                        rank_delta: row.get(6)?,
+                        artist: row.get(7)?,
+                        title: row.get(8)?,
+                        entity_type: row.get(9)?,
+                        artwork_url: row.get(10)?,
+                        streams: row.get(11)?,
+                        views: row.get(12)?,
+                        points: row.get(13)?,
+                        external_url: row.get(14)?,
+                        tidal_id: row.get(15)?,
+                        resolution_status: row.get(16)?,
+                    })
+                })
+                .optional()?;
+            cells.insert((*source_key).to_string(), cell);
+        }
+        rows.push(ChartMatrixRow {
+            region: (*region).to_string(),
+            cells,
+        });
+    }
+
+    Ok(rows)
+}
 
 // ─── Server Config ────────────────────────────────────────
 

--- a/noor-server/src/db/schema.rs
+++ b/noor-server/src/db/schema.rs
@@ -49,6 +49,7 @@ const MIGRATIONS: &[&str] = &[
     MIGRATION_045,
     MIGRATION_046,
     MIGRATION_047,
+    MIGRATION_048,
 ];
 
 const MIGRATION_001: &str = r#"
@@ -1303,6 +1304,85 @@ ALTER TABLE dj_transition_events ADD COLUMN runtime_renderer_reason TEXT;
 
 const MIGRATION_047: &str = r#"
 ALTER TABLE audio_dj_profiles ADD COLUMN waveform_peaks_blob BLOB NOT NULL DEFAULT X'';
+"#;
+
+const MIGRATION_048: &str = r#"
+CREATE TABLE IF NOT EXISTS chart_sources (
+    id INTEGER PRIMARY KEY,
+    source_key TEXT UNIQUE NOT NULL,
+    display_name TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    enabled INTEGER NOT NULL DEFAULT 1,
+    default_region TEXT,
+    refresh_interval_hours INTEGER NOT NULL DEFAULT 24,
+    last_success_at INTEGER,
+    last_error TEXT
+);
+
+CREATE TABLE IF NOT EXISTS chart_snapshots (
+    id INTEGER PRIMARY KEY,
+    source_key TEXT NOT NULL,
+    region TEXT NOT NULL,
+    period TEXT NOT NULL,
+    chart_date TEXT NOT NULL,
+    fetched_at INTEGER NOT NULL,
+    etag TEXT,
+    content_hash TEXT,
+    status TEXT NOT NULL,
+    UNIQUE (source_key, region, period, chart_date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_chart_snapshots_latest
+    ON chart_snapshots(source_key, region, period, chart_date DESC, fetched_at DESC);
+
+CREATE TABLE IF NOT EXISTS chart_entries (
+    id INTEGER PRIMARY KEY,
+    snapshot_id INTEGER NOT NULL REFERENCES chart_snapshots(id) ON DELETE CASCADE,
+    rank INTEGER NOT NULL,
+    rank_delta INTEGER,
+    artist TEXT NOT NULL,
+    title TEXT NOT NULL,
+    entity_type TEXT NOT NULL DEFAULT 'track',
+    album TEXT,
+    artwork_url TEXT,
+    external_track_id TEXT,
+    external_artist_id TEXT,
+    external_video_id TEXT,
+    external_url TEXT,
+    streams INTEGER,
+    stream_delta INTEGER,
+    views INTEGER,
+    likes INTEGER,
+    audience REAL,
+    audience_delta REAL,
+    points REAL,
+    points_delta REAL,
+    seven_day_streams INTEGER,
+    total_streams INTEGER,
+    days_on_chart INTEGER,
+    peak_rank INTEGER,
+    provider_positions_json TEXT,
+    raw_json TEXT,
+    UNIQUE (snapshot_id, rank)
+);
+
+CREATE INDEX IF NOT EXISTS idx_chart_entries_snapshot_rank
+    ON chart_entries(snapshot_id, rank);
+
+CREATE TABLE IF NOT EXISTS chart_entry_resolutions (
+    entry_id INTEGER PRIMARY KEY REFERENCES chart_entries(id) ON DELETE CASCADE,
+    external_candidate_id INTEGER REFERENCES external_track_candidates(id) ON DELETE SET NULL,
+    local_track_id INTEGER REFERENCES tracks(id) ON DELETE SET NULL,
+    tidal_id INTEGER,
+    status TEXT NOT NULL,
+    score REAL,
+    resolved_at INTEGER,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    last_error TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_chart_entry_resolutions_status
+    ON chart_entry_resolutions(status, resolved_at);
 "#;
 
 pub fn run_migrations(conn: &Connection) -> Result<()> {

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -837,6 +837,19 @@ pub fn api_routes(state: SharedState) -> Router {
         // Trending / charts (Phase 5)
         .route("/api/charts", get(chart_routes::get_charts))
         .route(
+            "/api/charts/snapshots",
+            get(chart_routes::get_chart_snapshots),
+        )
+        .route(
+            "/api/charts/spotify/daily/import",
+            post(chart_routes::import_spotify_daily_snapshot),
+        )
+        .route("/api/charts/matrix", get(chart_routes::get_chart_matrix))
+        .route(
+            "/api/charts/matrix/refresh",
+            post(chart_routes::refresh_chart_matrix),
+        )
+        .route(
             "/api/charts/lastfm/genres",
             get(chart_routes::list_lastfm_genres),
         )
@@ -14345,6 +14358,236 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn chart_snapshots_return_latest_ranked_entries_without_zero_tidal_id() {
+        let (db, db_path) = fresh_migrated_db();
+        db.with_conn(|conn| {
+            conn.execute(
+                "INSERT INTO chart_snapshots
+                    (id, source_key, region, period, chart_date, fetched_at, status)
+                 VALUES
+                    (1, 'spotify_daily', 'AU', 'daily', '2026-05-27', 100, 'ok'),
+                    (2, 'spotify_daily', 'AU', 'daily', '2026-05-28', 200, 'ok')",
+                [],
+            )?;
+            conn.execute(
+                "INSERT INTO chart_entries
+                    (id, snapshot_id, rank, rank_delta, artist, title, entity_type, streams)
+                 VALUES
+                    (10, 1, 1, 0, 'Old Artist', 'Old Track', 'track', 10),
+                    (20, 2, 2, -1, 'Second Artist', 'Second Track', 'track', 200),
+                    (21, 2, 1, 1, 'Top Artist', 'Top Track', 'track', 300)",
+                [],
+            )?;
+            conn.execute(
+                "INSERT INTO chart_entry_resolutions
+                    (entry_id, status, tidal_id)
+                 VALUES
+                    (20, 'unresolved', NULL),
+                    (21, 'tidal', 4242)",
+                [],
+            )?;
+            Ok(())
+        })
+        .expect("seed chart snapshots");
+
+        let response = json_request(
+            app_for_db(db),
+            "GET",
+            "/api/charts/snapshots?source=spotify_daily&period=daily&region=AU&limit=2",
+            "",
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await;
+
+        assert_eq!(body["snapshot"]["chart_date"], "2026-05-28");
+        assert_eq!(body["entries"].as_array().unwrap().len(), 2);
+        assert_eq!(body["entries"][0]["rank"], 1);
+        assert_eq!(body["entries"][0]["title"], "Top Track");
+        assert_eq!(body["entries"][0]["resolution_status"], "tidal");
+        assert_eq!(body["entries"][0]["tidal_id"], 4242);
+        assert_eq!(body["entries"][1]["rank"], 2);
+        assert_eq!(body["entries"][1]["title"], "Second Track");
+        assert_eq!(body["entries"][1]["resolution_status"], "unresolved");
+        assert!(body["entries"][1]["tidal_id"].is_null());
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[tokio::test]
+    async fn chart_matrix_returns_provider_cells_and_explicit_missing_cells() {
+        let (db, db_path) = fresh_migrated_db();
+        db.with_conn(|conn| {
+            queries::upsert_chart_snapshot(
+                conn,
+                &queries::ChartSnapshotSeed {
+                    source_key: "spotify_daily",
+                    region: "global",
+                    period: "daily",
+                    chart_date: "2026-05-27",
+                    fetched_at: 100,
+                    etag: None,
+                    content_hash: None,
+                    status: "ok",
+                },
+                &[queries::ChartEntrySeed {
+                    streams: Some(10),
+                    ..queries::ChartEntrySeed::track(1, "Old Artist", "Old Song")
+                }],
+            )?;
+            queries::upsert_chart_snapshot(
+                conn,
+                &queries::ChartSnapshotSeed {
+                    source_key: "spotify_daily",
+                    region: "global",
+                    period: "daily",
+                    chart_date: "2026-05-28",
+                    fetched_at: 200,
+                    etag: None,
+                    content_hash: None,
+                    status: "ok",
+                },
+                &[
+                    queries::ChartEntrySeed {
+                        streams: Some(500),
+                        tidal_id: Some(5001),
+                        resolution_status: Some("tidal"),
+                        ..queries::ChartEntrySeed::track(1, "Top Artist", "Top Song")
+                    },
+                    queries::ChartEntrySeed {
+                        streams: Some(400),
+                        ..queries::ChartEntrySeed::track(2, "Ignored Artist", "Ignored Song")
+                    },
+                ],
+            )?;
+            queries::upsert_chart_snapshot(
+                conn,
+                &queries::ChartSnapshotSeed {
+                    source_key: "spotify_daily",
+                    region: "global",
+                    period: "daily",
+                    chart_date: "2026-05-28",
+                    fetched_at: 205,
+                    etag: None,
+                    content_hash: Some("same-day-refresh"),
+                    status: "ok",
+                },
+                &[queries::ChartEntrySeed {
+                    streams: Some(550),
+                    tidal_id: Some(5001),
+                    resolution_status: Some("tidal"),
+                    ..queries::ChartEntrySeed::track(1, "Top Artist", "Top Song")
+                }],
+            )?;
+            queries::upsert_chart_snapshot(
+                conn,
+                &queries::ChartSnapshotSeed {
+                    source_key: "youtube_daily",
+                    region: "global",
+                    period: "daily",
+                    chart_date: "2026-05-28",
+                    fetched_at: 210,
+                    etag: None,
+                    content_hash: None,
+                    status: "ok",
+                },
+                &[queries::ChartEntrySeed {
+                    entity_type: "video",
+                    views: Some(900),
+                    resolution_status: Some("not_playable"),
+                    ..queries::ChartEntrySeed::track(1, "Video Artist", "Top Video")
+                }],
+            )?;
+            queries::upsert_chart_snapshot(
+                conn,
+                &queries::ChartSnapshotSeed {
+                    source_key: "shazam_daily",
+                    region: "AU",
+                    period: "daily",
+                    chart_date: "2026-05-28",
+                    fetched_at: 220,
+                    etag: None,
+                    content_hash: None,
+                    status: "ok",
+                },
+                &[queries::ChartEntrySeed::track(1, "AU Artist", "AU Shazam")],
+            )?;
+            Ok(())
+        })
+        .expect("seed chart matrix");
+
+        let response = json_request(app_for_db(db), "GET", "/api/charts/matrix", "").await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await;
+
+        let providers = body["providers"].as_array().expect("providers");
+        assert_eq!(providers.len(), 6);
+        assert_eq!(providers[0]["source_key"], "itunes_daily");
+        assert_eq!(providers[1]["source_key"], "spotify_daily");
+        assert_eq!(providers[2]["source_key"], "apple_music_daily");
+        assert_eq!(providers[3]["source_key"], "youtube_daily");
+        assert_eq!(providers[4]["source_key"], "shazam_daily");
+        assert_eq!(providers[5]["source_key"], "deezer_daily");
+
+        let rows = body["rows"].as_array().expect("rows");
+        let global = rows
+            .iter()
+            .find(|row| row["region"] == "global")
+            .expect("global row");
+        assert_eq!(global["cells"]["spotify_daily"]["title"], "Top Song");
+        assert_eq!(global["cells"]["spotify_daily"]["tidal_id"], 5001);
+        assert_eq!(global["cells"]["spotify_daily"]["streams"], 550);
+        assert_eq!(global["cells"]["spotify_daily"]["chart_date"], "2026-05-28");
+        assert_eq!(global["cells"]["youtube_daily"]["title"], "Top Video");
+        assert!(global["cells"]["itunes_daily"].is_null());
+        assert!(global["cells"]["deezer_daily"].is_null());
+
+        let au = rows
+            .iter()
+            .find(|row| row["region"] == "AU")
+            .expect("AU row");
+        assert_eq!(au["cells"]["shazam_daily"]["title"], "AU Shazam");
+        assert!(au["cells"]["shazam_daily"]["tidal_id"].is_null());
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[tokio::test]
+    async fn spotify_daily_import_endpoint_persists_snapshot_for_matrix() {
+        let (db, db_path) = fresh_migrated_db();
+        let csv = r#"rank,uri,artist_names,track_name,peak_rank,previous_rank,days_on_chart,streams
+1,spotify:track:imported,"Import Artist","Import Track",1,2,3,12345
+"#;
+
+        let response = json_request(
+            app_for_db(db.clone()),
+            "POST",
+            "/api/charts/spotify/daily/import?region=AU&date=2026-05-28",
+            csv,
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await;
+        assert_eq!(body["source"], "spotify_daily");
+        assert_eq!(body["region"], "AU");
+        assert_eq!(body["chart_date"], "2026-05-28");
+
+        let response = json_request(app_for_db(db), "GET", "/api/charts/matrix", "").await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await;
+        let au = body["rows"]
+            .as_array()
+            .expect("rows")
+            .iter()
+            .find(|row| row["region"] == "AU")
+            .expect("AU row");
+        assert_eq!(au["cells"]["spotify_daily"]["title"], "Import Track");
+        assert_eq!(au["cells"]["spotify_daily"]["streams"], 12345);
+
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[tokio::test]
     async fn dj_enabled_true_starts_current_pair_lookahead() {
         let (db, db_path) = fresh_migrated_db();
         let (_current, next) = seed_dj_queue_pair(&db);
@@ -16763,6 +17006,10 @@ mod tests {
             ("GET", "/api/tidal/moods"),
             ("GET", "/api/tidal/mood-page/mood_party"),
             ("GET", "/api/charts"),
+            ("GET", "/api/charts/snapshots"),
+            ("POST", "/api/charts/spotify/daily/import"),
+            ("GET", "/api/charts/matrix"),
+            ("POST", "/api/charts/matrix/refresh"),
             ("GET", "/api/charts/lastfm/genres"),
             ("GET", "/api/charts/lastfm/countries"),
             ("GET", "/api/server/token"),

--- a/noor-server/src/server/routes/chart_routes.rs
+++ b/noor-server/src/server/routes/chart_routes.rs
@@ -30,6 +30,20 @@ pub(super) struct ChartParams {
     tag: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+pub(super) struct ChartSnapshotParams {
+    source: Option<String>,
+    period: Option<String>,
+    region: Option<String>,
+    limit: Option<u32>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct SpotifyDailyImportParams {
+    region: Option<String>,
+    date: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize)]
 struct ChartTidalPlayable {
     tidal_id: i64,
@@ -119,6 +133,17 @@ struct ChartCacheEntry {
     inserted_at: Instant,
     payload: serde_json::Value,
 }
+
+const MATRIX_PROVIDERS: [(&str, &str); 6] = [
+    ("itunes_daily", "iTunes"),
+    ("spotify_daily", "Spotify"),
+    ("apple_music_daily", "Apple Music"),
+    ("youtube_daily", "YouTube"),
+    ("shazam_daily", "Shazam"),
+    ("deezer_daily", "Deezer"),
+];
+
+const MAIN_MATRIX_REGIONS: [&str; 6] = ["global", "US", "UK", "AU", "CA", "NZ"];
 
 fn chart_cache() -> &'static StdMutex<HashMap<String, ChartCacheEntry>> {
     static CACHE: OnceLock<StdMutex<HashMap<String, ChartCacheEntry>>> = OnceLock::new();
@@ -267,6 +292,220 @@ pub(super) async fn get_charts(
     });
     chart_cache_put(cache_key, payload.clone());
     Ok(Json(payload))
+}
+
+pub(super) async fn get_chart_snapshots(
+    State(state): State<SharedState>,
+    Query(params): Query<ChartSnapshotParams>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    let source_key = params
+        .source
+        .as_deref()
+        .map(|s| s.trim().to_ascii_lowercase())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "spotify_daily".to_string());
+    let period = params
+        .period
+        .as_deref()
+        .map(|s| s.trim().to_ascii_lowercase())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "daily".to_string());
+    let region = params
+        .region
+        .as_deref()
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .map(|s| {
+            if s.eq_ignore_ascii_case("global") {
+                "global".to_string()
+            } else {
+                s.to_ascii_uppercase()
+            }
+        })
+        .unwrap_or_else(|| "global".to_string());
+    let limit = params.limit.unwrap_or(50).clamp(1, 200);
+
+    let db = {
+        let s = state.read().await;
+        s.db.clone()
+    };
+    let snapshot = db
+        .with_conn(|conn| {
+            queries::get_latest_chart_snapshot(conn, &source_key, &region, &period, limit)
+        })
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": format!("chart snapshots: {e}") })),
+            )
+        })?;
+
+    match snapshot {
+        Some(snapshot) => Ok(Json(json!({
+            "source": source_key,
+            "period": period,
+            "region": region,
+            "limit": limit,
+            "snapshot": snapshot.snapshot,
+            "entries": snapshot.entries,
+        }))),
+        None => Ok(Json(json!({
+            "source": source_key,
+            "period": period,
+            "region": region,
+            "limit": limit,
+            "snapshot": Value::Null,
+            "entries": [],
+        }))),
+    }
+}
+
+pub(super) async fn import_spotify_daily_snapshot(
+    State(state): State<SharedState>,
+    Query(params): Query<SpotifyDailyImportParams>,
+    body: String,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    let region = normalize_chart_region(params.region.as_deref());
+    let now = chrono::Utc::now();
+    let chart_date = params
+        .date
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| now.date_naive().to_string());
+    let fetched_at = now.timestamp();
+    let db = {
+        let s = state.read().await;
+        s.db.clone()
+    };
+    let snapshot_id = db
+        .with_conn(|conn| {
+            crate::services::charts::spotify_daily::ingest_spotify_daily_csv(
+                conn,
+                &region,
+                &chart_date,
+                fetched_at,
+                &body,
+            )
+        })
+        .map_err(|e| {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": format!("spotify daily import: {e}") })),
+            )
+        })?;
+
+    Ok(Json(json!({
+        "source": "spotify_daily",
+        "period": "daily",
+        "region": region,
+        "chart_date": chart_date,
+        "snapshot_id": snapshot_id,
+    })))
+}
+
+pub(super) async fn get_chart_matrix(
+    State(state): State<SharedState>,
+    Query(params): Query<HashMap<String, String>>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    let region_group = params
+        .get("region_group")
+        .map(|s| s.trim().to_ascii_lowercase())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "main".to_string());
+
+    if region_group != "main" {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "unknown_region_group" })),
+        ));
+    }
+
+    let provider_keys: Vec<&str> = MATRIX_PROVIDERS.iter().map(|(key, _)| *key).collect();
+    let providers: Vec<_> = MATRIX_PROVIDERS
+        .iter()
+        .map(|(source_key, label)| json!({ "source_key": source_key, "label": label }))
+        .collect();
+
+    let db = {
+        let s = state.read().await;
+        s.db.clone()
+    };
+    let rows = db
+        .with_conn(|conn| {
+            queries::get_chart_matrix(conn, &MAIN_MATRIX_REGIONS, &provider_keys, "daily")
+        })
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": format!("chart matrix: {e}") })),
+            )
+        })?;
+
+    Ok(Json(json!({
+        "region_group": region_group,
+        "period": "daily",
+        "providers": providers,
+        "rows": rows,
+    })))
+}
+
+pub(super) async fn refresh_chart_matrix(
+    State(state): State<SharedState>,
+) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
+    let (http, db) = {
+        let s = state.read().await;
+        (s.http_client.clone(), s.db.clone())
+    };
+
+    let html = crate::services::charts::kworb_matrix::fetch_kworb_matrix_html(&http)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::BAD_GATEWAY,
+                Json(json!({ "error": format!("kworb matrix fetch: {e}") })),
+            )
+        })?;
+    let now = chrono::Utc::now();
+    let chart_date = now.date_naive().to_string();
+    let fetched_at = now.timestamp();
+    let report = db
+        .with_conn(|conn| {
+            crate::services::charts::kworb_matrix::ingest_kworb_matrix_html(
+                conn,
+                &chart_date,
+                fetched_at,
+                &html,
+            )
+        })
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": format!("kworb matrix ingest: {e}") })),
+            )
+        })?;
+
+    Ok(Json(json!({
+        "source": "kworb",
+        "chart_date": chart_date,
+        "fetched_at": fetched_at,
+        "report": report,
+    })))
+}
+
+fn normalize_chart_region(value: Option<&str>) -> String {
+    value
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| {
+            if s.eq_ignore_ascii_case("global") {
+                "global".to_string()
+            } else {
+                s.to_ascii_uppercase()
+            }
+        })
+        .unwrap_or_else(|| "global".to_string())
 }
 
 pub(super) async fn list_lastfm_genres() -> Json<Value> {

--- a/noor-server/src/server/routes/chart_routes.rs
+++ b/noor-server/src/server/routes/chart_routes.rs
@@ -69,116 +69,6 @@ const CHART_TRACK_SELECT_COLUMNS: &str =
     LEFT JOIN artists a ON t.artist_id = a.id
     LEFT JOIN albums al ON t.album_id = al.id";
 
-/// Fill in missing artwork for chart entries by searching Tidal for the
-/// (artist, title) pair. Updates `image_url` (top-level fallback) and the
-/// nested `tidal_playable.artwork_url` so the frontend's preference chain
-/// always lands on something usable.
-async fn enrich_chart_artwork(state: &SharedState, entries: &mut Vec<ChartEntryDto>) {
-    use futures::stream::{FuturesUnordered, StreamExt};
-
-    /// Last.fm's blank-star fallback. We never want to surface this: both the
-    /// usable-art check below and the replace-on-enrich path treat it as empty.
-    const LASTFM_PLACEHOLDER: &str = "2a96cbd8b46e442fc41c2b86b821562f";
-
-    fn is_unusable(url: Option<&str>) -> bool {
-        let Some(url) = url else { return true };
-        let trimmed = url.trim();
-        trimmed.is_empty() || trimmed.contains(LASTFM_PLACEHOLDER)
-    }
-
-    fn has_usable_art(e: &ChartEntryDto) -> bool {
-        let local_ok = !is_unusable(
-            e.local_track
-                .as_ref()
-                .and_then(|t| t.artwork_url.as_deref()),
-        );
-        let tp_ok = !is_unusable(
-            e.tidal_playable
-                .as_ref()
-                .and_then(|tp| tp.artwork_url.as_deref()),
-        );
-        let img_ok = !is_unusable(e.image_url.as_deref());
-        local_ok || tp_ok || img_ok
-    }
-
-    let needs: Vec<(usize, String, String)> = entries
-        .iter()
-        .enumerate()
-        .filter_map(|(idx, e)| {
-            if has_usable_art(e) {
-                return None;
-            }
-            let title = e
-                .local_track
-                .as_ref()
-                .map(|t| t.title.clone())
-                .or_else(|| e.tidal_playable.as_ref().map(|tp| tp.title.clone()))?;
-            let artist = e
-                .local_track
-                .as_ref()
-                .and_then(|t| t.artist_name.clone())
-                .or_else(|| {
-                    e.tidal_playable
-                        .as_ref()
-                        .and_then(|tp| tp.artist_name.clone())
-                })?;
-            Some((idx, artist, title))
-        })
-        .collect();
-
-    if needs.is_empty() {
-        return;
-    }
-
-    let (tokens, tidal_http_client) = {
-        let s = state.read().await;
-        (s.tidal_tokens.clone(), s.tidal_http_client.clone())
-    };
-    let tokens = match tokens {
-        Some(t) => Some(t),
-        None => super::load_persisted_tidal_tokens(state)
-            .await
-            .ok()
-            .flatten(),
-    };
-    let Some(tokens) = tokens else {
-        return;
-    };
-
-    let client = TidalClient::with_http(
-        tidal_http_client,
-        tokens.access_token.clone(),
-        tokens.country_code.clone(),
-    );
-
-    let mut tasks = FuturesUnordered::new();
-    for (idx, artist, title) in needs {
-        let client = client.clone();
-        tasks.push(async move {
-            let q = format!("{artist} {title}");
-            let result = client.search(&q, 1).await.ok();
-            let url = result
-                .and_then(|r| r.into_iter().next())
-                .and_then(|t| t.artwork_url);
-            (idx, url)
-        });
-    }
-
-    while let Some((idx, url)) = tasks.next().await {
-        let Some(url) = url else { continue };
-        if let Some(entry) = entries.get_mut(idx) {
-            if is_unusable(entry.image_url.as_deref()) {
-                entry.image_url = Some(url.clone());
-            }
-            if let Some(tp) = entry.tidal_playable.as_mut()
-                && is_unusable(tp.artwork_url.as_deref())
-            {
-                tp.artwork_url = Some(url);
-            }
-        }
-    }
-}
-
 /// Look up the most-confident genre name for each track id in a single query.
 /// Returns a map keyed by track_id; tracks with no genre rows are absent.
 fn fetch_top_genres_for_tracks(
@@ -351,7 +241,7 @@ pub(super) async fn get_charts(
         return Ok(Json(cached));
     }
 
-    let mut entries: Vec<ChartEntryDto> = match source.as_str() {
+    let entries: Vec<ChartEntryDto> = match source.as_str() {
         "tidal" => fetch_tidal_chart(&state, limit as i32).await.map_err(|e| {
             (
                 StatusCode::BAD_GATEWAY,
@@ -367,12 +257,6 @@ pub(super) async fn get_charts(
                 )
             })?,
     };
-
-    // Backfill missing artwork via Tidal search. Last.fm's chart.getTopTracks
-    // mostly returns a generic placeholder image, and many older library albums
-    // have NULL artwork_url, so this is the difference between blank tiles and
-    // real covers on the trending shelf.
-    enrich_chart_artwork(&state, &mut entries).await;
 
     let payload = json!({
         "source": source,

--- a/noor-server/src/server/routes/chart_routes.rs
+++ b/noor-server/src/server/routes/chart_routes.rs
@@ -459,7 +459,7 @@ pub(super) async fn refresh_chart_matrix(
         (s.http_client.clone(), s.db.clone())
     };
 
-    let html = crate::services::charts::kworb_matrix::fetch_kworb_matrix_html(&http)
+    let pages = crate::services::charts::kworb_matrix::fetch_kworb_chart_pages(&http)
         .await
         .map_err(|e| {
             (
@@ -472,11 +472,11 @@ pub(super) async fn refresh_chart_matrix(
     let fetched_at = now.timestamp();
     let report = db
         .with_conn(|conn| {
-            crate::services::charts::kworb_matrix::ingest_kworb_matrix_html(
+            crate::services::charts::kworb_matrix::ingest_kworb_chart_pages(
                 conn,
                 &chart_date,
                 fetched_at,
-                &html,
+                &pages,
             )
         })
         .map_err(|e| {

--- a/noor-server/src/services/charts/kworb_matrix.rs
+++ b/noor-server/src/services/charts/kworb_matrix.rs
@@ -15,6 +15,7 @@ const KWORB_COUNTRY_INDEX_URLS: &[&str] = &[
     "https://kworb.net/charts/index_n.html",
     "https://kworb.net/charts/index_u.html",
 ];
+const MAX_KWORB_DETAIL_ROWS: usize = 200;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct KworbMatrixCell {
@@ -26,11 +27,33 @@ pub struct KworbMatrixCell {
     pub external_url: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KworbChartEntry {
+    pub rank: i64,
+    pub rank_delta: Option<i64>,
+    pub artist: String,
+    pub title: String,
+    pub external_url: Option<String>,
+    pub streams: Option<i64>,
+    pub views: Option<i64>,
+    pub points: Option<i64>,
+    pub seven_day_streams: Option<i64>,
+    pub total_streams: Option<i64>,
+    pub days_on_chart: Option<i64>,
+    pub peak_rank: Option<i64>,
+}
+
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct KworbMatrixIngestReport {
     pub rows_seen: usize,
     pub entries_written: usize,
     pub snapshots_written: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct KworbChartPages {
+    pub matrix_html: String,
+    pub detail_pages: BTreeMap<String, String>,
 }
 
 pub async fn fetch_kworb_matrix_html(client: &reqwest::Client) -> Result<String> {
@@ -45,6 +68,30 @@ pub async fn fetch_kworb_matrix_html(client: &reqwest::Client) -> Result<String>
         }
     }
     Ok(html)
+}
+
+pub async fn fetch_kworb_chart_pages(client: &reqwest::Client) -> Result<KworbChartPages> {
+    let matrix_html = fetch_kworb_matrix_html(client).await?;
+    let detail_urls = kworb_detail_urls_for_matrix_html(&matrix_html).unwrap_or_default();
+    let mut detail_pages = BTreeMap::new();
+    let detail_fetches = detail_urls.into_iter().map(|url| async move {
+        let result = fetch_kworb_page(client, &url).await;
+        (url, result)
+    });
+
+    for (url, result) in futures::future::join_all(detail_fetches).await {
+        match result {
+            Ok(page) => {
+                detail_pages.insert(url, page);
+            }
+            Err(err) => warn!(%url, error = %err, "kworb chart detail page fetch failed"),
+        }
+    }
+
+    Ok(KworbChartPages {
+        matrix_html,
+        detail_pages,
+    })
 }
 
 async fn fetch_kworb_page(client: &reqwest::Client, url: &str) -> Result<String> {
@@ -201,11 +248,147 @@ fn parse_kworb_line_cells(input: &str) -> Vec<KworbMatrixCell> {
     cells
 }
 
+pub fn parse_kworb_detail_html(source_key: &str, input: &str) -> Result<Vec<KworbChartEntry>> {
+    let mut entries = parse_kworb_detail_table_entries(source_key, input);
+
+    let mut seen = BTreeSet::new();
+    entries.retain(|entry| {
+        seen.insert((
+            entry.rank,
+            entry.artist.to_ascii_lowercase(),
+            entry.title.to_ascii_lowercase(),
+        ))
+    });
+    entries.sort_by_key(|entry| entry.rank);
+
+    if entries.is_empty() {
+        return Err(anyhow!("kworb chart detail rows not found"));
+    }
+
+    Ok(entries)
+}
+
+fn parse_kworb_detail_table_entries(source_key: &str, input: &str) -> Vec<KworbChartEntry> {
+    let mut entries = Vec::new();
+    let mut headers: Vec<String> = Vec::new();
+
+    for row in table_rows(input) {
+        let row_cells = table_cells(&row);
+        if row_cells.len() < 2 {
+            continue;
+        }
+
+        let values = row_cells
+            .iter()
+            .map(|cell| plain_text(&cell.html))
+            .collect::<Vec<_>>();
+        if values.iter().any(|value| {
+            let normalized = normalize_label(value);
+            normalized == "artistandtitle" || normalized == "artisttitle"
+        }) {
+            headers = values.iter().map(|value| normalize_label(value)).collect();
+            continue;
+        }
+
+        let Some((rank_index, rank)) = values
+            .iter()
+            .enumerate()
+            .find_map(|(index, value)| parse_rank(value).map(|rank| (index, rank)))
+        else {
+            continue;
+        };
+
+        let Some(title_index) = detail_title_cell_index(&values, rank_index) else {
+            continue;
+        };
+        let (artist, title) = split_artist_title(&values[title_index]);
+        if title.is_empty() {
+            continue;
+        }
+
+        let rank_delta = metric_by_header(&headers, &values, &["p"])
+            .and_then(|value| parse_rank_delta(&value))
+            .or_else(|| {
+                values
+                    .get(rank_index + 1)
+                    .and_then(|value| parse_rank_delta(value))
+            });
+        let streams = if source_key == "spotify_daily" {
+            metric_by_header(&headers, &values, &["streams"])
+                .and_then(|value| parse_integer_metric(&value))
+        } else {
+            None
+        };
+        let views = if source_key == "youtube_daily" {
+            metric_by_header(&headers, &values, &["views"])
+                .and_then(|value| parse_integer_metric(&value))
+        } else {
+            None
+        };
+        let points = if source_key != "spotify_daily" && source_key != "youtube_daily" {
+            metric_by_header(&headers, &values, &["points", "streams", "views"])
+                .and_then(|value| parse_integer_metric(&value))
+        } else {
+            None
+        };
+        let seven_day_streams = metric_by_header(&headers, &values, &["7day"])
+            .and_then(|value| parse_integer_metric(&value));
+        let total_streams = metric_by_header(&headers, &values, &["total"])
+            .and_then(|value| parse_integer_metric(&value));
+        let days_on_chart = metric_by_header(&headers, &values, &["days"])
+            .and_then(|value| parse_integer_metric(&value));
+        let peak_rank = metric_by_header(&headers, &values, &["pk", "peak"])
+            .and_then(|value| parse_rank(&value));
+
+        entries.push(KworbChartEntry {
+            rank,
+            rank_delta,
+            artist,
+            title,
+            external_url: first_href(&row_cells[title_index].html).or_else(|| first_href(&row)),
+            streams,
+            views,
+            points,
+            seven_day_streams,
+            total_streams,
+            days_on_chart,
+            peak_rank,
+        });
+    }
+
+    entries
+}
+
 pub fn ingest_kworb_matrix_html(
     conn: &Connection,
     chart_date: &str,
     fetched_at: i64,
     input: &str,
+) -> Result<KworbMatrixIngestReport> {
+    ingest_kworb_matrix_html_with_details(conn, chart_date, fetched_at, input, &BTreeMap::new())
+}
+
+pub fn ingest_kworb_chart_pages(
+    conn: &Connection,
+    chart_date: &str,
+    fetched_at: i64,
+    pages: &KworbChartPages,
+) -> Result<KworbMatrixIngestReport> {
+    ingest_kworb_matrix_html_with_details(
+        conn,
+        chart_date,
+        fetched_at,
+        &pages.matrix_html,
+        &pages.detail_pages,
+    )
+}
+
+pub fn ingest_kworb_matrix_html_with_details(
+    conn: &Connection,
+    chart_date: &str,
+    fetched_at: i64,
+    input: &str,
+    detail_pages: &BTreeMap<String, String>,
 ) -> Result<KworbMatrixIngestReport> {
     let cells = parse_kworb_matrix_html(input)?;
     let mut grouped: BTreeMap<(String, String), Vec<KworbMatrixCell>> = BTreeMap::new();
@@ -229,18 +412,50 @@ pub fn ingest_kworb_matrix_html(
             content_hash: None,
             status: "ok",
         };
-        let entries = cells
-            .iter()
-            .enumerate()
-            .map(|(index, cell)| ChartEntrySeed {
-                external_url: cell.external_url.as_deref(),
-                raw_json: Some(json!({
-                    "provider": cell.provider_label,
-                    "source": "kworb",
-                })),
-                ..ChartEntrySeed::track((index + 1) as i64, &cell.artist, &cell.title)
-            })
-            .collect::<Vec<_>>();
+        let detail_url = cells.iter().find_map(|cell| cell.external_url.as_deref());
+        let detail_entries = detail_url
+            .and_then(|url| detail_pages.get(url).map(|html| (url, html)))
+            .and_then(|(url, html)| {
+                parse_kworb_detail_html(source_key, html)
+                    .ok()
+                    .map(|rows| (url, rows))
+            });
+        let entries = match detail_entries.as_ref() {
+            Some((url, rows)) if !rows.is_empty() => rows
+                .iter()
+                .take(MAX_KWORB_DETAIL_ROWS)
+                .map(|entry| {
+                    let mut seed = ChartEntrySeed::track(entry.rank, &entry.artist, &entry.title);
+                    seed.rank_delta = entry.rank_delta;
+                    seed.external_url = entry.external_url.as_deref();
+                    seed.streams = entry.streams;
+                    seed.views = entry.views;
+                    seed.points = entry.points.map(|value| value as f64);
+                    seed.seven_day_streams = entry.seven_day_streams;
+                    seed.total_streams = entry.total_streams;
+                    seed.days_on_chart = entry.days_on_chart;
+                    seed.peak_rank = entry.peak_rank;
+                    seed.raw_json = Some(json!({
+                        "provider": cells[0].provider_label,
+                        "source": "kworb",
+                        "detail_url": *url,
+                    }));
+                    seed
+                })
+                .collect::<Vec<_>>(),
+            _ => cells
+                .iter()
+                .enumerate()
+                .map(|(index, cell)| ChartEntrySeed {
+                    external_url: cell.external_url.as_deref(),
+                    raw_json: Some(json!({
+                        "provider": cell.provider_label,
+                        "source": "kworb",
+                    })),
+                    ..ChartEntrySeed::track((index + 1) as i64, &cell.artist, &cell.title)
+                })
+                .collect::<Vec<_>>(),
+        };
         upsert_chart_snapshot(conn, &snapshot, &entries)?;
         entries_written += entries.len();
         snapshots_written += 1;
@@ -374,6 +589,15 @@ fn providers_from_header(line: &str) -> Option<Vec<(&'static str, &'static str)>
     }
 }
 
+fn kworb_detail_urls_for_matrix_html(input: &str) -> Result<BTreeSet<String>> {
+    let cells = parse_kworb_matrix_html(input)?;
+    Ok(cells
+        .into_iter()
+        .filter_map(|cell| cell.external_url)
+        .filter(|url| url.starts_with("https://kworb.net/"))
+        .collect())
+}
+
 fn region_for_country(label: &str) -> Option<&'static str> {
     match normalize_label(label).as_str() {
         "worldwide" | "global" => Some("global"),
@@ -399,6 +623,80 @@ fn split_artist_title(text: &str) -> (String, String) {
         return (artist.trim().to_string(), title.trim().to_string());
     }
     ("Unknown artist".to_string(), text.trim().to_string())
+}
+
+fn detail_title_cell_index(values: &[String], rank_index: usize) -> Option<usize> {
+    values
+        .iter()
+        .enumerate()
+        .skip(rank_index + 1)
+        .find(|(_, value)| value.contains(" - "))
+        .map(|(index, _)| index)
+        .or_else(|| {
+            values
+                .iter()
+                .enumerate()
+                .skip(rank_index + 1)
+                .find(|(_, value)| {
+                    let normalized = normalize_label(value);
+                    !value.is_empty()
+                        && !is_metric_like(value)
+                        && normalized != "re"
+                        && normalized != "new"
+                        && normalized != "steady"
+                })
+                .map(|(index, _)| index)
+        })
+}
+
+fn metric_by_header(headers: &[String], values: &[String], names: &[&str]) -> Option<String> {
+    headers
+        .iter()
+        .enumerate()
+        .find(|(_, header)| names.iter().any(|name| header == name))
+        .and_then(|(index, _)| values.get(index).cloned())
+}
+
+fn parse_rank(value: &str) -> Option<i64> {
+    let digits = value
+        .trim()
+        .chars()
+        .take_while(|ch| ch.is_ascii_digit())
+        .collect::<String>();
+    if digits.is_empty() {
+        None
+    } else {
+        digits.parse::<i64>().ok()
+    }
+}
+
+fn parse_rank_delta(value: &str) -> Option<i64> {
+    let trimmed = value.trim();
+    if trimmed == "=" {
+        return Some(0);
+    }
+    if trimmed.eq_ignore_ascii_case("RE") || trimmed.eq_ignore_ascii_case("NEW") {
+        return None;
+    }
+    let signed = trimmed.replace(',', "");
+    let parsed = signed.parse::<i64>().ok()?;
+    Some(-parsed)
+}
+
+fn parse_integer_metric(value: &str) -> Option<i64> {
+    let normalized = value.trim().trim_start_matches('+').replace(',', "");
+    normalized.parse::<i64>().ok()
+}
+
+fn is_metric_like(value: &str) -> bool {
+    let value = value.trim();
+    value == "="
+        || value.eq_ignore_ascii_case("RE")
+        || value.eq_ignore_ascii_case("NEW")
+        || value
+            .trim_start_matches(['+', '-'])
+            .chars()
+            .all(|ch| ch.is_ascii_digit() || ch == ',' || ch == '.')
 }
 
 fn tr_start_regex() -> &'static Regex {
@@ -432,6 +730,85 @@ fn line_break_regex() -> &'static Regex {
 mod tests {
     use super::*;
     use crate::db::{queries, schema};
+
+    #[test]
+    fn kworb_detail_parser_reads_ranked_track_rows() {
+        let html = r#"
+<table>
+  <tr><th>Pos</th><th>P+</th><th>Artist and Title</th><th>Days</th><th>Pk</th><th>Streams</th><th>7Day</th><th>Total</th></tr>
+  <tr><td>1</td><td>=</td><td><a href="/spotify/track/a.html">Justin Bieber - Beauty And A Beat (feat. Nicki Minaj)</a></td><td>24</td><td>1</td><td>1,234,567</td><td>7,654,321</td><td>45,000,000</td></tr>
+  <tr><td>2</td><td>+3</td><td><a href="/spotify/track/b.html">Drake - ICEMAN</a></td><td>3</td><td>2</td><td>999,999</td><td>2,000,000</td><td>3,000,000</td></tr>
+</table>
+"#;
+
+        let entries = parse_kworb_detail_html("spotify_daily", html).expect("parse detail rows");
+
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].rank, 1);
+        assert_eq!(entries[0].artist, "Justin Bieber");
+        assert_eq!(entries[0].title, "Beauty And A Beat (feat. Nicki Minaj)");
+        assert_eq!(entries[0].streams, Some(1_234_567));
+        assert_eq!(entries[0].seven_day_streams, Some(7_654_321));
+        assert_eq!(entries[0].total_streams, Some(45_000_000));
+        assert_eq!(entries[0].days_on_chart, Some(24));
+        assert_eq!(entries[0].peak_rank, Some(1));
+        assert_eq!(entries[0].rank_delta, Some(0));
+        assert_eq!(entries[1].rank_delta, Some(-3));
+        assert_eq!(
+            entries[1].external_url.as_deref(),
+            Some("https://kworb.net/spotify/track/b.html")
+        );
+    }
+
+    #[test]
+    fn kworb_matrix_ingest_prefers_detail_rows_for_chart_snapshots() {
+        let conn = Connection::open_in_memory().expect("open memory db");
+        schema::run_migrations(&conn).expect("run migrations");
+        let index_html = r#"
+<table>
+  <tr><th>Country</th><th>Spotify</th></tr>
+  <tr><td>Worldwide</td><td><a href="/spotify/country/global_daily.html">Justin Bieber - Beauty And A Beat (feat. Nicki Minaj)</a></td></tr>
+</table>
+"#;
+        let detail_html = r#"
+<table>
+  <tr><th>Pos</th><th>P+</th><th>Artist and Title</th><th>Streams</th></tr>
+  <tr><td>1</td><td>=</td><td><a href="/spotify/track/a.html">Justin Bieber - Beauty And A Beat (feat. Nicki Minaj)</a></td><td>1,234,567</td></tr>
+  <tr><td>2</td><td>-1</td><td><a href="/spotify/track/b.html">Drake - ICEMAN</a></td><td>999,999</td></tr>
+  <tr><td>3</td><td>+4</td><td><a href="/spotify/track/c.html">Olivia Rodrigo - the cure</a></td><td>888,888</td></tr>
+</table>
+"#;
+        let detail_pages = BTreeMap::from([(
+            "https://kworb.net/spotify/country/global_daily.html".to_string(),
+            detail_html.to_string(),
+        )]);
+
+        let report = ingest_kworb_matrix_html_with_details(
+            &conn,
+            "2026-05-29",
+            1234,
+            index_html,
+            &detail_pages,
+        )
+        .expect("ingest detail snapshot");
+
+        assert_eq!(report.entries_written, 3);
+        assert_eq!(report.snapshots_written, 1);
+        let snapshot =
+            queries::get_latest_chart_snapshot(&conn, "spotify_daily", "global", "daily", 20)
+                .expect("read snapshot")
+                .expect("snapshot exists");
+        assert_eq!(snapshot.entries.len(), 3);
+        assert_eq!(snapshot.entries[1].title, "ICEMAN");
+        assert_eq!(snapshot.entries[2].rank, 3);
+        assert_eq!(snapshot.entries[2].streams, Some(888_888));
+        let matrix = queries::get_chart_matrix(&conn, &["global"], &["spotify_daily"], "daily")
+            .expect("read matrix");
+        assert_eq!(
+            matrix[0].cells["spotify_daily"].as_ref().unwrap().title,
+            "Beauty And A Beat (feat. Nicki Minaj)"
+        );
+    }
 
     #[test]
     fn kworb_matrix_ingest_writes_provider_snapshots_for_supported_regions() {

--- a/noor-server/src/services/charts/kworb_matrix.rs
+++ b/noor-server/src/services/charts/kworb_matrix.rs
@@ -259,9 +259,17 @@ struct HtmlCell {
 }
 
 fn table_rows(input: &str) -> Vec<String> {
-    row_regex()
-        .captures_iter(input)
-        .filter_map(|capture| capture.get(1).map(|m| m.as_str().to_string()))
+    tr_start_regex()
+        .split(input)
+        .skip(1)
+        .filter_map(|part| {
+            let row = part.split("</tr>").next().unwrap_or(part);
+            if row.contains("<td") || row.contains("<th") {
+                Some(row.to_string())
+            } else {
+                None
+            }
+        })
         .collect()
 }
 
@@ -393,9 +401,9 @@ fn split_artist_title(text: &str) -> (String, String) {
     ("Unknown artist".to_string(), text.trim().to_string())
 }
 
-fn row_regex() -> &'static Regex {
+fn tr_start_regex() -> &'static Regex {
     static REGEX: OnceLock<Regex> = OnceLock::new();
-    REGEX.get_or_init(|| Regex::new(r#"(?is)<tr[^>]*>(.*?)</tr>"#).expect("row regex"))
+    REGEX.get_or_init(|| Regex::new(r#"(?is)<tr[^>]*>"#).expect("tr start regex"))
 }
 
 fn cell_regex() -> &'static Regex {
@@ -494,6 +502,45 @@ mod tests {
         assert_eq!(
             matrix[1].cells["youtube_daily"].as_ref().unwrap().title,
             "AU YouTube"
+        );
+    }
+
+    #[test]
+    fn kworb_matrix_ingest_handles_kworb_rows_without_closing_tr_tags() {
+        let conn = Connection::open_in_memory().expect("open memory db");
+        schema::run_migrations(&conn).expect("run migrations");
+        let html = r#"
+<table>
+<thead><tr><th>Country</th><th>iTunes</th><th>Spotify</th><th>Apple Music</th><th>YouTube</th><th>Shazam</th><th>Deezer</th></tr></thead><tbody>
+<tr><td><div>Worldwide</div></td><td><div><a href="/ww/index.html">The Chemical Brothers - Go</a></div></td><td><div><a href="/spotify/country/global_daily.html">Justin Bieber - Beauty And A Beat (feat. Nicki Minaj)</a></div></td><td><div><a href="/apple_songs/index.html">Justin Bieber - Beauty and a Beat</a></div></td><td><div><a href="/youtube/index.html">ALPHA DRIVE ONE 'OMG!' MV</a></div></td><td><div><a href="/charts/shazam/ww.html">The Chemical Brothers - Go</a></div></td><td><div><a href="/charts/deezer/ww.html">Ella Langley - Choosin' Texas</a></div></td>
+<tr><td><div>United States</div></td><td><div><a href="/charts/itunes/us.html">Ella Langley - Choosin' Texas</a></div></td><td><div><a href="/spotify/country/us_daily.html">Drake - Janice STFU</a></div></td><td><div><a href="/charts/apple_s/us.html">Drake - Janice STFU</a></div></td><td><div><a href="/youtube/insights/us_daily.html">Ella Langley - Choosin' Texas</a></div></td><td><div><a href="/charts/shazam/us.html">Drake - Janice STFU</a></div></td><td><div><a href="/charts/deezer/us.html">Ella Langley - Choosin' Texas</a></div></td>
+<tr><td><div>Australia</div></td><td><div><a href="/charts/itunes/au.html">Ella Langley - Choosin' Texas</a></div></td><td><div><a href="/spotify/country/au_daily.html">Olivia Rodrigo - the cure</a></div></td><td><div><a href="/charts/apple_s/au.html">Olivia Rodrigo - the cure</a></div></td><td><div><a href="/youtube/insights/au_daily.html">HUNTR/X - Golden</a></div></td><td><div><a href="/charts/shazam/au.html">Josh Fawaz - Like a Prayer</a></div></td><td><div><a href="/charts/deezer/au.html">Sabrina Carpenter - When Did You Get Hot?</a></div></td>
+</tbody></table>
+"#;
+
+        let report =
+            ingest_kworb_matrix_html(&conn, "2026-05-29", 1234, html).expect("ingest matrix");
+
+        assert_eq!(report.entries_written, 18);
+        assert_eq!(report.snapshots_written, 18);
+        let matrix = queries::get_chart_matrix(
+            &conn,
+            &["global", "US", "AU"],
+            &["spotify_daily", "youtube_daily", "deezer_daily"],
+            "daily",
+        )
+        .expect("read matrix");
+        assert_eq!(
+            matrix[1].cells["spotify_daily"].as_ref().unwrap().title,
+            "Janice STFU"
+        );
+        assert_eq!(
+            matrix[1].cells["youtube_daily"].as_ref().unwrap().artist,
+            "Ella Langley"
+        );
+        assert_eq!(
+            matrix[2].cells["deezer_daily"].as_ref().unwrap().title,
+            "When Did You Get Hot?"
         );
     }
 

--- a/noor-server/src/services/charts/kworb_matrix.rs
+++ b/noor-server/src/services/charts/kworb_matrix.rs
@@ -1,0 +1,542 @@
+use crate::db::queries::{ChartEntrySeed, ChartSnapshotSeed, upsert_chart_snapshot};
+use anyhow::{Context, Result, anyhow};
+use regex::Regex;
+use rusqlite::Connection;
+use serde::Serialize;
+use serde_json::json;
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::OnceLock;
+use tracing::warn;
+
+pub const KWORB_CHARTS_URL: &str = "https://kworb.net/charts";
+const KWORB_COUNTRY_INDEX_URLS: &[&str] = &[
+    "https://kworb.net/charts/index_a.html",
+    "https://kworb.net/charts/index_c.html",
+    "https://kworb.net/charts/index_n.html",
+    "https://kworb.net/charts/index_u.html",
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KworbMatrixCell {
+    pub region: String,
+    pub source_key: String,
+    pub provider_label: String,
+    pub artist: String,
+    pub title: String,
+    pub external_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct KworbMatrixIngestReport {
+    pub rows_seen: usize,
+    pub entries_written: usize,
+    pub snapshots_written: usize,
+}
+
+pub async fn fetch_kworb_matrix_html(client: &reqwest::Client) -> Result<String> {
+    let mut html = fetch_kworb_page(client, KWORB_CHARTS_URL).await?;
+    for url in KWORB_COUNTRY_INDEX_URLS {
+        match fetch_kworb_page(client, url).await {
+            Ok(page) => {
+                html.push('\n');
+                html.push_str(&page);
+            }
+            Err(err) => warn!(%url, error = %err, "kworb country chart page fetch failed"),
+        }
+    }
+    Ok(html)
+}
+
+async fn fetch_kworb_page(client: &reqwest::Client, url: &str) -> Result<String> {
+    let response = client
+        .get(url)
+        .send()
+        .await
+        .with_context(|| format!("fetch kworb chart page {url}"))?
+        .error_for_status()
+        .with_context(|| format!("kworb chart page status {url}"))?;
+    response
+        .text()
+        .await
+        .with_context(|| format!("read kworb chart page {url}"))
+}
+
+pub fn parse_kworb_matrix_html(input: &str) -> Result<Vec<KworbMatrixCell>> {
+    let mut cells = parse_kworb_table_cells(input).unwrap_or_default();
+    cells.extend(parse_kworb_line_cells(input));
+
+    let mut seen = BTreeSet::new();
+    cells.retain(|cell| {
+        seen.insert((
+            cell.region.clone(),
+            cell.source_key.clone(),
+            cell.artist.clone(),
+            cell.title.clone(),
+        ))
+    });
+
+    if cells.is_empty() {
+        return Err(anyhow!("kworb matrix rows not found"));
+    }
+
+    Ok(cells)
+}
+
+fn parse_kworb_table_cells(input: &str) -> Result<Vec<KworbMatrixCell>> {
+    let rows = table_rows(input);
+    let header_cells = rows
+        .iter()
+        .map(|row| table_cells(row))
+        .find(|cells| {
+            cells
+                .first()
+                .map(|cell| plain_text(&cell.html).eq_ignore_ascii_case("country"))
+                .unwrap_or(false)
+        })
+        .ok_or_else(|| anyhow!("kworb matrix country header not found"))?;
+
+    let providers = header_cells
+        .iter()
+        .enumerate()
+        .skip(1)
+        .filter_map(|(index, cell)| {
+            let label = plain_text(&cell.html);
+            source_key_for_provider(&label).map(|source_key| (index, source_key, label))
+        })
+        .collect::<Vec<_>>();
+
+    if providers.is_empty() {
+        return Err(anyhow!("kworb matrix provider columns not found"));
+    }
+
+    let mut cells = Vec::new();
+    for row in rows {
+        let row_cells = table_cells(&row);
+        if row_cells.len() < 2 {
+            continue;
+        }
+        let country = plain_text(&row_cells[0].html);
+        if country.eq_ignore_ascii_case("country") {
+            continue;
+        }
+        let Some(region) = region_for_country(&country) else {
+            continue;
+        };
+
+        for (index, source_key, provider_label) in &providers {
+            let Some(cell) = row_cells.get(*index) else {
+                continue;
+            };
+            let text = plain_text(&cell.html);
+            if text.is_empty() || text == "-" {
+                continue;
+            }
+            let (artist, title) = split_artist_title(&text);
+            cells.push(KworbMatrixCell {
+                region: region.to_string(),
+                source_key: (*source_key).to_string(),
+                provider_label: provider_label.clone(),
+                artist,
+                title,
+                external_url: first_href(&cell.html),
+            });
+        }
+    }
+
+    Ok(cells)
+}
+
+fn parse_kworb_line_cells(input: &str) -> Vec<KworbMatrixCell> {
+    let lines = html_lines(input);
+    let mut cells = Vec::new();
+    let mut index = 0usize;
+    while index < lines.len() {
+        let Some(providers) = providers_from_header(&lines[index]) else {
+            index += 1;
+            continue;
+        };
+        index += 1;
+
+        while index < lines.len() {
+            let line = &lines[index];
+            if providers_from_header(line).is_some() {
+                break;
+            }
+            if line.ends_with(':') {
+                index += 1;
+                continue;
+            }
+            let Some(region) = region_for_country(line) else {
+                index += 1;
+                continue;
+            };
+            index += 1;
+
+            for (source_key, provider_label) in &providers {
+                while index < lines.len() && lines[index].ends_with(':') {
+                    index += 1;
+                }
+                if index >= lines.len()
+                    || providers_from_header(&lines[index]).is_some()
+                    || region_for_country(&lines[index]).is_some()
+                {
+                    break;
+                }
+                let text = &lines[index];
+                if !text.is_empty() && text != "-" {
+                    let (artist, title) = split_artist_title(text);
+                    cells.push(KworbMatrixCell {
+                        region: region.to_string(),
+                        source_key: (*source_key).to_string(),
+                        provider_label: (*provider_label).to_string(),
+                        artist,
+                        title,
+                        external_url: None,
+                    });
+                }
+                index += 1;
+            }
+        }
+    }
+    cells
+}
+
+pub fn ingest_kworb_matrix_html(
+    conn: &Connection,
+    chart_date: &str,
+    fetched_at: i64,
+    input: &str,
+) -> Result<KworbMatrixIngestReport> {
+    let cells = parse_kworb_matrix_html(input)?;
+    let mut grouped: BTreeMap<(String, String), Vec<KworbMatrixCell>> = BTreeMap::new();
+    for cell in cells {
+        grouped
+            .entry((cell.source_key.clone(), cell.region.clone()))
+            .or_default()
+            .push(cell);
+    }
+
+    let mut entries_written = 0usize;
+    let mut snapshots_written = 0usize;
+    for ((source_key, region), cells) in &grouped {
+        let snapshot = ChartSnapshotSeed {
+            source_key,
+            region,
+            period: "daily",
+            chart_date,
+            fetched_at,
+            etag: None,
+            content_hash: None,
+            status: "ok",
+        };
+        let entries = cells
+            .iter()
+            .enumerate()
+            .map(|(index, cell)| ChartEntrySeed {
+                external_url: cell.external_url.as_deref(),
+                raw_json: Some(json!({
+                    "provider": cell.provider_label,
+                    "source": "kworb",
+                })),
+                ..ChartEntrySeed::track((index + 1) as i64, &cell.artist, &cell.title)
+            })
+            .collect::<Vec<_>>();
+        upsert_chart_snapshot(conn, &snapshot, &entries)?;
+        entries_written += entries.len();
+        snapshots_written += 1;
+    }
+
+    Ok(KworbMatrixIngestReport {
+        rows_seen: grouped.len(),
+        entries_written,
+        snapshots_written,
+    })
+}
+
+#[derive(Debug)]
+struct HtmlCell {
+    html: String,
+}
+
+fn table_rows(input: &str) -> Vec<String> {
+    row_regex()
+        .captures_iter(input)
+        .filter_map(|capture| capture.get(1).map(|m| m.as_str().to_string()))
+        .collect()
+}
+
+fn table_cells(row: &str) -> Vec<HtmlCell> {
+    cell_regex()
+        .captures_iter(row)
+        .filter_map(|capture| {
+            capture.get(1).map(|m| HtmlCell {
+                html: m.as_str().to_string(),
+            })
+        })
+        .collect()
+}
+
+fn plain_text(input: &str) -> String {
+    let without_tags = tag_regex().replace_all(input, " ");
+    decode_entities(&without_tags)
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn html_lines(input: &str) -> Vec<String> {
+    let with_breaks = line_break_regex().replace_all(input, "\n");
+    let without_tags = tag_regex().replace_all(&with_breaks, " ");
+    decode_entities(&without_tags)
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(|line| line.split_whitespace().collect::<Vec<_>>().join(" "))
+        .collect()
+}
+
+fn decode_entities(input: &str) -> String {
+    input
+        .replace("&amp;", "&")
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+        .replace("&apos;", "'")
+        .replace("&nbsp;", " ")
+        .replace("&ndash;", "-")
+        .replace("&mdash;", "-")
+}
+
+fn first_href(input: &str) -> Option<String> {
+    href_regex()
+        .captures(input)
+        .and_then(|capture| capture.get(1).map(|m| decode_entities(m.as_str())))
+        .map(|href| {
+            if href.starts_with("http://") || href.starts_with("https://") {
+                href
+            } else {
+                format!("https://kworb.net/{}", href.trim_start_matches('/'))
+            }
+        })
+}
+
+fn source_key_for_provider(label: &str) -> Option<&'static str> {
+    match normalize_label(label).as_str() {
+        "itunes" => Some("itunes_daily"),
+        "spotify" => Some("spotify_daily"),
+        "applemusic" => Some("apple_music_daily"),
+        "youtube" => Some("youtube_daily"),
+        "shazam" => Some("shazam_daily"),
+        "deezer" => Some("deezer_daily"),
+        _ => None,
+    }
+}
+
+fn providers_from_header(line: &str) -> Option<Vec<(&'static str, &'static str)>> {
+    let normalized = normalize_label(line);
+    if !normalized.starts_with("country") {
+        return None;
+    }
+
+    let mut providers = [
+        ("itunes", "itunes_daily", "iTunes"),
+        ("spotify", "spotify_daily", "Spotify"),
+        ("applemusic", "apple_music_daily", "Apple Music"),
+        ("youtube", "youtube_daily", "YouTube"),
+        ("shazam", "shazam_daily", "Shazam"),
+        ("deezer", "deezer_daily", "Deezer"),
+    ]
+    .into_iter()
+    .filter_map(|(needle, source_key, label)| {
+        normalized
+            .find(needle)
+            .map(|position| (position, source_key, label))
+    })
+    .collect::<Vec<_>>();
+
+    providers.sort_by_key(|(position, _, _)| *position);
+    if providers.is_empty() {
+        None
+    } else {
+        Some(
+            providers
+                .into_iter()
+                .map(|(_, source_key, label)| (source_key, label))
+                .collect(),
+        )
+    }
+}
+
+fn region_for_country(label: &str) -> Option<&'static str> {
+    match normalize_label(label).as_str() {
+        "worldwide" | "global" => Some("global"),
+        "unitedstates" | "usa" | "us" => Some("US"),
+        "unitedkingdom" | "uk" => Some("UK"),
+        "australia" | "au" => Some("AU"),
+        "canada" | "ca" => Some("CA"),
+        "newzealand" | "nz" => Some("NZ"),
+        _ => None,
+    }
+}
+
+fn normalize_label(label: &str) -> String {
+    label
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric())
+        .collect::<String>()
+        .to_ascii_lowercase()
+}
+
+fn split_artist_title(text: &str) -> (String, String) {
+    if let Some((artist, title)) = text.split_once(" - ") {
+        return (artist.trim().to_string(), title.trim().to_string());
+    }
+    ("Unknown artist".to_string(), text.trim().to_string())
+}
+
+fn row_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| Regex::new(r#"(?is)<tr[^>]*>(.*?)</tr>"#).expect("row regex"))
+}
+
+fn cell_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| Regex::new(r#"(?is)<t[dh][^>]*>(.*?)</t[dh]>"#).expect("cell regex"))
+}
+
+fn tag_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| Regex::new(r#"(?is)<[^>]+>"#).expect("tag regex"))
+}
+
+fn href_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| Regex::new(r#"(?is)<a\s+[^>]*href=["']([^"']+)["']"#).expect("href regex"))
+}
+
+fn line_break_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| {
+        Regex::new(r#"(?is)</(?:a|td|th|tr|p|div|li|h[1-6])>|<br\s*/?>"#).expect("line break regex")
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::{queries, schema};
+
+    #[test]
+    fn kworb_matrix_ingest_writes_provider_snapshots_for_supported_regions() {
+        let conn = Connection::open_in_memory().expect("open memory db");
+        schema::run_migrations(&conn).expect("run migrations");
+        let html = r#"
+<table>
+  <tr><th>Country</th><th>iTunes</th><th>Spotify</th><th>Apple Music</th><th>YouTube</th><th>Shazam</th><th>Deezer</th></tr>
+  <tr>
+    <td>Worldwide</td>
+    <td><a href="/itunes/song/a.html">Artist A - Song A</a></td>
+    <td><a href="/spotify/track/b.html">Artist B - Song B</a></td>
+    <td>Artist C - Song C</td>
+    <td>Artist D - Song D</td>
+    <td>Artist E - Song E</td>
+    <td>Artist F - Song F</td>
+  </tr>
+  <tr>
+    <td>Australia</td>
+    <td>AU Artist - AU iTunes</td>
+    <td>AU Artist - AU Spotify</td>
+    <td>-</td>
+    <td>AU Video - AU YouTube</td>
+    <td>AU Shazam - AU Song</td>
+    <td>AU Deezer - AU Song</td>
+  </tr>
+</table>
+"#;
+
+        let report =
+            ingest_kworb_matrix_html(&conn, "2026-05-28", 1234, html).expect("ingest matrix");
+
+        assert_eq!(report.entries_written, 11);
+        assert_eq!(report.snapshots_written, 11);
+        let matrix = queries::get_chart_matrix(
+            &conn,
+            &["global", "AU"],
+            &[
+                "itunes_daily",
+                "spotify_daily",
+                "apple_music_daily",
+                "youtube_daily",
+            ],
+            "daily",
+        )
+        .expect("read matrix");
+        assert_eq!(
+            matrix[0].cells["itunes_daily"].as_ref().unwrap().title,
+            "Song A"
+        );
+        assert_eq!(
+            matrix[0].cells["itunes_daily"]
+                .as_ref()
+                .unwrap()
+                .external_url
+                .as_deref(),
+            Some("https://kworb.net/itunes/song/a.html")
+        );
+        assert_eq!(
+            matrix[0].cells["spotify_daily"].as_ref().unwrap().artist,
+            "Artist B"
+        );
+        assert_eq!(
+            matrix[1].cells["spotify_daily"].as_ref().unwrap().title,
+            "AU Spotify"
+        );
+        assert!(matrix[1].cells["apple_music_daily"].is_none());
+        assert_eq!(
+            matrix[1].cells["youtube_daily"].as_ref().unwrap().title,
+            "AU YouTube"
+        );
+    }
+
+    #[test]
+    fn kworb_line_matrix_parser_handles_rendered_country_sequences() {
+        let text = r#"
+Country iTunes Spotify Apple Music YouTube Shazam Deezer
+Worldwide
+Muse - Hexagons
+Michael Jackson - Billie Jean
+Drake - Janice STFU
+ZEROBASEONE - TOP 5
+The Chemical Brothers - Go
+Ella Langley - Choosin' Texas
+United States
+Ella Langley - Choosin' Texas
+Drake - Janice STFU
+Drake - Janice STFU
+Drake - Janice STFU
+Ella Langley - Choosin' Texas
+Ella Langley - Choosin' Texas
+Australia
+The Chemical Brothers - Go
+Ella Langley - Choosin' Texas
+Drake - Janice STFU
+HUNTR/X - Golden
+The Chemical Brothers - Go
+Olivia Rodrigo - drop dead
+"#;
+
+        let cells = parse_kworb_matrix_html(text).expect("parse rendered text");
+
+        let au_spotify = cells
+            .iter()
+            .find(|cell| cell.region == "AU" && cell.source_key == "spotify_daily")
+            .expect("AU Spotify");
+        assert_eq!(au_spotify.artist, "Ella Langley");
+        assert_eq!(au_spotify.title, "Choosin' Texas");
+        let us_youtube = cells
+            .iter()
+            .find(|cell| cell.region == "US" && cell.source_key == "youtube_daily")
+            .expect("US YouTube");
+        assert_eq!(us_youtube.artist, "Drake");
+        assert_eq!(us_youtube.title, "Janice STFU");
+    }
+}

--- a/noor-server/src/services/charts/mod.rs
+++ b/noor-server/src/services/charts/mod.rs
@@ -1,1 +1,3 @@
 pub mod curated;
+pub mod kworb_matrix;
+pub mod spotify_daily;

--- a/noor-server/src/services/charts/spotify_daily.rs
+++ b/noor-server/src/services/charts/spotify_daily.rs
@@ -1,0 +1,302 @@
+use crate::db::queries::{ChartEntrySeed, ChartSnapshotSeed, upsert_chart_snapshot};
+use anyhow::{Context, Result, anyhow};
+use rusqlite::Connection;
+use serde_json::json;
+use sha2::{Digest, Sha256};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpotifyDailyChartRow {
+    pub rank: i64,
+    pub rank_delta: Option<i64>,
+    pub artist: String,
+    pub title: String,
+    pub spotify_track_id: Option<String>,
+    pub external_url: Option<String>,
+    pub streams: Option<i64>,
+    pub peak_rank: Option<i64>,
+    pub days_on_chart: Option<i64>,
+}
+
+impl SpotifyDailyChartRow {
+    pub fn as_entry_seed(&self) -> ChartEntrySeed<'_> {
+        ChartEntrySeed {
+            rank: self.rank,
+            rank_delta: self.rank_delta,
+            artist: &self.artist,
+            title: &self.title,
+            entity_type: "track",
+            external_track_id: self.spotify_track_id.as_deref(),
+            external_url: self.external_url.as_deref(),
+            streams: self.streams,
+            peak_rank: self.peak_rank,
+            days_on_chart: self.days_on_chart,
+            raw_json: Some(json!({
+                "provider": "spotify",
+                "spotify_track_id": self.spotify_track_id,
+                "streams": self.streams,
+            })),
+            ..ChartEntrySeed::track(self.rank, &self.artist, &self.title)
+        }
+    }
+}
+
+pub fn parse_spotify_daily_csv(input: &str) -> Result<Vec<SpotifyDailyChartRow>> {
+    let mut lines = input.lines().filter(|line| !line.trim().is_empty());
+    let header_line = lines
+        .next()
+        .ok_or_else(|| anyhow!("spotify chart csv is empty"))?;
+    let headers = parse_csv_line(header_line)
+        .into_iter()
+        .map(|header| normalize_header(&header))
+        .collect::<Vec<_>>();
+
+    let mut rows = Vec::new();
+    for (index, line) in lines.enumerate() {
+        let fields = parse_csv_line(line);
+        if fields.iter().all(|field| field.trim().is_empty()) {
+            continue;
+        }
+        let field = |name: &str| -> Option<&str> {
+            headers
+                .iter()
+                .position(|header| header == name)
+                .and_then(|idx| fields.get(idx))
+                .map(String::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+        };
+
+        let rank = field("rank")
+            .ok_or_else(|| anyhow!("missing rank at row {}", index + 2))?
+            .parse::<i64>()
+            .with_context(|| format!("invalid rank at row {}", index + 2))?;
+        let artist = field("artist_names")
+            .or_else(|| field("artist"))
+            .ok_or_else(|| anyhow!("missing artist at row {}", index + 2))?
+            .to_string();
+        let title = field("track_name")
+            .or_else(|| field("title"))
+            .ok_or_else(|| anyhow!("missing title at row {}", index + 2))?
+            .to_string();
+        let previous_rank = field("previous_rank").and_then(parse_optional_i64);
+        let peak_rank = field("peak_rank").and_then(parse_optional_i64);
+        let days_on_chart = field("days_on_chart")
+            .and_then(parse_optional_i64)
+            .or_else(|| {
+                field("weeks_on_chart")
+                    .and_then(parse_optional_i64)
+                    .map(|weeks| weeks * 7)
+            });
+        let streams = field("streams").and_then(parse_optional_i64);
+        let spotify_track_id = field("uri")
+            .or_else(|| field("spotify_url"))
+            .or_else(|| field("track_url"))
+            .and_then(extract_spotify_track_id);
+        let external_url = spotify_track_id
+            .as_ref()
+            .map(|id| format!("https://open.spotify.com/track/{id}"));
+
+        rows.push(SpotifyDailyChartRow {
+            rank,
+            rank_delta: previous_rank.map(|prev| prev - rank),
+            artist,
+            title,
+            spotify_track_id,
+            external_url,
+            streams,
+            peak_rank,
+            days_on_chart,
+        });
+    }
+
+    Ok(rows)
+}
+
+pub fn ingest_spotify_daily_csv(
+    conn: &Connection,
+    region: &str,
+    chart_date: &str,
+    fetched_at: i64,
+    input: &str,
+) -> Result<i64> {
+    let rows = parse_spotify_daily_csv(input)?;
+    let content_hash = content_sha256(input);
+    let snapshot = ChartSnapshotSeed {
+        source_key: "spotify_daily",
+        region,
+        period: "daily",
+        chart_date,
+        fetched_at,
+        etag: None,
+        content_hash: Some(&content_hash),
+        status: "ok",
+    };
+    let entries = rows
+        .iter()
+        .map(SpotifyDailyChartRow::as_entry_seed)
+        .collect::<Vec<_>>();
+
+    upsert_chart_snapshot(conn, &snapshot, &entries)
+}
+
+fn content_sha256(input: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(input.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+fn normalize_header(value: &str) -> String {
+    value
+        .trim()
+        .trim_matches('\u{feff}')
+        .to_ascii_lowercase()
+        .replace([' ', '-'], "_")
+}
+
+fn parse_optional_i64(value: &str) -> Option<i64> {
+    let cleaned = value.trim().replace(',', "");
+    if cleaned.is_empty() || cleaned == "-" {
+        return None;
+    }
+    cleaned.parse::<i64>().ok()
+}
+
+fn extract_spotify_track_id(value: &str) -> Option<String> {
+    let value = value.trim();
+    if value.is_empty() {
+        return None;
+    }
+    if let Some(id) = value.strip_prefix("spotify:track:") {
+        return non_empty_id(id);
+    }
+    if let Some((_, tail)) = value.split_once("/track/") {
+        let id = tail.split(['?', '&', '/']).next().unwrap_or("").trim();
+        return non_empty_id(id);
+    }
+    non_empty_id(value)
+}
+
+fn non_empty_id(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn parse_csv_line(line: &str) -> Vec<String> {
+    let mut fields = Vec::new();
+    let mut current = String::new();
+    let mut chars = line.chars().peekable();
+    let mut in_quotes = false;
+
+    while let Some(ch) = chars.next() {
+        match ch {
+            '"' if in_quotes && chars.peek() == Some(&'"') => {
+                current.push('"');
+                let _ = chars.next();
+            }
+            '"' => in_quotes = !in_quotes,
+            ',' if !in_quotes => {
+                fields.push(current.trim().to_string());
+                current.clear();
+            }
+            _ => current.push(ch),
+        }
+    }
+    fields.push(current.trim().to_string());
+    fields
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::{queries, schema};
+    use rusqlite::Connection;
+
+    #[test]
+    fn spotify_daily_csv_rows_normalize_to_chart_entry_seeds() {
+        let csv = r#"rank,uri,artist_names,track_name,peak_rank,previous_rank,weeks_on_chart,streams
+1,spotify:track:abc123,"Sabrina Carpenter","Espresso",1,2,12,"1,234,567"
+2,https://open.spotify.com/track/def456?si=share,"Kendrick Lamar, SZA","Luther",1,,5,987654
+3,,PinkPantheress,"Stateside + Zara Larsson",3,-,1,-
+"#;
+
+        let rows = parse_spotify_daily_csv(csv).expect("parse csv");
+
+        assert_eq!(rows.len(), 3);
+        assert_eq!(rows[0].rank, 1);
+        assert_eq!(rows[0].rank_delta, Some(1));
+        assert_eq!(rows[0].artist, "Sabrina Carpenter");
+        assert_eq!(rows[0].title, "Espresso");
+        assert_eq!(rows[0].spotify_track_id.as_deref(), Some("abc123"));
+        assert_eq!(
+            rows[0].external_url.as_deref(),
+            Some("https://open.spotify.com/track/abc123")
+        );
+        assert_eq!(rows[0].streams, Some(1_234_567));
+        assert_eq!(rows[0].days_on_chart, Some(84));
+
+        assert_eq!(rows[1].artist, "Kendrick Lamar, SZA");
+        assert_eq!(rows[1].spotify_track_id.as_deref(), Some("def456"));
+        assert_eq!(rows[1].rank_delta, None);
+
+        let seed = rows[2].as_entry_seed();
+        assert_eq!(seed.rank, 3);
+        assert_eq!(seed.artist, "PinkPantheress");
+        assert_eq!(seed.title, "Stateside + Zara Larsson");
+        assert_eq!(seed.entity_type, "track");
+        assert_eq!(seed.streams, None);
+        assert_eq!(seed.resolution_status, None);
+    }
+
+    #[test]
+    fn spotify_daily_ingest_replaces_daily_snapshot_and_feeds_matrix() {
+        let conn = Connection::open_in_memory().expect("open memory db");
+        schema::run_migrations(&conn).expect("run migrations");
+        let first_csv = r#"rank,uri,artist_names,track_name,peak_rank,previous_rank,days_on_chart,streams
+1,spotify:track:first,"First Artist","First Track",1,2,8,1000
+2,spotify:track:second,"Second Artist","Second Track",2,3,4,900
+"#;
+        let refresh_csv = r#"rank,uri,artist_names,track_name,peak_rank,previous_rank,days_on_chart,streams
+1,spotify:track:updated,"Updated Artist","Updated Track",1,4,9,1200
+"#;
+
+        ingest_spotify_daily_csv(&conn, "global", "2026-05-28", 100, first_csv)
+            .expect("ingest first snapshot");
+        ingest_spotify_daily_csv(&conn, "global", "2026-05-28", 200, refresh_csv)
+            .expect("ingest refresh snapshot");
+
+        let latest =
+            queries::get_latest_chart_snapshot(&conn, "spotify_daily", "global", "daily", 10)
+                .expect("read latest snapshot")
+                .expect("latest snapshot");
+        assert_eq!(latest.snapshot.chart_date, "2026-05-28");
+        assert_eq!(latest.snapshot.fetched_at, 200);
+        assert_eq!(latest.entries.len(), 1);
+        assert_eq!(latest.entries[0].rank, 1);
+        assert_eq!(latest.entries[0].artist, "Updated Artist");
+        assert_eq!(latest.entries[0].title, "Updated Track");
+        assert_eq!(
+            latest.entries[0].external_url.as_deref(),
+            Some("https://open.spotify.com/track/updated")
+        );
+        assert_eq!(latest.entries[0].streams, Some(1200));
+        assert!(latest.entries[0].tidal_id.is_none());
+        assert_eq!(latest.entries[0].resolution_status, "unresolved");
+
+        let matrix = queries::get_chart_matrix(
+            &conn,
+            &["global"],
+            &["spotify_daily", "youtube_daily"],
+            "daily",
+        )
+        .expect("read matrix");
+        assert_eq!(
+            matrix[0].cells["spotify_daily"].as_ref().unwrap().title,
+            "Updated Track"
+        );
+        assert!(matrix[0].cells["youtube_daily"].is_none());
+    }
+}


### PR DESCRIPTION
Summary:
- Reapplies the chart ingestion/provider matrix commits that were accidentally merged and then reverted in PR #84.
- Adds daily provider snapshots, ranked Kworb matrix ingestion, Spotify chart metadata cache, and Market pulse data wiring.
- Excludes chart layout standardization and Last.fm/scrobbling changes.

Verification:
- cargo check -p noor-server
- pnpm test -- daily_chart_shelf_contract.test.ts spotify-chart-meta-cache.test.ts
- pnpm check
- pnpm lint
- pnpm run build

Notes:
- cargo check currently reports existing dead-code warnings only.