### PR TITLE
feat(lastfm): add profile recommendation panels

### DIFF
--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -1856,8 +1856,13 @@ export interface ListenBrainzStatus {
 
 export interface ProviderRecommendationItem {
 	provider: 'lastfm' | 'listenbrainz' | string;
-	local_track_id: number;
+	entity_type?: 'track' | 'artist' | 'album' | string;
+	local_track_id: number | null;
 	tidal_id: number | null;
+	local_artist_id?: number | null;
+	tidal_artist_id?: number | null;
+	local_album_id?: number | null;
+	tidal_album_id?: number | null;
 	title: string;
 	artist_name: string | null;
 	album_title: string | null;
@@ -1870,6 +1875,7 @@ export interface ProviderRecommendationItem {
 
 export interface ProviderRecommendationShelf {
 	provider: 'lastfm' | 'listenbrainz' | string;
+	entity_type?: 'track' | 'artist' | 'album' | string;
 	title: string;
 	status: 'ok' | 'empty' | 'error' | string;
 	message?: string;

--- a/frontend/src/lib/components/charts/ChartMural.svelte
+++ b/frontend/src/lib/components/charts/ChartMural.svelte
@@ -65,6 +65,20 @@
 	}: Props = $props();
 
 	let currentItem = $derived(items[currentIndex] ?? items[0] ?? null);
+
+	function muralLayoutClass(count: number): string {
+		if (count <= 1) return 'layout-count-1';
+		if (count <= 2) return 'layout-count-2';
+		if (count <= 3) return 'layout-count-3';
+		if (count <= 4) return 'layout-count-4';
+		if (count <= 6) return 'layout-count-6';
+		if (count <= 8) return 'layout-count-8';
+		if (count <= 10) return 'layout-count-10';
+		if (count <= 12) return 'layout-count-12';
+		if (count <= 15) return 'layout-count-15';
+		if (count <= 16) return 'layout-count-16';
+		return 'layout-count-20';
+	}
 </script>
 
 {#if loading}
@@ -81,7 +95,7 @@
 			if (onCardContext) void onCardContext(event);
 		}}
 	>
-		<div class="chart-mural-bg" aria-hidden="true">
+		<div class={`chart-mural-bg ${muralLayoutClass(items.length)}`} aria-hidden="true">
 			{#each items as item, index (item.id)}
 				<button
 					class="chart-mural-tile"
@@ -179,6 +193,56 @@
 		grid-template-columns: repeat(10, minmax(0, 1fr));
 		grid-template-rows: repeat(2, minmax(0, 1fr));
 		background: linear-gradient(120deg, var(--panel-bg), color-mix(in srgb, var(--chart-mural-accent) 16%, transparent));
+	}
+
+	.chart-mural-bg.layout-count-1 {
+		grid-template-columns: minmax(0, 1fr);
+		grid-template-rows: minmax(0, 1fr);
+	}
+
+	.chart-mural-bg.layout-count-2 {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		grid-template-rows: minmax(0, 1fr);
+	}
+
+	.chart-mural-bg.layout-count-3 {
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+		grid-template-rows: minmax(0, 1fr);
+	}
+
+	.chart-mural-bg.layout-count-4 {
+		grid-template-columns: repeat(4, minmax(0, 1fr));
+		grid-template-rows: minmax(0, 1fr);
+	}
+
+	.chart-mural-bg.layout-count-6 {
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+		grid-template-rows: repeat(2, minmax(0, 1fr));
+	}
+
+	.chart-mural-bg.layout-count-8 {
+		grid-template-columns: repeat(4, minmax(0, 1fr));
+		grid-template-rows: repeat(2, minmax(0, 1fr));
+	}
+
+	.chart-mural-bg.layout-count-10 {
+		grid-template-columns: repeat(5, minmax(0, 1fr));
+		grid-template-rows: repeat(2, minmax(0, 1fr));
+	}
+
+	.chart-mural-bg.layout-count-12 {
+		grid-template-columns: repeat(6, minmax(0, 1fr));
+		grid-template-rows: repeat(2, minmax(0, 1fr));
+	}
+
+	.chart-mural-bg.layout-count-15 {
+		grid-template-columns: repeat(5, minmax(0, 1fr));
+		grid-template-rows: repeat(3, minmax(0, 1fr));
+	}
+
+	.chart-mural-bg.layout-count-16 {
+		grid-template-columns: repeat(8, minmax(0, 1fr));
+		grid-template-rows: repeat(2, minmax(0, 1fr));
 	}
 
 	.chart-mural-bg::after {
@@ -344,7 +408,8 @@
 
 	.chart-nav {
 		position: absolute;
-		top: 50%;
+		right: var(--space-3);
+		bottom: var(--space-4);
 		z-index: var(--z-raised);
 		display: grid;
 		place-items: center;
@@ -357,8 +422,7 @@
 		cursor: pointer;
 		font-size: var(--font-size-xl);
 		line-height: 1;
-		opacity: 0;
-		transform: translateY(-50%);
+		opacity: 0.78;
 		transition: opacity var(--motion-fast), background var(--motion-fast);
 	}
 
@@ -373,7 +437,7 @@
 	}
 
 	.chart-nav--prev {
-		left: var(--space-3);
+		right: calc(var(--space-3) + clamp(32px, 3vw, 40px) + var(--space-2));
 	}
 
 	.chart-nav--next {
@@ -395,6 +459,35 @@
 	@media (max-width: 760px) {
 		.chart-mural-bg {
 			grid-template-columns: repeat(5, minmax(0, 1fr));
+			grid-template-rows: repeat(4, minmax(0, 1fr));
+		}
+
+		.chart-mural-bg.layout-count-1 {
+			grid-template-columns: minmax(0, 1fr);
+			grid-template-rows: minmax(0, 1fr);
+		}
+
+		.chart-mural-bg.layout-count-2,
+		.chart-mural-bg.layout-count-3 {
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+			grid-template-rows: repeat(2, minmax(0, 1fr));
+		}
+
+		.chart-mural-bg.layout-count-4,
+		.chart-mural-bg.layout-count-6 {
+			grid-template-columns: repeat(3, minmax(0, 1fr));
+			grid-template-rows: repeat(2, minmax(0, 1fr));
+		}
+
+		.chart-mural-bg.layout-count-8,
+		.chart-mural-bg.layout-count-10 {
+			grid-template-columns: repeat(5, minmax(0, 1fr));
+			grid-template-rows: repeat(2, minmax(0, 1fr));
+		}
+
+		.chart-mural-bg.layout-count-12,
+		.chart-mural-bg.layout-count-15 {
+			grid-template-columns: repeat(4, minmax(0, 1fr));
 			grid-template-rows: repeat(4, minmax(0, 1fr));
 		}
 

--- a/frontend/src/lib/components/charts/trending_shelf_contract.test.ts
+++ b/frontend/src/lib/components/charts/trending_shelf_contract.test.ts
@@ -80,4 +80,22 @@ describe('trending shelf contract', () => {
 		expect(muralSource).toContain('color: var(--chart-mural-accent)');
 		expect(muralSource).not.toContain('.chart-mural-title {\n\t\tcolor: var(--chart-mural-accent)');
 	});
+
+	test('keeps mural navigation controls out of the title area', () => {
+		expect(muralSource).toContain('bottom: var(--space-4)');
+		expect(muralSource).toContain('right: calc(var(--space-3) + clamp(32px, 3vw, 40px) + var(--space-2))');
+		expect(muralSource).not.toContain('top: 50%');
+		expect(muralSource).not.toContain('left: var(--space-3)');
+	});
+
+	test('fits short mural item sets instead of forcing every panel into twenty slots', () => {
+		expect(muralSource).toContain('muralLayoutClass(items.length)');
+		expect(muralSource).toContain("if (count <= 12) return 'layout-count-12'");
+		expect(muralSource).toContain('.chart-mural-bg.layout-count-6');
+		expect(muralSource).toContain('grid-template-columns: repeat(3, minmax(0, 1fr))');
+		expect(muralSource).toContain('.chart-mural-bg.layout-count-12');
+		expect(muralSource).toContain('grid-template-columns: repeat(6, minmax(0, 1fr))');
+		expect(muralSource).toContain('.chart-mural-bg.layout-count-16');
+		expect(muralSource).toContain('grid-template-columns: repeat(8, minmax(0, 1fr))');
+	});
 });

--- a/frontend/src/lib/components/home/HomeRecommendationsShelf.svelte
+++ b/frontend/src/lib/components/home/HomeRecommendationsShelf.svelte
@@ -1,20 +1,55 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { ApiError, api, type ProviderRecommendationShelf } from '$lib/api/client';
+	import { goto } from '$app/navigation';
+	import {
+		ApiError,
+		api,
+		type ProviderRecommendationItem,
+		type ProviderRecommendationShelf,
+		type TidalPlayable,
+	} from '$lib/api/client';
+	import ChartMural, { type ChartMuralItem } from '$lib/components/charts/ChartMural.svelte';
+	import SectionHeader from '$lib/components/ui/SectionHeader.svelte';
+	import EmptyState from '$lib/components/ui/EmptyState.svelte';
+	import { playChartTidalTrack, playChartTidalTracks } from '$lib/player/play_trending';
 	import { playTrackNow } from '$lib/stores/player';
-	import { wheelToHorizontal } from '$lib/actions/wheel-to-horizontal';
-	import PlayOverlay from '$lib/components/ui/PlayOverlay.svelte';
-	import { upscaleTidalArtwork } from '$lib/utils/artwork';
 
 	type State = 'hidden' | 'loading' | 'ready' | 'empty' | 'error';
+
+	const ROTATE_MS = 5500;
+	const PANEL_LIMIT = 20;
 
 	let shelves = $state<ProviderRecommendationShelf[]>([]);
 	let viewState = $state<State>('hidden');
 	let errorMsg = $state('');
-	let failedArtwork = $state<Record<string, boolean>>({});
+	let currentIndexes = $state<Record<string, number>>({});
+	let pausedShelves = $state<Record<string, boolean>>({});
+	let playingAllShelves = $state<Record<string, boolean>>({});
+	let resolvingItems = $state<Record<string, boolean>>({});
+	let lazyArtwork = $state<Record<string, string>>({});
+
+	let visibleShelves = $derived(shelves.filter((shelf) => shelf.items.length > 0));
 
 	onMount(() => {
 		void load();
+	});
+
+	$effect(() => {
+		for (const shelf of visibleShelves) {
+			const key = shelfKey(shelf);
+			const count = shelfItems(shelf).length;
+			if ((currentIndexes[key] ?? 0) >= count) currentIndexes = { ...currentIndexes, [key]: 0 };
+		}
+	});
+
+	$effect(() => {
+		const timer = setInterval(() => {
+			for (const shelf of visibleShelves) {
+				const key = shelfKey(shelf);
+				if (!pausedShelves[key] && shelfItems(shelf).length > 1) jumpItem(shelf, 1);
+			}
+		}, ROTATE_MS);
+		return () => clearInterval(timer);
 	});
 
 	async function load() {
@@ -34,6 +69,7 @@
 			viewState = 'loading';
 			const response = await api.getHomeRecommendations();
 			shelves = response.shelves ?? [];
+			currentIndexes = {};
 			viewState = shelves.some((shelf) => shelf.items.length > 0) ? 'ready' : 'empty';
 		} catch (err) {
 			if (err instanceof ApiError && err.status === 404) {
@@ -45,269 +81,288 @@
 		}
 	}
 
-	function artworkFor(url: string | null): string | null {
-		return upscaleTidalArtwork(url, 320);
+	function shelfKey(shelf: ProviderRecommendationShelf): string {
+		return `${shelf.provider}:${shelf.entity_type ?? 'track'}:${shelf.title}`;
 	}
 
-	function markArtworkFailed(key: string) {
-		failedArtwork = { ...failedArtwork, [key]: true };
+	function itemEntity(item: ProviderRecommendationItem): string {
+		return item.entity_type ?? 'track';
+	}
+
+	function isTrackShelf(shelf: ProviderRecommendationShelf): boolean {
+		return (shelf.entity_type ?? 'track') === 'track';
+	}
+
+	function shelfItems(shelf: ProviderRecommendationShelf): ProviderRecommendationItem[] {
+		return shelf.items.slice(0, PANEL_LIMIT);
+	}
+
+	function currentIndexFor(shelf: ProviderRecommendationShelf): number {
+		return currentIndexes[shelfKey(shelf)] ?? 0;
+	}
+
+	function currentItemFor(shelf: ProviderRecommendationShelf): ProviderRecommendationItem | null {
+		const items = shelfItems(shelf);
+		return items[currentIndexFor(shelf)] ?? items[0] ?? null;
+	}
+
+	function itemKey(shelf: ProviderRecommendationShelf, item: ProviderRecommendationItem, index: number): string {
+		const entity = itemEntity(item);
+		const localId = item.local_track_id;
+		if (entity === 'track' && typeof localId === 'number' && localId > 0) return `track:local:${localId}`;
+		const tidalId = item.tidal_id;
+		if (entity === 'track' && typeof tidalId === 'number' && tidalId > 0) return `track:tidal:${tidalId}`;
+		if (entity === 'artist' && item.local_artist_id) return `artist:local:${item.local_artist_id}`;
+		if (entity === 'artist' && item.tidal_artist_id) return `artist:tidal:${item.tidal_artist_id}`;
+		if (entity === 'album' && item.local_album_id) return `album:local:${item.local_album_id}`;
+		if (entity === 'album' && item.tidal_album_id) return `album:tidal:${item.tidal_album_id}`;
+		return `${shelfKey(shelf)}:${index}:${item.artist_name ?? ''}:${item.title}`;
+	}
+
+	function itemArtwork(shelf: ProviderRecommendationShelf, item: ProviderRecommendationItem, index: number): string | null {
+		return lazyArtwork[itemKey(shelf, item, index)] ?? item.artwork_url ?? null;
+	}
+
+	function itemFallbackText(item: ProviderRecommendationItem): string {
+		return (item.title.trim()[0] ?? 'N').toUpperCase();
+	}
+
+	function itemSubtitle(item: ProviderRecommendationItem, index: number): string {
+		if (itemEntity(item) === 'artist') return `#${index + 1} - Artist`;
+		return `#${index + 1} - ${item.artist_name ?? 'Unknown artist'}`;
+	}
+
+	function itemMetric(shelf: ProviderRecommendationShelf, item: ProviderRecommendationItem, index: number): string {
+		const count = shelfItems(shelf).length;
+		const position = `${index + 1} of ${count}`;
+		return item.reason ? `${position} - ${item.reason}` : position;
+	}
+
+	function shelfMuralItems(shelf: ProviderRecommendationShelf): ChartMuralItem[] {
+		return shelfItems(shelf).map((item, index) => {
+			const key = itemKey(shelf, item, index);
+			return {
+				id: key,
+				title: item.title,
+				subtitle: itemSubtitle(item, index),
+				artwork: itemArtwork(shelf, item, index),
+				fallbackText: itemFallbackText(item),
+				tileLabel: `Select ${item.title}`,
+				tileTitle: `${index + 1}. ${item.title} - ${item.artist_name ?? 'Unknown artist'}`,
+				lazy: {
+					enabled: itemArtwork(shelf, item, index) === null,
+					query: {
+						artist: itemEntity(item) === 'artist' ? item.title : item.artist_name,
+						title: itemEntity(item) === 'artist' ? '' : item.title,
+					},
+					onResolve: (url: string) => {
+						lazyArtwork = { ...lazyArtwork, [key]: url };
+					},
+				},
+			};
+		});
+	}
+
+	function itemToTidalPlayable(item: ProviderRecommendationItem): TidalPlayable {
+		return {
+			tidal_id: item.tidal_id ?? 0,
+			title: item.title,
+			artist_name: item.artist_name,
+			album_title: item.album_title,
+			artwork_url: item.artwork_url,
+			duration_ms: null,
+			artist_tidal_id: null,
+			track_id: item.local_track_id ?? undefined,
+			local_id: item.local_track_id,
+			is_in_library: Boolean(item.local_track_id),
+		};
+	}
+
+	function itemActionLabel(item: ProviderRecommendationItem): string {
+		if (item.local_track_id) return 'Play';
+		if ((item.tidal_id ?? 0) > 0) return 'Play from TIDAL';
+		return 'Resolve on TIDAL';
+	}
+
+	function selectItem(shelf: ProviderRecommendationShelf, index: number) {
+		currentIndexes = { ...currentIndexes, [shelfKey(shelf)]: index };
+	}
+
+	function jumpItem(shelf: ProviderRecommendationShelf, delta: number) {
+		const items = shelfItems(shelf);
+		if (items.length === 0) return;
+		const key = shelfKey(shelf);
+		const index = currentIndexes[key] ?? 0;
+		currentIndexes = { ...currentIndexes, [key]: (index + delta + items.length) % items.length };
+	}
+
+	async function playItem(shelf: ProviderRecommendationShelf, item: ProviderRecommendationItem, index: number) {
+		if (itemEntity(item) !== 'track') {
+			await openRecommendationItem(item);
+			return;
+		}
+		if (item.local_track_id) {
+			void playTrackNow(item.local_track_id);
+			return;
+		}
+		const key = itemKey(shelf, item, index);
+		resolvingItems = { ...resolvingItems, [key]: true };
+		try {
+			await playChartTidalTrack(itemToTidalPlayable(item));
+		} finally {
+			resolvingItems = { ...resolvingItems, [key]: false };
+		}
+	}
+
+	async function playAllRecommendations(shelf: ProviderRecommendationShelf) {
+		const key = shelfKey(shelf);
+		const items = shelfItems(shelf);
+		if (playingAllShelves[key] || items.length === 0) return;
+		playingAllShelves = { ...playingAllShelves, [key]: true };
+		try {
+			await playChartTidalTracks(items.map(itemToTidalPlayable), 'recommendations');
+		} finally {
+			playingAllShelves = { ...playingAllShelves, [key]: false };
+		}
+	}
+
+	async function openRecommendationItem(item: ProviderRecommendationItem) {
+		const entity = itemEntity(item);
+		if (entity === 'artist') {
+			if (item.local_artist_id) return goto(`/artists/${item.local_artist_id}`);
+			if (item.tidal_artist_id) return goto(`/tidal/artists/${item.tidal_artist_id}`);
+			return goto(`/search?q=${encodeURIComponent(item.title)}`);
+		}
+		if (entity === 'album') {
+			if (item.local_album_id) return goto(`/albums/${item.local_album_id}`);
+			if (item.tidal_album_id) return goto(`/tidal/albums/${item.tidal_album_id}`);
+			const query = [item.artist_name, item.title].filter(Boolean).join(' ');
+			return goto(`/search?q=${encodeURIComponent(query)}`);
+		}
+	}
+
+	function actionLabel(item: ProviderRecommendationItem): string {
+		const entity = itemEntity(item);
+		if (entity === 'artist') return item.local_artist_id || item.tidal_artist_id ? 'Open artist' : 'Search artist';
+		if (entity === 'album') return item.local_album_id || item.tidal_album_id ? 'Open album' : 'Search album';
+		return itemActionLabel(item);
+	}
+
+	function shelfSubtitle(shelf: ProviderRecommendationShelf): string {
+		if (shelf.provider === 'lastfm' && shelf.entity_type === 'artist') return 'Artists similar to your Last.fm profile.';
+		if (shelf.provider === 'lastfm' && shelf.entity_type === 'album') return 'Albums from artists near your Last.fm taste.';
+		if (shelf.provider === 'lastfm') return 'Based on your Last.fm loved, recent, and top tracks.';
+		return 'Based on your connected listening profile.';
 	}
 </script>
 
 {#if viewState === 'hidden'}
 	<!-- Hidden until a profile integration is connected. -->
 {:else if viewState === 'loading'}
-	<section class="discovery-section" data-section="provider-recommendations">
-		<div class="section-header">
-			<div class="section-title-group">
-				<p class="eyebrow">Connected profiles</p>
-				<h2>Recommendations</h2>
-			</div>
-			<span class="loading-indicator">Loading...</span>
-		</div>
-		<div class="recommendation-rail" use:wheelToHorizontal>
-			{#each [0, 1, 2, 3, 4, 5] as i (i)}
-				<div class="recommendation-card skeleton">
-					<div class="art skeleton-art"></div>
-					<div class="meta">
-						<div class="skeleton-line title-line"></div>
-						<div class="skeleton-line artist-line"></div>
-					</div>
-				</div>
-			{/each}
-		</div>
+	<section class="profile-recommendations" data-section="provider-recommendations">
+		<SectionHeader
+			eyebrow="Connected profiles"
+			title="Recommendations"
+			subtitle="Building your Last.fm panels"
+			variant="charts"
+			level={2}
+		/>
+		<ChartMural
+			ariaLabel="Loading Last.fm recommendations"
+			kindLabel="Last.fm recommended"
+			title="Loading recommendations"
+			subtitle="Checking your profile seeds"
+			loading
+			loadingLabel="Loading Last.fm recommendations"
+			accent="lastfm"
+		/>
 	</section>
 {:else if viewState === 'ready'}
-	{#each shelves as shelf (shelf.provider)}
-		<section class="discovery-section" data-section={`provider-recommendations-${shelf.provider}`}>
-			<div class="section-header">
-				<div class="section-title-group">
-					<p class="eyebrow">{shelf.provider}</p>
-					<h2>{shelf.title}</h2>
-				</div>
-				{#if shelf.status === 'error'}
-					<button type="button" class="inline-link" onclick={load}>Retry</button>
-				{/if}
-			</div>
-
-			{#if shelf.items.length > 0}
-				<div class="recommendation-rail" use:wheelToHorizontal>
-					{#each shelf.items as item (`${shelf.provider}-${item.local_track_id}`)}
-						<button
-							type="button"
-							class="recommendation-card"
-							aria-label={`Play ${item.title}`}
-							onclick={() => void playTrackNow(item.local_track_id)}
-						>
-							<div class="art-wrap">
-								{#if artworkFor(item.artwork_url) && !failedArtwork[`${shelf.provider}-${item.local_track_id}`]}
-									<img
-										class="art"
-										src={artworkFor(item.artwork_url) ?? ''}
-										alt=""
-										onerror={() => markArtworkFailed(`${shelf.provider}-${item.local_track_id}`)}
-									/>
-								{:else}
-									<div class="art fallback">{item.title.slice(0, 1).toUpperCase()}</div>
-								{/if}
-								<PlayOverlay position="center" size="md" label={`Play ${item.title}`} />
-							</div>
-							<div class="meta">
-								<h3>{item.title}</h3>
-								<p>{item.artist_name ?? 'Unknown artist'}</p>
-								<span>{item.reason}</span>
-							</div>
-						</button>
-					{/each}
-				</div>
-			{:else}
-				<p class="muted-line">{shelf.message ?? 'No playable recommendations yet.'}</p>
+	<div class="profile-recommendations-list">
+		{#each visibleShelves as shelf (shelfKey(shelf))}
+			{@const currentItem = currentItemFor(shelf)}
+			{@const currentIndex = currentIndexFor(shelf)}
+			{@const key = shelfKey(shelf)}
+			{#if currentItem}
+				<section class="profile-recommendations" data-section={`provider-recommendations-${shelf.provider}-${shelf.entity_type ?? 'track'}`}>
+					<SectionHeader
+						eyebrow="Connected profiles"
+						title={shelf.title}
+						subtitle={shelfSubtitle(shelf)}
+						variant="charts"
+						level={2}
+					>
+						{#snippet actions()}
+							{#if isTrackShelf(shelf)}
+								<button
+									type="button"
+									class="btn btn-glass"
+									disabled={Boolean(playingAllShelves[key]) || shelfItems(shelf).length === 0}
+									onclick={() => playAllRecommendations(shelf)}
+								>
+									{playingAllShelves[key] ? 'Resolving...' : 'Play all'}
+								</button>
+							{/if}
+						{/snippet}
+					</SectionHeader>
+					<ChartMural
+						items={shelfMuralItems(shelf)}
+						currentIndex={currentIndex}
+						ariaLabel={`${shelf.title} carousel`}
+						kindLabel={shelf.provider === 'lastfm' ? `Last.fm ${shelf.entity_type ?? 'track'}s` : 'Connected profile'}
+						title={currentItem.title}
+						subtitle={itemSubtitle(currentItem, currentIndex)}
+						metric={itemMetric(shelf, currentItem, currentIndex)}
+						actionLabel={resolvingItems[itemKey(shelf, currentItem, currentIndex)] ? 'Resolving...' : actionLabel(currentItem)}
+						actionDisabled={Boolean(resolvingItems[itemKey(shelf, currentItem, currentIndex)])}
+						accent={shelf.provider === 'lastfm' ? 'lastfm' : 'accent'}
+						onSelect={(index) => selectItem(shelf, index)}
+						onJump={(delta) => jumpItem(shelf, delta)}
+						onPlay={() => playItem(shelf, currentItem, currentIndex)}
+						onPauseChange={(paused) => pausedShelves = { ...pausedShelves, [key]: paused }}
+					/>
+				</section>
 			{/if}
-		</section>
-	{/each}
+		{/each}
+	</div>
 {:else if viewState === 'empty'}
-	<section class="discovery-section" data-section="provider-recommendations-empty">
-		<div class="section-header">
-			<div class="section-title-group">
-				<p class="eyebrow">Connected profiles</p>
-				<h2>Recommendations</h2>
-			</div>
-		</div>
-		<p class="muted-line">
-			Connected profiles have no playable recommendations yet.
-			<a class="inline-link" href="/settings?category=account">Open account settings</a>
-		</p>
+	<section class="profile-recommendations" data-section="provider-recommendations-empty">
+		<SectionHeader
+			eyebrow="Connected profiles"
+			title="Recommendations"
+			subtitle="Last.fm has not returned profile recommendations yet"
+			variant="charts"
+			level={2}
+		/>
+		<EmptyState title="No profile recommendations yet" copy="Play, love, or backfill more tracks, then refresh this page." />
 	</section>
 {:else if viewState === 'error'}
-	<section class="discovery-section" data-section="provider-recommendations-error">
-		<div class="section-header">
-			<div class="section-title-group">
-				<p class="eyebrow">Connected profiles</p>
-				<h2>Recommendations</h2>
-			</div>
-		</div>
-		<p class="muted-line">
-			{errorMsg}
-			<button type="button" class="inline-link" onclick={load}>Retry</button>
-		</p>
+	<section class="profile-recommendations" data-section="provider-recommendations-error">
+		<SectionHeader
+			eyebrow="Connected profiles"
+			title="Recommendations"
+			subtitle="Provider request failed"
+			variant="charts"
+			level={2}
+		/>
+		<EmptyState title="Could not load recommendations" copy={errorMsg}>
+			{#snippet actions()}
+				<button type="button" class="btn btn-glass" onclick={load}>Retry</button>
+			{/snippet}
+		</EmptyState>
 	</section>
 {/if}
 
 <style>
-	.discovery-section {
+	.profile-recommendations {
 		display: flex;
 		flex-direction: column;
-		gap: 16px;
+		gap: var(--space-3);
 	}
 
-	.section-header {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		gap: 16px;
-	}
-
-	.section-title-group {
+	.profile-recommendations-list {
 		display: flex;
 		flex-direction: column;
-		gap: 4px;
-	}
-
-	.section-title-group h2 {
-		font-size: var(--font-size-lg);
-		font-weight: var(--font-weight-bold);
-		margin: 0;
-	}
-
-	.loading-indicator,
-	.muted-line,
-	.inline-link {
-		font-size: var(--font-size-xs);
-	}
-
-	.loading-indicator,
-	.muted-line {
-		color: var(--text-muted);
-	}
-
-	.inline-link {
-		border: 0;
-		background: transparent;
-		color: var(--accent);
-		padding: 0;
-		font: inherit;
-		cursor: pointer;
-	}
-
-	.recommendation-rail {
-		display: flex;
-		gap: 14px;
-		overflow-x: auto;
-		padding-bottom: 8px;
-		scroll-snap-type: x mandatory;
-	}
-
-	.recommendation-card {
-		flex: 0 0 180px;
-		width: 180px;
-		min-width: 180px;
-		display: flex;
-		flex-direction: column;
-		gap: 10px;
-		border: 1px solid transparent;
-		border-radius: 8px;
-		background: transparent;
-		padding: 8px;
-		color: inherit;
-		font: inherit;
-		text-align: left;
-		cursor: pointer;
-		scroll-snap-align: start;
-		transition: background var(--motion-base), border-color var(--motion-base);
-	}
-
-	.recommendation-card:hover,
-	.recommendation-card:focus-visible {
-		background: rgba(255, 255, 255, 0.04);
-		border-color: var(--border-subtle);
-	}
-
-	.art-wrap {
-		position: relative;
-		aspect-ratio: 1;
-		width: 100%;
-		overflow: hidden;
-		border-radius: 8px;
-		background: var(--bg-elevated);
-	}
-
-	.art {
-		width: 100%;
-		height: 100%;
-		object-fit: cover;
-		display: block;
-	}
-
-	.fallback {
-		display: grid;
-		place-items: center;
-		color: var(--text-secondary);
-		font-weight: var(--font-weight-bold);
-		background: linear-gradient(135deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.02));
-	}
-
-	.meta {
-		display: flex;
-		flex-direction: column;
-		gap: 4px;
-		min-width: 0;
-	}
-
-	.meta h3,
-	.meta p,
-	.meta span {
-		margin: 0;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-	}
-
-	.meta h3 {
-		font-size: var(--font-size-sm);
-		font-weight: var(--font-weight-semibold);
-		color: var(--text-primary);
-	}
-
-	.meta p,
-	.meta span {
-		font-size: var(--font-size-xs);
-		color: var(--text-muted);
-	}
-
-	.skeleton {
-		pointer-events: none;
-	}
-
-	.skeleton-art,
-	.skeleton-line {
-		border-radius: 8px;
-		background: linear-gradient(90deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.05));
-		background-size: 200% 100%;
-		animation: shimmer 1.4s infinite linear;
-	}
-
-	.title-line {
-		width: 80%;
-		height: 14px;
-	}
-
-	.artist-line {
-		width: 60%;
-		height: 12px;
-	}
-
-	@keyframes shimmer {
-		from { background-position: 200% 0; }
-		to { background-position: -200% 0; }
+		gap: var(--space-5);
 	}
 </style>

--- a/frontend/src/lib/components/home/home_recommendations_shelf_contract.test.ts
+++ b/frontend/src/lib/components/home/home_recommendations_shelf_contract.test.ts
@@ -7,6 +7,8 @@ const here = dirname(fileURLToPath(import.meta.url));
 const source = readFileSync(join(here, 'HomeRecommendationsShelf.svelte'), 'utf8');
 const homePage = readFileSync(join(here, '../../../routes/+page.svelte'), 'utf8');
 const client = readFileSync(join(here, '../../api/client.ts'), 'utf8');
+const playTrending = readFileSync(join(here, '../../player/play_trending.ts'), 'utf8');
+const serverRoutes = readFileSync(join(here, '../../../../../noor-server/src/server/routes.rs'), 'utf8');
 
 describe('home recommendations shelf contract', () => {
 	test('loads provider shelves independently after Home renders', () => {
@@ -24,14 +26,72 @@ describe('home recommendations shelf contract', () => {
 		expect(source).toContain("viewState === 'loading'");
 		expect(source).toContain("viewState === 'empty'");
 		expect(source).toContain("viewState === 'error'");
-		expect(source).toContain('Connected profiles have no playable recommendations yet.');
+		expect(source).toContain('No profile recommendations yet');
 		expect(source).toContain('Retry');
 	});
 
-	test('renders only playable local rows through the standard player path', () => {
+	test('renders Last.fm recommendations through the charts mural carousel', () => {
+		expect(source).toContain('ChartMural');
+		expect(source).toContain('type ChartMuralItem');
+		expect(source).toContain('PANEL_LIMIT = 20');
+		expect(source).toContain('visibleShelves');
+		expect(source).toContain('shelfMuralItems');
+		expect(serverRoutes).toContain('track_get_similar_with_artist_fallback');
+		expect(serverRoutes).toContain('recommendation_placeholder_item');
+		expect(serverRoutes).toContain('RECOMMENDATION_HOME_CACHE_KEY: &str = "home:v6"');
+		expect(serverRoutes).toContain('LASTFM_HOME_RECOMMENDATION_LIMIT: usize = 20');
+		expect(serverRoutes).toContain('LASTFM_HOME_SEED_LIMIT: usize = 12');
+		expect(serverRoutes).toContain('LASTFM_HOME_SIMILAR_LIMIT: usize = 20');
+		expect(serverRoutes).toContain('LASTFM_HOME_ARTIST_LIMIT: usize = 20');
+		expect(serverRoutes).toContain('LASTFM_HOME_ALBUM_LIMIT: usize = 20');
+	});
+
+	test('varies Last.fm seed reasons beyond stable top artists', () => {
+		expect(serverRoutes).toContain('load_lastfm_track_seeds');
+		expect(serverRoutes).toContain('load_lastfm_artist_seeds');
+		expect(serverRoutes).toContain('user_recent_tracks');
+		expect(serverRoutes).toContain('Because you played {} recently');
+		expect(serverRoutes).toContain('Because you loved {}');
+		expect(serverRoutes).toContain('Near your top artist {}');
+		expect(serverRoutes).toContain('recommendation_seed_window');
+	});
+
+	test('splits Last.fm tracks, artists, and albums into separate panels', () => {
+		expect(client).toContain("entity_type?: 'track' | 'artist' | 'album' | string");
+		expect(serverRoutes).toContain('Last.fm recommended tracks');
+		expect(serverRoutes).toContain('Last.fm recommended artists');
+		expect(serverRoutes).toContain('Last.fm recommended albums');
+		expect(serverRoutes).toContain('fetch_lastfm_artist_recommendations');
+		expect(serverRoutes).toContain('fetch_lastfm_album_recommendations');
+		expect(serverRoutes).toContain('resolve_recommendation_artist_item');
+		expect(serverRoutes).toContain('resolve_recommendation_album_item');
+		expect(source).toContain("shelf.entity_type === 'artist'");
+		expect(source).toContain("shelf.entity_type === 'album'");
+		expect(source).toContain('itemMetric');
+		expect(source).toContain('${index + 1} of ${count}');
+		expect(source).toContain('openRecommendationItem');
+		expect(source).toContain('local_artist_id');
+		expect(source).toContain('local_album_id');
+	});
+
+	test('plays local matches directly and resolves unresolved Last.fm items through TIDAL', () => {
 		expect(source).toContain('playTrackNow');
 		expect(source).toContain('item.local_track_id');
-		expect(source).toContain('upscaleTidalArtwork(url, 320)');
-		expect(source).toContain('onerror');
+		expect(source).toContain('playChartTidalTrack');
+		expect(source).toContain('tidal_id: item.tidal_id ?? 0');
+		expect(source).toContain('Resolve on TIDAL');
+	});
+
+	test('can play the visible recommendation set through standard TIDAL mix playback', () => {
+		expect(source).toContain('Play all');
+		expect(source).toContain('playingAllShelves');
+		expect(source).toContain('playAllRecommendations');
+		expect(source).toContain('playChartTidalTracks(items.map(itemToTidalPlayable)');
+		expect(source).not.toContain('api.queueAppendMany(queueRequests)');
+		expect(source).not.toContain('api.clearQueue()');
+		expect(playTrending).toContain('resolveChartTidalTrack');
+		expect(playTrending).toContain('api.searchTidal(q, 1)');
+		expect(playTrending).toContain('track.stream_ready !== false');
+		expect(playTrending).toContain('playTidalTracksNow(playable, label)');
 	});
 });

--- a/frontend/src/lib/player/play_trending.ts
+++ b/frontend/src/lib/player/play_trending.ts
@@ -1,26 +1,24 @@
 import { api, type TidalPlayable } from '$lib/api/client';
-import { playTidalTrackNow, playerError } from '$lib/stores/player';
+import { playTidalTrackNow, playTidalTracksNow, playerError } from '$lib/stores/player';
 
 /// Play a TidalPlayable from a chart entry. Last.fm-only entries arrive with
 /// `tidal_id === 0` (the backend doesn't pre-search Tidal for them); we resolve
 /// via Tidal search before handing off to the player.
-export async function playChartTidalTrack(tp: TidalPlayable): Promise<void> {
+export async function resolveChartTidalTrack(tp: TidalPlayable): Promise<TidalPlayable | null> {
 	if (tp.tidal_id !== 0) {
-		return playTidalTrackNow(tp);
+		return tp;
 	}
 	const q = [tp.artist_name, tp.title].filter(Boolean).join(' ');
 	if (!q) {
-		playerError.set({ message: "Couldn't find that track on Tidal." });
-		return;
+		return null;
 	}
 	try {
 		const results = await api.searchTidal(q, 1);
-		const hit = results.tracks[0];
+		const hit = results.tracks.find((track) => track.stream_ready !== false);
 		if (!hit) {
-			playerError.set({ message: "Couldn't find that track on Tidal." });
-			return;
+			return null;
 		}
-		return playTidalTrackNow({
+		return {
 			tidal_id: hit.tidal_id,
 			title: hit.title,
 			artist_name: hit.artist_name,
@@ -28,8 +26,33 @@ export async function playChartTidalTrack(tp: TidalPlayable): Promise<void> {
 			artwork_url: hit.artwork_url ?? tp.artwork_url,
 			duration_ms: hit.duration_ms,
 			artist_tidal_id: null,
-		});
+			album_tidal_id: hit.album_tidal_id,
+			local_id: hit.local_id ?? null,
+			is_in_library: hit.in_library,
+		};
 	} catch {
-		playerError.set({ message: "Couldn't find that track on Tidal." });
+		return null;
 	}
+}
+
+export async function playChartTidalTrack(tp: TidalPlayable): Promise<void> {
+	const playable = await resolveChartTidalTrack(tp);
+	if (!playable) {
+		playerError.set({ message: "Couldn't find that track on Tidal." });
+		return;
+	}
+	return playTidalTrackNow(playable);
+}
+
+export async function playChartTidalTracks(tracks: TidalPlayable[], label = 'recommendations'): Promise<void> {
+	const playable: TidalPlayable[] = [];
+	for (const track of tracks) {
+		const resolved = await resolveChartTidalTrack(track);
+		if (resolved) playable.push(resolved);
+	}
+	if (!playable.length) {
+		playerError.set({ message: 'No playable tracks ready yet.' });
+		return;
+	}
+	return playTidalTracksNow(playable, label);
 }

--- a/noor-server/src/metadata/lastfm.rs
+++ b/noor-server/src/metadata/lastfm.rs
@@ -4,6 +4,7 @@ use serde_json::Value;
 use std::collections::HashSet;
 
 const LASTFM_API_URL: &str = "https://ws.audioscrobbler.com/2.0/";
+const LASTFM_USER_AGENT: &str = "NOORwave/0.1 Last.fm integration";
 
 #[derive(Clone)]
 pub struct LastFmClient {
@@ -44,6 +45,16 @@ pub struct LastFmChartArtist {
     pub mbid: Option<String>,
     pub image_url: Option<String>,
     pub listeners: Option<u64>,
+    pub playcount: Option<u64>,
+    pub match_score: Option<f64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct LastFmChartAlbum {
+    pub artist: String,
+    pub title: String,
+    pub mbid: Option<String>,
+    pub image_url: Option<String>,
     pub playcount: Option<u64>,
 }
 
@@ -177,36 +188,19 @@ impl LastFmClient {
         })
     }
 
-    pub async fn user_profile_seed_tracks(
+    pub async fn user_recent_tracks(
         &self,
         user_name: &str,
         limit: usize,
     ) -> Result<Vec<LastFmChartTrack>> {
-        let mut seeds = Vec::new();
-        seeds.extend(
-            self.user_top_tracks(user_name, limit)
-                .await
-                .unwrap_or_default(),
-        );
-        seeds.extend(
-            self.user_loved_tracks(user_name, limit)
-                .await
-                .unwrap_or_default(),
-        );
-
-        let mut seen = HashSet::new();
-        let mut out = Vec::new();
-        for seed in seeds {
-            let key = crate::services::radio::normalize_for_dedup(&seed.artist, &seed.title);
-            if key.is_empty() || !seen.insert(key) {
-                continue;
-            }
-            out.push(seed);
-            if out.len() >= limit {
-                break;
-            }
-        }
-        Ok(out)
+        let payload = self
+            .get_json(&[
+                ("method", "user.getrecenttracks".to_string()),
+                ("user", user_name.to_string()),
+                ("limit", limit.min(100).to_string()),
+            ])
+            .await?;
+        Ok(parse_chart_tracks(&payload, limit))
     }
 
     pub async fn user_top_tracks(
@@ -238,6 +232,38 @@ impl LastFmClient {
             ])
             .await?;
         Ok(parse_chart_tracks(&payload, limit))
+    }
+
+    pub async fn user_top_artists(
+        &self,
+        user_name: &str,
+        limit: usize,
+    ) -> Result<Vec<LastFmChartArtist>> {
+        let payload = self
+            .get_json(&[
+                ("method", "user.gettopartists".to_string()),
+                ("user", user_name.to_string()),
+                ("period", "3month".to_string()),
+                ("limit", limit.min(100).to_string()),
+            ])
+            .await?;
+        Ok(parse_chart_artists(&payload, limit))
+    }
+
+    pub async fn user_top_albums(
+        &self,
+        user_name: &str,
+        limit: usize,
+    ) -> Result<Vec<LastFmChartAlbum>> {
+        let payload = self
+            .get_json(&[
+                ("method", "user.gettopalbums".to_string()),
+                ("user", user_name.to_string()),
+                ("period", "3month".to_string()),
+                ("limit", limit.min(100).to_string()),
+            ])
+            .await?;
+        Ok(parse_chart_albums(&payload, limit))
     }
 
     /// Public API: fetch up to `limit` tracks Last.fm considers similar to (artist, title).
@@ -421,6 +447,25 @@ impl LastFmClient {
         Ok(out)
     }
 
+    pub async fn artist_get_similar(
+        &self,
+        artist: &str,
+        limit: usize,
+    ) -> Result<Vec<LastFmChartArtist>> {
+        let artists = self.fetch_similar_artists(artist, limit).await?;
+        Ok(artists
+            .into_iter()
+            .map(|(name, match_score)| LastFmChartArtist {
+                name,
+                mbid: None,
+                image_url: None,
+                listeners: None,
+                playcount: None,
+                match_score: Some(match_score),
+            })
+            .collect())
+    }
+
     /// Fetch top track titles for an artist (Last.fm popularity-ordered).
     /// Internal helper for `track_get_similar_with_artist_fallback`.
     async fn fetch_artist_top_tracks(&self, artist: &str, limit: usize) -> Result<Vec<String>> {
@@ -444,6 +489,21 @@ impl LastFmClient {
             }
         }
         Ok(out)
+    }
+
+    pub async fn artist_top_albums(
+        &self,
+        artist: &str,
+        limit: usize,
+    ) -> Result<Vec<LastFmChartAlbum>> {
+        let payload = self
+            .get_json(&[
+                ("method", "artist.gettopalbums".to_string()),
+                ("artist", artist.to_string()),
+                ("limit", limit.min(50).to_string()),
+            ])
+            .await?;
+        Ok(parse_chart_albums(&payload, limit))
     }
 
     /// Fetch top global or geo chart tracks from Last.fm.
@@ -719,6 +779,7 @@ impl LastFmClient {
         let response = self
             .http
             .get(LASTFM_API_URL)
+            .header(reqwest::header::USER_AGENT, LASTFM_USER_AGENT)
             .query(&query)
             .timeout(LASTFM_TIMEOUT)
             .send()
@@ -809,7 +870,8 @@ pub(crate) fn parse_chart_tracks(payload: &Value, limit: usize) -> Vec<LastFmCha
         .get("tracks")
         .and_then(|v| v.get("track"))
         .or_else(|| payload.get("toptracks").and_then(|v| v.get("track")))
-        .or_else(|| payload.get("lovedtracks").and_then(|v| v.get("track")));
+        .or_else(|| payload.get("lovedtracks").and_then(|v| v.get("track")))
+        .or_else(|| payload.get("recenttracks").and_then(|v| v.get("track")));
     let arr = value_as_array(tracks_value);
 
     let mut out = Vec::new();
@@ -872,6 +934,46 @@ pub(crate) fn parse_chart_artists(payload: &Value, limit: usize) -> Vec<LastFmCh
             mbid,
             image_url: largest_image_url(entry),
             listeners: parse_u64_field(entry, "listeners"),
+            playcount: parse_u64_field(entry, "playcount"),
+            match_score: None,
+        });
+    }
+    out
+}
+
+pub(crate) fn parse_chart_albums(payload: &Value, limit: usize) -> Vec<LastFmChartAlbum> {
+    let albums_value = payload
+        .get("albums")
+        .and_then(|v| v.get("album"))
+        .or_else(|| payload.get("topalbums").and_then(|v| v.get("album")));
+    let arr = value_as_array(albums_value);
+
+    let mut out = Vec::new();
+    for entry in arr.into_iter().take(limit) {
+        let title = match entry.get("name").and_then(Value::as_str) {
+            Some(s) if !s.trim().is_empty() => s.trim().to_string(),
+            _ => continue,
+        };
+        let artist_name = entry
+            .get("artist")
+            .and_then(|a| a.get("name").or_else(|| a.get("#text")))
+            .and_then(Value::as_str)
+            .or_else(|| entry.get("artist").and_then(Value::as_str))
+            .map(|s| s.trim().to_string())
+            .unwrap_or_default();
+        if artist_name.is_empty() {
+            continue;
+        }
+        let mbid = entry
+            .get("mbid")
+            .and_then(Value::as_str)
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+        out.push(LastFmChartAlbum {
+            artist: artist_name,
+            title,
+            mbid,
+            image_url: largest_image_url(entry),
             playcount: parse_u64_field(entry, "playcount"),
         });
     }
@@ -1034,6 +1136,36 @@ mod tests {
     }
 
     #[test]
+    fn parses_top_album_payload() {
+        let payload = json!({
+            "topalbums": {
+                "album": [
+                    {
+                        "name": "Promises",
+                        "artist": { "name": "Floating Points" },
+                        "mbid": "",
+                        "playcount": "44",
+                        "image": [
+                            { "size": "small", "#text": "small.jpg" },
+                            { "size": "mega", "#text": "mega.jpg" }
+                        ]
+                    },
+                    { "name": " " }
+                ]
+            }
+        });
+
+        let albums = parse_chart_albums(&payload, 10);
+
+        assert_eq!(albums.len(), 1);
+        assert_eq!(albums[0].title, "Promises");
+        assert_eq!(albums[0].artist, "Floating Points");
+        assert_eq!(albums[0].playcount, Some(44));
+        assert_eq!(albums[0].image_url.as_deref(), Some("mega.jpg"));
+        assert!(albums[0].mbid.is_none());
+    }
+
+    #[test]
     fn parses_loved_tracks_as_profile_seed_tracks() {
         let payload = json!({
             "lovedtracks": {
@@ -1054,6 +1186,29 @@ mod tests {
         assert_eq!(tracks[0].title, "Loved One");
         assert_eq!(tracks[0].artist, "Seed Artist");
         assert_eq!(tracks[0].playcount, Some(8));
+    }
+
+    #[test]
+    fn parses_recent_tracks_as_profile_seed_tracks() {
+        let payload = json!({
+            "recenttracks": {
+                "track": [
+                    {
+                        "name": "Recent One",
+                        "artist": { "#text": "Recent Artist" },
+                        "mbid": ""
+                    },
+                    { "name": "" }
+                ]
+            }
+        });
+
+        let tracks = parse_chart_tracks(&payload, 10);
+
+        assert_eq!(tracks.len(), 1);
+        assert_eq!(tracks[0].title, "Recent One");
+        assert_eq!(tracks[0].artist, "Recent Artist");
+        assert!(tracks[0].mbid.is_none());
     }
 }
 

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -1,6 +1,8 @@
 use crate::db::queries;
 use crate::metadata::discogs::DiscogsClient;
-use crate::metadata::lastfm::LastFmClient;
+use crate::metadata::lastfm::{
+    LastFmChartAlbum, LastFmChartArtist, LastFmChartTrack, LastFmClient,
+};
 use crate::playback::{automix, pending, player, queue, runtime as playback_runtime};
 use crate::services::discovery::{
     DiscoveryCandidateSeed, DiscoveryProvider, TidalDiscoveryProvider,
@@ -13995,32 +13997,80 @@ async fn get_home_recommendations(
     let listenbrainz = load_or_fetch_recommendation_shelf(state.clone(), "listenbrainz").await;
     Ok(Json(json!({
         "shelves": [
-            recommendation_shelf_json("lastfm", "Last.fm profile picks", lastfm),
-            recommendation_shelf_json("listenbrainz", "ListenBrainz recommends", listenbrainz),
+            recommendation_shelf_json("lastfm", "Last.fm recommended tracks", Some("track"), &lastfm),
+            recommendation_shelf_json("lastfm", "Last.fm recommended artists", Some("artist"), &lastfm),
+            recommendation_shelf_json("lastfm", "Last.fm recommended albums", Some("album"), &lastfm),
+            recommendation_shelf_json("listenbrainz", "ListenBrainz recommends", Some("track"), &listenbrainz),
         ]
     })))
+}
+
+const RECOMMENDATION_HOME_CACHE_KEY: &str = "home:v6";
+const LASTFM_HOME_RECOMMENDATION_LIMIT: usize = 20;
+const LASTFM_HOME_SEED_LIMIT: usize = 12;
+const LASTFM_HOME_PROFILE_SOURCE_LIMIT: usize = 30;
+const LASTFM_HOME_RECENT_SEED_TARGET: usize = 8;
+const LASTFM_HOME_LOVED_SEED_TARGET: usize = 8;
+const LASTFM_HOME_TOP_SEED_TARGET: usize = 6;
+const LASTFM_HOME_SIMILAR_LIMIT: usize = 20;
+const LASTFM_HOME_ARTIST_LIMIT: usize = 20;
+const LASTFM_HOME_ALBUM_LIMIT: usize = 20;
+const LASTFM_HOME_ALBUM_SIMILAR_ARTIST_LIMIT: usize = 8;
+const LASTFM_HOME_ALBUMS_PER_ARTIST_LIMIT: usize = 5;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct LastFmTrackSeed {
+    artist: String,
+    title: String,
+    reason: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct LastFmArtistSeed {
+    name: String,
+    reason: String,
 }
 
 fn recommendation_shelf_json(
     provider: &str,
     title: &str,
-    result: anyhow::Result<Vec<Value>>,
+    entity_type: Option<&str>,
+    result: &anyhow::Result<Vec<Value>>,
 ) -> Value {
     match result {
-        Ok(items) => json!({
-            "provider": provider,
-            "title": title,
-            "status": if items.is_empty() { "empty" } else { "ok" },
-            "items": items,
-        }),
+        Ok(items) => {
+            let filtered = filter_recommendation_items(items, entity_type);
+            json!({
+                "provider": provider,
+                "title": title,
+                "entity_type": entity_type.unwrap_or("track"),
+                "status": if filtered.is_empty() { "empty" } else { "ok" },
+                "items": filtered,
+            })
+        }
         Err(error) => json!({
             "provider": provider,
             "title": title,
+            "entity_type": entity_type.unwrap_or("track"),
             "status": "error",
             "message": error.to_string(),
             "items": [],
         }),
     }
+}
+
+fn filter_recommendation_items(items: &[Value], entity_type: Option<&str>) -> Vec<Value> {
+    let wanted = entity_type.unwrap_or("track");
+    items
+        .iter()
+        .filter(|item| {
+            item.get("entity_type")
+                .and_then(Value::as_str)
+                .unwrap_or("track")
+                == wanted
+        })
+        .cloned()
+        .collect()
 }
 
 async fn load_or_fetch_recommendation_shelf(
@@ -14045,8 +14095,8 @@ async fn read_recommendation_cache(state: &SharedState, provider: &str) -> Optio
     s.db.with_conn(|conn| {
         conn.query_row(
             "SELECT payload_json FROM provider_recommendation_cache
-                  WHERE provider = ?1 AND cache_key = 'home' AND expires_at > ?2",
-            params![provider, now],
+                  WHERE provider = ?1 AND cache_key = ?2 AND expires_at > ?3",
+            params![provider, RECOMMENDATION_HOME_CACHE_KEY, now],
             |row| row.get::<_, String>(0),
         )
         .optional()
@@ -14059,7 +14109,7 @@ async fn read_recommendation_cache(state: &SharedState, provider: &str) -> Optio
 
 async fn write_recommendation_cache(state: &SharedState, provider: &str, items: &[Value]) {
     let now = unix_now_secs();
-    let expires = now + 60 * 60;
+    let expires = now + 6 * 60 * 60;
     let Ok(payload) = serde_json::to_string(items) else {
         return;
     };
@@ -14067,15 +14117,159 @@ async fn write_recommendation_cache(state: &SharedState, provider: &str, items: 
     let _ = s.db.with_conn(|conn| {
         conn.execute(
             "INSERT INTO provider_recommendation_cache (provider, cache_key, payload_json, fetched_at, expires_at)
-             VALUES (?1, 'home', ?2, ?3, ?4)
+             VALUES (?1, ?2, ?3, ?4, ?5)
              ON CONFLICT(provider, cache_key) DO UPDATE SET
                  payload_json = excluded.payload_json,
                  fetched_at = excluded.fetched_at,
                  expires_at = excluded.expires_at",
-            params![provider, payload, now, expires],
+            params![provider, RECOMMENDATION_HOME_CACHE_KEY, payload, now, expires],
         )?;
         Ok::<_, anyhow::Error>(())
     });
+}
+
+fn recommendation_seed_window() -> usize {
+    (unix_now_secs() / (6 * 60 * 60)) as usize
+}
+
+fn rotate_take<T: Clone>(items: &[T], limit: usize, salt: usize) -> Vec<T> {
+    if items.is_empty() || limit == 0 {
+        return Vec::new();
+    }
+    let offset = salt % items.len();
+    items
+        .iter()
+        .cycle()
+        .skip(offset)
+        .take(limit.min(items.len()))
+        .cloned()
+        .collect()
+}
+
+fn merge_lastfm_track_seeds(
+    recent: Vec<LastFmChartTrack>,
+    loved: Vec<LastFmChartTrack>,
+    top: Vec<LastFmChartTrack>,
+    salt: usize,
+    limit: usize,
+) -> Vec<LastFmTrackSeed> {
+    let mut out = Vec::new();
+    let mut seen = HashSet::new();
+    let mut push_track = |track: LastFmChartTrack, reason: String| {
+        if out.len() >= limit {
+            return;
+        }
+        let key = crate::services::radio::normalize_for_dedup(&track.artist, &track.title);
+        if key.is_empty() || !seen.insert(key) {
+            return;
+        }
+        out.push(LastFmTrackSeed {
+            artist: track.artist,
+            title: track.title,
+            reason,
+        });
+    };
+
+    for track in rotate_take(&recent, LASTFM_HOME_RECENT_SEED_TARGET, salt) {
+        let reason = format!("Because you played {} recently", track.title);
+        push_track(track, reason);
+    }
+    for track in rotate_take(&loved, LASTFM_HOME_LOVED_SEED_TARGET, salt + 3) {
+        let reason = format!("Because you loved {}", track.title);
+        push_track(track, reason);
+    }
+    for track in rotate_take(&top, LASTFM_HOME_TOP_SEED_TARGET, salt + 7) {
+        let reason = format!("Near your top track {}", track.title);
+        push_track(track, reason);
+    }
+
+    out
+}
+
+fn merge_lastfm_artist_seeds(
+    track_seeds: &[LastFmTrackSeed],
+    top_artists: Vec<LastFmChartArtist>,
+    top_albums: Vec<LastFmChartAlbum>,
+    salt: usize,
+    limit: usize,
+) -> Vec<LastFmArtistSeed> {
+    let mut out = Vec::new();
+    let mut seen = HashSet::new();
+    let mut push_artist = |name: String, reason: String| {
+        if out.len() >= limit {
+            return;
+        }
+        let trimmed = name.trim();
+        if trimmed.is_empty() {
+            return;
+        }
+        let key = trimmed.to_ascii_lowercase();
+        if !seen.insert(key) {
+            return;
+        }
+        out.push(LastFmArtistSeed {
+            name: trimmed.to_string(),
+            reason,
+        });
+    };
+
+    for seed in rotate_take(track_seeds, LASTFM_HOME_RECENT_SEED_TARGET, salt) {
+        push_artist(seed.artist.clone(), seed.reason.clone());
+    }
+    for artist in rotate_take(&top_artists, LASTFM_HOME_TOP_SEED_TARGET, salt + 5) {
+        let reason = format!("Near your top artist {}", artist.name);
+        push_artist(artist.name, reason);
+    }
+    for album in rotate_take(&top_albums, LASTFM_HOME_TOP_SEED_TARGET, salt + 11) {
+        let reason = format!("Because you play albums by {}", album.artist);
+        push_artist(album.artist, reason);
+    }
+
+    out
+}
+
+async fn load_lastfm_track_seeds(client: &LastFmClient, user: &str) -> Vec<LastFmTrackSeed> {
+    let recent = client
+        .user_recent_tracks(user, LASTFM_HOME_PROFILE_SOURCE_LIMIT)
+        .await
+        .unwrap_or_default();
+    let loved = client
+        .user_loved_tracks(user, LASTFM_HOME_PROFILE_SOURCE_LIMIT)
+        .await
+        .unwrap_or_default();
+    let top = client
+        .user_top_tracks(user, LASTFM_HOME_PROFILE_SOURCE_LIMIT)
+        .await
+        .unwrap_or_default();
+    merge_lastfm_track_seeds(
+        recent,
+        loved,
+        top,
+        recommendation_seed_window(),
+        LASTFM_HOME_SEED_LIMIT,
+    )
+}
+
+async fn load_lastfm_artist_seeds(
+    client: &LastFmClient,
+    user: &str,
+    track_seeds: &[LastFmTrackSeed],
+) -> Vec<LastFmArtistSeed> {
+    let top_artists = client
+        .user_top_artists(user, LASTFM_HOME_PROFILE_SOURCE_LIMIT)
+        .await
+        .unwrap_or_default();
+    let top_albums = client
+        .user_top_albums(user, LASTFM_HOME_PROFILE_SOURCE_LIMIT)
+        .await
+        .unwrap_or_default();
+    merge_lastfm_artist_seeds(
+        track_seeds,
+        top_artists,
+        top_albums,
+        recommendation_seed_window(),
+        LASTFM_HOME_SEED_LIMIT,
+    )
 }
 
 async fn fetch_lastfm_home_recommendations(state: &SharedState) -> anyhow::Result<Vec<Value>> {
@@ -14094,12 +14288,29 @@ async fn fetch_lastfm_home_recommendations(state: &SharedState) -> anyhow::Resul
     let Some(client) = LastFmClient::load(http, &db) else {
         return Ok(Vec::new());
     };
-    let seeds = client.user_profile_seed_tracks(&user, 4).await?;
+    let track_seeds = load_lastfm_track_seeds(&client, &user).await;
+    let artist_seeds = load_lastfm_artist_seeds(&client, &user, &track_seeds).await;
+    let mut out = Vec::new();
+    out.extend(fetch_lastfm_track_recommendations(state, &client, &track_seeds).await?);
+    out.extend(fetch_lastfm_artist_recommendations(state, &client, &artist_seeds).await?);
+    out.extend(fetch_lastfm_album_recommendations(state, &client, &artist_seeds).await?);
+    Ok(out)
+}
+
+async fn fetch_lastfm_track_recommendations(
+    state: &SharedState,
+    client: &LastFmClient,
+    seeds: &[LastFmTrackSeed],
+) -> anyhow::Result<Vec<Value>> {
     let mut out = Vec::new();
     let mut seen = HashSet::new();
     for seed in seeds {
         for similar in client
-            .track_get_similar(&seed.artist, &seed.title, 8)
+            .track_get_similar_with_artist_fallback(
+                &seed.artist,
+                &seed.title,
+                LASTFM_HOME_SIMILAR_LIMIT,
+            )
             .await
             .unwrap_or_default()
         {
@@ -14114,14 +14325,106 @@ async fn fetch_lastfm_home_recommendations(state: &SharedState) -> anyhow::Resul
                 &similar.title,
                 None,
                 Some(similar.match_score),
-                "Profile similar track",
+                &seed.reason,
             )
             .await
             {
                 out.push(item);
+            } else {
+                out.push(recommendation_placeholder_item(
+                    "lastfm",
+                    &similar.artist,
+                    &similar.title,
+                    similar.mbid.as_deref(),
+                    Some(similar.match_score),
+                    &seed.reason,
+                ));
             }
-            if out.len() >= 12 {
+            if out.len() >= LASTFM_HOME_RECOMMENDATION_LIMIT {
                 return Ok(out);
+            }
+        }
+    }
+    Ok(out)
+}
+
+async fn fetch_lastfm_artist_recommendations(
+    state: &SharedState,
+    client: &LastFmClient,
+    seeds: &[LastFmArtistSeed],
+) -> anyhow::Result<Vec<Value>> {
+    let mut out = Vec::new();
+    let mut seen = HashSet::new();
+    for seed in seeds {
+        for artist in client
+            .artist_get_similar(&seed.name, LASTFM_HOME_SIMILAR_LIMIT)
+            .await
+            .unwrap_or_default()
+        {
+            let key = artist.name.trim().to_ascii_lowercase();
+            if key.is_empty() || !seen.insert(key) {
+                continue;
+            }
+            out.push(
+                resolve_recommendation_artist_item(
+                    state,
+                    "lastfm",
+                    &artist.name,
+                    artist.mbid.as_deref(),
+                    artist.match_score,
+                    &seed.reason,
+                    artist.image_url.as_deref(),
+                )
+                .await,
+            );
+            if out.len() >= LASTFM_HOME_ARTIST_LIMIT {
+                return Ok(out);
+            }
+        }
+    }
+    Ok(out)
+}
+
+async fn fetch_lastfm_album_recommendations(
+    state: &SharedState,
+    client: &LastFmClient,
+    seeds: &[LastFmArtistSeed],
+) -> anyhow::Result<Vec<Value>> {
+    let mut out = Vec::new();
+    let mut seen = HashSet::new();
+    for seed in seeds {
+        let similar_artists = client
+            .artist_get_similar(&seed.name, LASTFM_HOME_ALBUM_SIMILAR_ARTIST_LIMIT)
+            .await
+            .unwrap_or_default();
+        for artist in similar_artists {
+            for album in client
+                .artist_top_albums(&artist.name, LASTFM_HOME_ALBUMS_PER_ARTIST_LIMIT)
+                .await
+                .unwrap_or_default()
+            {
+                let key = crate::services::radio::normalize_for_dedup(&album.artist, &album.title);
+                if key.is_empty() || !seen.insert(key) {
+                    continue;
+                }
+                out.push(
+                    resolve_recommendation_album_item(
+                        state,
+                        "lastfm",
+                        &album.artist,
+                        &album.title,
+                        album.mbid.as_deref(),
+                        artist
+                            .match_score
+                            .or_else(|| album.playcount.map(|count| count as f64)),
+                        &seed.reason,
+                        album.image_url.as_deref(),
+                    )
+                    .await,
+                );
+                if out.len() >= LASTFM_HOME_ALBUM_LIMIT {
+                    return Ok(out);
+                }
             }
         }
     }
@@ -14165,6 +14468,15 @@ async fn fetch_listenbrainz_home_recommendations(
         .await
         {
             out.push(item);
+        } else {
+            out.push(recommendation_placeholder_item(
+                "listenbrainz",
+                &rec.artist,
+                &rec.title,
+                rec.mbid.as_deref(),
+                rec.score,
+                "Collaborative filtering",
+            ));
         }
         if out.len() >= 12 {
             break;
@@ -14202,6 +14514,7 @@ async fn resolve_recommendation_item(
                         |row| {
                             Ok(json!({
                                 "provider": provider,
+                                "entity_type": "track",
                                 "local_track_id": row.get::<_, i64>(0)?,
                                 "tidal_id": row.get::<_, Option<i64>>(1)?,
                                 "title": row.get::<_, String>(2)?,
@@ -14234,6 +14547,7 @@ async fn resolve_recommendation_item(
                 |row| {
                     Ok(json!({
                         "provider": provider,
+                        "entity_type": "track",
                         "local_track_id": row.get::<_, i64>(0)?,
                         "tidal_id": row.get::<_, Option<i64>>(1)?,
                         "title": row.get::<_, String>(2)?,
@@ -14252,6 +14566,163 @@ async fn resolve_recommendation_item(
         })
         .ok()
         .flatten()
+}
+
+async fn resolve_recommendation_artist_item(
+    state: &SharedState,
+    provider: &str,
+    artist: &str,
+    mbid: Option<&str>,
+    score: Option<f64>,
+    reason: &str,
+    image_url: Option<&str>,
+) -> Value {
+    let s = state.read().await;
+    s.db
+        .with_conn(|conn| {
+            conn.query_row(
+                "SELECT id, tidal_id, name, photo_url
+                   FROM artists
+                  WHERE LOWER(name) = LOWER(?1)
+                  ORDER BY tidal_id IS NULL, id ASC
+                  LIMIT 1",
+                params![artist],
+                |row| {
+                    Ok(json!({
+                        "provider": provider,
+                        "entity_type": "artist",
+                        "local_artist_id": row.get::<_, i64>(0)?,
+                        "tidal_artist_id": row.get::<_, Option<i64>>(1)?,
+                        "local_track_id": null,
+                        "tidal_id": null,
+                        "title": row.get::<_, String>(2)?,
+                        "artist_name": row.get::<_, String>(2)?,
+                        "album_title": null,
+                        "artwork_url": row.get::<_, Option<String>>(3)?.or_else(|| image_url.map(str::to_string)),
+                        "mbid": mbid,
+                        "score": score,
+                        "reason": reason,
+                        "playable": true,
+                    }))
+                },
+            )
+            .optional()
+            .map_err(Into::into)
+        })
+        .ok()
+        .flatten()
+        .unwrap_or_else(|| {
+            json!({
+                "provider": provider,
+                "entity_type": "artist",
+                "local_artist_id": null,
+                "tidal_artist_id": null,
+                "local_track_id": null,
+                "tidal_id": null,
+                "title": artist,
+                "artist_name": artist,
+                "album_title": null,
+                "artwork_url": image_url,
+                "mbid": mbid,
+                "score": score,
+                "reason": reason,
+                "playable": false,
+            })
+        })
+}
+
+async fn resolve_recommendation_album_item(
+    state: &SharedState,
+    provider: &str,
+    artist: &str,
+    title: &str,
+    mbid: Option<&str>,
+    score: Option<f64>,
+    reason: &str,
+    image_url: Option<&str>,
+) -> Value {
+    let s = state.read().await;
+    s.db
+        .with_conn(|conn| {
+            conn.query_row(
+                "SELECT al.id, al.tidal_id, al.title, a.id, a.tidal_id, a.name, al.artwork_url
+                   FROM albums al
+                   LEFT JOIN artists a ON a.id = al.artist_id
+                  WHERE LOWER(al.title) = LOWER(?1)
+                    AND LOWER(COALESCE(a.name, '')) = LOWER(?2)
+                  ORDER BY al.tidal_id IS NULL, al.id ASC
+                  LIMIT 1",
+                params![title, artist],
+                |row| {
+                    Ok(json!({
+                        "provider": provider,
+                        "entity_type": "album",
+                        "local_album_id": row.get::<_, i64>(0)?,
+                        "tidal_album_id": row.get::<_, Option<i64>>(1)?,
+                        "local_artist_id": row.get::<_, Option<i64>>(3)?,
+                        "tidal_artist_id": row.get::<_, Option<i64>>(4)?,
+                        "local_track_id": null,
+                        "tidal_id": null,
+                        "title": row.get::<_, String>(2)?,
+                        "artist_name": row.get::<_, Option<String>>(5)?,
+                        "album_title": row.get::<_, String>(2)?,
+                        "artwork_url": row.get::<_, Option<String>>(6)?.or_else(|| image_url.map(str::to_string)),
+                        "mbid": mbid,
+                        "score": score,
+                        "reason": reason,
+                        "playable": true,
+                    }))
+                },
+            )
+            .optional()
+            .map_err(Into::into)
+        })
+        .ok()
+        .flatten()
+        .unwrap_or_else(|| {
+            json!({
+                "provider": provider,
+                "entity_type": "album",
+                "local_album_id": null,
+                "tidal_album_id": null,
+                "local_artist_id": null,
+                "tidal_artist_id": null,
+                "local_track_id": null,
+                "tidal_id": null,
+                "title": title,
+                "artist_name": artist,
+                "album_title": title,
+                "artwork_url": image_url,
+                "mbid": mbid,
+                "score": score,
+                "reason": reason,
+                "playable": false,
+            })
+        })
+}
+
+fn recommendation_placeholder_item(
+    provider: &str,
+    artist: &str,
+    title: &str,
+    mbid: Option<&str>,
+    score: Option<f64>,
+    reason: &str,
+) -> Value {
+    json!({
+        "provider": provider,
+        "entity_type": "track",
+        "local_track_id": null,
+        "tidal_id": 0,
+        "title": title,
+        "artist_name": artist,
+        "album_title": null,
+        "artwork_url": null,
+        "mbid": mbid,
+        "score": score,
+        "reason": reason,
+        "playable": false,
+    })
 }
 
 fn unix_now_secs() -> i64 {
@@ -14336,6 +14807,99 @@ mod tests {
             reason: None,
             is_pending: source == "automix-new",
         }
+    }
+
+    fn lastfm_test_track(artist: &str, title: &str) -> LastFmChartTrack {
+        LastFmChartTrack {
+            artist: artist.to_string(),
+            title: title.to_string(),
+            mbid: None,
+            image_url: None,
+            listeners: None,
+            playcount: None,
+        }
+    }
+
+    fn lastfm_test_artist(name: &str) -> LastFmChartArtist {
+        LastFmChartArtist {
+            name: name.to_string(),
+            mbid: None,
+            image_url: None,
+            listeners: None,
+            playcount: None,
+            match_score: None,
+        }
+    }
+
+    fn lastfm_test_album(artist: &str, title: &str) -> LastFmChartAlbum {
+        LastFmChartAlbum {
+            artist: artist.to_string(),
+            title: title.to_string(),
+            mbid: None,
+            image_url: None,
+            playcount: None,
+        }
+    }
+
+    #[test]
+    fn lastfm_track_seed_merge_prioritizes_recent_and_loved_context() {
+        let seeds = merge_lastfm_track_seeds(
+            vec![
+                lastfm_test_track("Recent Artist", "Recent One"),
+                lastfm_test_track("Recent Artist", "Recent Two"),
+            ],
+            vec![lastfm_test_track("Loved Artist", "Loved One")],
+            vec![lastfm_test_track("Top Artist", "Top One")],
+            0,
+            4,
+        );
+
+        assert_eq!(seeds.len(), 4);
+        assert_eq!(seeds[0].reason, "Because you played Recent One recently");
+        assert_eq!(seeds[1].reason, "Because you played Recent Two recently");
+        assert_eq!(seeds[2].reason, "Because you loved Loved One");
+        assert_eq!(seeds[3].reason, "Near your top track Top One");
+    }
+
+    #[test]
+    fn lastfm_artist_seed_merge_uses_track_context_before_top_artists() {
+        let track_seeds = vec![
+            LastFmTrackSeed {
+                artist: "Recent Artist".to_string(),
+                title: "Recent One".to_string(),
+                reason: "Because you played Recent One recently".to_string(),
+            },
+            LastFmTrackSeed {
+                artist: "Recent Artist".to_string(),
+                title: "Duplicate Artist".to_string(),
+                reason: "Because you loved Duplicate Artist".to_string(),
+            },
+        ];
+        let seeds = merge_lastfm_artist_seeds(
+            &track_seeds,
+            vec![lastfm_test_artist("Top Artist")],
+            vec![lastfm_test_album("Album Artist", "Album One")],
+            0,
+            3,
+        );
+
+        assert_eq!(
+            seeds,
+            vec![
+                LastFmArtistSeed {
+                    name: "Recent Artist".to_string(),
+                    reason: "Because you played Recent One recently".to_string(),
+                },
+                LastFmArtistSeed {
+                    name: "Top Artist".to_string(),
+                    reason: "Near your top artist Top Artist".to_string(),
+                },
+                LastFmArtistSeed {
+                    name: "Album Artist".to_string(),
+                    reason: "Because you play albums by Album Artist".to_string(),
+                },
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds Last.fm-backed profile recommendation panels across the home/chart surfaces, with client API wiring, chart mural integration, playback helper updates, and contract coverage for the new shelf behavior.

## Validation

- `git diff --name-status origin/charts-layout-standardization...HEAD`
- `cargo check -p noor-server` in `E:\NOORwave\.worktrees\lastfm-profile-recommendations-pr` passed with existing dead-code warnings.
- `pnpm test -- home_recommendations_shelf_contract.test.ts trending_shelf_contract.test.ts` passed from `E:\NOORwave\frontend` because the isolated worktree had no `node_modules`.

## Notes

Opened as a focused PR split from the local `charts-layout-standardization` ahead commits.