### PR TITLE
Standardize chart layout

### DIFF
--- a/frontend/src/lib/components/charts/ChartMural.svelte
+++ b/frontend/src/lib/components/charts/ChartMural.svelte
@@ -1,0 +1,413 @@
+<script lang="ts">
+	import ArtworkImage from '$lib/components/ui/ArtworkImage.svelte';
+	import { lazyTidalArt } from '$lib/actions/lazy-tidal-art';
+
+	export type ChartMuralAccent = 'accent' | 'lastfm';
+
+	export type ChartMuralItem = {
+		id: string;
+		title: string;
+		subtitle: string;
+		artwork: string | null;
+		fallbackText: string;
+		tileLabel: string;
+		tileTitle: string;
+		lazy?: {
+			enabled: boolean;
+			query: {
+				artist: string | null;
+				title: string;
+			};
+			onResolve: (url: string) => void;
+		};
+	};
+
+	type Props = {
+		items?: ChartMuralItem[];
+		currentIndex?: number;
+		ariaLabel: string;
+		kindLabel: string;
+		title: string;
+		subtitle: string;
+		metric?: string;
+		actionLabel?: string;
+		actionDisabled?: boolean;
+		accent?: ChartMuralAccent;
+		loading?: boolean;
+		loadingLabel?: string;
+		onSelect?: (index: number) => void;
+		onJump?: (delta: number) => void;
+		onPlay?: () => void | Promise<void>;
+		onCardContext?: (event: MouseEvent) => void | Promise<void>;
+		onItemContext?: (event: MouseEvent, index: number) => void | Promise<void>;
+		onPauseChange?: (paused: boolean) => void;
+	};
+
+	let {
+		items = [],
+		currentIndex = 0,
+		ariaLabel,
+		kindLabel,
+		title,
+		subtitle,
+		metric = '',
+		actionLabel = 'Play',
+		actionDisabled = false,
+		accent = 'accent',
+		loading = false,
+		loadingLabel = 'Loading chart mural',
+		onSelect = () => {},
+		onJump = () => {},
+		onPlay = () => {},
+		onCardContext,
+		onItemContext,
+		onPauseChange,
+	}: Props = $props();
+
+	let currentItem = $derived(items[currentIndex] ?? items[0] ?? null);
+</script>
+
+{#if loading}
+	<div class="chart-mural-loading">{loadingLabel}</div>
+{:else if currentItem}
+	<div
+		class="chart-mural"
+		class:accent-lastfm={accent === 'lastfm'}
+		onmouseenter={() => onPauseChange?.(true)}
+		onmouseleave={() => onPauseChange?.(false)}
+		role="region"
+		aria-label={ariaLabel}
+		oncontextmenu={(event) => {
+			if (onCardContext) void onCardContext(event);
+		}}
+	>
+		<div class="chart-mural-bg" aria-hidden="true">
+			{#each items as item, index (item.id)}
+				<button
+					class="chart-mural-tile"
+					class:featured={currentItem.id === item.id}
+					type="button"
+					onclick={() => onSelect(index)}
+					oncontextmenu={(event) => {
+						if (onItemContext) void onItemContext(event, index);
+					}}
+					aria-label={item.tileLabel}
+					title={item.tileTitle}
+					use:lazyTidalArt={{
+						enabled: item.lazy?.enabled ?? false,
+						query: item.lazy?.query ?? { artist: null, title: item.title },
+						onResolve: item.lazy?.onResolve ?? (() => {}),
+					}}
+				>
+					<ArtworkImage
+						src={item.artwork}
+						size={320}
+						className="chart-mural-art"
+						fallbackText={item.fallbackText}
+						decorative
+					/>
+				</button>
+			{/each}
+		</div>
+		<div class="chart-mural-shade"></div>
+		<div class="chart-mural-content">
+			<div class="chart-mural-meta">
+				<span class="chart-mural-kind">{kindLabel}</span>
+				<h3 class="chart-mural-title">{title}</h3>
+				<p class="chart-mural-sub">{subtitle}</p>
+				<div class="chart-mural-actions">
+					<button
+						class="btn btn-primary chart-mural-play"
+						type="button"
+						disabled={actionDisabled}
+						onclick={() => void onPlay()}
+					>
+						<svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor" aria-hidden="true">
+							<path d="M3 2.5l10 5.5-10 5.5V2.5z"/>
+						</svg>
+						{actionLabel}
+					</button>
+					{#if metric}
+						<span>{metric}</span>
+					{/if}
+				</div>
+			</div>
+		</div>
+		{#if items.length > 1}
+			<button
+				class="chart-nav chart-nav--prev"
+				type="button"
+				onclick={() => onJump(-1)}
+				aria-label="Previous chart entry"
+			>
+				&lsaquo;
+			</button>
+			<button
+				class="chart-nav chart-nav--next"
+				type="button"
+				onclick={() => onJump(1)}
+				aria-label="Next chart entry"
+			>
+				&rsaquo;
+			</button>
+		{/if}
+	</div>
+{/if}
+
+<style>
+	.chart-mural {
+		--chart-mural-accent: var(--accent);
+		--chart-mural-soft: var(--accent-soft);
+		position: relative;
+		min-height: clamp(220px, 24vw, 360px);
+		border: 1px solid var(--panel-border);
+		border-radius: var(--radius-md);
+		overflow: hidden;
+		background: var(--panel-bg);
+	}
+
+	.chart-mural.accent-lastfm {
+		--chart-mural-accent: var(--service-lastfm);
+		--chart-mural-soft: color-mix(in srgb, var(--service-lastfm) 18%, var(--bg-surface));
+	}
+
+	.chart-mural-bg {
+		position: absolute;
+		inset: -7%;
+		z-index: 0;
+		display: grid;
+		grid-template-columns: repeat(10, minmax(0, 1fr));
+		grid-template-rows: repeat(2, minmax(0, 1fr));
+		background: linear-gradient(120deg, var(--panel-bg), color-mix(in srgb, var(--chart-mural-accent) 16%, transparent));
+	}
+
+	.chart-mural-bg::after {
+		content: '';
+		position: absolute;
+		inset: 0;
+		background:
+			radial-gradient(circle at 78% 42%, rgba(255,255,255,0.2), transparent 30%),
+			linear-gradient(90deg, rgba(0,0,0,0.08), transparent 42%, rgba(0,0,0,0.04));
+		pointer-events: none;
+	}
+
+	.chart-mural-tile {
+		appearance: none;
+		position: relative;
+		min-width: 0;
+		min-height: 0;
+		padding: 0;
+		border: 0;
+		background: var(--bg-raised);
+		color: var(--text-primary);
+		cursor: pointer;
+		overflow: hidden;
+		opacity: 0.96;
+		filter: saturate(1.18) brightness(1.14);
+		transform: skewX(-7deg) scaleX(1.08);
+		transform-origin: center;
+		transition:
+			filter var(--motion-fast),
+			opacity var(--motion-fast),
+			transform var(--motion-base),
+			box-shadow var(--motion-base);
+	}
+
+	.chart-mural-tile::after {
+		content: '';
+		position: absolute;
+		inset: 0;
+		background: linear-gradient(90deg, rgba(0,0,0,0.18), transparent 48%, rgba(0,0,0,0.2));
+		opacity: 0.18;
+		pointer-events: none;
+	}
+
+	.chart-mural-tile:hover,
+	.chart-mural-tile:focus-visible,
+	.chart-mural-tile.featured {
+		z-index: var(--z-raised);
+		opacity: 1;
+		filter: saturate(1.8) brightness(1.4);
+		transform: skewX(-7deg) scaleX(1.08) scale(1.045);
+		box-shadow:
+			0 0 0 1px rgba(255,255,255,0.3),
+			0 14px 30px rgba(0,0,0,0.32),
+			0 0 24px color-mix(in srgb, var(--chart-mural-accent) 34%, transparent);
+		outline: none;
+	}
+
+	:global(.chart-mural-art),
+	:global(.chart-mural-art.fallback) {
+		display: block;
+		width: 100%;
+		height: 100%;
+	}
+
+	:global(.chart-mural-art) {
+		object-fit: cover;
+		transform: skewX(7deg) scale(1.24);
+		transition: transform var(--motion-base);
+	}
+
+	.chart-mural-tile:hover :global(.chart-mural-art),
+	.chart-mural-tile:focus-visible :global(.chart-mural-art),
+	.chart-mural-tile.featured :global(.chart-mural-art) {
+		transform: skewX(7deg) scale(1.34);
+	}
+
+	:global(.chart-mural-art.fallback) {
+		display: grid;
+		place-items: center;
+		background: linear-gradient(135deg, var(--bg-raised), var(--chart-mural-soft));
+		color: rgba(255,255,255,0.78);
+		font-size: var(--font-size-xl);
+		font-weight: var(--font-weight-bold);
+	}
+
+	.chart-mural-shade {
+		position: absolute;
+		inset: 0;
+		z-index: var(--z-base);
+		background: linear-gradient(90deg, rgba(0,0,0,0.72) 0%, rgba(0,0,0,0.36) 42%, rgba(0,0,0,0.08) 78%, transparent 100%);
+		pointer-events: none;
+	}
+
+	.chart-mural-content {
+		position: relative;
+		z-index: calc(var(--z-base) + 1);
+		display: grid;
+		align-items: center;
+		min-height: inherit;
+		padding: var(--space-5);
+		pointer-events: none;
+	}
+
+	.chart-mural-meta {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-1);
+		max-width: min(42rem, 58vw);
+		text-shadow: 0 2px 18px rgba(0,0,0,0.62);
+	}
+
+	.chart-mural-kind {
+		color: var(--chart-mural-accent);
+		font-size: var(--font-size-2xs);
+		font-weight: var(--font-weight-semibold);
+		letter-spacing: 0;
+		text-transform: uppercase;
+	}
+
+	.chart-mural-title {
+		margin: 0;
+		color: var(--text-primary);
+		font-size: var(--font-size-4xl);
+		font-weight: var(--font-weight-bold);
+		line-height: var(--line-height-tight);
+		letter-spacing: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.chart-mural-sub {
+		margin: 0 0 var(--space-2);
+		color: var(--text-secondary);
+		font-size: var(--font-size-sm);
+	}
+
+	.chart-mural-actions {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		pointer-events: auto;
+	}
+
+	.chart-mural-actions span {
+		color: var(--text-secondary);
+		font-size: var(--font-size-xs);
+		font-weight: var(--font-weight-semibold);
+	}
+
+	.chart-mural-play {
+		display: flex;
+		align-items: center;
+		gap: var(--space-1);
+		font-size: var(--font-size-sm);
+		font-weight: var(--font-weight-semibold);
+	}
+
+	.chart-mural-play:disabled {
+		cursor: not-allowed;
+		opacity: 0.58;
+	}
+
+	.chart-nav {
+		position: absolute;
+		top: 50%;
+		z-index: var(--z-raised);
+		display: grid;
+		place-items: center;
+		width: clamp(32px, 3vw, 40px);
+		aspect-ratio: 1 / 1;
+		border: 1px solid var(--panel-border);
+		border-radius: 50%;
+		background: rgba(0,0,0,0.5);
+		color: var(--text-primary);
+		cursor: pointer;
+		font-size: var(--font-size-xl);
+		line-height: 1;
+		opacity: 0;
+		transform: translateY(-50%);
+		transition: opacity var(--motion-fast), background var(--motion-fast);
+	}
+
+	.chart-mural:hover .chart-nav,
+	.chart-nav:focus-visible {
+		opacity: 1;
+		outline: none;
+	}
+
+	.chart-nav:hover {
+		background: rgba(0,0,0,0.75);
+	}
+
+	.chart-nav--prev {
+		left: var(--space-3);
+	}
+
+	.chart-nav--next {
+		right: var(--space-3);
+	}
+
+	.chart-mural-loading {
+		display: grid;
+		place-items: center;
+		min-height: clamp(180px, 20vw, 280px);
+		border: 1px solid var(--panel-border);
+		border-radius: var(--radius-md);
+		background: var(--panel-bg);
+		color: var(--text-secondary);
+		font-size: var(--font-size-sm);
+		font-weight: var(--font-weight-semibold);
+	}
+
+	@media (max-width: 760px) {
+		.chart-mural-bg {
+			grid-template-columns: repeat(5, minmax(0, 1fr));
+			grid-template-rows: repeat(4, minmax(0, 1fr));
+		}
+
+		.chart-mural-content {
+			padding: var(--space-4);
+		}
+
+		.chart-mural-meta {
+			max-width: 100%;
+		}
+
+		.chart-mural-title {
+			font-size: var(--font-size-3xl);
+		}
+	}
+</style>

--- a/frontend/src/lib/components/charts/DailyChartShelf.svelte
+++ b/frontend/src/lib/components/charts/DailyChartShelf.svelte
@@ -6,11 +6,15 @@
 		type ChartMatrixResponse,
 		type ChartSnapshotEntry,
 		type ChartSnapshotResponse,
+		type TidalPlayable,
 		type TidalSearchTrack,
 	} from '$lib/api/client';
 	import EmptyState from '$lib/components/ui/EmptyState.svelte';
-	import ArtworkImage from '$lib/components/ui/ArtworkImage.svelte';
 	import { playTidalTrackNow, playerError } from '$lib/stores/player';
+	import { openContextMenu } from '$lib/stores/context_menu';
+	import { buildTidalTrackMenu } from '$lib/player/track_menu';
+	import SectionHeader from '$lib/components/ui/SectionHeader.svelte';
+	import ChartMural, { type ChartMuralItem } from '$lib/components/charts/ChartMural.svelte';
 
 	const REGIONS = [
 		{ code: 'global', label: 'Global' },
@@ -45,6 +49,17 @@
 
 	let chartEntries = $derived(data?.entries ?? []);
 	let currentEntry = $derived(chartEntries[currentEntryIndex] ?? chartEntries[0] ?? null);
+	let muralItems = $derived<ChartMuralItem[]>(
+		chartEntries.map((entry) => ({
+			id: String(entry.id),
+			title: entry.title,
+			subtitle: entrySubtitle(entry),
+			artwork: entryArtwork(entry),
+			fallbackText: entryFallbackText(entry),
+			tileLabel: `Select ${entry.title}`,
+			tileTitle: `${entry.rank}. ${entry.title} - ${entry.artist}`,
+		})),
+	);
 
 	onMount(() => {
 		void loadMatrix();
@@ -255,6 +270,41 @@
 		});
 	}
 
+	function playableFromHit(hit: TidalSearchTrack, fallbackArtwork: string | null): TidalPlayable {
+		return {
+			tidal_id: hit.tidal_id,
+			title: hit.title,
+			artist_name: hit.artist_name,
+			album_title: hit.album_title,
+			artwork_url: hit.artwork_url ?? fallbackArtwork,
+			duration_ms: hit.duration_ms,
+			artist_tidal_id: hit.artist_id,
+			album_tidal_id: hit.album_tidal_id,
+			local_id: hit.local_id,
+			is_in_library: hit.in_library,
+		};
+	}
+
+	async function openEntryContext(e: MouseEvent, entry: ChartSnapshotEntry) {
+		e.preventDefault();
+		e.stopPropagation();
+		const hit = resolvedTracks[entry.id] ?? (await resolveEntry(entry));
+		if (!hit) return;
+		const playable = playableFromHit(hit, entry.artwork_url);
+		openContextMenu(e, buildTidalTrackMenu(playable), playable.title);
+	}
+
+	async function openMatrixCellContext(e: MouseEvent, cell: ChartMatrixCell) {
+		e.preventDefault();
+		e.stopPropagation();
+		const hit =
+			resolvedTracks[cell.entry_id] ??
+			(await resolveChartItem(cell.entry_id, cell.artist, cell.title, cell.entity_type, cell.tidal_id));
+		if (!hit) return;
+		const playable = playableFromHit(hit, cell.artwork_url);
+		openContextMenu(e, buildTidalTrackMenu(playable), playable.title);
+	}
+
 	function entryArtwork(entry: ChartSnapshotEntry): string | null {
 		return resolvedTracks[entry.id]?.artwork_url ?? entry.artwork_url;
 	}
@@ -284,11 +334,8 @@
 </script>
 
 <section class="daily-chart-shelf">
-	<div class="section-header">
-		<div class="section-title-group">
-			<p class="eyebrow">Charts - Provider matrix</p>
-			<h2>Market pulse</h2>
-		</div>
+	<SectionHeader eyebrow="Charts - Provider matrix" title="Market pulse" variant="charts" level={2}>
+		{#snippet actions()}
 		<div class="region-tabs" role="tablist" aria-label="Daily chart region">
 			{#each REGIONS as region (region.code)}
 				<button
@@ -303,7 +350,8 @@
 				</button>
 			{/each}
 		</div>
-	</div>
+		{/snippet}
+	</SectionHeader>
 
 	{#if matrix?.providers.length}
 		<div class="source-tabs" role="tablist" aria-label="Daily chart provider">
@@ -323,59 +371,41 @@
 	{/if}
 
 	{#if chartEntries.length > 0 && currentEntry}
-		<div
-			class="chart-mural-card"
-			onmouseenter={() => carouselPaused = true}
-			onmouseleave={() => carouselPaused = false}
-			role="region"
-			aria-label={`${selectedProviderLabel()} ${selectedRegionLabel()} top ${chartEntries.length}`}
-		>
-			<div class="chart-mural-bg" aria-hidden="true">
-				{#each chartEntries as entry (entry.id)}
-					<button
-						class="chart-mural-tile"
-						class:chart-mural-tile--featured={currentEntry.id === entry.id}
-						type="button"
-						onclick={() => selectEntry(entry.id)}
-						aria-label={`Select ${entry.title}`}
-						title={`${entry.rank}. ${entry.title} - ${entry.artist}`}
-					>
-						<ArtworkImage
-							src={entryArtwork(entry)}
-							size={320}
-							className="chart-mural-art"
-							fallbackText={entryFallbackText(entry)}
-							decorative
-						/>
-					</button>
-				{/each}
-			</div>
-			<div class="chart-mural-shade"></div>
-			<div class="chart-mural-content">
-				<div class="chart-mural-meta">
-					<span class="chart-mural-kind">
-						{selectedProviderLabel()} top {chartEntries.length} - {selectedRegionLabel()}
-					</span>
-					<h3 class="chart-mural-title">{currentEntry.title}</h3>
-					<p class="chart-mural-sub">{entrySubtitle(currentEntry)}</p>
-					<div class="chart-mural-actions">
-						<button class="btn btn-primary chart-mural-play" type="button" onclick={() => void playEntry(currentEntry)}>
-							<svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor" aria-hidden="true">
-								<path d="M3 2.5l10 5.5-10 5.5V2.5z"/>
-							</svg>
-							Play
-						</button>
-						<span>{entryMetric(currentEntry)}</span>
-					</div>
-				</div>
-			</div>
-			{#if chartEntries.length > 1}
-				<button class="chart-nav chart-nav--prev" type="button" onclick={() => jumpEntry(-1)} aria-label="Previous chart entry">&lsaquo;</button>
-				<button class="chart-nav chart-nav--next" type="button" onclick={() => jumpEntry(1)} aria-label="Next chart entry">&rsaquo;</button>
-			{/if}
-		</div>
+		<ChartMural
+			items={muralItems}
+			currentIndex={currentEntryIndex}
+			ariaLabel={`${selectedProviderLabel()} ${selectedRegionLabel()} top ${chartEntries.length}`}
+			kindLabel={`${selectedProviderLabel()} top ${chartEntries.length} - ${selectedRegionLabel()}`}
+			title={currentEntry.title}
+			subtitle={entrySubtitle(currentEntry)}
+			metric={entryMetric(currentEntry)}
+			actionLabel="Play"
+			loading={loading && chartEntries.length === 0}
+			loadingLabel="Loading chart mural"
+			onSelect={(index) => {
+				const entry = chartEntries[index];
+				if (entry) selectEntry(entry.id);
+			}}
+			onJump={jumpEntry}
+			onPlay={() => playEntry(currentEntry)}
+			onCardContext={(event) => currentEntry && openEntryContext(event, currentEntry)}
+			onItemContext={(event, index) => {
+				const entry = chartEntries[index];
+				if (entry) void openEntryContext(event, entry);
+			}}
+			onPauseChange={(paused) => carouselPaused = paused}
+		/>
 	{:else if loading}
-		<div class="chart-mural-loading">Loading chart mural</div>
+		<ChartMural
+			items={[]}
+			currentIndex={0}
+			ariaLabel="Loading market pulse"
+			kindLabel=""
+			title=""
+			subtitle=""
+			loading
+			loadingLabel="Loading chart mural"
+		/>
 	{:else if error}
 		<EmptyState
 			title="Daily chart unavailable"
@@ -422,6 +452,9 @@
 								if (cell) pickProvider(row.region, provider.source_key);
 								else pickRegion(row.region);
 							}}
+							oncontextmenu={(e) => {
+								if (cell) void openMatrixCellContext(e, cell);
+							}}
 							aria-label={`${provider.label} ${row.region}`}
 						>
 							{#if cell}
@@ -466,36 +499,6 @@
 		display: flex;
 		flex-direction: column;
 		gap: var(--space-3);
-	}
-
-	.section-header {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		gap: var(--gap-sm);
-		flex-wrap: wrap;
-	}
-
-	.section-title-group {
-		display: flex;
-		flex-direction: column;
-		gap: var(--space-1);
-	}
-
-	.eyebrow {
-		margin: 0;
-		font-size: var(--font-size-xs);
-		font-weight: var(--font-weight-semibold);
-		text-transform: uppercase;
-		letter-spacing: 0;
-		color: var(--service-spotify);
-	}
-
-	h2 {
-		margin: 0;
-		font-size: var(--font-size-lg);
-		font-weight: var(--font-weight-bold);
-		line-height: var(--line-height-tight);
 	}
 
 	.region-tabs {
@@ -562,230 +565,6 @@
 		border-color: var(--accent-line);
 		color: var(--text-primary);
 		outline: none;
-	}
-
-	.chart-mural-card {
-		position: relative;
-		min-height: clamp(220px, 24vw, 360px);
-		border: 1px solid var(--panel-border);
-		border-radius: var(--radius-md);
-		overflow: hidden;
-		background: var(--panel-bg);
-	}
-
-	.chart-mural-bg {
-		position: absolute;
-		inset: -7%;
-		z-index: 0;
-		display: grid;
-		grid-template-columns: repeat(10, minmax(0, 1fr));
-		grid-template-rows: repeat(2, minmax(0, 1fr));
-		background: linear-gradient(120deg, var(--panel-bg), color-mix(in srgb, var(--accent-soft) 24%, transparent));
-	}
-
-	.chart-mural-bg::after {
-		content: '';
-		position: absolute;
-		inset: 0;
-		background:
-			radial-gradient(circle at 78% 42%, rgba(255,255,255,0.2), transparent 30%),
-			linear-gradient(90deg, rgba(0,0,0,0.06), transparent 42%, rgba(0,0,0,0.02));
-		pointer-events: none;
-	}
-
-	.chart-mural-tile {
-		appearance: none;
-		position: relative;
-		min-width: 0;
-		min-height: 0;
-		padding: 0;
-		border: 0;
-		background: var(--bg-raised);
-		color: var(--text-primary);
-		cursor: pointer;
-		overflow: hidden;
-		opacity: 0.96;
-		filter: saturate(1.18) brightness(1.16);
-		transform: skewX(-7deg) scaleX(1.08);
-		transform-origin: center;
-		transition:
-			filter var(--motion-fast),
-			opacity var(--motion-fast),
-			transform var(--motion-base),
-			box-shadow var(--motion-base);
-	}
-
-	.chart-mural-tile::after {
-		content: '';
-		position: absolute;
-		inset: 0;
-		background: linear-gradient(90deg, rgba(0,0,0,0.18), transparent 48%, rgba(0,0,0,0.2));
-		opacity: 0.18;
-		pointer-events: none;
-	}
-
-	.chart-mural-tile:hover,
-	.chart-mural-tile:focus-visible,
-	.chart-mural-tile--featured {
-		z-index: var(--z-raised);
-		opacity: 1;
-		filter: saturate(1.8) brightness(1.42);
-		transform: skewX(-7deg) scaleX(1.08) scale(1.045);
-		box-shadow:
-			0 0 0 1px rgba(255,255,255,0.32),
-			0 14px 30px rgba(0,0,0,0.32),
-			0 0 24px color-mix(in srgb, var(--accent) 38%, transparent);
-		outline: none;
-	}
-
-	:global(.chart-mural-art),
-	:global(.chart-mural-art.fallback) {
-		display: block;
-		width: 100%;
-		height: 100%;
-	}
-
-	:global(.chart-mural-art) {
-		object-fit: cover;
-		transform: skewX(7deg) scale(1.24);
-		transition: transform var(--motion-base);
-	}
-
-	.chart-mural-tile:hover :global(.chart-mural-art),
-	.chart-mural-tile:focus-visible :global(.chart-mural-art),
-	.chart-mural-tile--featured :global(.chart-mural-art) {
-		transform: skewX(7deg) scale(1.34);
-	}
-
-	:global(.chart-mural-art.fallback) {
-		display: grid;
-		place-items: center;
-		background: linear-gradient(135deg, var(--bg-raised), color-mix(in srgb, var(--accent-soft) 28%, var(--bg-surface)));
-		color: rgba(255,255,255,0.78);
-		font-size: var(--font-size-xl);
-		font-weight: var(--font-weight-bold);
-	}
-
-	.chart-mural-shade {
-		position: absolute;
-		inset: 0;
-		z-index: var(--z-base);
-		background: linear-gradient(90deg, rgba(0,0,0,0.7) 0%, rgba(0,0,0,0.34) 42%, rgba(0,0,0,0.06) 78%, transparent 100%);
-		pointer-events: none;
-	}
-
-	.chart-mural-content {
-		position: relative;
-		z-index: calc(var(--z-base) + 1);
-		display: grid;
-		align-items: center;
-		min-height: inherit;
-		padding: var(--space-5);
-		pointer-events: none;
-	}
-
-	.chart-mural-meta {
-		display: flex;
-		flex-direction: column;
-		gap: var(--space-1);
-		max-width: min(42rem, 58vw);
-		text-shadow: 0 2px 18px rgba(0,0,0,0.62);
-	}
-
-	.chart-mural-kind {
-		color: var(--accent);
-		font-size: var(--font-size-2xs);
-		font-weight: var(--font-weight-semibold);
-		letter-spacing: 0;
-		text-transform: uppercase;
-	}
-
-	.chart-mural-title {
-		margin: 0;
-		color: var(--text-primary);
-		font-size: var(--font-size-4xl);
-		font-weight: var(--font-weight-bold);
-		line-height: var(--line-height-tight);
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-	}
-
-	.chart-mural-sub {
-		margin: 0 0 var(--space-2);
-		color: var(--text-secondary);
-		font-size: var(--font-size-sm);
-	}
-
-	.chart-mural-actions {
-		display: flex;
-		align-items: center;
-		gap: var(--space-2);
-		pointer-events: auto;
-	}
-
-	.chart-mural-actions span {
-		color: var(--text-secondary);
-		font-size: var(--font-size-xs);
-		font-weight: var(--font-weight-semibold);
-	}
-
-	.chart-mural-play {
-		display: flex;
-		align-items: center;
-		gap: var(--space-1);
-		font-size: var(--font-size-sm);
-		font-weight: var(--font-weight-semibold);
-	}
-
-	.chart-nav {
-		position: absolute;
-		top: 50%;
-		z-index: var(--z-raised);
-		display: grid;
-		place-items: center;
-		width: clamp(32px, 3vw, 40px);
-		aspect-ratio: 1 / 1;
-		border: 1px solid var(--panel-border);
-		border-radius: 50%;
-		background: rgba(0,0,0,0.5);
-		color: var(--text-primary);
-		cursor: pointer;
-		font-size: var(--font-size-xl);
-		line-height: 1;
-		opacity: 0;
-		transform: translateY(-50%);
-		transition: opacity var(--motion-fast), background var(--motion-fast);
-	}
-
-	.chart-mural-card:hover .chart-nav,
-	.chart-nav:focus-visible {
-		opacity: 1;
-		outline: none;
-	}
-
-	.chart-nav:hover {
-		background: rgba(0,0,0,0.75);
-	}
-
-	.chart-nav--prev {
-		left: var(--space-3);
-	}
-
-	.chart-nav--next {
-		right: var(--space-3);
-	}
-
-	.chart-mural-loading {
-		display: grid;
-		place-items: center;
-		min-height: clamp(180px, 20vw, 280px);
-		border: 1px solid var(--panel-border);
-		border-radius: var(--radius-md);
-		background: var(--panel-bg);
-		color: var(--text-secondary);
-		font-size: var(--font-size-sm);
-		font-weight: var(--font-weight-semibold);
 	}
 
 	.matrix-shell {
@@ -925,9 +704,9 @@
 	}
 
 	.chip {
-		border: 0;
+		border: 1px solid var(--panel-border);
 		border-radius: 999px;
-		background: transparent;
+		background: var(--panel-bg);
 		color: var(--text-muted);
 		font-size: var(--font-size-xs);
 		font-weight: var(--font-weight-semibold);
@@ -935,36 +714,21 @@
 		padding: var(--space-2) var(--space-3);
 		cursor: pointer;
 		white-space: nowrap;
-		transition: background var(--motion-base), color var(--motion-base);
+		transition: background var(--motion-base), border-color var(--motion-base), color var(--motion-base);
 	}
 
 	.chip:hover,
 	.chip:focus-visible {
+		background: var(--bg-hover);
+		border-color: var(--accent-line);
 		color: var(--text-primary);
 		outline: none;
 	}
 
 	.chip.active {
 		background: var(--bg-hover);
+		border-color: var(--accent-line);
 		color: var(--text-primary);
 	}
 
-	@media (max-width: 760px) {
-		.chart-mural-bg {
-			grid-template-columns: repeat(5, minmax(0, 1fr));
-			grid-template-rows: repeat(4, minmax(0, 1fr));
-		}
-
-		.chart-mural-content {
-			padding: var(--space-4);
-		}
-
-		.chart-mural-meta {
-			max-width: 100%;
-		}
-
-		.chart-mural-title {
-			font-size: var(--font-size-3xl);
-		}
-	}
 </style>

--- a/frontend/src/lib/components/charts/TrendingShelf.svelte
+++ b/frontend/src/lib/components/charts/TrendingShelf.svelte
@@ -15,12 +15,17 @@
 	import {
 		api,
 		type ChartEntry,
+		type TidalPlayable,
 		type Track,
 		type LastfmCountry,
 		type LastfmGenre,
 	} from '$lib/api/client';
 	import { playTrackNow } from '$lib/stores/player';
+	import { openContextMenu } from '$lib/stores/context_menu';
 	import { playChartTidalTrack } from '$lib/player/play_trending';
+	import { canPlayTrack, getPlayableLabel } from '$lib/player/playable';
+	import { buildTrackMenu, buildTidalTrackMenu } from '$lib/player/track_menu';
+	import SectionHeader from '$lib/components/ui/SectionHeader.svelte';
 	import {
 		selectedTrendingMode,
 		selectedCountry,
@@ -28,7 +33,7 @@
 		type TrendingMode,
 	} from '$lib/stores/trending-prefs';
 	import { getCached, putCached } from '$lib/stores/trending-cache';
-	import TrendingCard from '$lib/components/TrendingCard.svelte';
+	import ChartMural, { type ChartMuralItem } from '$lib/components/charts/ChartMural.svelte';
 	import EmptyState from '$lib/components/ui/EmptyState.svelte';
 
 	interface Props {
@@ -36,7 +41,7 @@
 	}
 	let { limit = 12 }: Props = $props();
 
-	// `tidal` is intentionally absent — the editorial-chart endpoint returns
+	// `tidal` is intentionally absent - the editorial-chart endpoint returns
 	// 404 ("not confirmed" in the Tidal client warning), so exposing the tab
 	// would always render an empty state. Add it back here when that endpoint
 	// is sorted; the store/type/backend route still accept the value.
@@ -45,6 +50,7 @@
 		{ id: 'country', label: 'Country' },
 		{ id: 'genre', label: 'Genre' },
 	];
+	const ROTATE_MS = 8000;
 
 	let countries = $state<LastfmCountry[]>([]);
 	let genres = $state<LastfmGenre[]>([]);
@@ -55,8 +61,32 @@
 	// state before the on-mount fetch flips it on.
 	let loading = $state(true);
 	let error = $state(false);
+	let currentEntryIndex = $state(0);
+	let muralPaused = $state(false);
+	let resolvingEntries = $state<Record<string, boolean>>({});
+	let lazyArtwork = $state<Record<string, string>>({});
 
 	let lastToken = '';
+	let visibleEntries = $derived(tracks.slice(0, limit));
+	let currentEntry = $derived(visibleEntries[currentEntryIndex] ?? visibleEntries[0] ?? null);
+	let muralItems = $derived<ChartMuralItem[]>(
+		visibleEntries.map((entry, index) => ({
+			id: entryKey(entry, index),
+			title: entryTitle(entry),
+			subtitle: entrySubtitle(entry, index),
+			artwork: entryArtwork(entry, index),
+			fallbackText: entryFallbackText(entry),
+			tileLabel: `Select ${entryTitle(entry)}`,
+			tileTitle: `${index + 1}. ${entryTitle(entry)} - ${entryArtist(entry) ?? 'Unknown artist'}`,
+			lazy: {
+				enabled: needsLazyArtwork(entry, index),
+				query: { artist: entryArtist(entry), title: entryTitle(entry) },
+				onResolve: (url) => {
+					lazyArtwork = { ...lazyArtwork, [entryKey(entry, index)]: url };
+				},
+			},
+		})),
+	);
 
 	function tokenFor(mode: TrendingMode, country: string, genre: string): string {
 		if (mode === 'country') return `country:${country}`;
@@ -66,7 +96,7 @@
 
 	// Per-entry key for the grid each-block. Last.fm-only entries arrive with
 	// `tidal_playable.tidal_id === 0` (placeholder), so `??` falls through to
-	// the index-based fallback, since 0 is falsy-but-not-nullish — without
+	// the index-based fallback, since 0 is falsy-but-not-nullish - without
 	// this, every unresolved card collides on key `0` and Svelte throws
 	// `each_key_duplicate`, which prevents the whole shelf from rendering.
 	function entryKey(entry: ChartEntry, i: number): string {
@@ -79,12 +109,106 @@
 		return `lf:${i}:${artist}:${title}`;
 	}
 
+	function optionalStringField(entry: ChartEntry, key: 'display_title' | 'display_subtitle'): string | null {
+		const value = (entry as unknown as Record<string, unknown>)[key];
+		return typeof value === 'string' && value.trim() ? value : null;
+	}
+
+	function entryTitle(entry: ChartEntry): string {
+		return optionalStringField(entry, 'display_title') ?? entry.local_track?.title ?? entry.tidal_playable?.title ?? 'Unknown track';
+	}
+
+	function entryArtist(entry: ChartEntry): string | null {
+		return optionalStringField(entry, 'display_subtitle') ?? entry.local_track?.artist_name ?? entry.tidal_playable?.artist_name ?? null;
+	}
+
+	function entryTarget(entry: ChartEntry): Track | TidalPlayable | null {
+		return entry.local_track ?? entry.tidal_playable ?? null;
+	}
+
+	const LASTFM_PLACEHOLDER_HASH = '2a96cbd8b46e442fc41c2b86b821562f';
+	function usableArtwork(...candidates: (string | null | undefined)[]): string | null {
+		for (const candidate of candidates) {
+			if (!candidate) continue;
+			const trimmed = candidate.trim();
+			if (!trimmed) continue;
+			if (trimmed.includes(LASTFM_PLACEHOLDER_HASH)) continue;
+			return trimmed;
+		}
+		return null;
+	}
+
+	function entryArtwork(entry: ChartEntry, index: number): string | null {
+		return usableArtwork(
+			lazyArtwork[entryKey(entry, index)],
+			entry.local_track?.artwork_url,
+			entry.tidal_playable?.artwork_url,
+			entry.image_url,
+		);
+	}
+
+	function needsLazyArtwork(entry: ChartEntry, index: number): boolean {
+		return entryArtwork(entry, index) === null;
+	}
+
+	function entryFallbackText(entry: ChartEntry): string {
+		return (entryTitle(entry).trim()[0] ?? 'N').toUpperCase();
+	}
+
+	function entrySubtitle(entry: ChartEntry, index: number): string {
+		return `#${index + 1} - ${entryArtist(entry) ?? 'Unknown artist'}`;
+	}
+
+	function isEntryUnresolved(entry: ChartEntry): boolean {
+		return entry.local_track === null &&
+			entry.tidal_playable !== null &&
+			entry.tidal_playable.tidal_id <= 0;
+	}
+
+	function isEntryPlayable(entry: ChartEntry): boolean {
+		const target = entryTarget(entry);
+		return target !== null && (canPlayTrack(target) || isEntryUnresolved(entry));
+	}
+
+	function entryStatusLabel(entry: ChartEntry, index: number): string {
+		const key = entryKey(entry, index);
+		if (resolvingEntries[key]) return 'Resolving';
+		if (entry.local_track) return 'In library';
+		if (isEntryUnresolved(entry)) return 'Resolve on TIDAL';
+		if (entry.tidal_playable) return 'TIDAL ready';
+		return 'Unavailable';
+	}
+
+	function entryActionLabel(entry: ChartEntry, index: number): string {
+		const key = entryKey(entry, index);
+		if (resolvingEntries[key]) return 'Resolving...';
+		if (isEntryUnresolved(entry)) return 'Resolve on TIDAL';
+		const target = entryTarget(entry);
+		return target ? getPlayableLabel(target) : 'Unavailable';
+	}
+
+	function currentKindLabel(): string {
+		return `Last.fm top ${visibleEntries.length} - ${subLabel}`;
+	}
+
 	onMount(() => {
 		// Migrate stale 'tidal' from the pre-merge source key before reads happen.
 		if (!MODES.some((m) => m.id === get(selectedTrendingMode))) {
 			selectedTrendingMode.set('worldwide');
 		}
 		void loadCurated();
+	});
+
+	$effect(() => {
+		if (currentEntryIndex >= visibleEntries.length) currentEntryIndex = 0;
+	});
+
+	$effect(() => {
+		if (visibleEntries.length <= 1) return;
+		const timer = setInterval(() => {
+			if (!muralPaused) jumpEntry(1);
+		}, ROTATE_MS);
+		return () => clearInterval(timer);
 	});
 
 	// Idiomatic Svelte 5: $effect tracks $store reads and re-runs on any change.
@@ -108,6 +232,7 @@
 		const cached = getCached(token);
 		if (cached) {
 			tracks = cached;
+			currentEntryIndex = 0;
 			loading = false;
 			error = false;
 			return;
@@ -131,7 +256,7 @@
 	}
 
 	async function load(mode: TrendingMode, country: string, genre: string, token: string) {
-		// Keep `tracks` populated while we fetch — replacing only when new data
+		// Keep `tracks` populated while we fetch - replacing only when new data
 		// lands avoids the flash-to-empty-state and the resulting grid reflow.
 		loading = true;
 		error = false;
@@ -148,6 +273,7 @@
 			}
 			const next = data.tracks ?? [];
 			tracks = next;
+			currentEntryIndex = 0;
 			// Only cache non-empty payloads so a transient 5xx returning [] doesn't
 			// poison the cache for 6h.
 			if (next.length > 0) putCached(token, next);
@@ -177,6 +303,46 @@
 		void playTrackNow(t.id);
 	}
 
+	function selectEntry(index: number) {
+		currentEntryIndex = index;
+	}
+
+	function jumpEntry(delta: number) {
+		if (visibleEntries.length === 0) return;
+		currentEntryIndex = (currentEntryIndex + delta + visibleEntries.length) % visibleEntries.length;
+	}
+
+	async function playEntry(entry: ChartEntry, index: number) {
+		const target = entryTarget(entry);
+		if (!target || (!canPlayTrack(target) && !isEntryUnresolved(entry))) return;
+		if (entry.local_track) {
+			onTrack(entry.local_track);
+			return;
+		}
+		if (!entry.tidal_playable) return;
+		const key = entryKey(entry, index);
+		resolvingEntries = { ...resolvingEntries, [key]: isEntryUnresolved(entry) };
+		try {
+			await playChartTidalTrack(entry.tidal_playable);
+		} finally {
+			resolvingEntries = { ...resolvingEntries, [key]: false };
+		}
+	}
+
+	function handleEntryContext(e: MouseEvent, entry: ChartEntry) {
+		e.preventDefault();
+		e.stopPropagation();
+		const local = entry.local_track;
+		if (local) {
+			openContextMenu(e, buildTrackMenu(local), local.title);
+			return;
+		}
+		const tidal = entry.tidal_playable;
+		if (tidal) {
+			openContextMenu(e, buildTidalTrackMenu(tidal), tidal.title);
+		}
+	}
+
 	const subLabel = $derived.by(() => {
 		const m = $selectedTrendingMode;
 		if (m === 'country') {
@@ -191,31 +357,29 @@
 </script>
 
 <section class="trending-shelf">
-	<div class="section-header">
-		<div class="section-title-group">
-			<p class="eyebrow">From Last.fm <span class="eyebrow-dot" aria-hidden="true">·</span> Now moving</p>
-			<h2>Trending <span class="sub">· {subLabel}</span></h2>
-		</div>
-		<div class="trending-controls">
-			<div class="chip-group" role="tablist" aria-label="Trending scope">
-				{#each MODES as m (m.id)}
-					<button
-						type="button"
-						class="chip"
-						class:active={m.id === $selectedTrendingMode}
-						onclick={() => pickMode(m.id)}
-						role="tab"
-						aria-selected={m.id === $selectedTrendingMode}
-					>
-						{m.label}
-					</button>
-				{/each}
+	<SectionHeader eyebrow="From Last.fm - Now moving" title="Trending" subtitle={subLabel} variant="charts" level={2}>
+		{#snippet actions()}
+			<div class="trending-controls">
+				<div class="chip-group" role="tablist" aria-label="Trending scope">
+					{#each MODES as m (m.id)}
+						<button
+							type="button"
+							class="chip"
+							class:active={m.id === $selectedTrendingMode}
+							onclick={() => pickMode(m.id)}
+							role="tab"
+							aria-selected={m.id === $selectedTrendingMode}
+						>
+							{m.label}
+						</button>
+					{/each}
+				</div>
+				<!-- Always-rendered, fixed-width slot - flips opacity instead of mounting/unmounting,
+				     so the chip group doesn't reflow when fetches start/finish. -->
+				<span class="loading-indicator" class:visible={loading} aria-hidden={!loading}>Loading...</span>
 			</div>
-			<!-- Always-rendered, fixed-width slot — flips opacity instead of mounting/unmounting,
-			     so the chip group doesn't reflow when fetches start/finish. -->
-			<span class="loading-indicator" class:visible={loading} aria-hidden={!loading}>Loading…</span>
-		</div>
-	</div>
+		{/snippet}
+	</SectionHeader>
 
 	<!-- Always-rendered subrow; content swaps by mode. Reserves stable vertical
 	     space so the grid below doesn't jump when modes change. -->
@@ -249,22 +413,32 @@
 		{/if}
 	</div>
 
-	{#if tracks.length > 0}
-		<div class="trending-grid">
-			{#each tracks.slice(0, limit) as entry, i (entryKey(entry, i))}
-				<TrendingCard {entry} index={i} {onTrack} onTidal={playChartTidalTrack} />
-			{/each}
-		</div>
-	{:else if loading}
-		<!-- Skeleton grid so the area isn't blank during the first fetch (was a
-		     "did the page break?" UX cliff with the previous render-nothing branch). -->
-		<div class="trending-grid">
-			{#each Array.from({ length: Math.min(limit, 8) }) as _, i (i)}
-				<div class="skeleton-card" aria-hidden="true"></div>
-			{/each}
-		</div>
+	{#if tracks.length > 0 || loading}
+		<ChartMural
+			items={muralItems}
+			currentIndex={currentEntryIndex}
+			ariaLabel={`Last.fm ${subLabel} top ${visibleEntries.length}`}
+			kindLabel={currentKindLabel()}
+			title={currentEntry ? entryTitle(currentEntry) : ''}
+			subtitle={currentEntry ? entrySubtitle(currentEntry, currentEntryIndex) : ''}
+			metric={currentEntry ? currentEntry.genre ?? entryStatusLabel(currentEntry, currentEntryIndex) : ''}
+			actionLabel={currentEntry ? entryActionLabel(currentEntry, currentEntryIndex) : 'Unavailable'}
+			actionDisabled={!currentEntry || !isEntryPlayable(currentEntry)}
+			accent="lastfm"
+			loading={loading && tracks.length === 0}
+			loadingLabel="Loading Last.fm chart"
+			onSelect={selectEntry}
+			onJump={jumpEntry}
+			onPlay={() => currentEntry && playEntry(currentEntry, currentEntryIndex)}
+			onCardContext={(event) => currentEntry && handleEntryContext(event, currentEntry)}
+			onItemContext={(event, index) => {
+				const entry = visibleEntries[index];
+				if (entry) handleEntryContext(event, entry);
+			}}
+			onPauseChange={(paused) => muralPaused = paused}
+		/>
 	{:else if error}
-		<EmptyState title="Couldn’t load this chart" copy="Try another scope or check the Last.fm key in Settings." />
+		<EmptyState title="Couldn't load this chart" copy="Try another scope or check the Last.fm key in Settings." />
 	{:else}
 		<EmptyState title="Nothing trending here yet" copy="Try another country, genre, or scope." />
 	{/if}
@@ -274,53 +448,13 @@
 	.trending-shelf {
 		display: flex;
 		flex-direction: column;
-		gap: 14px;
-	}
-
-	.section-header {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		gap: 16px;
-		flex-wrap: wrap;
-	}
-
-	.section-title-group {
-		display: flex;
-		flex-direction: column;
-		gap: 4px;
-	}
-
-	.section-title-group h2 {
-		font-size: var(--font-size-lg);
-		font-weight: var(--font-weight-bold);
-		margin: 0;
-	}
-
-	.section-title-group h2 .sub {
-		color: var(--text-muted);
-		font-weight: var(--font-weight-medium);
-		font-size: var(--font-size-md);
-		margin-left: 2px;
-	}
-
-	.eyebrow {
-		font-size: var(--font-size-xs);
-		font-weight: var(--font-weight-semibold);
-		text-transform: uppercase;
-		letter-spacing: 0.08em;
-		color: var(--service-lastfm);
-		margin: 0;
-	}
-	.eyebrow-dot {
-		color: var(--text-muted);
-		margin: 0 4px;
+		gap: var(--space-3);
 	}
 
 	.trending-controls {
 		display: flex;
 		align-items: center;
-		gap: 12px;
+		gap: var(--space-2);
 		flex-wrap: nowrap; /* keeps chip-group + loading slot on a single line */
 		min-width: 0;
 	}
@@ -328,46 +462,55 @@
 	.chip-group {
 		display: inline-flex;
 		gap: var(--space-1);
-		padding: 2px;
+		padding: var(--space-1);
 		background: var(--panel-bg);
 		border: 1px solid var(--panel-border);
 		border-radius: 999px;
 	}
 
 	.chip {
-		background: transparent;
-		border: none;
+		background: var(--panel-bg);
+		border: 1px solid var(--panel-border);
 		color: var(--text-muted);
 		font: inherit;
 		font-size: var(--font-size-xs);
-		font-weight: var(--font-weight-medium);
-		padding: 4px 10px;
+		font-weight: var(--font-weight-semibold);
+		line-height: 1;
+		padding: var(--space-2) var(--space-3);
 		border-radius: 999px;
 		cursor: pointer;
-		transition: background var(--motion-fast), color var(--motion-fast);
+		white-space: nowrap;
+		transition: background var(--motion-base), border-color var(--motion-base), color var(--motion-base);
 	}
 
-	.chip:hover { color: var(--text-primary); }
+	.chip:hover,
+	.chip:focus-visible {
+		background: var(--bg-hover);
+		border-color: var(--accent-line);
+		color: var(--text-primary);
+		outline: none;
+	}
 
 	.chip.active {
 		background: var(--bg-hover);
+		border-color: var(--accent-line);
 		color: var(--text-primary);
 	}
 
 	.chip-row {
 		display: flex;
 		flex-wrap: wrap;
-		gap: 6px;
+		gap: var(--space-1);
 		/* Reserves one row of chip height even when worldwide mode renders no
 		   chips, so switching modes doesn't shift the grid below. */
-		min-height: 28px;
+		min-height: clamp(28px, 2vw, 36px);
 	}
 
 	.chip.secondary {
-		background: rgba(255, 255, 255, 0.04);
+		background: var(--panel-bg);
 	}
 	.chip.secondary.active {
-		background: rgba(255, 255, 255, 0.16);
+		background: var(--bg-hover);
 	}
 
 	.loading-indicator {
@@ -375,43 +518,13 @@
 		color: var(--text-muted);
 		font-style: italic;
 		/* Reserve the slot so the chip group never reflows when loading toggles. */
-		min-width: 60px;
+		min-width: clamp(52px, 4vw, 68px);
 		opacity: 0;
-		transition: opacity 0.18s ease;
+		transition: opacity var(--motion-fast);
 		pointer-events: none;
 	}
 	.loading-indicator.visible {
 		opacity: 1;
 	}
 
-	.trending-grid {
-		display: grid;
-		grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
-		gap: 14px;
-	}
-
-	@media (max-width: 720px) {
-		.trending-grid {
-			grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
-			gap: 10px;
-		}
-	}
-
-	.skeleton-card {
-		aspect-ratio: 1;
-		border-radius: var(--radius-md);
-		background: linear-gradient(
-			110deg,
-			rgba(255, 255, 255, 0.04) 30%,
-			rgba(255, 255, 255, 0.08) 50%,
-			rgba(255, 255, 255, 0.04) 70%
-		);
-		background-size: 200% 100%;
-		animation: skeleton-shimmer 1.4s ease-in-out infinite;
-	}
-
-	@keyframes skeleton-shimmer {
-		0% { background-position: 200% 0; }
-		100% { background-position: -200% 0; }
-	}
 </style>

--- a/frontend/src/lib/components/charts/daily_chart_shelf_contract.test.ts
+++ b/frontend/src/lib/components/charts/daily_chart_shelf_contract.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, test } from 'vitest';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const source = readFileSync(join(here, 'DailyChartShelf.svelte'), 'utf8');
+const muralSource = readFileSync(join(here, 'ChartMural.svelte'), 'utf8');
 const chartsPage = readFileSync(
 	join(here, '..', '..', '..', 'routes', 'charts', '+page.svelte'),
 	'utf8',
@@ -20,13 +21,19 @@ describe('daily chart shelf contract', () => {
 		expect(source).toContain('snapshotRefreshAttempted');
 		expect(source).toContain('next.entries.length < Math.min(10, LIMIT)');
 
-		const trendingIndex = chartsPage.indexOf('<TrendingShelf limit={12} />');
+		const trendingIndex = chartsPage.indexOf('<TrendingShelf limit={20} />');
 		const dailyIndex = chartsPage.indexOf('<DailyChartShelf />');
-		const playlistsIndex = chartsPage.indexOf('<h2 class="block-title">Spotify chart playlists</h2>');
+		const playlistsIndex = chartsPage.indexOf('title="Chart playlists"');
 
 		expect(trendingIndex).toBeGreaterThan(-1);
 		expect(dailyIndex).toBeGreaterThan(trendingIndex);
 		expect(playlistsIndex).toBeGreaterThan(dailyIndex);
+		expect(chartsPage).toContain('PageHeader');
+		expect(chartsPage).toContain('variant="editorial"');
+		expect(chartsPage).toContain('SectionHeader');
+		expect(chartsPage).toContain('variant="charts"');
+		expect(chartsPage).toContain('level={2}');
+		expect(chartsPage).not.toContain('style="background-image');
 	});
 
 	test('keeps empty and restart states visible when refresh cannot populate data', () => {
@@ -46,13 +53,19 @@ describe('daily chart shelf contract', () => {
 	});
 
 	test('uses provider chips and a top 20 mural instead of duplicate leader cards', () => {
+		expect(source).toContain('SectionHeader');
+		expect(source).toContain('variant="charts"');
+		expect(source).toContain('level={2}');
 		expect(source).toContain('source-tabs');
-		expect(source).toContain('chart-mural-card');
-		expect(source).toContain('chartEntries as entry');
+		expect(source).toContain('ChartMural');
+		expect(source).toContain('type ChartMuralItem');
+		expect(muralSource).toContain('chart-mural');
+		expect(source).toContain('chartEntries.map((entry');
 		expect(source).toContain('currentEntry');
 		expect(source).toContain('pickProvider(selectedRegion, provider.source_key)');
 		expect(source).not.toContain('provider-card');
 		expect(source).not.toContain('Provider snapshot');
+		expect(source).not.toContain('chart-mural-card');
 	});
 
 	test('resolves visible chart entries against TIDAL for artwork and playback', () => {
@@ -60,8 +73,30 @@ describe('daily chart shelf contract', () => {
 		expect(source).toContain('resolvedTracks');
 		expect(source).toContain('playTidalTrackNow');
 		expect(source).toContain('TIDAL ready');
-		expect(source).toContain('chart-mural-art');
+		expect(muralSource).toContain('chart-mural-art');
 		expect(source).toContain('async function resolveVisibleEntries(entries');
 		expect(source).toContain('async function playEntry(entry');
+	});
+
+	test('uses shared context menus and standardized pill controls', () => {
+		expect(source).toContain('openContextMenu');
+		expect(source).toContain('buildTidalTrackMenu');
+		expect(source).toContain('openEntryContext');
+		expect(source).toContain('openMatrixCellContext');
+		expect(source).toContain('oncontextmenu');
+		expect(source).toContain('border: 1px solid var(--panel-border)');
+		expect(source).toContain('border-color: var(--accent-line)');
+	});
+
+	test('keeps chart page titles neutral with shared headers and artwork images', () => {
+		expect(chartsPage).toContain('<PageHeader');
+		expect(chartsPage).toContain('variant="editorial"');
+		expect(chartsPage).toContain('<SectionHeader');
+		expect(chartsPage).toContain('<ArtworkImage');
+		expect(chartsPage).toContain('className="chart-playlist-art"');
+		expect(chartsPage).not.toContain('service-spotify');
+		expect(source).not.toContain('service-spotify');
+		expect(muralSource).toContain('.chart-mural-title');
+		expect(muralSource).toContain('color: var(--text-primary)');
 	});
 });

--- a/frontend/src/lib/components/charts/trending_shelf_contract.test.ts
+++ b/frontend/src/lib/components/charts/trending_shelf_contract.test.ts
@@ -1,0 +1,83 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, test } from 'vitest';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(join(here, 'TrendingShelf.svelte'), 'utf8');
+const muralSource = readFileSync(join(here, 'ChartMural.svelte'), 'utf8');
+
+describe('trending shelf contract', () => {
+	test('renders Last.fm charts with the market-pulse mural treatment', () => {
+		expect(source).toContain('ChartMural');
+		expect(source).toContain('type ChartMuralItem');
+		expect(source).toContain('<ChartMural');
+		expect(source).toContain('accent="lastfm"');
+		expect(source).toContain('muralItems');
+		expect(muralSource).toContain('chart-mural');
+		expect(muralSource).toContain('chart-mural-bg');
+		expect(muralSource).toContain('chart-mural-tile');
+		expect(muralSource).toContain('chart-mural-art');
+		expect(source).toContain('currentEntry');
+		expect(source).toContain('visibleEntries');
+		expect(source).toContain('ROTATE_MS');
+		expect(muralSource).toContain('repeat(10, minmax(0, 1fr))');
+		expect(muralSource).toContain('repeat(5, minmax(0, 1fr))');
+		expect(muralSource).toContain('ArtworkImage');
+		expect(muralSource).toContain('size={320}');
+		expect(muralSource).toContain('use:lazyTidalArt');
+		expect(source).not.toContain('TrendingCard');
+		expect(source).not.toContain('lastfm-mural');
+	});
+
+	test('keeps Last.fm scopes, cache, and empty states wired', () => {
+		expect(source).toContain('SectionHeader');
+		expect(source).toContain('variant="charts"');
+		expect(source).toContain('level={2}');
+		expect(source).toContain('api.getLastfmCountries()');
+		expect(source).toContain('api.getLastfmGenres()');
+		expect(source).toContain("api.getTrending({ source: 'lastfm', limit, country })");
+		expect(source).toContain("api.getTrending({ source: 'lastfm', limit, tag: genre })");
+		expect(source).toContain('getCached(token)');
+		expect(source).toContain('putCached(token, next)');
+		expect(source).toContain('Couldn');
+		expect(source).toContain('Nothing trending here yet');
+		expect(source).not.toContain('lastfm-more');
+		expect(source).not.toContain('lastfm-chart-list');
+		expect(source).not.toContain('artistSignals');
+		expect(source).not.toContain('tagSignals');
+		expect(source).not.toContain('loadSignalPanels');
+		expect(source).not.toContain('lastfm-signal-grid');
+		expect(source).not.toContain('artist-signal-art');
+		expect(source).not.toContain('tag-signal-chip');
+	});
+
+	test('preserves playback, TIDAL resolution, artwork fallback, and menus', () => {
+		expect(source).toContain('playTrackNow');
+		expect(source).toContain('playChartTidalTrack');
+		expect(source).toContain('isEntryUnresolved');
+		expect(source).toContain('Resolve on TIDAL');
+		expect(source).toContain('LASTFM_PLACEHOLDER_HASH');
+		expect(source).toContain('needsLazyArtwork');
+		expect(source).toContain('buildTrackMenu');
+		expect(source).toContain('buildTidalTrackMenu');
+		expect(source).toContain('handleEntryContext');
+		expect(source).toContain('onCardContext');
+		expect(source).toContain('onItemContext');
+	});
+
+	test('standardizes pill controls with bordered active chips', () => {
+		expect(source).toContain('border: 1px solid var(--panel-border)');
+		expect(source).toContain('border-color: var(--accent-line)');
+		expect(source).toContain('padding: var(--space-2) var(--space-3)');
+		expect(source).not.toContain('padding: 4px 10px');
+	});
+
+	test('keeps mural titles neutral while allowing small source accents', () => {
+		expect(muralSource).toContain('.chart-mural-title');
+		expect(muralSource).toContain('color: var(--text-primary)');
+		expect(muralSource).toContain('.chart-mural-kind');
+		expect(muralSource).toContain('color: var(--chart-mural-accent)');
+		expect(muralSource).not.toContain('.chart-mural-title {\n\t\tcolor: var(--chart-mural-accent)');
+	});
+});

--- a/frontend/src/lib/components/ui/PageHeader.svelte
+++ b/frontend/src/lib/components/ui/PageHeader.svelte
@@ -5,18 +5,20 @@
 		title,
 		subtitle = '',
 		eyebrow = '',
+		variant = 'default',
 		actions,
 		meta
 	}: {
 		title: string;
 		subtitle?: string;
 		eyebrow?: string;
+		variant?: 'default' | 'editorial';
 		actions?: Snippet;
 		meta?: Snippet;
 	} = $props();
 </script>
 
-<header class="page-header">
+<header class="page-header" class:editorial={variant === 'editorial'}>
 	<div class="intro">
 		{#if eyebrow}
 			<p class="eyebrow">{eyebrow}</p>
@@ -71,6 +73,13 @@
 		font-size: var(--font-size-2xl);
 		font-weight: var(--font-weight-bold);
 		line-height: var(--line-height-tight);
+		letter-spacing: 0;
+	}
+
+	.page-header.editorial h1 {
+		color: var(--text-primary);
+		font-size: var(--font-size-3xl);
+		font-weight: var(--font-weight-bold);
 		letter-spacing: 0;
 	}
 

--- a/frontend/src/lib/components/ui/SectionHeader.svelte
+++ b/frontend/src/lib/components/ui/SectionHeader.svelte
@@ -5,21 +5,29 @@
 		title,
 		subtitle = '',
 		eyebrow = '',
+		variant = 'default',
+		level = 3,
 		actions
 	}: {
 		title: string;
 		subtitle?: string;
 		eyebrow?: string;
+		variant?: 'default' | 'charts';
+		level?: 2 | 3;
 		actions?: Snippet;
 	} = $props();
 </script>
 
-<div class="section-header">
+<div class="section-header" class:charts={variant === 'charts'}>
 	<div class="copy">
 		{#if eyebrow}
 			<p class="eyebrow">{eyebrow}</p>
 		{/if}
-		<h3>{title}</h3>
+		{#if level === 2}
+			<h2 class="title">{title}</h2>
+		{:else}
+			<h3 class="title">{title}</h3>
+		{/if}
 		{#if subtitle}
 			<p class="subtitle">{subtitle}</p>
 		{/if}
@@ -57,6 +65,42 @@
 
 	.subtitle {
 		color: var(--text-secondary);
+	}
+
+	.title {
+		margin: 0;
+	}
+
+	.section-header.charts {
+		align-items: center;
+	}
+
+	.section-header.charts .copy {
+		gap: var(--space-1);
+	}
+
+	.section-header.charts .eyebrow {
+		margin: 0;
+		color: var(--text-muted);
+		font-size: var(--font-size-xs);
+		font-weight: var(--font-weight-semibold);
+		letter-spacing: 0;
+		line-height: 1;
+	}
+
+	.section-header.charts .title {
+		color: var(--text-primary);
+		font-size: var(--font-size-lg);
+		font-weight: var(--font-weight-bold);
+		line-height: var(--line-height-tight);
+		letter-spacing: 0;
+	}
+
+	.section-header.charts .subtitle {
+		margin: 0;
+		color: var(--text-secondary);
+		font-size: var(--font-size-sm);
+		line-height: var(--line-height-snug);
 	}
 
 	.actions {

--- a/frontend/src/routes/charts/+page.svelte
+++ b/frontend/src/routes/charts/+page.svelte
@@ -5,6 +5,9 @@
   import { goto } from '$app/navigation';
   import TrendingShelf from '$lib/components/charts/TrendingShelf.svelte';
   import DailyChartShelf from '$lib/components/charts/DailyChartShelf.svelte';
+  import PageHeader from '$lib/components/ui/PageHeader.svelte';
+  import SectionHeader from '$lib/components/ui/SectionHeader.svelte';
+  import ArtworkImage from '$lib/components/ui/ArtworkImage.svelte';
   import {
     getCachedSpotifyChartMetaMap,
     putCachedSpotifyChartMeta,
@@ -82,24 +85,28 @@
 <svelte:head><title>Charts . NOOR</title></svelte:head>
 
 <div class="page">
-  <header class="page-header">
-    <p class="eyebrow">Charts</p>
-    <h1>What's hot</h1>
-    <p class="sub">Worldwide trending tracks from Last.fm and editorial Spotify chart playlists.</p>
-  </header>
+  <PageHeader
+    eyebrow="Charts"
+    title="What's hot"
+    subtitle="Worldwide trending tracks from Last.fm and editorial Spotify chart playlists."
+    variant="editorial"
+  />
 
   <section class="trending-block">
-    <TrendingShelf limit={12} />
+    <TrendingShelf limit={20} />
   </section>
 
   <section class="daily-block">
     <DailyChartShelf />
   </section>
 
-  <section>
-    <h2 class="block-title">Spotify chart playlists</h2>
-    <p class="block-sub">Click any to play on TIDAL.</p>
-  </section>
+  <SectionHeader
+    eyebrow="Spotify playlists"
+    title="Chart playlists"
+    subtitle="Click any to play on TIDAL."
+    variant="charts"
+    level={2}
+  />
 
   <div class="grid">
     {#each CHARTS as c (c.id)}
@@ -110,11 +117,13 @@
         oncontextmenu={(e) => { e.preventDefault(); openContextMenu(e, chartMenu(c.id, c.title), c.title); }}
       >
         <div class="art-wrap">
-          {#if m?.thumbnail}
-            <div class="art" style="background-image:url('{m.thumbnail}')"></div>
-          {:else}
-            <div class="art fallback">M</div>
-          {/if}
+          <ArtworkImage
+            src={m?.thumbnail ?? null}
+            alt={m?.title ?? c.title}
+            size={320}
+            className="chart-playlist-art"
+            fallbackText="M"
+          />
         </div>
         <div class="meta">
           <p class="title">{m?.title ?? c.title}</p>
@@ -126,13 +135,7 @@
 </div>
 
 <style>
-  .page { max-width: var(--content-width); margin: 0 auto; padding: 32px 28px 96px; display: flex; flex-direction: column; gap: 24px; }
-  .page-header { display: flex; flex-direction: column; gap: 4px; }
-  .eyebrow { font-size: var(--font-size-xs); letter-spacing: 0.08em; text-transform: uppercase; color: var(--service-spotify); margin: 0; font-weight: var(--font-weight-bold); }
-  .page-header h1 { margin: 0; font-size: var(--font-size-3xl); font-weight: 800; }
-  .page-header .sub { margin: 0; font-size: var(--font-size-sm); color: var(--text-secondary); }
-  .block-title { margin: 0 0 4px; font-size: var(--font-size-lg); font-weight: var(--font-weight-bold); color: var(--text-primary); }
-  .block-sub { margin: 0 0 var(--space-3); font-size: var(--font-size-sm); color: var(--text-secondary); }
+  .page { max-width: var(--content-width); margin: 0 auto; padding: var(--space-5) var(--space-4) var(--space-7); display: flex; flex-direction: column; gap: var(--space-5); }
   .trending-block { display: flex; flex-direction: column; gap: var(--gap); }
 
   .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(min(180px, 100%), 1fr)); gap: var(--gap); }
@@ -153,9 +156,9 @@
   .card:hover, .card:focus-visible { background: var(--bg-hover); border-color: var(--panel-border); outline: none; }
   .card:focus-visible { border-color: var(--accent-line); }
   .art-wrap { position: relative; aspect-ratio: 1 / 1; width: 100%; border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-hover); }
-  .art { width: 100%; height: 100%; background-size: cover; background-position: center; transition: transform var(--motion-base); }
-  .card:hover .art { transform: scale(1.05); }
-  .art.fallback { display: flex; align-items: center; justify-content: center; font-size: var(--font-size-4xl); color: var(--text-muted); }
+  :global(.chart-playlist-art) { width: 100%; height: 100%; object-fit: cover; transition: transform var(--motion-base); }
+  .card:hover :global(.chart-playlist-art) { transform: scale(1.05); }
+  :global(.chart-playlist-art.fallback) { display: flex; align-items: center; justify-content: center; background: var(--bg-hover); color: var(--text-muted); font-size: var(--font-size-4xl); font-weight: var(--font-weight-bold); }
   .meta { display: flex; flex-direction: column; gap: var(--space-1); min-width: 0; }
   .meta .title { margin: 0; font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; line-height: var(--line-height-snug); }
   .meta .sub { font-size: var(--font-size-xs); color: var(--text-secondary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }


### PR DESCRIPTION
Summary:
- Reapplies the charts layout standardization as a stacked PR on top of the chart ingestion/provider matrix branch.
- Adds shared ChartMural, PageHeader editorial variant, SectionHeader charts variant, and standardized /charts mural rendering.
- Excludes Last.fm/scrobbling settings and recommendation work.

Verification:
- pnpm test -- trending_shelf_contract.test.ts daily_chart_shelf_contract.test.ts
- pnpm check
- pnpm lint
- pnpm run build

Stacking:
- Base branch is codex/chart-ingestion-provider-matrix because this layout depends on DailyChartShelf and chart matrix APIs from that PR.