### PR TITLE
fix(playback): gate previews and startup analysis

### DIFF
--- a/noor-server/src/playback/runtime/mod.rs
+++ b/noor-server/src/playback/runtime/mod.rs
@@ -1541,6 +1541,12 @@ fn arm_drop_preview_in_state(
     generation: u64,
     trigger_position_samples: u64,
 ) -> bool {
+    if !state.dj_engine_enabled {
+        if let Some(active) = state.engine.as_ref() {
+            active.shared.clear_drop_preview_trigger();
+        }
+        return false;
+    }
     let Some(active) = state
         .engine
         .as_ref()
@@ -1584,6 +1590,9 @@ fn set_dj_engine_enabled_in_state(state: &mut PlaybackRuntimeLoopState, enabled:
     state.prepared_dj_mixer = None;
     state.prepared_drop_preview_mixer = None;
     state.last_dj_renderer_failure = None;
+    if let Some(engine) = state.engine.as_ref() {
+        engine.shared.clear_drop_preview_trigger();
+    }
     if let Some(engine) = state.next_engine.as_mut() {
         engine.job.prepared_transition = None;
     }
@@ -1987,6 +1996,7 @@ fn run_runtime_loop(
                         };
                         match engine_result {
                             Ok(engine) => {
+                                engine.shared.suppress_started_event();
                                 engine.shared.paused.store(true, Ordering::SeqCst);
                                 state.drop_preview_engine = Some(engine);
                                 let _ = prepare_drop_preview_mixer(
@@ -2123,6 +2133,12 @@ fn run_runtime_loop(
                     generation,
                     trigger_position_samples,
                 } => {
+                    if !state.dj_engine_enabled {
+                        if let Some(active) = state.engine.as_ref() {
+                            active.shared.clear_drop_preview_trigger();
+                        }
+                        return std::ops::ControlFlow::Continue(());
+                    }
                     if state
                         .engine
                         .as_ref()
@@ -4537,6 +4553,29 @@ mod tests {
     }
 
     #[test]
+    fn dj_flag_off_refuses_to_arm_drop_preview() {
+        let mut state = test_runtime_loop_state();
+        state.dj_engine_enabled = false;
+        let active = test_engine_with_shared(1, 20);
+        active
+            .shared
+            .drop_preview_trigger_samples
+            .store(99, Ordering::Relaxed);
+        state.engine = Some(active);
+
+        assert!(!arm_drop_preview_in_state(&state, 1, 20, 144_000));
+
+        let active = state.engine.as_ref().expect("active engine");
+        assert_eq!(
+            active
+                .shared
+                .drop_preview_trigger_samples
+                .load(Ordering::Relaxed),
+            u64::MAX
+        );
+    }
+
+    #[test]
     fn mixer_promotion_stops_outgoing_without_legacy_fade() {
         let mut state = test_runtime_loop_state();
         start_dj_lookahead_in_state(
@@ -4745,6 +4784,15 @@ mod tests {
     fn disabling_dj_discards_ready_mixer_without_stopping_playback() {
         let mut state = state_with_ready_dj_pair();
         assert!(prepare_dj_mixer_for_pair(&mut state, 64).is_ok());
+        let active = state.engine.as_ref().expect("active engine");
+        active
+            .shared
+            .drop_preview_trigger_samples
+            .store(144_000, Ordering::Relaxed);
+        active
+            .shared
+            .drop_preview_start_signaled
+            .store(false, Ordering::Relaxed);
 
         set_dj_engine_enabled_in_state(&mut state, false);
 
@@ -4755,6 +4803,13 @@ mod tests {
         assert!(!active.shared.stopped.load(Ordering::SeqCst));
         assert!(!next.shared.stopped.load(Ordering::SeqCst));
         assert!(next.job.prepared_transition.is_none());
+        assert_eq!(
+            active
+                .shared
+                .drop_preview_trigger_samples
+                .load(Ordering::Relaxed),
+            u64::MAX
+        );
     }
 
     #[test]

--- a/noor-server/src/playback/runtime/shared.rs
+++ b/noor-server/src/playback/runtime/shared.rs
@@ -219,11 +219,13 @@ fn write_output_buffer<T>(
 
     if guard.started && !guard.started_notified {
         guard.started_notified = true;
-        let _ = event_tx.send(PlaybackRuntimeEvent::Started {
-            track_id: shared.track_id,
-            generation: shared.generation,
-            source: shared.source_kind,
-        });
+        if shared.started_event_enabled.load(Ordering::Relaxed) {
+            let _ = event_tx.send(PlaybackRuntimeEvent::Started {
+                track_id: shared.track_id,
+                generation: shared.generation,
+                source: shared.source_kind,
+            });
+        }
     }
 
     if guard.started && written == 0 && guard.finished && !guard.finished_notified {
@@ -345,6 +347,7 @@ pub(crate) struct PlaybackSharedState {
     pub(crate) suppress_crossfade_after_seek: AtomicBool,
     pub(crate) drop_preview_trigger_samples: AtomicU64,
     pub(crate) drop_preview_start_signaled: AtomicBool,
+    pub(crate) started_event_enabled: AtomicBool,
     pub(crate) fadein_start_samples: AtomicU64,
     pub(crate) device_sample_rate: u32,
     pub(crate) device_channels: u16,
@@ -399,11 +402,23 @@ impl PlaybackSharedState {
             suppress_crossfade_after_seek: AtomicBool::new(false),
             drop_preview_trigger_samples: AtomicU64::new(u64::MAX),
             drop_preview_start_signaled: AtomicBool::new(false),
+            started_event_enabled: AtomicBool::new(true),
             fadein_start_samples: AtomicU64::new(u64::MAX),
             device_sample_rate,
             device_channels,
             target_sample_rate: AtomicU32::new(device_sample_rate),
         }
+    }
+
+    pub(crate) fn suppress_started_event(&self) {
+        self.started_event_enabled.store(false, Ordering::Relaxed);
+    }
+
+    pub(crate) fn clear_drop_preview_trigger(&self) {
+        self.drop_preview_trigger_samples
+            .store(u64::MAX, Ordering::Relaxed);
+        self.drop_preview_start_signaled
+            .store(true, Ordering::Relaxed);
     }
 
     pub(crate) fn reset_buffer(&self) {
@@ -661,6 +676,56 @@ mod tests {
         // Idempotent overwrite is fine - the callback re-publishes on every drain.
         shared.publish_buffered_samples(0);
         assert_eq!(shared.buffered_samples.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn started_event_emits_for_normal_playback() {
+        let shared = test_shared_state();
+        {
+            let mut buffer = shared.buffer.lock().expect("buffer");
+            buffer.samples = vec![0.1, 0.2];
+        }
+        let (command_tx, _) = mpsc::channel();
+        let (event_tx, mut event_rx) = tokio::sync::broadcast::channel(4);
+        let mut output = [0.0f32; 2];
+
+        write_output_f32(&mut output, &shared, &command_tx, &event_tx);
+
+        match event_rx.try_recv().expect("started event") {
+            PlaybackRuntimeEvent::Started {
+                track_id,
+                generation,
+                source,
+            } => {
+                assert_eq!(track_id, 1);
+                assert_eq!(generation, 1);
+                assert_eq!(source, PlaybackSourceKind::TidalStream);
+            }
+            other => panic!("expected Started, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn suppress_started_event_keeps_preview_from_publishing_track_start() {
+        let shared = test_shared_state();
+        shared.suppress_started_event();
+        {
+            let mut buffer = shared.buffer.lock().expect("buffer");
+            buffer.samples = vec![0.1, 0.2];
+        }
+        let (command_tx, _) = mpsc::channel();
+        let (event_tx, mut event_rx) = tokio::sync::broadcast::channel(4);
+        let mut output = [0.0f32; 2];
+
+        write_output_f32(&mut output, &shared, &command_tx, &event_tx);
+
+        assert!(
+            event_rx.try_recv().is_err(),
+            "drop preview playback must not publish Started"
+        );
+        let buffer = shared.buffer.lock().expect("buffer");
+        assert!(buffer.started);
+        assert!(buffer.started_notified);
     }
 
     #[test]

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -145,6 +145,9 @@ async fn schedule_drop_preview_for_pair(
             .playback_runtime_info
             .as_ref()
             .and_then(|info| info.active_track_id);
+        if !state_guard.db.with_conn(queries::is_dj_engine_enabled)? {
+            return Ok(());
+        }
         if active_id != Some(current_track_id)
             || current_playback_generation(&state_guard) != lookahead.queue_generation
         {
@@ -238,6 +241,9 @@ async fn schedule_drop_preview_for_pair(
             .playback_runtime_info
             .as_ref()
             .and_then(|info| info.active_track_id);
+        if !state_guard.db.with_conn(queries::is_dj_engine_enabled)? {
+            return Ok(());
+        }
         if active_id != Some(current_track_id)
             || current_playback_generation(&state_guard) != lookahead.queue_generation
         {

--- a/noor-server/src/server/routes/dj_routes.rs
+++ b/noor-server/src/server/routes/dj_routes.rs
@@ -608,8 +608,10 @@ pub(super) async fn queue_missing_dj_profiles_for_current_pair(
                 if !queries::is_dj_engine_enabled(conn)? {
                     return Ok(Vec::new());
                 }
-                if foreground_playback_is_buffering(conn, &state_guard)? {
-                    tracing::debug!("Deferring DJ profile rebuilds while playback is buffering");
+                if foreground_playback_needs_network_priority(conn, &state_guard)? {
+                    tracing::debug!(
+                        "Deferring DJ profile rebuilds while playback needs network priority"
+                    );
                     return Ok(Vec::new());
                 }
                 let pair = super::active_dj_pair_for_state_and_conn(&state_guard, conn)?;
@@ -1051,18 +1053,45 @@ fn dj_profile_inflight_key(key: &AudioDjProfileKey) -> String {
     format!("{}:{}", key.media_ref_kind, key.media_ref_id)
 }
 
-fn foreground_playback_is_buffering(
+fn foreground_playback_needs_network_priority(
     conn: &rusqlite::Connection,
     state: &crate::AppState,
 ) -> anyhow::Result<bool> {
-    if state
-        .audio_active
-        .load(std::sync::atomic::Ordering::Relaxed)
-        || state.playback_runtime.is_none()
-    {
+    let is_playing = player::load_state(conn)?.is_playing;
+    let runtime_present = state.playback_runtime.is_some();
+    if !is_playing || !runtime_present {
         return Ok(false);
     }
-    Ok(player::load_state(conn)?.is_playing)
+    let audio_active = state
+        .audio_active
+        .load(std::sync::atomic::Ordering::Relaxed);
+    let buffer_ahead_ms = if audio_active {
+        state
+            .playback_runtime
+            .as_ref()
+            .zip(state.playback_runtime_info.as_ref())
+            .map(|(runtime, info)| {
+                let position_ms = runtime
+                    .handle
+                    .get_position_ms(info.sample_rate, info.channels)
+                    .max(0);
+                let buffered_ms = runtime
+                    .handle
+                    .get_buffered_ms(info.sample_rate, info.channels)
+                    .max(0);
+                buffered_ms.saturating_sub(position_ms)
+            })
+    } else {
+        None
+    };
+    Ok(
+        crate::services::audio_analysis::should_defer_background_analysis_for_playback(
+            is_playing,
+            runtime_present,
+            audio_active,
+            buffer_ahead_ms,
+        ),
+    )
 }
 
 fn deck_needs_profile_rebuild(deck: &DjDeckStatus) -> bool {

--- a/noor-server/src/services/audio_analysis/mod.rs
+++ b/noor-server/src/services/audio_analysis/mod.rs
@@ -11,6 +11,7 @@ pub mod scanner;
 pub mod tempo;
 
 pub const CURRENT_ANALYSIS_VERSION: &str = "v9";
+pub(crate) const BACKGROUND_ANALYSIS_MIN_BUFFER_AHEAD_MS: i64 = 15_000;
 
 /// Server-config key controlling whether the playback-driven actor analyses
 /// audio at all. Defaults to enabled. Stored in the `server_config` k/v table
@@ -42,6 +43,23 @@ pub fn set_passive_enabled(conn: &Connection, enabled: bool) -> rusqlite::Result
         rusqlite::params![PASSIVE_DSP_ENABLED_KEY, if enabled { "1" } else { "0" }],
     )?;
     Ok(())
+}
+
+pub(crate) fn should_defer_background_analysis_for_playback(
+    is_playing: bool,
+    runtime_present: bool,
+    audio_active: bool,
+    buffer_ahead_ms: Option<i64>,
+) -> bool {
+    if !is_playing || !runtime_present {
+        return false;
+    }
+    if !audio_active {
+        return true;
+    }
+    buffer_ahead_ms
+        .map(|ms| ms < BACKGROUND_ANALYSIS_MIN_BUFFER_AHEAD_MS)
+        .unwrap_or(true)
 }
 
 pub type AnalysisJob = (i64, Vec<f32>, u32); // (track_id, mono_samples, sample_rate)
@@ -272,6 +290,37 @@ mod tests {
         let planned = prepare_passive_analysis_job(input, u32::MAX, 30, true);
 
         assert!(planned.is_none());
+    }
+
+    #[test]
+    fn background_analysis_defers_until_playback_has_buffer_runway() {
+        assert!(!should_defer_background_analysis_for_playback(
+            false,
+            true,
+            true,
+            Some(0),
+        ));
+        assert!(!should_defer_background_analysis_for_playback(
+            true,
+            false,
+            true,
+            Some(0),
+        ));
+        assert!(should_defer_background_analysis_for_playback(
+            true, true, false, None,
+        ));
+        assert!(should_defer_background_analysis_for_playback(
+            true,
+            true,
+            true,
+            Some(BACKGROUND_ANALYSIS_MIN_BUFFER_AHEAD_MS - 1),
+        ));
+        assert!(!should_defer_background_analysis_for_playback(
+            true,
+            true,
+            true,
+            Some(BACKGROUND_ANALYSIS_MIN_BUFFER_AHEAD_MS),
+        ));
     }
 
     #[test]

--- a/noor-server/src/services/audio_analysis/queue_prescanner.rs
+++ b/noor-server/src/services/audio_analysis/queue_prescanner.rs
@@ -555,14 +555,14 @@ async fn load_candidates(state: &SharedState) -> Result<(Vec<PrescanCandidate>, 
 
 async fn run_batch(state: &SharedState, event_rx: &mut broadcast::Receiver<AppEvent>) {
     // Respect the global passive-DSP toggle.
-    let (passive_on, playback_buffering) = {
+    let (passive_on, playback_needs_network) = {
         let state_guard = state.read().await;
         state_guard
             .db
             .with_conn(|conn| {
                 Ok::<_, anyhow::Error>((
                     super::is_passive_enabled(conn),
-                    foreground_playback_is_buffering(conn, &state_guard)?,
+                    foreground_playback_needs_network_priority(conn, &state_guard)?,
                 ))
             })
             .unwrap_or((true, false))
@@ -570,8 +570,8 @@ async fn run_batch(state: &SharedState, event_rx: &mut broadcast::Receiver<AppEv
     if !passive_on {
         return;
     }
-    if playback_buffering {
-        tracing::debug!("queue prescanner deferred while playback is buffering");
+    if playback_needs_network {
+        tracing::debug!("queue prescanner deferred while playback needs network priority");
         return;
     }
 
@@ -644,18 +644,43 @@ async fn run_batch(state: &SharedState, event_rx: &mut broadcast::Receiver<AppEv
     }
 }
 
-fn foreground_playback_is_buffering(
+fn foreground_playback_needs_network_priority(
     conn: &rusqlite::Connection,
     state: &crate::AppState,
 ) -> anyhow::Result<bool> {
-    if state
-        .audio_active
-        .load(std::sync::atomic::Ordering::Relaxed)
-        || state.playback_runtime.is_none()
-    {
+    let is_playing = crate::playback::player::load_state(conn)?.is_playing;
+    let runtime_present = state.playback_runtime.is_some();
+    if !is_playing || !runtime_present {
         return Ok(false);
     }
-    Ok(crate::playback::player::load_state(conn)?.is_playing)
+    let audio_active = state
+        .audio_active
+        .load(std::sync::atomic::Ordering::Relaxed);
+    let buffer_ahead_ms = if audio_active {
+        state
+            .playback_runtime
+            .as_ref()
+            .zip(state.playback_runtime_info.as_ref())
+            .map(|(runtime, info)| {
+                let position_ms = runtime
+                    .handle
+                    .get_position_ms(info.sample_rate, info.channels)
+                    .max(0);
+                let buffered_ms = runtime
+                    .handle
+                    .get_buffered_ms(info.sample_rate, info.channels)
+                    .max(0);
+                buffered_ms.saturating_sub(position_ms)
+            })
+    } else {
+        None
+    };
+    Ok(super::should_defer_background_analysis_for_playback(
+        is_playing,
+        runtime_present,
+        audio_active,
+        buffer_ahead_ms,
+    ))
 }
 
 /// Spawn the long-lived queue-lookahead actor. Subscribes to queue/track


### PR DESCRIPTION
## Summary

- Gates drop preview behavior to DJ mode so non-DJ playback paths do not expose or trigger drop preview state.
- Defers background analysis during startup so startup playback work is not competing with the prescanner immediately.

## Validation

- `git diff --name-status origin/charts-layout-standardization...HEAD`
- `cargo check -p noor-server` in `E:\NOORwave\.worktrees\drop-preview-dj-mode-pr` passed with existing dead-code warnings after adding both playback commits.

## Notes

Opened as a focused playback PR split from the local `charts-layout-standardization` commits.