### PR TITLE
Make TIDAL mix/album/playlist real, mutable queue rows

### DIFF
--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -1,0 +1,79 @@
+#!/bin/sh
+# repowise-hook-start
+# Auto-syncs the repowise wiki after each commit (background, non-blocking).
+#
+# Lives in .githooks/ because this repo sets core.hooksPath=.githooks, which
+# makes git ignore .git/hooks/ entirely. `repowise hook install` writes to
+# .git/hooks/ and is therefore dead here. Do not move back.
+#
+# Hardened against the silent-stale regression: a bare `repowise update`
+# ignores REPOWISE_MODEL from .repowise/.env and falls back to its built-in
+# default (llama3.2). That model isn't pulled locally, so every page 404s,
+# yet `update` still exits 0 AND advances the sync pointer -- leaving a wiki
+# that looks current but was never regenerated. We defend in three ways:
+#   1. read the model from .repowise/config.yaml (single source of truth) and
+#      pass it explicitly,
+#   2. preflight that the model is actually pulled in ollama,
+#   3. post-check the run output and drop a .repowise/.update.error marker if
+#      generation failed, so the failure is visible instead of silent.
+{
+  ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+  [ -d "$ROOT/.repowise" ] || exit 0
+  HEAD=$(git rev-parse HEAD 2>/dev/null) || HEAD=""
+  TS=$(date +%s 2>/dev/null) || TS=""
+  if [ -n "$TS" ]; then
+    printf '{"target_commit":"%s","queued_at":%s}\n' "$HEAD" "$TS" \
+      > "$ROOT/.repowise/.update.queued" 2>/dev/null || true
+  fi
+  LOG="$ROOT/.repowise/.update.log"
+  {
+    printf '\n--- post-commit hook fired at %s for HEAD %s ---\n' \
+      "$(date 2>/dev/null)" "$HEAD"
+  } >> "$LOG" 2>/dev/null || true
+  (
+    cd "$ROOT" || exit 1
+    CFG="$ROOT/.repowise/config.yaml"
+    ERRMARK="$ROOT/.repowise/.update.error"
+    RUNLOG="$ROOT/.repowise/.update.run.log"
+    rm -f "$ERRMARK" 2>/dev/null || true
+
+    # Single source of truth: read provider/model from config.yaml, fall back
+    # to the known-good local values if the file is missing or malformed.
+    MODEL=$(sed -n 's/^model:[[:space:]]*//p' "$CFG" 2>/dev/null | head -n1)
+    PROVIDER=$(sed -n 's/^provider:[[:space:]]*//p' "$CFG" 2>/dev/null | head -n1)
+    [ -n "$MODEL" ] || MODEL=qwen2.5-coder:7b
+    [ -n "$PROVIDER" ] || PROVIDER=ollama
+
+    fail() {
+      printf '[%s] repowise auto-update FAILED: %s\n' "$(date 2>/dev/null)" "$1" \
+        | tee -a "$LOG" > "$ERRMARK" 2>/dev/null
+      exit 1
+    }
+
+    # Preflight: the generation model must be pulled, else every page 404s.
+    if [ "$PROVIDER" = "ollama" ] && command -v ollama >/dev/null 2>&1; then
+      MODEL_BASE=$(printf '%s' "$MODEL" | cut -d: -f1)
+      ollama list 2>/dev/null | grep -q "$MODEL_BASE" \
+        || fail "model '$MODEL' not in \`ollama list\` (run: ollama pull $MODEL)"
+    fi
+
+    if command -v repowise >/dev/null 2>&1; then
+      RW="repowise"
+    elif command -v uv >/dev/null 2>&1; then
+      RW="uv run repowise"
+    else
+      fail "repowise CLI not found on PATH"
+    fi
+
+    $RW update --provider "$PROVIDER" --model "$MODEL" > "$RUNLOG" 2>&1
+    RC=$?
+    cat "$RUNLOG" >> "$LOG" 2>/dev/null || true
+
+    # Post-check: catch the silent failure repowise itself reports as success.
+    [ "$RC" -eq 0 ] || fail "repowise update exited $RC"
+    if grep -qiE 'page_generation_failed|not_found_error|model .* not found|error code: 404' "$RUNLOG" 2>/dev/null; then
+      fail "page generation errored (model/provider problem) -- see $RUNLOG"
+    fi
+  ) &
+} >/dev/null 2>&1
+# repowise-hook-end

--- a/docs/dev/repowise-ollama-windows.md
+++ b/docs/dev/repowise-ollama-windows.md
@@ -61,6 +61,30 @@ The local config excludes noise that hurts RepoWise signal:
 - screenshots, videos, Playwright reports, and test result artifacts
 - `target/`, frontend build output, coverage output, and `node_modules/`
 
+Hardened sync (guard against silent-stale):
+
+```powershell
+scripts\repowise-sync.ps1                              # update with preflight + post-verify
+scripts\repowise-sync.ps1 -Since <ref> -CascadeBudget 300 -Reindex   # full catch-up
+```
+
+Use this instead of a bare `repowise update` for any manual catch-up. Why:
+`repowise update` ignores `REPOWISE_MODEL` from `.repowise/.env` and falls back
+to its built-in default model (`llama3.2`). That model isn't pulled here, so
+every page 404s, yet `update` still **exits 0 and advances the sync pointer** -
+the wiki looks current but was never regenerated. `repowise-sync.ps1` reads the
+model from `config.yaml`, passes it explicitly, preflights that ollama + the
+model + the embedder alias are present, and fails loudly (non-zero exit) if any
+page generation errors.
+
+The post-commit hook (`.githooks/post-commit`) applies the same three guards
+automatically after each commit. When it detects a failure it writes a marker
+file at `.repowise/.update.error` (cleared on the next successful run); if the
+wiki ever looks stale, check for that file and read `.repowise/.update.run.log`.
+The hook lives in `.githooks/` on purpose - this repo sets
+`core.hooksPath=.githooks`, so a hook in `.git/hooks/` (where `repowise hook
+install` writes) is silently ignored.
+
 Coverage and health:
 
 ```powershell

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -7,6 +7,8 @@
 
 /* ── Dark theme (default) ─────────────────────────────── */
 :root {
+	color-scheme: dark;
+
 	--bg-base:       #0b0b0f;
 	--bg-elevated:   #111117;
 	--bg-raised:     #18181f;
@@ -90,24 +92,26 @@
 
 /* ── Light theme ──────────────────────────────────────── */
 [data-theme="light"] {
-	--bg-base:       #f5f4f2;
+	color-scheme: light;
+
+	--bg-base:       #f2f4f7;
 	--bg-elevated:   #ffffff;
-	--bg-raised:     #eeecea;
-	--bg-surface:    rgba(0, 0, 0, 0.028);
-	--bg-hover:      rgba(0, 0, 0, 0.046);
+	--bg-raised:     #e4e8ef;
+	--bg-surface:    rgba(22, 29, 43, 0.07);
+	--bg-hover:      rgba(22, 29, 43, 0.12);
 
-	--surface-0:     #f5f4f2;
-	--surface-1:     rgba(0, 0, 0, 0.04);
-	--surface-2:     rgba(0, 0, 0, 0.08);
+	--surface-0:     #f2f4f7;
+	--surface-1:     rgba(22, 29, 43, 0.08);
+	--surface-2:     rgba(22, 29, 43, 0.14);
 
-	--panel-bg:      rgba(255, 255, 255, 0.78);
-	--panel-border:  rgba(0, 0, 0, 0.09);
-	--panel-shadow:  0 4px 24px rgba(0, 0, 0, 0.08);
+	--panel-bg:      rgba(255, 255, 255, 0.92);
+	--panel-border:  rgba(22, 29, 43, 0.16);
+	--panel-shadow:  0 8px 28px rgba(22, 29, 43, 0.13);
 
-	--text-primary:  rgba(10, 10, 14, 0.92);
-	--text-secondary:rgba(10, 10, 14, 0.56);
-	--text-tertiary: rgba(10, 10, 14, 0.38);
-	--text-muted:    rgba(10, 10, 14, 0.22);
+	--text-primary:  rgba(9, 13, 22, 0.96);
+	--text-secondary:rgba(9, 13, 22, 0.72);
+	--text-tertiary: rgba(9, 13, 22, 0.54);
+	--text-muted:    rgba(9, 13, 22, 0.42);
 
 	--accent:        #5558e0;
 	--accent-soft:   rgba(85, 88, 224, 0.10);
@@ -115,9 +119,9 @@
 	--accent-strong: #3a3dc8;
 	--accent-glow:   rgba(85, 88, 224, 0.14);
 
-	--border-subtle: rgba(0, 0, 0, 0.08);
-	--border-muted:  rgba(0, 0, 0, 0.08);
-	--border-strong: rgba(0, 0, 0, 0.16);
+	--border-subtle: rgba(22, 29, 43, 0.12);
+	--border-muted:  rgba(22, 29, 43, 0.16);
+	--border-strong: rgba(22, 29, 43, 0.26);
 
 	--state-success:  #2d9e6a;
 	--state-warning:  #a07a20;
@@ -131,27 +135,27 @@
 	/* --service-* tokens cascade from :root — they are brand colors, not theme
 	 * variables, so they stay stable across themes. */
 
-	--input-bg:      rgba(0, 0, 0, 0.03);
-	--input-border:  rgba(0, 0, 0, 0.13);
-	--input-focus:   rgba(0, 0, 0, 0.05);
+	--input-bg:      rgba(255, 255, 255, 0.88);
+	--input-border:  rgba(22, 29, 43, 0.22);
+	--input-focus:   rgba(85, 88, 224, 0.10);
 
 	--scrollbar-thumb:       rgba(0, 0, 0, 0.12);
 	--scrollbar-thumb-hover: rgba(0, 0, 0, 0.22);
 
-	--right-panel-bg:   rgba(0, 0, 0, 0.015);
-	--right-panel-sep:  rgba(0, 0, 0, 0.07);
+	--right-panel-bg:   rgba(255, 255, 255, 0.64);
+	--right-panel-sep:  rgba(22, 29, 43, 0.13);
 	--sidebar-bg:       transparent;
 
 	/* Genre Atlas semantic tokens */
-	--atlas-bg: linear-gradient(170deg, #f7f9ff 0%, #f2f4fb 50%, #ebedf8 100%);
-	--atlas-haze-a: rgba(85, 88, 224, 0.08);
-	--atlas-haze-b: rgba(125, 104, 217, 0.06);
-	--atlas-haze-c: rgba(44, 146, 126, 0.06);
-	--instrument-surface: rgba(255, 255, 255, 0.72);
-	--instrument-surface-strong: rgba(255, 255, 255, 0.84);
-	--instrument-border: rgba(37, 45, 80, 0.14);
-	--instrument-edge: rgba(255, 255, 255, 0.8);
-	--signal-text: rgba(10, 14, 28, 0.62);
+	--atlas-bg: linear-gradient(170deg, #f8fafc 0%, #eef3fb 52%, #dde5f1 100%);
+	--atlas-haze-a: rgba(85, 88, 224, 0.10);
+	--atlas-haze-b: rgba(125, 104, 217, 0.08);
+	--atlas-haze-c: rgba(44, 146, 126, 0.08);
+	--instrument-surface: rgba(255, 255, 255, 0.86);
+	--instrument-surface-strong: rgba(248, 250, 252, 0.96);
+	--instrument-border: rgba(37, 45, 80, 0.20);
+	--instrument-edge: rgba(255, 255, 255, 0.94);
+	--signal-text: rgba(9, 13, 22, 0.70);
 	--family-accent: var(--accent);
 	--heat-intensity: 0.52;
 }

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -3717,11 +3717,17 @@ export const api = {
 		});
 	},
 
-	searchTidal(q: string, limit = 20, signal?: AbortSignal, offset = 0): Promise<TidalSearchResults> {
+	searchTidal(
+		q: string,
+		limit = 20,
+		signal?: AbortSignal,
+		offset = 0,
+		timeoutMs?: number,
+	): Promise<TidalSearchResults> {
 		return fetchApi<TidalSearchResults>(
 			'/api/tidal/search',
 			{ q, limit: String(limit), offset: String(offset) },
-			{ signal },
+			{ signal, timeoutMs },
 		);
 	},
 

--- a/frontend/src/lib/player/queue_row_favorite_contract.test.ts
+++ b/frontend/src/lib/player/queue_row_favorite_contract.test.ts
@@ -2,13 +2,25 @@ import { describe, expect, test } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
-const source = readFileSync(resolve(__dirname, '../../routes/+layout.svelte'), 'utf8');
+const layoutSource = readFileSync(resolve(__dirname, '../../routes/+layout.svelte'), 'utf8');
+const menuSource = readFileSync(resolve(__dirname, './track_menu.ts'), 'utf8');
 
-describe('queue row favorite contract', () => {
-	test('row favorite actions require a local track id', () => {
-		expect(source).toContain('function canFavoriteQueueRow(item: QueueItemType): boolean');
-		expect(source).toContain('return item.is_pending !== true && item.track.id > 0;');
-		expect(source).toContain('disabled={!canFavoriteQueueRow(item)}');
-		expect(source).toContain('Favorite unavailable for this queue row');
+describe('queue row actions contract', () => {
+	test('per-row actions collapse into a single overflow menu, not inline pills', () => {
+		// The noisy hover pills (favourite / play-next / remove) were replaced by
+		// one overflow button that opens the shared context menu.
+		expect(layoutSource).toContain('class="queue-overflow"');
+		expect(layoutSource).toContain('openQueueRowMenuFromButton(item, event)');
+		// The old inline-pill machinery is gone.
+		expect(layoutSource).not.toContain('canFavoriteQueueRow');
+		expect(layoutSource).not.toContain('class="queue-action icon"');
+	});
+
+	test('the shared menu reaches favourite + queue mutations for ephemeral TIDAL rows', () => {
+		// Ephemeral TIDAL rows are real, mutable queue rows now, so their menu
+		// carries the queue-aware actions keyed on the real queue id.
+		expect(menuSource).toContain('queueItemId?: number');
+		expect(menuSource).toContain("label: 'Move next'");
+		expect(menuSource).toContain("label: 'Remove from queue'");
 	});
 });

--- a/frontend/src/lib/player/track_menu.ts
+++ b/frontend/src/lib/player/track_menu.ts
@@ -54,6 +54,14 @@ export interface BuildTrackMenuOptions {
 
 export interface BuildTidalTrackMenuOptions {
 	inQueue?: boolean;
+	/**
+	 * Set when this TIDAL track is a real, mutable queue row (an ephemeral
+	 * mix/album/playlist row). Enables "Move next" + "Remove from queue" against
+	 * the row instead of the library-less defaults.
+	 */
+	queueItemId?: number;
+	/** Callback after a destructive action like remove, so caller can refetch. */
+	onRemoved?: () => void;
 	/** See BuildTrackMenuOptions.remoteRoutes. */
 	remoteRoutes?: boolean;
 }
@@ -186,14 +194,21 @@ export function buildTrackMenu(track: MenuTrack, options: BuildTrackMenuOptions 
 export function buildTidalTrackMenu(track: TidalPlayable, options: BuildTidalTrackMenuOptions = {}): MenuItem[] {
 	const playable = canPlayTrack(track);
 	const playableLabel = getPlayableLabel(track);
+	const queueItemId = options.queueItemId;
 	const items: MenuItem[] = [
-		{
-			label: 'Play next',
-			icon: '⤴',
-			disabled: !playable,
-			hint: playable ? undefined : playableLabel,
-			onSelect: () => void playTidalTrackNext(track),
-		},
+		queueItemId != null
+			? {
+					label: 'Move next',
+					icon: '⤴',
+					onSelect: () => void moveQueueTrackNext(queueItemId),
+				}
+			: {
+					label: 'Play next',
+					icon: '⤴',
+					disabled: !playable,
+					hint: playable ? undefined : playableLabel,
+					onSelect: () => void playTidalTrackNext(track),
+				},
 		...(options.inQueue
 			? []
 			: [{
@@ -250,6 +265,19 @@ export function buildTidalTrackMenu(track: TidalPlayable, options: BuildTidalTra
 		hint: playable ? undefined : playableLabel,
 		onSelect: () => void playTidalTrackNow(track),
 	});
+
+	if (queueItemId != null) {
+		items.push(SEPARATOR);
+		items.push({
+			label: 'Remove from queue',
+			icon: '×',
+			danger: true,
+			onSelect: async () => {
+				await removeTrackFromQueue(queueItemId);
+				options.onRemoved?.();
+			},
+		});
+	}
 
 	return items;
 }

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -2246,6 +2246,11 @@
 		transform-origin: center;
 	}
 
+	:global([data-theme="light"]) .wallpaper-layer {
+		opacity: 0.22;
+		filter: blur(var(--wallpaper-blur, 10px)) saturate(0.78);
+	}
+
 	.remote-shell {
 		position: relative;
 		z-index: 1;
@@ -2312,6 +2317,22 @@
 		background: rgba(9, 9, 14, 0.44);
 		backdrop-filter: blur(var(--wallpaper-blur, 10px)) saturate(1.1);
 		-webkit-backdrop-filter: blur(var(--wallpaper-blur, 10px)) saturate(1.1);
+	}
+
+	:global([data-theme="light"]) .app-shell.has-wallpaper .sidebar {
+		background:
+			linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(248, 250, 252, 0.82)),
+			var(--sidebar-bg);
+	}
+
+	:global([data-theme="light"]) .app-shell.has-wallpaper .workspace {
+		background: rgba(248, 250, 252, 0.82);
+	}
+
+	:global([data-theme="light"]) .app-shell.has-wallpaper .now-playing-panel {
+		background:
+			linear-gradient(180deg, rgba(255, 255, 255, 0.88), rgba(248, 250, 252, 0.84)),
+			var(--right-panel-bg);
 	}
 
 	.sidebar {

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -39,7 +39,6 @@
 		clearQueue as clearQueueAction,
 		restoreQueueItems,
 		saveQueueAsPlaylist,
-		playTidalTrackNext,
 		playTidalTrackNow
 	} from '$lib/stores/player';
 	import { get } from 'svelte/store';
@@ -57,8 +56,6 @@
 	import ContextMenu from '$lib/components/ContextMenu.svelte';
 	import Toast from '$lib/components/Toast.svelte';
 	import CommandPalette from '$lib/components/CommandPalette.svelte';
-	import QueueReasonCard from '$lib/components/QueueReasonCard.svelte';
-	import { formatReasonForScreenReader } from '$lib/utils/reason';
 	import ShortcutHelp from '$lib/components/ShortcutHelp.svelte';
 	import PlayerBar from '$lib/shell/PlayerBar.svelte';
 	import SidebarNav from '$lib/shell/SidebarNav.svelte';
@@ -244,75 +241,6 @@
 		}
 	}
 
-	// Phase 2b: queue-row "why is this here" tooltip. Tracks the
-	// reason string of the currently-hovered row plus the cursor
-	// position so QueueReasonCard can place itself near the trigger.
-	let hoveredReason = $state<string | null>(null);
-	let reasonMouseX = $state(0);
-	let reasonMouseY = $state(0);
-
-	function showQueueReason(reason: string | null | undefined, event: MouseEvent) {
-		if (!reason) return;
-		hoveredReason = reason;
-		reasonMouseX = event.clientX;
-		reasonMouseY = event.clientY;
-	}
-
-	function moveQueueReason(event: MouseEvent) {
-		if (hoveredReason === null) return;
-		reasonMouseX = event.clientX;
-		reasonMouseY = event.clientY;
-	}
-
-	function hideQueueReason() {
-		hoveredReason = null;
-	}
-
-	let activeQueueActionsRowId = $state<number | null>(null);
-	let queueActionsAlwaysVisible = $state(false);
-
-	function setQueueActionsRowActive(itemId: number) {
-		if (queueActionsAlwaysVisible) return;
-		activeQueueActionsRowId = itemId;
-	}
-
-	function clearQueueActionsRow(itemId: number) {
-		if (activeQueueActionsRowId === itemId) {
-			activeQueueActionsRowId = null;
-		}
-	}
-
-	function handleQueueRowMouseLeave(event: MouseEvent, itemId: number) {
-		const current = event.currentTarget;
-		if (
-			current instanceof HTMLElement &&
-			document.activeElement instanceof Node &&
-			current.contains(document.activeElement)
-		) {
-			return;
-		}
-		clearQueueActionsRow(itemId);
-	}
-
-	function handleQueueRowFocusOut(event: FocusEvent, itemId: number) {
-		const current = event.currentTarget;
-		const next = event.relatedTarget;
-		if (current instanceof HTMLElement && next instanceof Node && current.contains(next)) {
-			return;
-		}
-		clearQueueActionsRow(itemId);
-	}
-
-	function queueActionsAccessible(itemId: number): boolean {
-		return queueActionsAlwaysVisible || activeQueueActionsRowId === itemId;
-	}
-
-	function updateQueueActionsVisibility(query: MediaQueryList | MediaQueryListEvent) {
-		queueActionsAlwaysVisible = query.matches;
-		if (queueActionsAlwaysVisible) {
-			activeQueueActionsRowId = null;
-		}
-	}
 	let mobileFavoritePending = $state(false);
 	let desktopFavoritePending = $state(false);
 
@@ -422,13 +350,9 @@
 
 		window.addEventListener('keydown', handleGlobalKeydown);
 		window.addEventListener('wheel', handleGlobalWheel, { passive: false });
-		const queueActionsMedia = window.matchMedia('(max-width: 760px)');
-		updateQueueActionsVisibility(queueActionsMedia);
-		queueActionsMedia.addEventListener('change', updateQueueActionsVisibility);
 		return () => {
 			window.removeEventListener('keydown', handleGlobalKeydown);
 			window.removeEventListener('wheel', handleGlobalWheel);
-			queueActionsMedia.removeEventListener('change', updateQueueActionsVisibility);
 			cancelStartupPrewarm?.();
 			for (const unlisten of tauriUpdateUnlisteners) unlisten();
 			unsubPalette();
@@ -712,8 +636,12 @@
 	}
 
 	async function handleQueueTrackPlay(item: QueueItemType) {
+		// Ephemeral TIDAL rows (mix/album/playlist) stream via the ephemeral
+		// path, which jumps to the clicked track and trims the rows before it.
+		// Library rows jump to their queue position. Detection is by the track
+		// (tidal_ephemeral source), not the queue id, which is now positive.
 		const tidal = queueItemTidalPlayable(item);
-		if (tidal && item.id < 0) {
+		if (tidal) {
 			await playTidalTrackNow(tidal);
 		} else {
 			await playTrackNow(item.track.id);
@@ -762,16 +690,6 @@
 			if (playingIdx >= 0 && newIdx <= playingIdx) return;
 		}
 		await moveQueueItem(item.id, newIdx);
-	}
-
-	async function handleQueueRemove(queueItemId: number, event: MouseEvent) {
-		event.stopPropagation();
-		await removeTrackFromQueue(queueItemId);
-	}
-
-	async function handleQueueMoveNext(queueItemId: number, event: MouseEvent) {
-		event.stopPropagation();
-		await moveQueueTrackNext(queueItemId);
 	}
 
 	function formatQuality(q: string | null) {
@@ -837,37 +755,25 @@
 		return queueItemToTidalPlayable(item);
 	}
 
-	function isEphemeralQueueItem(item: QueueItemType): boolean {
-		return item.id < 0 && queueItemTidalPlayable(item) != null;
-	}
-
-	async function handleQueuePlayNext(item: QueueItemType, event: MouseEvent) {
-		event.stopPropagation();
+	// Ephemeral TIDAL rows are now real, mutable queue rows, so their ⋯/right-click
+	// menu gets the queue-aware actions (Move next, Remove from queue) keyed on the
+	// real queue id.
+	function queueRowMenuItems(item: QueueItemType) {
 		const tidal = queueItemTidalPlayable(item);
-		if (tidal && item.id < 0) {
-			await playTidalTrackNext(tidal);
-			return;
-		}
-		await handleQueueMoveNext(item.id, event);
+		return tidal
+			? buildTidalTrackMenu(tidal, { inQueue: true, queueItemId: item.id })
+			: pickMenuBuilder(item.track, { queueItemId: item.id, isPending: item.is_pending });
 	}
 
 	function openQueueRowMenu(item: QueueItemType, event: MouseEvent) {
 		event.preventDefault();
 		event.stopPropagation();
-		const tidal = queueItemTidalPlayable(item);
-		const items = tidal
-			? buildTidalTrackMenu(tidal, { inQueue: true })
-			: pickMenuBuilder(item.track, { queueItemId: item.id, isPending: item.is_pending });
-		openContextMenu(event, items, item.track.title);
+		openContextMenu(event, queueRowMenuItems(item), item.track.title);
 	}
 
 	function openQueueRowMenuFromButton(item: QueueItemType, event: MouseEvent) {
 		event.stopPropagation();
-		const tidal = queueItemTidalPlayable(item);
-		const items = tidal
-			? buildTidalTrackMenu(tidal, { inQueue: true })
-			: pickMenuBuilder(item.track, { queueItemId: item.id, isPending: item.is_pending });
-		openMenuAtElement(event.currentTarget as HTMLElement, items, item.track.title);
+		openMenuAtElement(event.currentTarget as HTMLElement, queueRowMenuItems(item), item.track.title);
 	}
 
 	function openQueueArtistContextMenu(item: QueueItemType, event: MouseEvent) {
@@ -884,19 +790,6 @@
 			}),
 			item.track.artist_name ?? 'Unknown artist'
 		);
-	}
-
-	async function handleQueueRowFavorite(trackId: number, event: MouseEvent) {
-		event.stopPropagation();
-		try {
-			await toggleTrackFavorite(trackId);
-		} catch {
-			// toggleTrackFavorite surfaces its own error in the player store.
-		}
-	}
-
-	function canFavoriteQueueRow(item: QueueItemType): boolean {
-		return item.is_pending !== true && item.track.id > 0;
 	}
 
 	// ─── Queue drag-to-reorder ────────────────────────────────────────────────
@@ -1341,7 +1234,6 @@
 <CommandPalette />
 <QuietMode />
 <ShortcutHelp open={shortcutHelpOpen} onClose={closeShortcutHelp} />
-<QueueReasonCard reason={hoveredReason} mouseX={reasonMouseX} mouseY={reasonMouseY} />
 
 {#if showPkceReloginNotice}
 	<div class="pkce-relogin-backdrop" role="presentation">
@@ -1713,7 +1605,6 @@
 					{#each upcomingQueue.slice(0, queueVisibleCount) as item, i (`${item.id}-${i}`)}
 						{@const aid = item.track.artist_id}
 						{@const isPending = item.is_pending === true}
-						{@const actionsAccessible = queueActionsAccessible(item.id)}
 						<div
 							role="listitem"
 							class:active={isQueueItemActive(item, $currentTrack, $currentQueueItemId, upcomingQueue)}
@@ -1722,20 +1613,31 @@
 							class:pending={isPending}
 							class="queue-row"
 							title={isPending ? 'Resolving on TIDAL...' : undefined}
-							draggable={true}
 							data-track-id={item.track.id}
 							oncontextmenu={(event) => openQueueRowMenu(item, event)}
-							ondragstart={(event) => handleQueueDragStart(event, item)}
 							ondragover={(event) => handleQueueDragOver(event, item)}
 							ondragleave={() => handleQueueDragLeave(item)}
 							ondrop={(event) => void handleQueueDrop(event, item)}
 							ondragend={handleQueueDragEnd}
-							onmouseenter={() => setQueueActionsRowActive(item.id)}
-							onmouseleave={(event) => handleQueueRowMouseLeave(event, item.id)}
-							onfocusin={() => setQueueActionsRowActive(item.id)}
-							onfocusout={(event) => handleQueueRowFocusOut(event, item.id)}
 						>
-							<span class="queue-grip" aria-hidden="true" title="Drag to reorder">⋮⋮</span>
+							<!-- Full-bleed hit target: clicking anywhere on the row that
+							     isn't an interactive child plays/jumps to this track. -->
+							<button
+								class="queue-row-hit"
+								type="button"
+								aria-label={isPending ? `Pending: ${item.track.title}` : `Play ${item.track.title}`}
+								aria-disabled={isPending}
+								disabled={isPending}
+								onclick={isPending ? undefined : () => void handleQueueTrackPlay(item)}
+								onkeydown={(event) => handleQueueTrackKeydown(item, event)}
+							></button>
+							<span
+								class="queue-grip"
+								aria-hidden="true"
+								title="Drag to reorder"
+								draggable={!isPending}
+								ondragstart={(event) => handleQueueDragStart(event, item)}
+							>⋮⋮</span>
 							<div class="queue-art-wrap" title={formatQueueSource(item.source)}>
 								{#if isPending}
 									<div class="queue-art placeholder pending-art" title="Resolving track...">
@@ -1758,19 +1660,7 @@
 							</div>
 
 							<div class="queue-meta">
-								<button
-									class="queue-row-play"
-									type="button"
-									aria-label={isPending
-										? `Pending: ${item.track.title}`
-										: `Play ${item.track.title}`}
-									aria-disabled={isPending}
-									disabled={isPending}
-									onclick={isPending ? undefined : () => void handleQueueTrackPlay(item)}
-									onkeydown={(event) => handleQueueTrackKeydown(item, event)}
-								>
-									<span class="queue-title">{item.track.title}</span>
-								</button>
+								<span class="queue-title">{item.track.title}</span>
 								{#if isPending}
 									<span class="queue-artist pending-label">
 										<span class="queue-inline-spinner" aria-hidden="true"></span>
@@ -1790,62 +1680,14 @@
 
 							<div class="queue-side">
 								<span class="queue-time">{formatTrackDuration(item.track.duration_ms)}</span>
-								<div
-									class="queue-actions"
-									inert={!actionsAccessible}
-									aria-hidden={actionsAccessible ? undefined : 'true'}
-								>
-									{#if item.reason}
-										{@const reasonDesc = formatReasonForScreenReader(item.reason)}
-										{@const reasonId = `queue-reason-${item.id}`}
-										<button
-											class="queue-action icon reason"
-											aria-label="Why is this here?"
-											aria-describedby={reasonDesc ? reasonId : undefined}
-											title="Why is this here?"
-											onmouseenter={(event) => showQueueReason(item.reason, event)}
-											onmousemove={moveQueueReason}
-											onmouseleave={hideQueueReason}
-											onfocus={(event) => showQueueReason(item.reason, event as unknown as MouseEvent)}
-											onblur={hideQueueReason}
-											onclick={stopPropagation}
-										>ⓘ</button>
-										{#if reasonDesc}
-											<span id={reasonId} class="queue-sr-status">{reasonDesc}</span>
-										{/if}
-									{/if}
+								{#if !isPending}
 									<button
-										class="queue-action icon"
-										class:active={item.track.is_favorite}
-										aria-label={!canFavoriteQueueRow(item)
-											? 'Favorite unavailable for this queue row'
-											: item.track.is_favorite ? 'Remove from favourites' : 'Add to favourites'}
-										title={!canFavoriteQueueRow(item)
-											? 'Favorite this track after it starts playing'
-											: item.track.is_favorite ? 'Remove from favourites' : 'Add to favourites'}
-										disabled={!canFavoriteQueueRow(item)}
-										onclick={(event) => void handleQueueRowFavorite(item.track.id, event)}
-									>{item.track.is_favorite ? '♥' : '♡'}</button>
-									<button
-										class="queue-action icon"
+										class="queue-overflow"
 										aria-label="More actions"
 										title="More actions"
 										onclick={(event) => openQueueRowMenuFromButton(item, event)}
 									>⋯</button>
-									<button
-										class="queue-action icon"
-										aria-label={isEphemeralQueueItem(item) ? 'Promote to play next' : 'Play next'}
-										title={isEphemeralQueueItem(item) ? 'Add this TIDAL mix track as next in the queue' : 'Play next'}
-										onclick={(event) => void handleQueuePlayNext(item, event)}
-									>↑</button>
-									<button
-										class="queue-action icon remove"
-										aria-label="Remove from queue"
-										title={isEphemeralQueueItem(item) ? 'TIDAL mix rows cannot be removed yet' : 'Remove from queue'}
-										disabled={isEphemeralQueueItem(item)}
-										onclick={(event) => void handleQueueRemove(item.id, event)}
-									>×</button>
-								</div>
+								{/if}
 							</div>
 						</div>
 					{/each}
@@ -2093,7 +1935,6 @@
 					{#each upcomingQueue.slice(0, queueVisibleCount) as item, i (`${item.id}-${i}`)}
 						{@const aid = item.track.artist_id}
 						{@const isPending = item.is_pending === true}
-						{@const actionsAccessible = queueActionsAccessible(item.id)}
 						<div
 							role="listitem"
 							class="queue-row"
@@ -2101,11 +1942,16 @@
 							class:pending={isPending}
 							title={isPending ? 'Resolving on TIDAL...' : undefined}
 							oncontextmenu={(event) => openQueueRowMenu(item, event)}
-							onmouseenter={() => setQueueActionsRowActive(item.id)}
-							onmouseleave={(event) => handleQueueRowMouseLeave(event, item.id)}
-							onfocusin={() => setQueueActionsRowActive(item.id)}
-							onfocusout={(event) => handleQueueRowFocusOut(event, item.id)}
 						>
+							<button
+								class="queue-row-hit"
+								type="button"
+								aria-label={isPending ? `Pending: ${item.track.title}` : `Play ${item.track.title}`}
+								aria-disabled={isPending}
+								disabled={isPending}
+								onclick={isPending ? undefined : () => void handleQueueTrackPlay(item)}
+								onkeydown={(event) => handleQueueTrackKeydown(item, event)}
+							></button>
 							<div class="queue-art-wrap" title={formatQueueSource(item.source)}>
 								{#if isPending}
 									<div class="queue-art placeholder pending-art" title="Resolving track...">
@@ -2127,19 +1973,7 @@
 								<span class="queue-source-dot source-{queueSourceSlug(item.source)}" aria-hidden="true"></span>
 							</div>
 							<div class="queue-meta">
-								<button
-									class="queue-row-play"
-									type="button"
-									aria-label={isPending
-										? `Pending: ${item.track.title}`
-										: `Play ${item.track.title}`}
-									aria-disabled={isPending}
-									disabled={isPending}
-									onclick={isPending ? undefined : () => void handleQueueTrackPlay(item)}
-									onkeydown={(event) => handleQueueTrackKeydown(item, event)}
-								>
-									<span class="queue-title">{item.track.title}</span>
-								</button>
+								<span class="queue-title">{item.track.title}</span>
 								{#if isPending}
 									<span class="queue-artist pending-label">
 										<span class="queue-inline-spinner" aria-hidden="true"></span>
@@ -2158,30 +1992,12 @@
 							</div>
 							<div class="queue-side">
 								<span class="queue-time">{formatTrackDuration(item.track.duration_ms)}</span>
-								<div
-									class="queue-actions"
-									inert={!actionsAccessible}
-									aria-hidden={actionsAccessible ? undefined : 'true'}
-								>
-									<button
-										class="queue-action icon"
-										aria-label="More actions"
-										onclick={(e) => openQueueRowMenuFromButton(item, e)}
-									>⋯</button>
-									<button
-										class="queue-action icon"
-										aria-label={isEphemeralQueueItem(item) ? 'Promote to play next' : 'Play next'}
-										title={isEphemeralQueueItem(item) ? 'Add this TIDAL mix track as next in the queue' : 'Play next'}
-										onclick={(e) => void handleQueuePlayNext(item, e)}
-									>↑</button>
-									<button
-										class="queue-action icon remove"
-										aria-label="Remove from queue"
-										title={isEphemeralQueueItem(item) ? 'TIDAL mix rows cannot be removed yet' : 'Remove from queue'}
-										disabled={isEphemeralQueueItem(item)}
-										onclick={(e) => void handleQueueRemove(item.id, e)}
-									>×</button>
-								</div>
+								<button
+									class="queue-overflow"
+									aria-label="More actions"
+									title="More actions"
+									onclick={(e) => openQueueRowMenuFromButton(item, e)}
+								>⋯</button>
 							</div>
 						</div>
 					{/each}
@@ -2759,7 +2575,6 @@
 		.queue-row,
 		.queue-row:hover,
 		.queue-row:focus-within,
-		.queue-action:hover,
 		.queue-icon-btn:hover:not(:disabled),
 		.queue-undo-btn:hover,
 		.queue-jump-chip:hover,
@@ -2984,6 +2799,7 @@
 	}
 
 	.queue-row {
+		position: relative;
 		display: flex;
 		align-items: center;
 		gap: 10px;
@@ -2995,6 +2811,50 @@
 			border-color var(--motion-fast),
 			background var(--motion-fast),
 			transform var(--motion-fast);
+	}
+
+	/* Full-bleed click target sits behind the row content. Non-interactive
+	   content (art, title, time) has pointer-events:none so clicks fall through
+	   to it; interactive children (grip, artist link, overflow) re-enable. */
+	.queue-row-hit {
+		position: absolute;
+		inset: 0;
+		z-index: 0;
+		margin: 0;
+		padding: 0;
+		border: none;
+		background: transparent;
+		border-radius: inherit;
+		cursor: pointer;
+	}
+
+	.queue-row-hit:disabled {
+		cursor: default;
+	}
+
+	.queue-row-hit:focus-visible {
+		outline: 2px solid var(--accent-line);
+		outline-offset: -2px;
+	}
+
+	.queue-row > .queue-grip,
+	.queue-row > .queue-art-wrap,
+	.queue-row > .queue-meta,
+	.queue-row > .queue-side {
+		position: relative;
+		z-index: 1;
+	}
+
+	.queue-art-wrap,
+	.queue-meta,
+	.queue-time {
+		pointer-events: none;
+	}
+
+	.queue-grip,
+	.queue-meta .queue-artist[href],
+	.queue-overflow {
+		pointer-events: auto;
 	}
 
 	.queue-row:hover,
@@ -3130,29 +2990,6 @@
 		gap: 2px;
 	}
 
-	.queue-row-play {
-		display: block;
-		width: 100%;
-		padding: 0;
-		margin: 0;
-		border: none;
-		background: transparent;
-		color: inherit;
-		text-align: left;
-		font: inherit;
-		cursor: pointer;
-		border-radius: 4px;
-	}
-
-	.queue-row-play:disabled {
-		cursor: default;
-	}
-
-	.queue-row-play:focus-visible {
-		outline: 2px solid var(--accent-line);
-		outline-offset: 2px;
-	}
-
 	.queue-title {
 		font-weight: var(--font-weight-semibold);
 		font-size: var(--font-size-sm);
@@ -3212,103 +3049,44 @@
 	}
 
 	.queue-side {
-		position: relative;
 		display: flex;
 		align-items: center;
 		justify-content: flex-end;
-		gap: 8px;
-		min-width: 76px;
+		gap: 6px;
 		flex-shrink: 0;
 		margin-left: auto;
 	}
 
-	.queue-time {
-		transition: opacity var(--motion-fast);
-	}
-
-	.queue-row:hover .queue-time {
-		opacity: 0;
-	}
-
-	.queue-row:focus-within .queue-side {
-		min-width: max-content;
-	}
-
-	.queue-row:focus-within .queue-time {
-		opacity: 1;
-	}
-
-	.queue-actions {
-		position: absolute;
-		right: 0;
-		top: 50%;
-		transform: translateY(-50%);
-		display: flex;
-		align-items: center;
-		gap: 4px;
-		opacity: 0;
-		pointer-events: none;
-		transition: opacity var(--motion-fast);
-	}
-
-	.queue-row:hover .queue-actions {
-		opacity: 1;
-		pointer-events: auto;
-	}
-
-	.queue-row:focus-within .queue-actions {
-		position: static;
-		transform: none;
-		opacity: 1;
-		pointer-events: auto;
-	}
-
-	.queue-action {
-		padding: 5px 8px;
-		border-radius: 999px;
-		background: color-mix(in srgb, var(--instrument-surface) 82%, transparent);
-		border: 1px solid color-mix(in srgb, var(--instrument-border) 56%, transparent);
-		color: var(--text-primary);
-		font-size: var(--font-size-xs);
-		cursor: pointer;
-		transition: background var(--motion-fast), color var(--motion-fast), border-color var(--motion-fast);
-	}
-
-	.queue-action:hover {
-		background: color-mix(in srgb, var(--instrument-surface-strong) 92%, transparent);
-		border-color: color-mix(in srgb, var(--instrument-border) 82%, transparent);
-		transform: translateY(-1px);
-	}
-
-	.queue-action:disabled {
-		cursor: not-allowed;
-		opacity: 0.45;
-	}
-
-	.queue-action:disabled:hover {
-		background: color-mix(in srgb, var(--instrument-surface) 82%, transparent);
-		border-color: color-mix(in srgb, var(--instrument-border) 56%, transparent);
-		color: var(--text-primary);
-	}
-
-	.queue-action.icon {
+	/* Single overflow button replaces the old cluster of hover pills: low-key by
+	   default, brightens on row hover/focus. The context menu holds every action
+	   (play next, favourite, radio, remove), so the row stays calm. */
+	.queue-overflow {
 		width: 28px;
 		height: 28px;
 		padding: 0;
 		display: inline-grid;
 		place-items: center;
-		font-size: var(--font-size-sm);
+		border-radius: 999px;
+		border: 1px solid transparent;
+		background: transparent;
+		color: var(--text-tertiary);
+		font-size: var(--font-size-md);
 		line-height: 1;
+		cursor: pointer;
+		opacity: 0.55;
+		transition: background var(--motion-fast), color var(--motion-fast),
+			border-color var(--motion-fast), opacity var(--motion-fast);
 	}
 
-	.queue-action.icon.active {
-		color: var(--accent-strong, #6366f1);
+	.queue-row:hover .queue-overflow,
+	.queue-row:focus-within .queue-overflow {
+		opacity: 1;
 	}
 
-	.queue-action.icon.remove:hover {
-		background: color-mix(in srgb, var(--state-error) 22%, transparent);
-		border-color: color-mix(in srgb, var(--state-error) 55%, transparent);
-		color: var(--state-error);
+	.queue-overflow:hover {
+		background: color-mix(in srgb, var(--instrument-surface-strong) 92%, transparent);
+		border-color: color-mix(in srgb, var(--instrument-border) 70%, transparent);
+		color: var(--text-primary);
 	}
 
 	.queue-empty {
@@ -4045,14 +3823,10 @@
 	/* ── Small phones (≤ 760px): queue touch tweaks ─────── */
 	@media (max-width: 760px) {
 		.queue-row { align-items: flex-start; }
-		.queue-side { min-width: auto; align-items: flex-end; }
+		.queue-side { align-items: flex-end; }
 		.queue-time { display: none; }
-		.queue-actions {
-			position: static;
-			transform: none;
-			opacity: 1;
-			pointer-events: auto;
-		}
+		/* Overflow stays tappable without a hover state on touch. */
+		.queue-overflow { opacity: 1; }
 	}
 
 	/* ─── Connect screen ───────────────────── */

--- a/frontend/src/routes/artists/[id]/+page.svelte
+++ b/frontend/src/routes/artists/[id]/+page.svelte
@@ -252,32 +252,60 @@
 				: bioText.slice(0, BIO_TRUNCATE).trimEnd() + '…'
 	);
 
-	let showAllPopular = $state(false);
-	// Library tracks ordered by play_count; float favorites within that.
-	let libraryPopular = $derived(
-		[...tracks].sort((a, b) => {
-			if (a.is_favorite !== b.is_favorite) return a.is_favorite ? -1 : 1;
-			return b.play_count - a.play_count;
-		})
+	type PopularTrackItem =
+		| { kind: 'local'; track: Track }
+		| { kind: 'tidal'; track: TidalDiscographyTrack };
+
+	function localPopularityScore(track: Track): number {
+		const spotifyPlaycount = track.isrc ? playcountByIsrc.get(track.isrc) : undefined;
+		return spotifyPlaycount ?? track.play_count ?? 0;
+	}
+
+	function popularItemKey(item: PopularTrackItem): string {
+		return item.kind === 'local' ? `local-${item.track.id}` : `tidal-${item.track.tidal_id}`;
+	}
+
+	// "Top tracks" follows TIDAL's popularity-ranked top-tracks order when
+	// available, replacing TIDAL rows with local rows where the user owns them.
+	// Local-only leftovers are appended by known playcount as a fallback.
+	let popularItems = $derived.by<PopularTrackItem[]>(() => {
+		const byTidalId = new Map<number, Track>();
+		for (const track of tracks) {
+			if (track.tidal_id != null && track.tidal_id > 0) byTidalId.set(track.tidal_id, track);
+		}
+
+		const seenLocalIds = new Set<number>();
+		const seenTidalIds = new Set<number>();
+		const ordered: PopularTrackItem[] = [];
+
+		for (const tidalTrack of tidalTopTracks) {
+			if (seenTidalIds.has(tidalTrack.tidal_id)) continue;
+			seenTidalIds.add(tidalTrack.tidal_id);
+			const localTrack = byTidalId.get(tidalTrack.tidal_id);
+			if (localTrack) {
+				seenLocalIds.add(localTrack.id);
+				ordered.push({ kind: 'local', track: localTrack });
+			} else {
+				ordered.push({ kind: 'tidal', track: tidalTrack });
+			}
+		}
+
+		const localRemainder = tracks
+			.filter((track) => !seenLocalIds.has(track.id))
+			.sort((a, b) => localPopularityScore(b) - localPopularityScore(a));
+
+		if (ordered.length === 0) {
+			return localRemainder.map((track) => ({ kind: 'local', track }));
+		}
+
+		ordered.push(...localRemainder.map((track) => ({ kind: 'local' as const, track })));
+		return ordered;
+	});
+	let popularMaxPlays = $derived(
+		Math.max(1, ...popularItems.map((item) => item.kind === 'local' ? localPopularityScore(item.track) : 0))
 	);
-	// TIDAL top tracks the user does NOT already own. These render under the
-	// library section in TIDAL's relevance order so the surface always shows
-	// the artist's catalog even when the user has zero library matches.
-	let tidalOnlyTopTracks = $derived(
-		tidalTopTracks.filter(
-			(tt) => !tracks.some((lt) => lt.tidal_id != null && lt.tidal_id === tt.tidal_id),
-		),
-	);
-	let popularMaxPlays = $derived(libraryPopular[0]?.play_count ?? 1);
-	// "Top tracks" = library + TIDAL-only, capped at 10 unless expanded.
-	let popularDisplayCount = $derived(showAllPopular ? Infinity : 10);
-	let visibleLibraryPopular = $derived(libraryPopular.slice(0, popularDisplayCount));
-	let visibleTidalPopular = $derived(
-		showAllPopular
-			? tidalOnlyTopTracks
-			: tidalOnlyTopTracks.slice(0, Math.max(0, popularDisplayCount - libraryPopular.length))
-	);
-	let totalPopularCandidates = $derived(libraryPopular.length + tidalOnlyTopTracks.length);
+	let visiblePopularItems = $derived(popularItems.slice(0, 10));
+	let totalPopularCandidates = $derived(popularItems.length);
 
 	function artistTrackPlayable(track: TidalDiscographyTrack) {
 		return tidalDiscographyTrackToPlayable(track, { artistTidalId: artist?.tidal_id ?? null });
@@ -479,14 +507,11 @@
 		return title.toLowerCase().includes(filterQuery.toLowerCase());
 	}
 
-	const filteredLibraryPopular = $derived(
-		visibleLibraryPopular.filter((t) => matchesFilter(t.title))
-	);
-	const filteredTidalPopular = $derived(
-		visibleTidalPopular.filter((t) => matchesFilter(t.title))
+	const filteredPopularItems = $derived(
+		visiblePopularItems.filter((item) => matchesFilter(item.track.title))
 	);
 	const hasAnyPopular = $derived(
-		filteredLibraryPopular.length > 0 || filteredTidalPopular.length > 0
+		filteredPopularItems.length > 0
 	);
 
 	const filteredTidalFullAlbums = $derived(
@@ -736,12 +761,14 @@
 			<section class="section">
 				<h2 class="section-title">Top tracks</h2>
 				<ol class="popular-list">
-					{#each filteredLibraryPopular as track, idx (track.id)}
+					{#each filteredPopularItems as item, idx (popularItemKey(item))}
+						{#if item.kind === 'local'}
+							{@const track = item.track}
 						{@const streamCount = track.isrc ? playcountByIsrc.get(track.isrc) : undefined}
 						<div class="popular-row-wrap">
 							<div
 								class="pop-bar"
-								style="width: {Math.max(4, ((track.play_count ?? 0) / popularMaxPlays) * 100)}%"
+								style="width: {Math.max(4, (localPopularityScore(track) / popularMaxPlays) * 100)}%"
 							></div>
 							<TrackRow
 								{track}
@@ -756,8 +783,8 @@
 								menuOptions={{ hideArtistActions: true }}
 							/>
 						</div>
-					{/each}
-					{#each filteredTidalPopular as track, idx (`tidal-${track.tidal_id}`)}
+						{:else}
+							{@const track = item.track}
 						{@const playable = artistTrackPlayable(track)}
 						{@const playable_ok = canPlayTrack(playable)}
 						{@const trackArt = artworkCandidate(track.artwork_url, 320)}
@@ -783,7 +810,7 @@
 								(e.key === 'Enter' || e.key === ' ')
 								&& (e.preventDefault(), playable_ok && void playTidalTrackNow(playable))}
 						>
-							<span class="tidal-row-num">{filteredLibraryPopular.length + idx + 1}</span>
+							<span class="tidal-row-num">{idx + 1}</span>
 							{#if trackArt}
 								<img
 									class="tidal-row-art"
@@ -802,16 +829,13 @@
 							</span>
 							<span class="tidal-pill" aria-label="From TIDAL">TIDAL</span>
 						</li>
+						{/if}
 					{/each}
 				</ol>
-				{#if !showAllPopular && totalPopularCandidates > 10}
-					<button class="show-all-btn" onclick={() => (showAllPopular = true)}>
-						Show all {totalPopularCandidates}
-					</button>
-				{:else if showAllPopular && totalPopularCandidates > 10}
-					<button class="show-all-btn" onclick={() => (showAllPopular = false)}>
-						Show fewer
-					</button>
+				{#if totalPopularCandidates > 10}
+					<a class="show-all-btn" href={`/artists/${artistId}/discography/tracks`}>
+						See all {totalPopularCandidates}
+					</a>
 				{/if}
 			</section>
 		{/if}
@@ -938,6 +962,7 @@
 					<div class="shelf-head">
 						<h2 class="section-title">Albums</h2>
 						<span class="shelf-count">{filteredTidalFullAlbums.length}</span>
+						<a class="shelf-link" href={`/artists/${artistId}/discography/albums`}>See all</a>
 					</div>
 					<MediaRail
 						items={filteredTidalFullAlbums}
@@ -955,6 +980,7 @@
 					<div class="shelf-head">
 						<h2 class="section-title">Singles and EPs</h2>
 						<span class="shelf-count">{filteredTidalSinglesEPs.length}</span>
+						<a class="shelf-link" href={`/artists/${artistId}/discography/singles`}>See all</a>
 					</div>
 					<MediaRail
 						items={filteredTidalSinglesEPs}
@@ -986,6 +1012,7 @@
 					<div class="shelf-head">
 						<h2 class="section-title">Compilations</h2>
 						<span class="shelf-count">{filteredTidalCompilations.length}</span>
+						<a class="shelf-link" href={`/artists/${artistId}/discography/compilations`}>See all</a>
 					</div>
 					<MediaRail
 						items={filteredTidalCompilations}
@@ -1570,6 +1597,18 @@
 	.shelf-count {
 		color: var(--text-tertiary);
 		font-size: var(--font-size-sm);
+	}
+
+	.shelf-link {
+		margin-left: auto;
+		color: var(--text-secondary);
+		font-size: var(--font-size-sm);
+		font-weight: var(--font-weight-semibold);
+		text-decoration: none;
+	}
+
+	.shelf-link:hover {
+		color: var(--text-primary);
 	}
 
 	.popular-list {

--- a/frontend/src/routes/artists/[id]/discography/[section]/+page.svelte
+++ b/frontend/src/routes/artists/[id]/discography/[section]/+page.svelte
@@ -1,0 +1,417 @@
+<script lang="ts">
+	import { page } from '$app/state';
+	import type { Track, TidalDiscographyAlbum, TidalDiscographyTrack } from '$lib/api/client';
+	import { cachedApi } from '$lib/cache/api_queries';
+	import TrackRow from '$lib/components/TrackRow.svelte';
+	import TidalTrackRow from '$lib/components/TidalTrackRow.svelte';
+	import ArtworkImage from '$lib/components/ui/ArtworkImage.svelte';
+	import EmptyState from '$lib/components/ui/EmptyState.svelte';
+	import Skeleton from '$lib/components/ui/Skeleton.svelte';
+	import { buildAlbumMenu } from '$lib/player/album_menu';
+	import { openContextMenu } from '$lib/stores/context_menu';
+	import { playAlbum, playArtist, playTidalAlbum } from '$lib/stores/player';
+	import { tidalDiscographyTrackToPlayable } from '$lib/utils/track';
+
+	type Section = 'tracks' | 'albums' | 'singles' | 'compilations';
+	type PopularTrackItem =
+		| { kind: 'local'; track: Track }
+		| { kind: 'tidal'; track: TidalDiscographyTrack };
+
+	const SECTION_LABELS: Record<Section, string> = {
+		tracks: 'Top tracks',
+		albums: 'Albums',
+		singles: 'Singles and EPs',
+		compilations: 'Compilations',
+	};
+
+	let artistId = $derived(Number(page.params.id));
+	let section = $derived(normalizeSection(page.params.section));
+
+	let artist = $state<{ id: number; tidal_id: number | null; name: string } | null>(null);
+	let tracks = $state<Track[]>([]);
+	let tidalTracks = $state<TidalDiscographyTrack[]>([]);
+	let tidalAlbums = $state<TidalDiscographyAlbum[]>([]);
+	let loading = $state(true);
+	let error = $state<string | null>(null);
+	let query = $state('');
+	let loadSeq = 0;
+
+	function normalizeSection(raw: string | undefined): Section {
+		if (raw === 'tracks' || raw === 'albums' || raw === 'singles' || raw === 'compilations') {
+			return raw;
+		}
+		return 'tracks';
+	}
+
+	async function load(id: number) {
+		const seq = ++loadSeq;
+		loading = true;
+		error = null;
+		try {
+			const [artistRes, tracksRes, discographyRes] = await Promise.allSettled([
+				cachedApi.getArtist(id),
+				cachedApi.getArtistTracks(id),
+				cachedApi.getArtistDiscography(id),
+			]);
+			if (seq !== loadSeq) return;
+			artist = artistRes.status === 'fulfilled' ? artistRes.value : null;
+			tracks = tracksRes.status === 'fulfilled' ? tracksRes.value.tracks : [];
+			if (discographyRes.status === 'fulfilled') {
+				tidalTracks = discographyRes.value.top_tracks ?? [];
+				tidalAlbums = discographyRes.value.albums ?? [];
+			} else {
+				tidalTracks = [];
+				tidalAlbums = [];
+			}
+			if (artistRes.status !== 'fulfilled' && tracksRes.status !== 'fulfilled') {
+				error = `Failed to load artist: ${tracksRes.reason}`;
+			}
+		} finally {
+			if (seq === loadSeq) loading = false;
+		}
+	}
+
+	$effect(() => {
+		const id = artistId;
+		void load(id);
+	});
+
+	function categorize(album: TidalDiscographyAlbum): Section {
+		switch (album.source_filter) {
+			case 'COMPILATIONS':
+				return 'compilations';
+			case 'EPSANDSINGLES':
+				return 'singles';
+			case 'ALBUMS':
+			case 'LIVE':
+				return 'albums';
+		}
+		const type = (album.release_type ?? '').toUpperCase();
+		if (type === 'COMPILATION') return 'compilations';
+		if (type === 'SINGLE' || type === 'EP') return 'singles';
+		return 'albums';
+	}
+
+	function releaseSort(a: TidalDiscographyAlbum, b: TidalDiscographyAlbum): number {
+		const ad = a.release_date ?? '';
+		const bd = b.release_date ?? '';
+		if (ad === bd) return a.title.localeCompare(b.title);
+		if (!ad) return 1;
+		if (!bd) return -1;
+		return bd.localeCompare(ad);
+	}
+
+	let popularItems = $derived.by<PopularTrackItem[]>(() => {
+		const localByTidalId = new Map<number, Track>();
+		for (const track of tracks) {
+			if (track.tidal_id != null && track.tidal_id > 0) localByTidalId.set(track.tidal_id, track);
+		}
+		const seenLocalIds = new Set<number>();
+		const items: PopularTrackItem[] = [];
+		for (const tidalTrack of tidalTracks) {
+			const localTrack = localByTidalId.get(tidalTrack.tidal_id);
+			if (localTrack) {
+				seenLocalIds.add(localTrack.id);
+				items.push({ kind: 'local', track: localTrack });
+			} else {
+				items.push({ kind: 'tidal', track: tidalTrack });
+			}
+		}
+		const leftovers = tracks
+			.filter((track) => !seenLocalIds.has(track.id))
+			.sort((a, b) => (b.play_count ?? 0) - (a.play_count ?? 0));
+		if (items.length === 0) return leftovers.map((track) => ({ kind: 'local', track }));
+		items.push(...leftovers.map((track) => ({ kind: 'local' as const, track })));
+		return items;
+	});
+
+	let albumsForSection = $derived(
+		[...tidalAlbums].filter((album) => categorize(album) === section).sort(releaseSort)
+	);
+
+	function matches(text: string | null | undefined): boolean {
+		const normalized = query.trim().toLowerCase();
+		if (!normalized) return true;
+		return (text ?? '').toLowerCase().includes(normalized);
+	}
+
+	let visibleTracks = $derived(
+		popularItems.filter((item) =>
+			matches(item.track.title) || matches(item.track.album_title)
+		)
+	);
+	let visibleAlbums = $derived(
+		albumsForSection.filter((album) => matches(album.title) || matches(album.artist_name))
+	);
+
+	function itemKey(item: PopularTrackItem): string {
+		return item.kind === 'local' ? `local-${item.track.id}` : `tidal-${item.track.tidal_id}`;
+	}
+
+	function artistTrackPlayable(track: TidalDiscographyTrack) {
+		return tidalDiscographyTrackToPlayable(track, { artistTidalId: artist?.tidal_id ?? null });
+	}
+
+	function albumHref(album: TidalDiscographyAlbum): string {
+		return album.local_id != null ? `/albums/${album.local_id}` : `/tidal/albums/${album.tidal_id}`;
+	}
+
+	function albumMenu(album: TidalDiscographyAlbum) {
+		return buildAlbumMenu(
+			{
+				local_id: album.local_id,
+				tidal_id: album.tidal_id,
+				title: album.title,
+				artist_name: album.artist_name,
+				in_library: album.in_library,
+			},
+			{ isLocal: album.in_library && album.local_id != null },
+		);
+	}
+
+	function playAlbumFromCard(album: TidalDiscographyAlbum, event: MouseEvent) {
+		event.preventDefault();
+		event.stopPropagation();
+		if (album.local_id != null) void playAlbum(album.local_id);
+		else void playTidalAlbum(album.tidal_id);
+	}
+</script>
+
+<div class="discography-page">
+	<a class="back-link" href={`/artists/${artistId}`}>Back to artist</a>
+
+	{#if loading}
+		<Skeleton rows={5} label="Loading discography" />
+	{:else if error}
+		<EmptyState title="Discography could not load" copy={error}>
+			{#snippet actions()}
+				<a class="empty-action" href={`/artists/${artistId}`}>Back to artist</a>
+			{/snippet}
+		</EmptyState>
+	{:else}
+		<header class="page-head">
+			<p class="eyebrow">{artist?.name ?? 'Artist'}</p>
+			<h1>{SECTION_LABELS[section]}</h1>
+			<p>{section === 'tracks' ? visibleTracks.length : visibleAlbums.length} results</p>
+		</header>
+
+		<div class="filter-bar">
+			<input
+				class="filter-input"
+				type="search"
+				placeholder={`Search ${SECTION_LABELS[section].toLowerCase()}...`}
+				bind:value={query}
+			/>
+		</div>
+
+		{#if section === 'tracks'}
+			{#if visibleTracks.length > 0}
+				<ol class="track-list">
+					{#each visibleTracks as item, idx (itemKey(item))}
+						{#if item.kind === 'local'}
+							<TrackRow
+								track={item.track}
+								variant="numbered"
+								index={idx}
+								isCurrent={false}
+								isPlaying={false}
+								showArtist={false}
+								onRowClick={() => void playArtist(artistId, item.track.id)}
+								menuOptions={{ hideArtistActions: true }}
+							/>
+						{:else}
+							<TidalTrackRow
+								track={artistTrackPlayable(item.track)}
+								variant="numbered"
+								index={idx}
+								showArtist={false}
+							/>
+						{/if}
+					{/each}
+				</ol>
+			{:else}
+				<p class="empty-copy">No tracks match this search.</p>
+			{/if}
+		{:else if visibleAlbums.length > 0}
+			<div class="album-grid">
+				{#each visibleAlbums as album (album.tidal_id)}
+					<a
+						class="album-card"
+						href={albumHref(album)}
+						oncontextmenu={(event) => {
+							event.preventDefault();
+							event.stopPropagation();
+							openContextMenu(event, albumMenu(album), album.title);
+						}}
+					>
+						<div class="album-art">
+							<ArtworkImage
+								src={album.artwork_url}
+								size={320}
+								fallbackText={album.title.slice(0, 1)}
+								decorative={true}
+							/>
+							<button
+								class="play-overlay"
+								type="button"
+								aria-label="Play {album.title}"
+								onclick={(event) => playAlbumFromCard(album, event)}
+							>Play</button>
+						</div>
+						<p class="album-title">{album.title}</p>
+						<p class="album-sub">
+							{#if album.release_date}{album.release_date.slice(0, 4)} / {/if}{album.number_of_tracks ?? 0} tracks
+						</p>
+					</a>
+				{/each}
+			</div>
+		{:else}
+			<p class="empty-copy">No releases match this search.</p>
+		{/if}
+	{/if}
+</div>
+
+<style>
+	.discography-page {
+		width: min(100%, var(--content-width));
+		margin: 0 auto;
+		padding: var(--space-5);
+	}
+
+	.back-link {
+		display: inline-flex;
+		margin-bottom: var(--space-4);
+		color: var(--text-secondary);
+		text-decoration: none;
+		font-size: var(--font-size-sm);
+	}
+
+	.back-link:hover {
+		color: var(--text-primary);
+	}
+
+	.page-head {
+		display: grid;
+		gap: var(--space-1);
+		margin-bottom: var(--space-4);
+	}
+
+	.eyebrow {
+		margin: 0;
+		color: var(--accent);
+		font-size: var(--font-size-xs);
+		font-weight: var(--font-weight-semibold);
+		text-transform: uppercase;
+		letter-spacing: 0;
+	}
+
+	h1 {
+		margin: 0;
+		font-size: var(--font-size-3xl);
+		line-height: var(--line-height-tight);
+	}
+
+	.page-head p {
+		margin: 0;
+		color: var(--text-secondary);
+		font-size: var(--font-size-sm);
+	}
+
+	.filter-bar {
+		margin-bottom: var(--space-4);
+	}
+
+	.filter-input {
+		width: min(420px, 100%);
+		padding: var(--space-2) var(--space-3);
+		border: 1px solid var(--input-border);
+		border-radius: 999px;
+		background: var(--input-bg);
+		color: var(--text-primary);
+		font-size: var(--font-size-sm);
+		outline: none;
+	}
+
+	.filter-input:focus {
+		border-color: var(--accent);
+		background: var(--input-focus);
+	}
+
+	.track-list {
+		list-style: none;
+		display: grid;
+		gap: var(--space-1);
+		margin: 0;
+		padding: 0;
+	}
+
+	.album-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(min(180px, 100%), 1fr));
+		gap: var(--space-4);
+	}
+
+	.album-card {
+		display: grid;
+		gap: var(--space-2);
+		color: inherit;
+		text-decoration: none;
+	}
+
+	.album-art {
+		position: relative;
+		aspect-ratio: 1 / 1;
+		overflow: hidden;
+		border-radius: var(--radius-sm);
+		background: var(--bg-surface);
+	}
+
+	.album-art :global(img),
+	.album-art :global(.fallback) {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+	}
+
+	.play-overlay {
+		position: absolute;
+		inset: auto var(--space-2) var(--space-2) auto;
+		border: 0;
+		border-radius: 999px;
+		padding: var(--space-1) var(--space-2);
+		background: var(--accent);
+		color: #fff;
+		font-size: var(--font-size-xs);
+		font-weight: var(--font-weight-semibold);
+		opacity: 0;
+		cursor: pointer;
+		transition: opacity var(--motion-fast), transform var(--motion-fast);
+		transform: translateY(4px);
+	}
+
+	.album-card:hover .play-overlay,
+	.album-card:focus-within .play-overlay {
+		opacity: 1;
+		transform: translateY(0);
+	}
+
+	.album-title,
+	.album-sub,
+	.empty-copy {
+		margin: 0;
+	}
+
+	.album-title {
+		font-size: var(--font-size-sm);
+		font-weight: var(--font-weight-semibold);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.album-sub,
+	.empty-copy {
+		color: var(--text-secondary);
+		font-size: var(--font-size-sm);
+	}
+</style>

--- a/frontend/src/routes/artists/artist_layout_contract.test.ts
+++ b/frontend/src/routes/artists/artist_layout_contract.test.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const source = readFileSync(join(here, '[id]', '+page.svelte'), 'utf8');
+const discographySource = readFileSync(join(here, '[id]', 'discography', '[section]', '+page.svelte'), 'utf8');
 
 function cssBlock(selector: string): string {
 	const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -91,6 +92,29 @@ describe('artist page layout contracts', () => {
 		expect(source).toContain('{@const playable = artistTrackPlayable(track)}');
 		expect(source).not.toContain('type TidalPlayable');
 		expect(source).not.toContain('function tidalDiscographyTrackToPlayable(t: TidalDiscographyTrack)');
+	});
+
+	test('orders top tracks through the TIDAL popularity list before local leftovers', () => {
+		expect(source).toContain("type PopularTrackItem =");
+		expect(source).toContain('for (const tidalTrack of tidalTopTracks)');
+		expect(source).toContain('const localTrack = byTidalId.get(tidalTrack.tidal_id);');
+		expect(source).toContain("ordered.push({ kind: 'local', track: localTrack });");
+		expect(source).toContain("ordered.push({ kind: 'tidal', track: tidalTrack });");
+		expect(source).toContain('ordered.push(...localRemainder.map((track) => ({ kind: \'local\' as const, track })))');
+		expect(source).not.toContain('if (a.is_favorite !== b.is_favorite) return a.is_favorite ? -1 : 1;');
+	});
+
+	test('links artist shelves to searchable see-all routes', () => {
+		expect(source).toContain('href={`/artists/${artistId}/discography/tracks`}');
+		expect(source).toContain('href={`/artists/${artistId}/discography/albums`}');
+		expect(source).toContain('href={`/artists/${artistId}/discography/singles`}');
+		expect(source).toContain('href={`/artists/${artistId}/discography/compilations`}');
+		expect(discographySource).toContain("type Section = 'tracks' | 'albums' | 'singles' | 'compilations';");
+		expect(discographySource).toContain('cachedApi.getArtistDiscography(id)');
+		expect(discographySource).toContain('type="search"');
+		expect(discographySource).toContain('<TrackRow');
+		expect(discographySource).toContain('<TidalTrackRow');
+		expect(discographySource).toContain('openContextMenu(event, albumMenu(album), album.title);');
 	});
 
 	test('keeps artist media rail context menus app-owned', () => {

--- a/frontend/src/routes/layout_queue_actions_a11y_contract.test.ts
+++ b/frontend/src/routes/layout_queue_actions_a11y_contract.test.ts
@@ -7,24 +7,24 @@ const here = dirname(fileURLToPath(import.meta.url));
 const source = readFileSync(join(here, '+layout.svelte'), 'utf8');
 const normalizedSource = source.replace(/\r\n/g, '\n');
 
-describe('queue action accessibility contracts', () => {
-	test('hidden queue actions leave the accessibility tree until row hover or focus', () => {
-		expect(source).toContain('let activeQueueActionsRowId = $state<number | null>(null)');
-		expect(source).toContain("window.matchMedia('(max-width: 760px)')");
-		expect(source).toContain('function queueActionsAccessible(itemId: number): boolean');
-		expect(source).toContain('onfocusin={() => setQueueActionsRowActive(item.id)}');
-		expect(source).toContain('onfocusout={(event) => handleQueueRowFocusOut(event, item.id)}');
-		expect(source).toContain('function handleQueueRowMouseLeave(event: MouseEvent, itemId: number)');
-		expect(source.match(/onmouseleave=\{\(event\) => handleQueueRowMouseLeave\(event, item\.id\)\}/g)?.length).toBe(2);
-		expect(source.match(/inert=\{!actionsAccessible\}/g)?.length).toBe(2);
-		expect(source.match(/aria-hidden=\{actionsAccessible \? undefined : 'true'\}/g)?.length).toBe(2);
+describe('queue row accessibility contracts', () => {
+	test('the whole row is one labelled play target, with a single labelled overflow action', () => {
+		// Play is a full-bleed hit button (sidebar + now-playing blocks).
+		expect(source.match(/class="queue-row-hit"/g)?.length).toBe(2);
+		expect(source).toContain('aria-label={isPending ? `Pending: ${item.track.title}` : `Play ${item.track.title}`}');
+		// Actions collapse to one always-present, labelled overflow button.
+		expect(source.match(/class="queue-overflow"/g)?.length).toBe(2);
+		expect(source).toContain("aria-label=\"More actions\"");
+		// The old hover-gated visibility machinery is gone, so nothing is hidden
+		// from the accessibility tree.
+		expect(source).not.toContain('queueActionsAccessible');
+		expect(source).not.toContain('inert={!actionsAccessible}');
 	});
 
-	test('focused queue rows keep duration visible beside row actions', () => {
-		expect(normalizedSource).toContain('.queue-row:hover .queue-time {');
-		expect(normalizedSource).not.toContain('.queue-row:hover .queue-time,\n\t.queue-row:focus-within .queue-time');
-		expect(normalizedSource).toContain('.queue-row:focus-within .queue-side {\n\t\tmin-width: max-content;\n\t}');
-		expect(normalizedSource).toContain('.queue-row:focus-within .queue-time {\n\t\topacity: 1;\n\t}');
-		expect(normalizedSource).toContain('.queue-row:focus-within .queue-actions {\n\t\tposition: static;\n\t\ttransform: none;');
+	test('pending rows disable play; duration is no longer hidden on hover', () => {
+		expect(source).toContain('disabled={isPending}');
+		// Duration stays visible at all times now (no opacity dance).
+		expect(normalizedSource).not.toContain('.queue-row:hover .queue-time {');
+		expect(normalizedSource).not.toContain('.queue-actions {');
 	});
 });

--- a/frontend/src/routes/search/+page.svelte
+++ b/frontend/src/routes/search/+page.svelte
@@ -34,6 +34,7 @@
   const ARTIST_ARTWORK_DELAY_MS = 220
   const ARTIST_ARTWORK_BATCH_SIZE = 4
   const DISCOVERY_PANEL_DELAY_MS = 320
+  const PRIMARY_TIDAL_SEARCH_TIMEOUT_MS = 8000
   const SECONDARY_PROVIDER_TIMEOUT_MS = 2500
   const ALL_VIEW_ARTIST_LIMIT = 8
   const ALL_VIEW_ALBUM_LIMIT = 8
@@ -160,6 +161,14 @@
   const hasFilters = $derived(Object.keys(parsedQuery.filters).length > 0)
 
   onMount(async () => {
+    if (typeof window !== 'undefined') {
+      const urlQuery = new URLSearchParams(window.location.search).get('q')?.trim()
+      if (urlQuery) {
+        query = urlQuery
+        onInput()
+      }
+    }
+
     const [genresRes, listensRes, playlistsRes] = await Promise.allSettled([
       cachedApi.getGenres(),
       cachedApi.getRecentListens(20),
@@ -210,6 +219,12 @@
     loadingSpotifyTracks = false
     loadingSpotifyAlbums = false
     secondarySpotifyQueued = false
+  }
+
+  function resetSearchActivity() {
+    loading = false
+    loadingMore = false
+    resetProviderLoading()
   }
 
   function clearSecondarySpotifyTimer() {
@@ -301,7 +316,7 @@
       // "play <query>" → fire immediately and clear input
       if (intent.intent.type === 'play') {
         loading = false
-        const r = await api.searchTidal(intent.free_text, 20, signal).catch(() => null)
+        const r = await api.searchTidal(intent.free_text, 20, signal, 0, PRIMARY_TIDAL_SEARCH_TIMEOUT_MS).catch(() => null)
         const first = r?.tracks[0]
         if (first) void playTidalTrackNow(toPlayable(first))
         query = ''
@@ -313,7 +328,7 @@
       // "similar to <query>" → start radio from first result
       if (intent.intent.type === 'radio') {
         loading = false
-        const r = await api.searchTidal(intent.free_text, 20, signal).catch(() => null)
+        const r = await api.searchTidal(intent.free_text, 20, signal, 0, PRIMARY_TIDAL_SEARCH_TIMEOUT_MS).catch(() => null)
         const first = r?.tracks[0]
         if (first) void startTidalSongRadio(toPlayable(first))
         query = ''
@@ -367,7 +382,7 @@
           const localPromise = cachedApi.search(q, INITIAL_SEARCH_PAGE_SIZE, signal)
           const tracksPromise = cached
             ? Promise.resolve(cached)
-            : api.searchTidal(q, INITIAL_SEARCH_PAGE_SIZE, signal, 0)
+            : api.searchTidal(q, INITIAL_SEARCH_PAGE_SIZE, signal, 0, PRIMARY_TIDAL_SEARCH_TIMEOUT_MS)
           let tidalPlaylistPromise: Promise<{ playlists: TidalSearchPlaylist[] }> | null = null
           let spotifyPlaylistPromise: Promise<SpotifyPlaylistSearchItem[]> | null = null
           let spotifyTrackSearchPromise: Promise<SpotifyTrackSearchItem[]> | null = null
@@ -550,7 +565,13 @@
     loadingMore = true
     try {
       if (needsTidal && results) {
-        const next = await api.searchTidal(pageQuery, LOAD_MORE_PAGE_SIZE, undefined, tidalOffset)
+        const next = await api.searchTidal(
+          pageQuery,
+          LOAD_MORE_PAGE_SIZE,
+          undefined,
+          tidalOffset,
+          PRIMARY_TIDAL_SEARCH_TIMEOUT_MS,
+        )
         if (!isCurrentLoadMore()) return
         tidalOffset += LOAD_MORE_PAGE_SIZE
         // De-dupe by id - Tidal occasionally returns overlapping pages.
@@ -981,8 +1002,14 @@
 
   function spotifyPlaylistMenuItems(playlist: SpotifyPlaylistSearchItem): MenuItem[] {
     return [
-      { label: 'Open', icon: '↗', onSelect: () => void goto(`/spotify-playlist/${playlist.spotifyId}`) },
+      { label: 'Open', icon: '↗', onSelect: () => void goto(spotifyPlaylistHref(playlist.spotifyId)) },
     ]
+  }
+
+  function spotifyPlaylistHref(spotifyId: string): string {
+    const params = new URLSearchParams({ from: 'search' })
+    if (activeQueryText) params.set('q', activeQueryText)
+    return `/spotify-playlist/${encodeURIComponent(spotifyId)}?${params.toString()}`
   }
 
   function trackContextMenu(track: TidalSearchTrack): MenuItem[] {
@@ -1208,6 +1235,7 @@
     invalidateSearchSideLoads()
     clearTimeout(debounceTimer)
     clearSecondarySpotifyTimer()
+    resetSearchActivity()
   })
 
   let pendingRestoreScroll: number | null = null
@@ -1636,7 +1664,7 @@
       </section>
     {/if}
 
-    {#if showPlaylists && (visiblePlaylists.local.length > 0 || visiblePlaylists.tidal.length > 0 || visiblePlaylists.spotify.length > 0)}
+    {#if showPlaylists && (playlistRailPending || visiblePlaylists.local.length > 0 || visiblePlaylists.tidal.length > 0 || visiblePlaylists.spotify.length > 0)}
       <section class="results-section">
         <h3 class="section-label">Playlists</h3>
         <div
@@ -1644,6 +1672,15 @@
           class:section-grid-albums={filterMode === 'playlists'}
           use:wheelToHorizontal
         >
+          {#if playlistRailPending && visiblePlaylists.local.length === 0 && visiblePlaylists.tidal.length === 0 && visiblePlaylists.spotify.length === 0}
+            {#each Array(4) as _, i (i)}
+              <div class="album-card playlist-loading-card" aria-hidden="true">
+                <div class="album-art playlist-loading-art"></div>
+                <p class="album-title playlist-loading-line"></p>
+                <p class="album-artist playlist-loading-line short"></p>
+              </div>
+            {/each}
+          {/if}
 
           {#each visiblePlaylists.local as playlist (playlist.id)}
             <a
@@ -1702,7 +1739,7 @@
           {#each visiblePlaylists.spotify as playlist (playlist.spotifyId)}
             <a
               class="album-card spotify-card"
-              href="/spotify-playlist/{playlist.spotifyId}"
+              href={spotifyPlaylistHref(playlist.spotifyId)}
               oncontextmenu={(e) => openSearchContextMenu(e, spotifyPlaylistMenuItems(playlist), playlist.title ?? 'Spotify playlist')}
             >
               <div class="art-wrap">
@@ -2509,6 +2546,24 @@
     color: rgba(255, 255, 255, 0.5);
   }
   .album-card:hover .album-art { opacity: 0.85; }
+  .playlist-loading-card {
+    pointer-events: none;
+  }
+  .playlist-loading-art,
+  .playlist-loading-line {
+    background: linear-gradient(90deg, var(--bg-raised), var(--bg-hover), var(--bg-raised));
+    background-size: 220% 100%;
+    animation: playlist-loading-pulse 1200ms ease-in-out infinite;
+  }
+  .playlist-loading-line {
+    display: block;
+    height: 12px;
+    border-radius: 999px;
+    margin: 8px 0 0;
+  }
+  .playlist-loading-line.short {
+    width: 62%;
+  }
   .album-title {
     font-size: var(--font-size-xs);
     color: var(--text-primary);
@@ -2810,4 +2865,8 @@
   .spotify-card :global(.art.fallback) { display: flex; align-items: center; justify-content: center; color: var(--text-muted); font-size: var(--font-size-3xl); }
   .spotify-card .card-title { font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
   .spotify-card .card-sub { font-size: var(--font-size-xs); color: var(--text-secondary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  @keyframes playlist-loading-pulse {
+    0% { background-position: 100% 0; }
+    100% { background-position: -100% 0; }
+  }
 </style>

--- a/frontend/src/routes/search/search_layout_contract.test.ts
+++ b/frontend/src/routes/search/search_layout_contract.test.ts
@@ -27,6 +27,7 @@ describe('search layout contracts', () => {
 	test('search page renders local results before external providers finish', () => {
 		expect(source).toContain('const INITIAL_SEARCH_PAGE_SIZE = 12');
 		expect(source).toContain('const SECONDARY_SEARCH_PAGE_SIZE = 8');
+		expect(source).toContain('const PRIMARY_TIDAL_SEARCH_TIMEOUT_MS = 8000');
 		expect(source).toContain('const SECONDARY_PROVIDER_TIMEOUT_MS = 2500');
 		expect(source).toContain('let searchGeneration = $state(0)');
 		expect(source).toContain('let loadMoreSeq = 0');
@@ -34,6 +35,7 @@ describe('search layout contracts', () => {
 		expect(source).toContain('loadMoreSeq += 1');
 		expect(source).toContain('loadingMore = false');
 		expect(source).toContain('const localPromise = cachedApi.search(q, INITIAL_SEARCH_PAGE_SIZE, signal)');
+		expect(source).toContain('api.searchTidal(q, INITIAL_SEARCH_PAGE_SIZE, signal, 0, PRIMARY_TIDAL_SEARCH_TIMEOUT_MS)');
 		expect(source).toContain('void localPromise.then((localResults) => {');
 		expect(source).toContain('if (!isCurrentSearch(q, generation, signal)) return');
 		expect(source).toContain('void tracksPromise.then((tidalResults) => {');
@@ -50,6 +52,26 @@ describe('search layout contracts', () => {
 		expect(source).toContain('const primaryProviderSearchDone = $derived(');
 		expect(source).toContain('const providerSearchDone = $derived(');
 		expect(source).toContain('{:else if allProviderResultsEmpty && providerSearchDone}');
+	});
+
+	test('search URL query and Spotify playlist links preserve resolver flow', () => {
+		expect(source).toContain("const urlQuery = new URLSearchParams(window.location.search).get('q')?.trim()");
+		expect(source).toContain('query = urlQuery');
+		expect(source).toContain('function spotifyPlaylistHref(spotifyId: string): string');
+		expect(source).toContain("const params = new URLSearchParams({ from: 'search' })");
+		expect(source).toContain("if (activeQueryText) params.set('q', activeQueryText)");
+		expect(source).toContain('return `/spotify-playlist/${encodeURIComponent(spotifyId)}?${params.toString()}`');
+		expect(source).toContain('href={spotifyPlaylistHref(playlist.spotifyId)}');
+		expect(source).toContain('onSelect: () => void goto(spotifyPlaylistHref(playlist.spotifyId))');
+		expect(source).not.toContain('href="/spotify-playlist/{playlist.spotifyId}"');
+	});
+
+	test('playlist provider pending state renders a visible loader', () => {
+		expect(source).toContain('{#if showPlaylists && (playlistRailPending || visiblePlaylists.local.length > 0 || visiblePlaylists.tidal.length > 0 || visiblePlaylists.spotify.length > 0)}');
+		expect(source).toContain('{#if playlistRailPending && visiblePlaylists.local.length === 0 && visiblePlaylists.tidal.length === 0 && visiblePlaylists.spotify.length === 0}');
+		expect(source).toContain('class="album-card playlist-loading-card"');
+		expect(source).toContain('.playlist-loading-art');
+		expect(source).toContain('@keyframes playlist-loading-pulse');
 	});
 
 	test('focused category filters prefetch one deeper page after the light initial batch', () => {
@@ -98,7 +120,7 @@ describe('search layout contracts', () => {
 		expect(source).toContain('searchGeneration === generation');
 		expect(source).toContain('lastQuery === pageQuery');
 		expect(source).toContain('filterMode === pageMode');
-		expect(source).toContain('const next = await api.searchTidal(pageQuery, LOAD_MORE_PAGE_SIZE, undefined, tidalOffset)');
+		expect(source).toContain('PRIMARY_TIDAL_SEARCH_TIMEOUT_MS,');
 		expect(source).toContain('if (!isCurrentLoadMore()) return');
 		expect(source).toContain('searchTidalPlaylists(pageQuery, undefined');
 		expect(source).toContain('searchSpotifyPlaylists(pageQuery, LOAD_MORE_PAGE_SIZE');
@@ -128,6 +150,17 @@ describe('search layout contracts', () => {
 		expect(source).toContain('underratedTracks = null');
 		expect(source).toContain('artistDiscographyArtworkGeneration += 1');
 		expect(source).toContain('discoveryLoadSeq += 1');
+	});
+
+	test('navigation abort clears visible search activity', () => {
+		expect(source).toContain('function resetSearchActivity()');
+		expect(source).toContain('loading = false');
+		expect(source).toContain('loadingMore = false');
+		expect(source).toContain('resetProviderLoading()');
+		expect(source).toContain('beforeNavigate(() => {');
+		expect(source).toContain('abortController?.abort()');
+		expect(source).toContain('clearSecondarySpotifyTimer()');
+		expect(source).toContain('resetSearchActivity()');
 	});
 
 	test('visible search results stay keyed to the committed query while typing the next one', () => {

--- a/frontend/src/routes/spotify-playlist/[id]/+page.svelte
+++ b/frontend/src/routes/spotify-playlist/[id]/+page.svelte
@@ -179,8 +179,12 @@
   function resolveBackLink(params: URLSearchParams): { href: string; label: string } {
     const from = params.get('from');
     const mood = params.get('mood');
+    const q = params.get('q')?.trim();
     if (from === 'moods' && mood && SPOTIFY_MOODS_BY_SLUG.has(mood)) {
       return { href: `/moods/${encodeURIComponent(mood)}`, label: 'Back to mood' };
+    }
+    if (from === 'search' && q) {
+      return { href: `/search?q=${encodeURIComponent(q)}`, label: 'Back to search' };
     }
     return { href: '/search', label: 'Back to search' };
   }

--- a/frontend/src/routes/spotify-playlist/spotify_playlist_back_contract.test.ts
+++ b/frontend/src/routes/spotify-playlist/spotify_playlist_back_contract.test.ts
@@ -35,6 +35,13 @@ describe('Spotify playlist back link contract', () => {
 		expect(source).toContain("label: 'Back to mood'");
 	});
 
+	test('returns to the originating search query when opened from search', () => {
+		expect(source).toContain("const q = params.get('q')?.trim();");
+		expect(source).toContain("from === 'search' && q");
+		expect(source).toContain("href: `/search?q=${encodeURIComponent(q)}`");
+		expect(source).toContain("label: 'Back to search'");
+	});
+
 	test('keeps search as the default direct-entry fallback', () => {
 		expect(source).toContain("return { href: '/search', label: 'Back to search' };");
 		expect(source).toContain('<a class="back-link" href={backLink.href}>&lt; {backLink.label}</a>');

--- a/noor-server/src/db/schema.rs
+++ b/noor-server/src/db/schema.rs
@@ -52,6 +52,7 @@ const MIGRATIONS: &[&str] = &[
     MIGRATION_048,
     MIGRATION_049,
     MIGRATION_050,
+    MIGRATION_051,
 ];
 
 const MIGRATION_001: &str = r#"
@@ -1447,6 +1448,20 @@ CREATE INDEX IF NOT EXISTS idx_provider_recommendation_cache_expiry
 const MIGRATION_050: &str = r#"
 ALTER TABLE audio_dj_profile_corrections
     ADD COLUMN manual_drop_blob BLOB NOT NULL DEFAULT X'';
+"#;
+
+// Ephemeral TIDAL queue rows. TIDAL mix/album/playlist tracks now live in the
+// `queue` table as real, mutable rows (positive ids) that stream ephemerally
+// instead of being imported. They keep `track_id` NULL forever and carry their
+// TIDAL metadata here so `load_queue` can hydrate a synthetic playable track
+// without a `tracks` row. `tidal_id_hint` (migration 030) holds the TIDAL id;
+// these columns hold the rest the streaming + display paths need. Distinct from
+// Last.fm pending rows, which DO get imported. See the queue ephemeral-row
+// helpers in playback/queue.rs.
+const MIGRATION_051: &str = r#"
+ALTER TABLE queue ADD COLUMN ephemeral_album_title TEXT;
+ALTER TABLE queue ADD COLUMN ephemeral_artwork_url TEXT;
+ALTER TABLE queue ADD COLUMN ephemeral_duration_ms INTEGER;
 "#;
 
 pub fn run_migrations(conn: &Connection) -> Result<()> {

--- a/noor-server/src/main.rs
+++ b/noor-server/src/main.rs
@@ -209,17 +209,6 @@ pub struct AppState {
     /// Symmetric key used to encrypt service secrets (currently only the
     /// Last.fm scrobble session_key — see `services/crypto.rs`).
     pub master_key: services::crypto::MasterKey,
-    /// Legacy pending ephemeral TIDAL tracks queued behind the currently-playing
-    /// ephemeral track (e.g. the rest of a TIDAL mix the user clicked into).
-    /// New persistent external queue actions should use pending rows in the
-    /// `queue` table instead of adding more producers to this in-memory queue.
-    /// Auto-advanced by `handle_runtime_finished` when the active ephemeral
-    /// track ends. Cleared on explicit stop or when the user starts a
-    /// different ephemeral track (`play_tidal_ephemeral` clears before
-    /// queuing). Stream URLs resolved lazily at advance time — TIDAL
-    /// stream URLs expire (~30 min) so pre-resolving the whole mix is wasteful.
-    pub pending_tidal_mix_queue:
-        Arc<std::sync::Mutex<std::collections::VecDeque<PendingEphemeralTidalTrack>>>,
     pub prepared_ephemeral_tidal_next: Option<PreparedEphemeralTidalNext>,
     /// Last.fm app shared secret, loaded once from `LASTFM_API_SECRET` env at
     /// boot. `None` disables every scrobble auth + scrobble call (endpoints
@@ -822,7 +811,6 @@ async fn main() -> Result<()> {
         refreshed_seeds: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         embedding_cache: Arc::new(std::sync::Mutex::new(None)),
         master_key,
-        pending_tidal_mix_queue: Arc::new(std::sync::Mutex::new(std::collections::VecDeque::new())),
         prepared_ephemeral_tidal_next: None,
         lastfm_api_secret,
         server_token,

--- a/noor-server/src/playback/automix.rs
+++ b/noor-server/src/playback/automix.rs
@@ -48,6 +48,16 @@ pub const AUTOMIX_MIN_UPCOMING: usize = 8;
 const AUTOMIX_BATCH_SIZE: usize = 12;
 const TRUE_SHUFFLE_POOL_MULTIPLIER: usize = 12;
 
+// Hub-track penalty strength for learned neighbours. The trainer already records
+// each candidate's in-degree percentile (how many seeds list it as a neighbour);
+// the radio re-ranker discounts high-in-degree "everyone's neighbour" hubs via
+// `apply_hub_penalty` (services/radio.rs), but automix historically ignored that
+// signal, so a handful of hubs (the XXXTentacion / Blur effect) bled into every
+// genre's queue regardless of fit. Mirror radio's `1/(1 + k*pct)` shape here.
+// Unlike radio this is unconditional (no blend/flag), so it stays mid-strength:
+// between radio's Familiar (0.20) and Adventurous profiles.
+const AUTOMIX_HUB_PENALTY: f64 = 0.35;
+
 #[derive(Debug, Clone)]
 struct ScoredTrack {
     track: Track,
@@ -855,6 +865,15 @@ fn automix_neighbor_policy(row: &queries::EmbeddingNeighborRow) -> GeneratedCand
         policy_reasons.push("texture-only learned signal");
     }
 
+    // Hub penalty: a candidate that's a top neighbour for a large share of seeds
+    // is a graph hub, not a genre match. Discount it the same way radio does so
+    // popular hubs don't dominate every automix queue. `candidate_in_degree_percentile`
+    // is 0 for tracks the trainer never saw as a neighbour, leaving them untouched.
+    if row.candidate_in_degree_percentile > 0.0 {
+        multiplier *= 1.0 / (1.0 + AUTOMIX_HUB_PENALTY * row.candidate_in_degree_percentile);
+        policy_reasons.push("hub penalty");
+    }
+
     GeneratedCandidatePolicy {
         score_multiplier: multiplier,
         reasons: policy_reasons,
@@ -1254,6 +1273,52 @@ mod tests {
             score_multiplier: multiplier,
             reasons: vec![reason],
         }
+    }
+
+    // Minimal neighbour row carrying only the fields the policy logic reads;
+    // everything else is zeroed so a test can isolate one signal at a time.
+    fn neighbor_row(track_id: i64, in_degree_pct: f64) -> queries::EmbeddingNeighborRow {
+        queries::EmbeddingNeighborRow {
+            track_id,
+            title: format!("track {track_id}"),
+            artist_name: None,
+            album_title: None,
+            artwork_url: None,
+            duration_ms: None,
+            best_quality: None,
+            score: 1.0,
+            behavioral_score: 0.5,
+            audio_score: 0.0,
+            metadata_score: 0.0,
+            reason_json: None,
+            confidence: 1.0,
+            support_count: 1,
+            support_transition: 1.0,
+            support_colisten: 0.0,
+            support_structure: 0.0,
+            support_metadata: 0.0,
+            candidate_in_degree: 0,
+            candidate_in_degree_percentile: in_degree_pct,
+            play_count_seed: 0,
+            play_count_candidate: 0,
+            primary_reason: Some("behavioral".to_string()),
+        }
+    }
+
+    #[test]
+    fn hub_candidates_are_penalized_relative_to_non_hubs() {
+        // Same supporting signal, different in-degree: the hub (high percentile)
+        // must come out with a strictly lower multiplier than the non-hub, and a
+        // non-hub (percentile 0) must be left untouched at 1.0.
+        let non_hub = automix_neighbor_policy(&neighbor_row(1, 0.0));
+        let mild = automix_neighbor_policy(&neighbor_row(2, 0.5));
+        let hub = automix_neighbor_policy(&neighbor_row(3, 0.99));
+
+        assert!((non_hub.score_multiplier - 1.0).abs() < 1e-9);
+        assert!(mild.score_multiplier < non_hub.score_multiplier);
+        assert!(hub.score_multiplier < mild.score_multiplier);
+        assert!(hub.reasons.iter().any(|r| *r == "hub penalty"));
+        assert!(!non_hub.reasons.iter().any(|r| *r == "hub penalty"));
     }
 
     #[test]

--- a/noor-server/src/playback/pending.rs
+++ b/noor-server/src/playback/pending.rs
@@ -39,10 +39,15 @@ use crate::db::{models::AudioDjProfileKey, queries};
 /// `Ok(true)` if this caller won the claim, `Ok(false)` if another resolver
 /// already holds it (or the row has been resolved/deleted).
 pub fn try_claim(conn: &Connection, queue_item_id: i64) -> Result<bool> {
+    // `pending_at IS NOT NULL` keeps ephemeral TIDAL rows (mix/album/playlist,
+    // which carry no pending_at) out of the resolver: they stream directly and
+    // must never be imported. Callers already filter on pending_at, but this is
+    // the lock-acquisition choke point so the guard lives here too.
     let updated = conn.execute(
         "UPDATE queue SET resolving_at = datetime('now')
          WHERE id = ?1
            AND track_id IS NULL
+           AND pending_at IS NOT NULL
            AND (resolving_at IS NULL OR resolving_at < datetime('now', '-30 seconds'))",
         params![queue_item_id],
     )?;

--- a/noor-server/src/playback/player.rs
+++ b/noor-server/src/playback/player.rs
@@ -2018,7 +2018,10 @@ mod tests {
                 resolving_at     TIMESTAMP,
                 resolved_at      TIMESTAMP,
                 tidal_match_score REAL,
-                tidal_id_hint    INTEGER
+                tidal_id_hint    INTEGER,
+                ephemeral_album_title TEXT,
+                ephemeral_artwork_url TEXT,
+                ephemeral_duration_ms INTEGER
             );
             CREATE TABLE genres (
                 id INTEGER PRIMARY KEY,
@@ -5010,7 +5013,10 @@ mod tests {
                 resolving_at     TIMESTAMP,
                 resolved_at      TIMESTAMP,
                 tidal_match_score REAL,
-                tidal_id_hint    INTEGER
+                tidal_id_hint    INTEGER,
+                ephemeral_album_title TEXT,
+                ephemeral_artwork_url TEXT,
+                ephemeral_duration_ms INTEGER
             );
             CREATE TABLE genres (id INTEGER PRIMARY KEY, name TEXT NOT NULL, slug TEXT NOT NULL, parent_id INTEGER);
             CREATE TABLE track_genres (

--- a/noor-server/src/playback/queue.rs
+++ b/noor-server/src/playback/queue.rs
@@ -58,6 +58,13 @@ pub fn load_queue(conn: &Connection) -> Result<Vec<QueueItem>> {
         // COALESCE fills non-nullable Track fields from pending_* columns so the
         // row mapper doesn't need to know whether a row is pending or resolved.
         // Columns 0-3: queue metadata; 4-25: Track fields; 26: is_pending flag.
+        // Ephemeral TIDAL rows (mix/album/playlist) are real rows with
+        // track_id NULL whose source is in EPHEMERAL_TIDAL_SOURCES. They are NOT
+        // pending (they stream directly), so is_pending excludes them and a
+        // separate is_ephemeral flag tells the mapper to hydrate the synthetic
+        // playable track from the ephemeral_* columns + tidal_id_hint instead of
+        // the tracks join. The `lt` join recovers a local id + favourite state
+        // when the TIDAL id already lives in the library.
         "SELECT q.id, q.position, q.source, q.reason,
                 COALESCE(t.id, 0),
                 COALESCE(t.title, q.pending_title, ''),
@@ -81,22 +88,38 @@ pub fn load_queue(conn: &Connection) -> Result<Vec<QueueItem>> {
                 t.date_added,
                 COALESCE(t.source, 'tidal_stream'),
                 al.artwork_url,
-                (q.track_id IS NULL) AS is_pending
+                (q.track_id IS NULL
+                    AND q.source NOT IN ('tidal_mix','tidal_album','tidal_playlist')) AS is_pending,
+                (q.track_id IS NULL
+                    AND q.source IN ('tidal_mix','tidal_album','tidal_playlist')) AS is_ephemeral,
+                q.tidal_id_hint,
+                q.ephemeral_album_title,
+                q.ephemeral_artwork_url,
+                q.ephemeral_duration_ms,
+                lt.id,
+                lt.is_favorite
          FROM queue q
          LEFT JOIN tracks t ON q.track_id = t.id
          LEFT JOIN artists a ON t.artist_id = a.id
          LEFT JOIN albums al ON t.album_id = al.id
+         LEFT JOIN tracks lt ON lt.tidal_id = q.tidal_id_hint
          ORDER BY q.position ASC, q.id ASC",
     )?;
 
     let items = stmt
         .query_map([], |row| {
+            let is_ephemeral: bool = row.get(27)?;
+            let track = if is_ephemeral {
+                ephemeral_track_from_row(row)?
+            } else {
+                track_from_row_with_offset(row, 4)?
+            };
             Ok(QueueItem {
                 id: row.get(0)?,
                 position: row.get(1)?,
                 source: row.get(2)?,
                 reason: row.get(3)?,
-                track: track_from_row_with_offset(row, 4)?,
+                track,
                 is_pending: row.get(26)?,
             })
         })?
@@ -370,6 +393,217 @@ fn insert_at_position(
             queue_id: conn.last_insert_rowid(),
         })
     }
+}
+
+/// Queue `source` labels whose rows are ephemeral TIDAL collection tracks:
+/// real, mutable queue rows that stream directly via `tidal_id` and are never
+/// imported into the library. Distinct from Last.fm pending rows. Kept in sync
+/// with the `IN (...)` literals in `load_queue` and the resolver/GC guards.
+pub const EPHEMERAL_TIDAL_SOURCES: [&str; 3] = ["tidal_mix", "tidal_album", "tidal_playlist"];
+
+/// A TIDAL track to enqueue as an ephemeral (never-imported) queue row.
+pub struct EphemeralTidalInsert<'a> {
+    pub tidal_id: i64,
+    pub title: &'a str,
+    pub artist: Option<&'a str>,
+    pub album_title: Option<&'a str>,
+    pub artwork_url: Option<&'a str>,
+    pub duration_ms: Option<i64>,
+}
+
+/// Append ephemeral TIDAL rows at the end of the queue with one position lookup.
+/// `source` must be one of [`EPHEMERAL_TIDAL_SOURCES`].
+pub fn append_ephemeral_tidal_tracks(
+    conn: &Connection,
+    inserts: &[EphemeralTidalInsert<'_>],
+    source: &str,
+) -> Result<Vec<QueueItem>> {
+    if inserts.is_empty() {
+        return load_queue(conn);
+    }
+    let start_position: i32 = conn.query_row(
+        "SELECT COALESCE(MAX(position), -1) + 1 FROM queue",
+        [],
+        |row| row.get(0),
+    )?;
+    let tx = conn.unchecked_transaction()?;
+    for (idx, insert) in inserts.iter().enumerate() {
+        insert_ephemeral_at_position(&tx, insert, source, start_position + idx as i32)?;
+    }
+    let queue = load_queue(&tx)?;
+    tx.commit()?;
+    Ok(queue)
+}
+
+fn insert_ephemeral_at_position(
+    conn: &Connection,
+    insert: &EphemeralTidalInsert<'_>,
+    source: &str,
+    position: i32,
+) -> Result<()> {
+    // track_id NULL + no pending_at: these rows are never resolved or GC-swept.
+    conn.execute(
+        "INSERT INTO queue (track_id, position, source,
+                            pending_artist, pending_title, tidal_id_hint,
+                            ephemeral_album_title, ephemeral_artwork_url, ephemeral_duration_ms)
+         VALUES (NULL, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        params![
+            position,
+            source,
+            insert.artist,
+            insert.title,
+            insert.tidal_id,
+            insert.album_title,
+            insert.artwork_url,
+            insert.duration_ms,
+        ],
+    )?;
+    Ok(())
+}
+
+fn ephemeral_pending_from_row(
+    row: &Row<'_>,
+    id_offset: usize,
+) -> rusqlite::Result<crate::PendingEphemeralTidalTrack> {
+    Ok(crate::PendingEphemeralTidalTrack {
+        tidal_track_id: row.get(id_offset)?,
+        title: row
+            .get::<_, Option<String>>(id_offset + 1)?
+            .unwrap_or_default(),
+        artist_name: row.get(id_offset + 2)?,
+        album_title: row.get(id_offset + 3)?,
+        artwork_url: row.get(id_offset + 4)?,
+        duration_ms: row.get(id_offset + 5)?,
+    })
+}
+
+const EPHEMERAL_TIDAL_ROW_FILTER: &str = "track_id IS NULL
+       AND source IN ('tidal_mix','tidal_album','tidal_playlist')
+       AND tidal_id_hint IS NOT NULL";
+
+/// Read the next upcoming ephemeral TIDAL row (lowest position) without removing
+/// it. Used by the DJ pre-buffer peek and transition-pair builder.
+pub fn peek_next_ephemeral_tidal_track(
+    conn: &Connection,
+) -> Result<Option<crate::PendingEphemeralTidalTrack>> {
+    Ok(conn
+        .query_row(
+            &format!(
+                "SELECT tidal_id_hint, pending_title, pending_artist,
+                        ephemeral_album_title, ephemeral_artwork_url, ephemeral_duration_ms
+                 FROM queue WHERE {EPHEMERAL_TIDAL_ROW_FILTER}
+                 ORDER BY position ASC, id ASC LIMIT 1"
+            ),
+            [],
+            |row| ephemeral_pending_from_row(row, 0),
+        )
+        .optional()?)
+}
+
+/// Read all upcoming ephemeral TIDAL rows in play order without removing them.
+/// Used to pre-warm DJ transition profiles for the rest of the mix.
+pub fn peek_ephemeral_tidal_tracks(
+    conn: &Connection,
+) -> Result<Vec<crate::PendingEphemeralTidalTrack>> {
+    let mut stmt = conn.prepare(&format!(
+        "SELECT tidal_id_hint, pending_title, pending_artist,
+                ephemeral_album_title, ephemeral_artwork_url, ephemeral_duration_ms
+         FROM queue WHERE {EPHEMERAL_TIDAL_ROW_FILTER}
+         ORDER BY position ASC, id ASC"
+    ))?;
+    let rows = stmt
+        .query_map([], |row| ephemeral_pending_from_row(row, 0))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(rows)
+}
+
+/// Read-and-delete the next upcoming ephemeral TIDAL row (lowest position).
+/// Mirrors the `VecDeque::pop_front` the old in-memory mix queue used.
+pub fn pop_next_ephemeral_tidal_track(
+    conn: &Connection,
+) -> Result<Option<crate::PendingEphemeralTidalTrack>> {
+    let tx = conn.unchecked_transaction()?;
+    let row: Option<(i64, crate::PendingEphemeralTidalTrack)> = tx
+        .query_row(
+            &format!(
+                "SELECT id, tidal_id_hint, pending_title, pending_artist,
+                        ephemeral_album_title, ephemeral_artwork_url, ephemeral_duration_ms
+                 FROM queue WHERE {EPHEMERAL_TIDAL_ROW_FILTER}
+                 ORDER BY position ASC, id ASC LIMIT 1"
+            ),
+            [],
+            |row| Ok((row.get(0)?, ephemeral_pending_from_row(row, 1)?)),
+        )
+        .optional()?;
+    let Some((queue_id, track)) = row else {
+        return Ok(None);
+    };
+    tx.execute("DELETE FROM queue WHERE id = ?1", params![queue_id])?;
+    tx.commit()?;
+    Ok(Some(track))
+}
+
+/// Find an upcoming ephemeral TIDAL row by its TIDAL id. Used to rebuild a
+/// synthetic track for DJ profile lookups when a mix track is still queued.
+pub fn find_ephemeral_tidal_track_by_tidal_id(
+    conn: &Connection,
+    tidal_id: i64,
+) -> Result<Option<crate::PendingEphemeralTidalTrack>> {
+    Ok(conn
+        .query_row(
+            &format!(
+                "SELECT tidal_id_hint, pending_title, pending_artist,
+                        ephemeral_album_title, ephemeral_artwork_url, ephemeral_duration_ms
+                 FROM queue WHERE {EPHEMERAL_TIDAL_ROW_FILTER} AND tidal_id_hint = ?1
+                 ORDER BY position ASC, id ASC LIMIT 1"
+            ),
+            params![tidal_id],
+            |row| ephemeral_pending_from_row(row, 0),
+        )
+        .optional()?)
+}
+
+/// Delete every ephemeral TIDAL row. Used on stop and when the user starts a
+/// track outside the current mix.
+pub fn delete_all_ephemeral_tidal_rows(conn: &Connection) -> Result<usize> {
+    Ok(conn.execute(
+        "DELETE FROM queue
+         WHERE track_id IS NULL
+           AND source IN ('tidal_mix','tidal_album','tidal_playlist')",
+        [],
+    )?)
+}
+
+/// "Jump to" trim: delete every ephemeral row up to and including the one whose
+/// TIDAL id matches `tidal_id` (which the caller is about to start playing).
+/// Returns true if that row was present; when absent (the user picked something
+/// outside the mix) the caller clears all ephemeral rows instead.
+pub fn trim_ephemeral_tidal_rows_through_tidal_id(
+    conn: &Connection,
+    tidal_id: i64,
+) -> Result<bool> {
+    let pos: Option<i32> = conn
+        .query_row(
+            &format!(
+                "SELECT position FROM queue
+                 WHERE {EPHEMERAL_TIDAL_ROW_FILTER} AND tidal_id_hint = ?1
+                 ORDER BY position ASC, id ASC LIMIT 1"
+            ),
+            params![tidal_id],
+            |row| row.get(0),
+        )
+        .optional()?;
+    let Some(pos) = pos else {
+        return Ok(false);
+    };
+    conn.execute(
+        "DELETE FROM queue
+         WHERE track_id IS NULL
+           AND source IN ('tidal_mix','tidal_album','tidal_playlist')
+           AND position <= ?1",
+        params![pos],
+    )?;
+    Ok(true)
 }
 
 pub fn replace_queue(conn: &Connection, tracks: &[Track], source: &str) -> Result<Vec<QueueItem>> {
@@ -724,6 +958,42 @@ fn track_from_row_with_offset(row: &Row<'_>, offset: usize) -> rusqlite::Result<
     })
 }
 
+/// Hydrate a synthetic playable `Track` for an ephemeral TIDAL queue row.
+///
+/// Mirrors the shape the old in-memory overlay built: negative `id` derived from
+/// the TIDAL id (or the local id when the track already lives in the library),
+/// `source = tidal_ephemeral`, metadata pulled from the queue row's pending_* /
+/// ephemeral_* columns. Column indices match the extended `load_queue` SELECT.
+fn ephemeral_track_from_row(row: &Row<'_>) -> rusqlite::Result<Track> {
+    let tidal_id: i64 = row.get(28)?;
+    let local_id: Option<i64> = row.get(32)?;
+    let library_favorite: Option<bool> = row.get(33)?;
+    Ok(Track {
+        id: local_id.unwrap_or(-tidal_id),
+        title: row.get(5)?, // COALESCE(t.title, q.pending_title, '')
+        artist_id: 0,
+        artist_name: row.get(7)?, // COALESCE(a.name, q.pending_artist)
+        album_id: None,
+        album_title: row.get(29)?,
+        disc_number: None,
+        track_number: None,
+        duration_ms: row.get(31)?,
+        isrc: None,
+        tidal_id: Some(tidal_id),
+        ytmusic_id: None,
+        soundcloud_id: None,
+        best_quality: Some("LOSSLESS".to_string()),
+        best_source: Some("tidal".to_string()),
+        fidelity_score: 0,
+        is_favorite: library_favorite.unwrap_or(false),
+        play_count: 0,
+        last_played_at: None,
+        date_added: None,
+        source: "tidal_ephemeral".to_string(),
+        artwork_url: row.get(30)?,
+    })
+}
+
 /// Remove stale pending rows and clear orphaned resolver locks.
 ///
 /// Two sweeps:
@@ -790,7 +1060,10 @@ mod tests {
                 resolving_at     TIMESTAMP,
                 resolved_at      TIMESTAMP,
                 tidal_match_score REAL,
-                tidal_id_hint    INTEGER
+                tidal_id_hint    INTEGER,
+                ephemeral_album_title TEXT,
+                ephemeral_artwork_url TEXT,
+                ephemeral_duration_ms INTEGER
             );
             CREATE TABLE genres (
                 id INTEGER PRIMARY KEY,
@@ -1548,5 +1821,125 @@ mod tests {
             )
             .unwrap();
         assert!(resolving_at.is_some());
+    }
+
+    fn ephemeral(tidal_id: i64, title: &str) -> EphemeralTidalInsert<'_> {
+        EphemeralTidalInsert {
+            tidal_id,
+            title,
+            artist: Some("Artist"),
+            album_title: Some("Album"),
+            artwork_url: Some("https://resources.tidal.com/x.jpg"),
+            duration_ms: Some(180_000),
+        }
+    }
+
+    #[test]
+    fn ephemeral_rows_load_as_playable_not_pending() {
+        let conn = conn();
+        append_ephemeral_tidal_tracks(
+            &conn,
+            &[ephemeral(501, "First"), ephemeral(502, "Second")],
+            "tidal_mix",
+        )
+        .unwrap();
+
+        let items = load_queue(&conn).unwrap();
+        assert_eq!(items.len(), 2);
+        for item in &items {
+            assert!(!item.is_pending, "ephemeral rows are directly playable");
+            assert_eq!(item.source, "tidal_mix");
+            assert_eq!(item.track.source, "tidal_ephemeral");
+            assert_eq!(item.track.album_title.as_deref(), Some("Album"));
+        }
+        // Synthetic negative track id derived from the TIDAL id, tidal_id set.
+        assert_eq!(items[0].track.id, -501);
+        assert_eq!(items[0].track.tidal_id, Some(501));
+        assert_eq!(items[0].track.title, "First");
+    }
+
+    #[test]
+    fn ephemeral_row_in_library_uses_local_id_and_favorite() {
+        let conn = conn();
+        // Track 1 already lives in the library with tidal_id 501.
+        conn.execute(
+            "UPDATE tracks SET tidal_id = 501, is_favorite = 1 WHERE id = 1",
+            [],
+        )
+        .unwrap();
+        append_ephemeral_tidal_tracks(&conn, &[ephemeral(501, "First")], "tidal_album").unwrap();
+
+        let items = load_queue(&conn).unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].track.id, 1, "library local id recovered");
+        assert!(items[0].track.is_favorite);
+        assert!(!items[0].is_pending);
+    }
+
+    #[test]
+    fn pop_next_ephemeral_consumes_in_order() {
+        let conn = conn();
+        append_ephemeral_tidal_tracks(
+            &conn,
+            &[
+                ephemeral(601, "A"),
+                ephemeral(602, "B"),
+                ephemeral(603, "C"),
+            ],
+            "tidal_mix",
+        )
+        .unwrap();
+
+        let first = pop_next_ephemeral_tidal_track(&conn).unwrap().unwrap();
+        assert_eq!(first.tidal_track_id, 601);
+        let second = peek_next_ephemeral_tidal_track(&conn).unwrap().unwrap();
+        assert_eq!(second.tidal_track_id, 602, "peek does not consume");
+        assert_eq!(load_queue(&conn).unwrap().len(), 2);
+    }
+
+    #[test]
+    fn trim_through_tidal_id_drops_rows_up_to_target() {
+        let conn = conn();
+        append_ephemeral_tidal_tracks(
+            &conn,
+            &[
+                ephemeral(701, "A"),
+                ephemeral(702, "B"),
+                ephemeral(703, "C"),
+            ],
+            "tidal_mix",
+        )
+        .unwrap();
+
+        let found = trim_ephemeral_tidal_rows_through_tidal_id(&conn, 702).unwrap();
+        assert!(found);
+        let remaining: Vec<i64> = peek_ephemeral_tidal_tracks(&conn)
+            .unwrap()
+            .into_iter()
+            .map(|t| t.tidal_track_id)
+            .collect();
+        assert_eq!(remaining, vec![703], "rows up to and including 702 removed");
+
+        // A tidal id outside the mix reports not-found and leaves rows intact.
+        assert!(!trim_ephemeral_tidal_rows_through_tidal_id(&conn, 999).unwrap());
+        assert_eq!(peek_ephemeral_tidal_tracks(&conn).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn delete_all_ephemeral_leaves_library_rows() {
+        let conn = conn();
+        // A real library queue row plus ephemeral rows.
+        conn.execute(
+            "INSERT INTO queue (track_id, position, source) VALUES (1, 0, 'user')",
+            [],
+        )
+        .unwrap();
+        append_ephemeral_tidal_tracks(&conn, &[ephemeral(801, "A")], "tidal_mix").unwrap();
+
+        let removed = delete_all_ephemeral_tidal_rows(&conn).unwrap();
+        assert_eq!(removed, 1);
+        let items = load_queue(&conn).unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].track.id, 1, "library row survives");
     }
 }

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -10,7 +10,7 @@ use crate::services::discovery_space as ds;
 use crate::services::learning as discovery_learning;
 use crate::services::tidal::{
     auth as tidal_auth,
-    client::{TidalClient, TidalSearchTrack, TidalSearchVideo, TidalTrack},
+    client::{TidalClient, TidalSearchCatalog, TidalSearchTrack, TidalSearchVideo, TidalTrack},
     import as tidal_import, mutations as tidal_mutations, stream as tidal_stream,
 };
 use crate::smart::discovery as discovery_engine;
@@ -62,6 +62,7 @@ const PLAYBACK_FINISH_DB_LOCK_RETRY_DELAY_SECS: u64 = 2;
 const PLAYBACK_ADVANCE_PENDING_SKIP_LIMIT: usize = 8;
 const PLAYBACK_PENDING_BUSY_RETRY_LIMIT: usize = 5;
 const PLAYBACK_PENDING_BUSY_RETRY_DELAY_MS: u64 = 200;
+const TIDAL_SEARCH_UPSTREAM_TIMEOUT_SECS: u64 = 8;
 
 static DROP_PREVIEW_ARM_ATTEMPTS: OnceLock<Mutex<HashMap<DropPreviewArmKey, Instant>>> =
     OnceLock::new();
@@ -9278,6 +9279,20 @@ struct TidalSearchVideoResp {
     r#type: String,
 }
 
+async fn search_tidal_catalog_with_timeout(
+    client: &TidalClient,
+    query: &str,
+    limit: i32,
+    offset: i32,
+) -> anyhow::Result<TidalSearchCatalog> {
+    tokio::time::timeout(
+        Duration::from_secs(TIDAL_SEARCH_UPSTREAM_TIMEOUT_SECS),
+        client.search_catalog_core(query, limit, offset),
+    )
+    .await
+    .map_err(|_| anyhow::anyhow!("TIDAL search timed out"))?
+}
+
 async fn tidal_search(
     State(state): State<SharedState>,
     Query(params): Query<TidalSearchParams>,
@@ -9335,7 +9350,7 @@ async fn tidal_search(
     let results = if let Some(hit) = cached {
         hit
     } else {
-        let fetched = match client.search_catalog_core(query, limit, offset).await {
+        let fetched = match search_tidal_catalog_with_timeout(&client, query, limit, offset).await {
             Ok(r) => r,
             Err(e) if error_looks_like_auth(&e) => {
                 let refreshed = recover_tidal_session(&state, &http_client, &tokens)
@@ -9353,8 +9368,7 @@ async fn tidal_search(
                     refreshed.access_token.clone(),
                     refreshed.country_code.clone(),
                 );
-                retry_client
-                    .search_catalog_core(query, limit, offset)
+                search_tidal_catalog_with_timeout(&retry_client, query, limit, offset)
                     .await
                     .map_err(|e2| {
                         (

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -5630,7 +5630,9 @@ async fn clear_ephemeral_playback_markers(state: &SharedState, clear_mix_queue: 
     state_guard.ephemeral_tidal_track = None;
     state_guard.prepared_ephemeral_tidal_next = None;
     if clear_mix_queue {
-        state_guard.pending_tidal_mix_queue.lock().unwrap().clear();
+        let _ = state_guard.db.with_conn(|conn| {
+            Ok::<_, anyhow::Error>(queue::delete_all_ephemeral_tidal_rows(conn)?)
+        });
     }
 }
 
@@ -5639,11 +5641,11 @@ pub(crate) fn active_ephemeral_tidal_mix_dj_pair(
 ) -> Option<crate::playback::dj_lookahead::DjLookaheadPair> {
     let current = state.ephemeral_tidal_track.as_ref()?;
     let pending = state
-        .pending_tidal_mix_queue
-        .lock()
-        .unwrap()
-        .iter()
-        .cloned()
+        .db
+        .with_conn(queue::peek_next_ephemeral_tidal_track)
+        .ok()
+        .flatten()
+        .into_iter()
         .collect::<Vec<_>>();
     crate::playback::dj_lookahead::build_ephemeral_tidal_mix_pair(current, pending.as_slice())
 }
@@ -5663,7 +5665,10 @@ pub(crate) fn active_ephemeral_tidal_mix_dj_labels(
             (current.title.clone(), current.artist_name.clone()),
         ));
     }
-    let pending = state.pending_tidal_mix_queue.lock().unwrap();
+    let pending = state
+        .db
+        .with_conn(queue::peek_ephemeral_tidal_tracks)
+        .unwrap_or_default();
     for track in pending.iter() {
         let media_ref = crate::playback::dj_lookahead::DjMediaRef::TidalTrack {
             tidal_id: track.tidal_track_id,
@@ -5716,8 +5721,9 @@ async fn overlay_snapshot_with_external_track_and_position(
         snapshot.state.position_ms = pos;
     }
     // Ephemeral Tidal track takes priority: it represents a track playing right
-    // now that has no DB record.
-    let has_ephemeral_tidal_track = state_guard.ephemeral_tidal_track.is_some();
+    // now that has no DB record. The rest of the mix is already present in
+    // snapshot.queue as real ephemeral TIDAL rows (loaded by load_queue), so no
+    // overlay painting is needed - the queue you see is the queue that is.
     if let Some(ephemeral) = &state_guard.ephemeral_tidal_track {
         snapshot.state.current_track = Some(ephemeral.clone());
     } else if snapshot.state.current_track.is_none()
@@ -5725,75 +5731,7 @@ async fn overlay_snapshot_with_external_track_and_position(
     {
         snapshot.state.current_track = Some(track.clone());
     }
-    // Surface the pending TIDAL mix queue (auto-advance items behind the
-    // currently-playing ephemeral track) into the visible queue so UP NEXT
-    // shows the rest of the mix instead of "empty".
-    let db = state_guard.db.clone();
-    let pending = state_guard
-        .pending_tidal_mix_queue
-        .lock()
-        .unwrap()
-        .iter()
-        .cloned()
-        .collect::<Vec<_>>();
     drop(state_guard);
-    if !pending.is_empty() {
-        if has_ephemeral_tidal_track {
-            snapshot.queue.clear();
-        }
-        let tidal_ids: Vec<i64> = pending.iter().map(|p| p.tidal_track_id).collect();
-        let library_states = db
-            .with_conn(|conn| queries::get_tidal_track_library_states(conn, &tidal_ids))
-            .unwrap_or_default();
-        let start_position = snapshot
-            .queue
-            .iter()
-            .map(|q| q.position)
-            .max()
-            .unwrap_or(-1)
-            + 1;
-        for (offset, p) in pending.into_iter().enumerate() {
-            let library_state = library_states.get(&p.tidal_track_id).copied();
-            let track = crate::db::models::Track {
-                id: library_state
-                    .map(|state| state.local_id)
-                    .unwrap_or(-p.tidal_track_id),
-                title: p.title,
-                artist_id: 0,
-                artist_name: p.artist_name,
-                album_id: None,
-                album_title: p.album_title,
-                disc_number: None,
-                track_number: None,
-                duration_ms: p.duration_ms,
-                isrc: None,
-                tidal_id: Some(p.tidal_track_id),
-                ytmusic_id: None,
-                soundcloud_id: None,
-                best_quality: Some("LOSSLESS".to_string()),
-                best_source: Some("tidal".to_string()),
-                fidelity_score: 0,
-                is_favorite: library_state
-                    .map(|state| state.is_favorite)
-                    .unwrap_or(false),
-                play_count: 0,
-                last_played_at: None,
-                date_added: None,
-                source: "tidal_ephemeral".to_string(),
-                artwork_url: p.artwork_url,
-            };
-            // Queue ids stay negative for in-memory mix rows. Track ids are
-            // local ids when the TIDAL id is already in the library.
-            snapshot.queue.push(crate::db::models::QueueItem {
-                id: -(offset as i64 + 1),
-                track,
-                position: start_position + offset as i32,
-                source: "tidal_mix".to_string(),
-                reason: None,
-                is_pending: false,
-            });
-        }
-    }
     snapshot
 }
 
@@ -7391,10 +7329,10 @@ async fn advance_ephemeral_next_if_needed(
     let next = {
         let state_guard = state.read().await;
         state_guard
-            .pending_tidal_mix_queue
-            .lock()
-            .unwrap()
-            .pop_front()
+            .db
+            .with_conn(queue::pop_next_ephemeral_tidal_track)
+            .ok()
+            .flatten()
     };
 
     if let Some(next) = next {
@@ -7875,23 +7813,8 @@ async fn set_playback_shuffle(
         .with_conn(|conn| player::set_shuffle_mode(conn, mode))
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
-    // The pending TIDAL mix queue lives in-memory outside the DB queue, so
-    // `set_shuffle_mode` above never sees it. Reorder it here so flipping shuffle
-    // on during a TIDAL mix actually changes what plays next. Pending entries
-    // carry no genre/artist_id metadata, so genre/weighted modes degrade to a
-    // plain Fisher-Yates - same shape as `true` shuffle.
-    if let Some(debug) = update.debug.as_ref() {
-        let mut q = state_guard.pending_tidal_mix_queue.lock().unwrap();
-        if q.len() > 1 {
-            use rand::seq::SliceRandom;
-            let mut rng = crate::playback::shuffle::seeded_rng(
-                debug.seed,
-                mode.as_str(),
-                "pending_tidal_mix",
-            );
-            q.make_contiguous().shuffle(&mut rng);
-        }
-    }
+    // Ephemeral TIDAL mix rows are real queue rows now, so `set_shuffle_mode`
+    // above already reordered them along with the rest of the queue.
 
     let _ = state_guard.event_tx.send(AppEvent::PlaybackStateChanged);
     let _ = state_guard.event_tx.send(AppEvent::QueueUpdated);
@@ -8616,7 +8539,7 @@ async fn clear_queue_route(State(state): State<SharedState>) -> Result<Json<Valu
                         queue::clear_queue(conn)?;
                     }
                 }
-                state_guard.pending_tidal_mix_queue.lock().unwrap().clear();
+                queue::delete_all_ephemeral_tidal_rows(conn)?;
                 // Return the full PlaybackSnapshot ({state, queue}) so the UI can
                 // refresh both at once - additive over the prior `{queue}` shape:
                 // existing consumers keep reading `queue`, new ones read
@@ -8689,20 +8612,6 @@ fn visible_track_playlist_source(
                 ..Default::default()
             })
         })
-}
-
-fn pending_tidal_playlist_source(
-    pending: crate::PendingEphemeralTidalTrack,
-) -> PlaylistFromQueueSource {
-    PlaylistFromQueueSource::Tidal(tidal_import::ImportTrackMetadata {
-        tidal_id: pending.tidal_track_id,
-        title: non_empty_or_default(Some(pending.title), "Unknown title"),
-        artist_name: non_empty_or_default(pending.artist_name, "Unknown artist"),
-        album_title: optional_non_empty(pending.album_title),
-        album_artwork_url: pending.artwork_url,
-        duration_ms: pending.duration_ms,
-        ..Default::default()
-    })
 }
 
 fn load_persisted_queue_playlist_sources(
@@ -8783,27 +8692,17 @@ async fn create_playlist_from_queue(
         ));
     }
     let include_tidal_only = payload.include_tidal_only.unwrap_or(true);
-    let (db, current_source, pending_tidal_sources) = {
+    let (db, current_source) = {
         let state = state.read().await;
+        // The currently-playing ephemeral track isn't a queue row; the rest of
+        // the mix is, and load_persisted_queue_playlist_sources surfaces those
+        // ephemeral rows via their tidal_id_hint below.
         let current = state
             .ephemeral_tidal_track
             .as_ref()
             .or(state.external_playback_track.as_ref())
             .and_then(|track| visible_track_playlist_source(track, include_tidal_only));
-        let pending = if include_tidal_only {
-            state
-                .pending_tidal_mix_queue
-                .lock()
-                .unwrap()
-                .iter()
-                .cloned()
-                .filter(|pending| pending.tidal_track_id > 0)
-                .map(pending_tidal_playlist_source)
-                .collect()
-        } else {
-            Vec::new()
-        };
-        (state.db.clone(), current, pending)
+        (state.db.clone(), current)
     };
 
     let persisted_sources = db
@@ -8817,7 +8716,6 @@ async fn create_playlist_from_queue(
     let mut sources = Vec::new();
     sources.extend(current_source);
     sources.extend(persisted_sources);
-    sources.extend(pending_tidal_sources);
 
     let track_ids = resolve_playlist_source_ids(&db, sources)
         .await
@@ -10167,22 +10065,19 @@ async fn play_tidal_ephemeral(
     State(state): State<SharedState>,
     Json(body): Json<PlayTidalRequest>,
 ) -> Result<Json<Value>, (StatusCode, Json<Value>)> {
-    // If the picked track is sitting in the pending mix queue, jump to it.
-    // drop entries before it (and the entry itself, which we're about to
-    // start) and leave the rest queued. Only fully clear when the user
-    // chose something outside the current mix.
+    // If the picked track is an ephemeral mix row, jump to it: drop rows before
+    // it (and the row itself, which we're about to start) and leave the rest
+    // queued. When it isn't part of the mix, clear the whole continuation.
     {
         let s = state.read().await;
-        let mut q = s.pending_tidal_mix_queue.lock().unwrap();
-        match q
-            .iter()
-            .position(|p| p.tidal_track_id == body.tidal_track_id)
-        {
-            Some(idx) => {
-                q.drain(..=idx);
+        let tidal_id = body.tidal_track_id;
+        let _ = s.db.with_conn(|conn| {
+            let trimmed = queue::trim_ephemeral_tidal_rows_through_tidal_id(conn, tidal_id)?;
+            if !trimmed {
+                queue::delete_all_ephemeral_tidal_rows(conn)?;
             }
-            None => q.clear(),
-        }
+            Ok::<_, anyhow::Error>(())
+        });
     }
     let track = crate::PendingEphemeralTidalTrack {
         tidal_track_id: body.tidal_track_id,
@@ -10210,6 +10105,21 @@ struct PlayTidalMixRequest {
     tracks: Vec<PlayTidalRequest>,
     #[serde(default)]
     shuffle_mode: Option<String>,
+    /// Collection kind for the queue rows: tidal_mix (default), tidal_album, or
+    /// tidal_playlist. Drives the queue source label; behavior is identical.
+    #[serde(default)]
+    source: Option<String>,
+}
+
+/// Delete the persisted ephemeral TIDAL continuation rows. Used on stop and when
+/// a failed mix start needs to leave no orphaned rows.
+async fn clear_ephemeral_tidal_continuation(state: &SharedState) {
+    let s = state.read().await;
+    if let Err(error) =
+        s.db.with_conn(|conn| Ok::<_, anyhow::Error>(queue::delete_all_ephemeral_tidal_rows(conn)?))
+    {
+        warn!(?error, "Failed to clear ephemeral TIDAL continuation rows");
+    }
 }
 
 fn shuffle_tidal_mix_tracks(
@@ -10242,6 +10152,12 @@ async fn clear_persisted_queue_for_tidal_mix(
         .db
         .with_conn(|conn| {
             queue::clear_queue(conn)?;
+            // Drop any dangling play-head anchor so a reused queue rowid can't be
+            // mistaken for the current item once new ephemeral rows are inserted.
+            conn.execute(
+                "UPDATE playback_state SET current_queue_item_id = NULL WHERE id = 1",
+                [],
+            )?;
             Ok::<_, anyhow::Error>(())
         })
         .map_err(|error| {
@@ -10254,6 +10170,15 @@ async fn clear_persisted_queue_for_tidal_mix(
                 Json(json!({ "error": "Failed to clear stale playback queue" })),
             )
         })
+}
+
+/// Map a producer-supplied collection source to one of
+/// [`queue::EPHEMERAL_TIDAL_SOURCES`], defaulting to `tidal_mix`.
+fn normalize_ephemeral_tidal_source(source: Option<&str>) -> String {
+    match source {
+        Some(s) if queue::EPHEMERAL_TIDAL_SOURCES.contains(&s) => s.to_string(),
+        _ => "tidal_mix".to_string(),
+    }
 }
 
 /// Play the first track immediately and stash the rest in the pending
@@ -10270,40 +10195,50 @@ async fn play_tidal_mix(
             Json(json!({ "error": "Mix has no tracks" })),
         ));
     }
+    let source = normalize_ephemeral_tidal_source(body.source.as_deref());
     let shuffle_debug = shuffle_tidal_mix_tracks(&mut tracks, body.shuffle_mode.as_deref());
 
-    let mut iter = tracks
-        .into_iter()
-        .map(|t| crate::PendingEphemeralTidalTrack {
-            tidal_track_id: t.tidal_track_id,
-            title: t.title,
-            artist_name: t.artist_name,
-            album_title: t.album_title,
-            artwork_url: t.artwork_url,
-            duration_ms: t.duration_ms,
-        });
-    let first = iter.next().expect("non-empty per check above");
+    let first = crate::PendingEphemeralTidalTrack {
+        tidal_track_id: tracks[0].tidal_track_id,
+        title: tracks[0].title.clone(),
+        artist_name: tracks[0].artist_name.clone(),
+        album_title: tracks[0].album_title.clone(),
+        artwork_url: tracks[0].artwork_url.clone(),
+        duration_ms: tracks[0].duration_ms,
+    };
     let first_tidal_id = first.tidal_track_id;
-    let rest: Vec<crate::PendingEphemeralTidalTrack> = iter.collect();
 
-    // Replace any existing pending queue with this mix's continuation.
-    {
-        let s = state.read().await;
-        let mut q = s.pending_tidal_mix_queue.lock().unwrap();
-        q.clear();
-        q.extend(rest);
-    }
-
+    // Wipe any prior queue + continuation first so a failed start leaves a clean
+    // slate, then play the first track and persist the rest as real, mutable
+    // ephemeral rows (not an in-memory deque).
+    clear_persisted_queue_for_tidal_mix(&state).await?;
     if let Err(error) = start_ephemeral_tidal_playback(&state, first).await {
-        let s = state.read().await;
-        s.pending_tidal_mix_queue.lock().unwrap().clear();
+        clear_ephemeral_tidal_continuation(&state).await;
         return Err(error);
     }
-    if let Err(error) = clear_persisted_queue_for_tidal_mix(&state).await {
+    let rest_inserts: Vec<queue::EphemeralTidalInsert<'_>> = tracks[1..]
+        .iter()
+        .map(|t| queue::EphemeralTidalInsert {
+            tidal_id: t.tidal_track_id,
+            title: &t.title,
+            artist: t.artist_name.as_deref(),
+            album_title: t.album_title.as_deref(),
+            artwork_url: t.artwork_url.as_deref(),
+            duration_ms: t.duration_ms,
+        })
+        .collect();
+    if !rest_inserts.is_empty() {
         let s = state.read().await;
-        s.pending_tidal_mix_queue.lock().unwrap().clear();
-        return Err(error);
+        if let Err(error) = s.db.with_conn(|conn| {
+            queue::append_ephemeral_tidal_tracks(conn, &rest_inserts, &source)?;
+            Ok::<_, anyhow::Error>(())
+        }) {
+            // The first track is already playing; a continuation-persist failure
+            // is soft - the mix just won't auto-advance. Don't abort playback.
+            warn!(?error, "Failed to persist TIDAL mix continuation rows");
+        }
     }
+
     let snapshot = build_live_playback_snapshot_json(&state).await?;
     {
         let s = state.read().await;
@@ -11249,12 +11184,13 @@ async fn handle_ephemeral_tidal_near_end(
         if current_track.id != current_track_id {
             return Ok(false);
         }
+        // Peek (don't pop) the next upcoming ephemeral row to pre-buffer it.
         let pending_tracks = state_guard
-            .pending_tidal_mix_queue
-            .lock()
-            .unwrap()
-            .iter()
-            .cloned()
+            .db
+            .with_conn(queue::peek_next_ephemeral_tidal_track)
+            .ok()
+            .flatten()
+            .into_iter()
             .collect::<Vec<_>>();
         let Some(pending_track) = pending_tracks.first().cloned() else {
             return Ok(false);
@@ -11402,10 +11338,10 @@ async fn handle_ephemeral_tidal_near_end(
             .as_ref()
             .and_then(|info| info.active_track_id);
         let pending_front = state_guard
-            .pending_tidal_mix_queue
-            .lock()
-            .unwrap()
-            .front()
+            .db
+            .with_conn(queue::peek_next_ephemeral_tidal_track)
+            .ok()
+            .flatten()
             .map(|track| track.tidal_track_id);
         if active_id != Some(current_track_id)
             || current_playback_generation(&state_guard) != generation
@@ -11797,10 +11733,10 @@ async fn try_adopt_prepared_ephemeral_tidal_next(
             return Ok(false);
         }
         let pending_front = state_guard
-            .pending_tidal_mix_queue
-            .lock()
-            .unwrap()
-            .front()
+            .db
+            .with_conn(queue::peek_next_ephemeral_tidal_track)
+            .ok()
+            .flatten()
             .map(|track| track.tidal_track_id);
         if pending_front != Some(prepared.tidal_track_id) {
             return Ok(false);
@@ -11850,12 +11786,20 @@ async fn try_adopt_prepared_ephemeral_tidal_next(
         {
             return Ok(true);
         }
-        let mut pending = state_guard.pending_tidal_mix_queue.lock().unwrap();
-        if pending.front().map(|track| track.tidal_track_id) != Some(prepared.tidal_track_id) {
+        // Consume the upcoming ephemeral row, but only if it's still the one we
+        // prepared (a concurrent reorder/remove could have changed it).
+        let popped = state_guard
+            .db
+            .with_conn(|conn| match queue::peek_next_ephemeral_tidal_track(conn)? {
+                Some(front) if front.tidal_track_id == prepared.tidal_track_id => {
+                    queue::pop_next_ephemeral_tidal_track(conn)
+                }
+                _ => Ok(None),
+            })
+            .unwrap_or(None);
+        if popped.is_none() {
             return Ok(true);
         }
-        let _ = pending.pop_front();
-        drop(pending);
 
         state_guard.external_playback_track = None;
         state_guard.ephemeral_tidal_track = Some(prepared.synthetic_track.clone());
@@ -12090,11 +12034,13 @@ async fn handle_runtime_finished(
             state_guard.pending_stream_display = None;
         }
         // Auto-advance through any queued ephemeral mix continuation before
-        // tearing down. Pop the next track out of the pending queue and start
-        // it; if the queue is empty, fall through to the existing teardown.
+        // tearing down. Pop the next ephemeral row out of the queue and start
+        // it; if there are none, fall through to the existing teardown.
         let next = {
             let s = state.read().await;
-            s.pending_tidal_mix_queue.lock().unwrap().pop_front()
+            s.db.with_conn(queue::pop_next_ephemeral_tidal_track)
+                .ok()
+                .flatten()
         };
         if let Some(next) = next {
             // Clear the previous ephemeral track marker so the new one's
@@ -12143,12 +12089,18 @@ async fn handle_runtime_finished(
                                 "Hit max consecutive failures advancing TIDAL mix; clearing remaining queue"
                             );
                             let s = state.read().await;
-                            s.pending_tidal_mix_queue.lock().unwrap().clear();
+                            let _ = s.db.with_conn(|conn| {
+                                Ok::<_, anyhow::Error>(queue::delete_all_ephemeral_tidal_rows(
+                                    conn,
+                                )?)
+                            });
                             break;
                         }
                         let popped = {
                             let s = state.read().await;
-                            s.pending_tidal_mix_queue.lock().unwrap().pop_front()
+                            s.db.with_conn(queue::pop_next_ephemeral_tidal_track)
+                                .ok()
+                                .flatten()
                         };
                         match popped {
                             Some(p) => current = p,

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -5636,13 +5636,16 @@ async fn clear_ephemeral_playback_markers(state: &SharedState, clear_mix_queue: 
     }
 }
 
+// Takes `conn` rather than opening its own `with_conn`: every caller already
+// holds the DB lock (inside `active_dj_pair_for_state_and_conn` and the
+// rebuild-profile route), and `Mutex<Connection>` is non-reentrant, so a nested
+// `with_conn` here deadlocks forever.
 pub(crate) fn active_ephemeral_tidal_mix_dj_pair(
     state: &crate::AppState,
+    conn: &rusqlite::Connection,
 ) -> Option<crate::playback::dj_lookahead::DjLookaheadPair> {
     let current = state.ephemeral_tidal_track.as_ref()?;
-    let pending = state
-        .db
-        .with_conn(queue::peek_next_ephemeral_tidal_track)
+    let pending = queue::peek_next_ephemeral_tidal_track(conn)
         .ok()
         .flatten()
         .into_iter()
@@ -5686,7 +5689,7 @@ pub(crate) fn active_dj_pair_for_state_and_conn(
     state: &crate::AppState,
     conn: &rusqlite::Connection,
 ) -> anyhow::Result<crate::playback::dj_lookahead::DjLookaheadPair> {
-    if let Some(pair) = active_ephemeral_tidal_mix_dj_pair(state)
+    if let Some(pair) = active_ephemeral_tidal_mix_dj_pair(state, conn)
         && pair.next.is_some()
     {
         return Ok(pair);

--- a/noor-server/src/server/routes/catalog_routes.rs
+++ b/noor-server/src/server/routes/catalog_routes.rs
@@ -857,6 +857,10 @@ pub(super) async fn get_artist_discography(
                         "artwork_url": artwork,
                         "album_title": t.album.as_ref().map(|al| al.title.clone()),
                         "album_tidal_id": t.album.as_ref().map(|al| al.id),
+                        "track_number": t.track_number,
+                        "disc_number": t.volume_number,
+                        "artist_name": t.artist.name,
+                        "artist_tidal_id": t.artist.id,
                     })
                 })
                 .collect()

--- a/noor-server/src/server/routes/dj_routes.rs
+++ b/noor-server/src/server/routes/dj_routes.rs
@@ -815,7 +815,7 @@ async fn rebuild_profile(
                     media_ref_kind: payload.media_ref_kind.clone(),
                     media_ref_id: payload.media_ref_id.clone(),
                 };
-                let pair = match super::active_ephemeral_tidal_mix_dj_pair(&state) {
+                let pair = match super::active_ephemeral_tidal_mix_dj_pair(&state, conn) {
                     Some(pair) => pair,
                     None => crate::playback::dj_lookahead::load_dj_lookahead_pair(conn)?,
                 };

--- a/noor-server/src/server/routes/dj_routes.rs
+++ b/noor-server/src/server/routes/dj_routes.rs
@@ -1416,12 +1416,12 @@ async fn rebuild_track_for_tidal_ref(
         return prepared.synthetic_track.clone();
     }
     if let Some(pending) = state_guard
-        .pending_tidal_mix_queue
-        .lock()
-        .unwrap()
-        .iter()
-        .find(|track| track.tidal_track_id == tidal_id)
-        .cloned()
+        .db
+        .with_conn(|conn| {
+            crate::playback::queue::find_ephemeral_tidal_track_by_tidal_id(conn, tidal_id)
+        })
+        .ok()
+        .flatten()
     {
         return synthetic_rebuild_track(&pending);
     }
@@ -2941,9 +2941,6 @@ mod tests {
                 &std::env::temp_dir().join(format!("noor-test-key-{}", uuid::Uuid::new_v4())),
             )
             .expect("test master key"),
-            pending_tidal_mix_queue: std::sync::Arc::new(std::sync::Mutex::new(
-                std::collections::VecDeque::new(),
-            )),
             prepared_ephemeral_tidal_next: None,
             lastfm_api_secret: None,
             server_token: String::new(),

--- a/noor-server/src/server/routes/tests.rs
+++ b/noor-server/src/server/routes/tests.rs
@@ -1005,7 +1005,6 @@ fn fresh_test_state(db: Database) -> crate::AppState {
             &std::env::temp_dir().join(format!("noor-test-key-{}", uuid::Uuid::new_v4())),
         )
         .expect("test master key"),
-        pending_tidal_mix_queue: Arc::new(std::sync::Mutex::new(std::collections::VecDeque::new())),
         prepared_ephemeral_tidal_next: None,
         lastfm_api_secret: None,
         server_token: String::new(),
@@ -3274,29 +3273,73 @@ async fn discovery_blend_add_appends_discoveries_without_replacing_queue() {
     let _ = std::fs::remove_file(db_path);
 }
 
-#[tokio::test]
-async fn tidal_mix_overlay_preserves_pending_deque_order() {
-    let (db, db_path) = fresh_migrated_db();
+/// Append ephemeral TIDAL rows for tests. Tuple: (tidal_id, title, artist,
+/// album, artwork, duration_ms).
+fn insert_ephemeral_rows(
+    db: &Database,
+    source: &str,
+    rows: &[(
+        i64,
+        &str,
+        Option<&str>,
+        Option<&str>,
+        Option<&str>,
+        Option<i64>,
+    )],
+) {
+    let inserts: Vec<crate::playback::queue::EphemeralTidalInsert<'_>> = rows
+        .iter()
+        .map(
+            |(id, title, artist, album, art, dur)| crate::playback::queue::EphemeralTidalInsert {
+                tidal_id: *id,
+                title,
+                artist: *artist,
+                album_title: *album,
+                artwork_url: *art,
+                duration_ms: *dur,
+            },
+        )
+        .collect();
     db.with_conn(|conn| {
-        conn.execute(
-            "INSERT INTO artists (id, name) VALUES (8101, 'Old Playlist Artist')",
-            [],
-        )?;
-        conn.execute(
-            "INSERT INTO tracks (id, title, artist_id, duration_ms)
-                 VALUES
-                    (8101, 'Old Playlist First', 8101, 200000),
-                    (8102, 'Old Playlist Second', 8101, 200000)",
-            [],
-        )?;
-        conn.execute(
-            "INSERT INTO queue (track_id, position, source)
-                 VALUES (8101, 0, 'playlist'), (8102, 1, 'playlist')",
-            [],
-        )?;
-        Ok(())
+        crate::playback::queue::append_ephemeral_tidal_tracks(conn, &inserts, source)?;
+        Ok::<_, anyhow::Error>(())
     })
     .unwrap();
+}
+
+#[tokio::test]
+async fn ephemeral_tidal_rows_appear_in_queue_in_order() {
+    let (db, db_path) = fresh_migrated_db();
+    insert_ephemeral_rows(
+        &db,
+        "tidal_mix",
+        &[
+            (
+                873_891_22,
+                "The Big Tree",
+                Some("Stand High Patrol"),
+                None,
+                None,
+                Some(180_000),
+            ),
+            (
+                341_378_223,
+                "Positive",
+                Some("Jamback"),
+                None,
+                None,
+                Some(170_000),
+            ),
+            (
+                172_522_829,
+                "Moi Aussi Marianne",
+                Some("Yatoba Lia"),
+                None,
+                None,
+                Some(210_000),
+            ),
+        ],
+    );
     let state = Arc::new(tokio::sync::RwLock::new(fresh_test_state(db)));
     {
         let mut guard = state.write().await;
@@ -3324,31 +3367,6 @@ async fn tidal_mix_overlay_preserves_pending_deque_order() {
             source: "tidal_ephemeral".to_string(),
             artwork_url: None,
         });
-        let mut pending = guard.pending_tidal_mix_queue.lock().unwrap();
-        pending.push_back(crate::PendingEphemeralTidalTrack {
-            tidal_track_id: 873_891_22,
-            title: "The Big Tree".to_string(),
-            artist_name: Some("Stand High Patrol".to_string()),
-            album_title: None,
-            artwork_url: None,
-            duration_ms: Some(180_000),
-        });
-        pending.push_back(crate::PendingEphemeralTidalTrack {
-            tidal_track_id: 341_378_223,
-            title: "Positive".to_string(),
-            artist_name: Some("Jamback".to_string()),
-            album_title: None,
-            artwork_url: None,
-            duration_ms: Some(170_000),
-        });
-        pending.push_back(crate::PendingEphemeralTidalTrack {
-            tidal_track_id: 172_522_829,
-            title: "Moi Aussi Marianne".to_string(),
-            artist_name: Some("Yatoba Lia".to_string()),
-            album_title: None,
-            artwork_url: None,
-            duration_ms: Some(210_000),
-        });
     }
 
     let snapshot = {
@@ -3357,6 +3375,7 @@ async fn tidal_mix_overlay_preserves_pending_deque_order() {
     };
     let snapshot = overlay_snapshot_with_external_track(&state, snapshot).await;
 
+    // Current comes from the ephemeral marker; the rest are real queue rows.
     assert_eq!(
         snapshot
             .state
@@ -3376,38 +3395,60 @@ async fn tidal_mix_overlay_preserves_pending_deque_order() {
     );
     assert!(
         snapshot.queue.iter().all(|item| item.source == "tidal_mix"),
-        "active TIDAL mix overlay must shadow the stale durable playlist queue"
+        "ephemeral TIDAL rows keep their collection source"
+    );
+    assert!(
+        snapshot.queue.iter().all(|item| !item.is_pending),
+        "ephemeral TIDAL rows are directly playable, not pending"
+    );
+    assert!(
+        snapshot
+            .queue
+            .iter()
+            .all(|item| item.track.tidal_id.is_some() && item.track.id < 0),
+        "ephemeral rows carry a tidal_id and a synthetic negative track id"
     );
 
     let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
-async fn tidal_mix_overlay_preserves_large_loaded_album_rows() {
+async fn ephemeral_tidal_album_rows_preserve_metadata() {
     let (db, db_path) = fresh_migrated_db();
-    db.with_conn(|conn| {
-        conn.execute(
-            "INSERT INTO artists (id, name) VALUES (8301, 'Unrelated Playlist Artist')",
-            [],
-        )?;
-        conn.execute(
-            "INSERT INTO tracks (id, title, artist_id, duration_ms)
-                 VALUES
-                    (8301, 'Unrelated Queue First', 8301, 200000),
-                    (8302, 'Unrelated Queue Second', 8301, 200000)",
-            [],
-        )?;
-        conn.execute(
-            "INSERT INTO queue (track_id, position, source)
-                 VALUES (8301, 0, 'playlist'), (8302, 1, 'playlist')",
-            [],
-        )?;
-        Ok(())
-    })
-    .unwrap();
-    let state = Arc::new(tokio::sync::RwLock::new(fresh_test_state(db)));
     let album_tidal_id = 58_520_793_i64;
     let tidal_track_base = album_tidal_id * 100;
+    let rows: Vec<(i64, String, String)> = (2..=45)
+        .map(|n| {
+            (
+                tidal_track_base + n,
+                format!("Anthology Track {n}"),
+                format!("https://resources.tidal.com/images/anthology-{n}/640x640.jpg"),
+            )
+        })
+        .collect();
+    let inserts: Vec<(
+        i64,
+        &str,
+        Option<&str>,
+        Option<&str>,
+        Option<&str>,
+        Option<i64>,
+    )> = rows
+        .iter()
+        .map(|(id, title, art)| {
+            (
+                *id,
+                title.as_str(),
+                Some("The Beatles"),
+                Some("Anthology 2"),
+                Some(art.as_str()),
+                Some(180_000),
+            )
+        })
+        .collect();
+    insert_ephemeral_rows(&db, "tidal_album", &inserts);
+
+    let state = Arc::new(tokio::sync::RwLock::new(fresh_test_state(db)));
     {
         let mut current = test_track(-(tidal_track_base + 1), "Anthology Track 1");
         current.artist_id = 0;
@@ -3420,19 +3461,6 @@ async fn tidal_mix_overlay_preserves_large_loaded_album_rows() {
 
         let mut guard = state.write().await;
         guard.ephemeral_tidal_track = Some(current);
-        let mut pending = guard.pending_tidal_mix_queue.lock().unwrap();
-        for track_number in 2..=45 {
-            pending.push_back(crate::PendingEphemeralTidalTrack {
-                tidal_track_id: tidal_track_base + track_number,
-                title: format!("Anthology Track {track_number}"),
-                artist_name: Some("The Beatles".to_string()),
-                album_title: Some("Anthology 2".to_string()),
-                artwork_url: Some(format!(
-                    "https://resources.tidal.com/images/anthology-{track_number}/640x640.jpg"
-                )),
-                duration_ms: Some(180_000 + track_number),
-            });
-        }
     }
 
     let snapshot = {
@@ -3469,21 +3497,17 @@ async fn tidal_mix_overlay_preserves_large_loaded_album_rows() {
             .collect::<Vec<_>>()
     );
     assert!(
-        snapshot.queue.iter().all(|item| item.source == "tidal_mix"
-            && item.track.album_title.as_deref() == Some("Anthology 2")
-            && item
-                .track
-                .artwork_url
-                .as_deref()
-                .is_some_and(|url| url.contains("resources.tidal.com"))),
-        "visible TIDAL album queue rows must preserve album metadata and artwork"
-    );
-    assert!(
         snapshot
             .queue
             .iter()
-            .all(|item| !item.track.title.starts_with("Unrelated Queue")),
-        "active TIDAL album overlay must not leak stale durable queue rows"
+            .all(|item| item.source == "tidal_album"
+                && item.track.album_title.as_deref() == Some("Anthology 2")
+                && item
+                    .track
+                    .artwork_url
+                    .as_deref()
+                    .is_some_and(|url| url.contains("resources.tidal.com"))),
+        "ephemeral TIDAL album rows must preserve album metadata and artwork"
     );
 
     let _ = std::fs::remove_file(db_path);
@@ -3513,45 +3537,48 @@ async fn tidal_mix_replacement_clears_stale_persisted_queue() {
     })
     .unwrap();
 
-    let state = Arc::new(tokio::sync::RwLock::new(fresh_test_state(db.clone())));
-    {
-        let guard = state.read().await;
-        guard.pending_tidal_mix_queue.lock().unwrap().push_back(
-            crate::PendingEphemeralTidalTrack {
-                tidal_track_id: 123_456,
-                title: "Album Track Two".to_string(),
-                artist_name: Some("Album Artist".to_string()),
-                album_title: Some("Album".to_string()),
-                artwork_url: Some(
-                    "https://resources.tidal.com/images/a/b/c/320x320.jpg".to_string(),
-                ),
-                duration_ms: Some(180_000),
-            },
-        );
-    }
+    // Both durable rows and a prior ephemeral continuation are wiped: the
+    // producer clears the slate before appending the new mix.
+    insert_ephemeral_rows(
+        &db,
+        "tidal_mix",
+        &[(
+            123_456,
+            "Album Track Two",
+            Some("Album Artist"),
+            Some("Album"),
+            Some("https://resources.tidal.com/images/a/b/c/320x320.jpg"),
+            Some(180_000),
+        )],
+    );
+    db.with_conn(|conn| {
+        conn.execute(
+            "UPDATE playback_state SET current_queue_item_id = 1 WHERE id = 1",
+            [],
+        )?;
+        Ok::<_, anyhow::Error>(())
+    })
+    .unwrap();
 
+    let state = Arc::new(tokio::sync::RwLock::new(fresh_test_state(db.clone())));
     if let Err((status, _)) = clear_persisted_queue_for_tidal_mix(&state).await {
         panic!("clear_persisted_queue_for_tidal_mix failed: {status}");
     }
 
-    let queue_len = db
+    let (queue_len, anchor): (i64, Option<i64>) = db
         .with_conn(|conn| {
-            conn.query_row("SELECT COUNT(*) FROM queue", [], |row| row.get::<_, i64>(0))
-                .map_err(anyhow::Error::from)
+            let len =
+                conn.query_row("SELECT COUNT(*) FROM queue", [], |row| row.get::<_, i64>(0))?;
+            let anchor = conn.query_row(
+                "SELECT current_queue_item_id FROM playback_state WHERE id = 1",
+                [],
+                |row| row.get::<_, Option<i64>>(0),
+            )?;
+            Ok::<_, anyhow::Error>((len, anchor))
         })
         .unwrap();
-    assert_eq!(queue_len, 0);
-    assert_eq!(
-        state
-            .read()
-            .await
-            .pending_tidal_mix_queue
-            .lock()
-            .unwrap()
-            .len(),
-        1,
-        "durable queue cleanup must preserve the active TIDAL continuation"
-    );
+    assert_eq!(queue_len, 0, "clear wipes durable + ephemeral rows alike");
+    assert_eq!(anchor, None, "the stale play-head anchor is dropped");
 
     let _ = std::fs::remove_file(db_path);
 }
@@ -3559,20 +3586,19 @@ async fn tidal_mix_replacement_clears_stale_persisted_queue() {
 #[tokio::test]
 async fn clear_queue_clears_pending_tidal_mix_overlay() {
     let (db, db_path) = fresh_migrated_db();
+    insert_ephemeral_rows(
+        &db,
+        "tidal_mix",
+        &[(
+            987_654,
+            "Queued TIDAL Mix Track",
+            Some("TIDAL Artist"),
+            Some("TIDAL Mix"),
+            None,
+            Some(180_000),
+        )],
+    );
     let state = Arc::new(tokio::sync::RwLock::new(fresh_test_state(db)));
-    {
-        let guard = state.read().await;
-        guard.pending_tidal_mix_queue.lock().unwrap().push_back(
-            crate::PendingEphemeralTidalTrack {
-                tidal_track_id: 987_654,
-                title: "Queued TIDAL Mix Track".to_string(),
-                artist_name: Some("TIDAL Artist".to_string()),
-                album_title: Some("TIDAL Mix".to_string()),
-                artwork_url: None,
-                duration_ms: Some(180_000),
-            },
-        );
-    }
     let app = api_routes(state.clone());
 
     let resp = app
@@ -3607,17 +3633,7 @@ async fn clear_queue_clears_pending_tidal_mix_overlay() {
     let queue = body["queue"].as_array().expect("queue array");
     assert!(
         queue.is_empty(),
-        "pending TIDAL mix overlay must not reappear after clear"
-    );
-    assert!(
-        state
-            .read()
-            .await
-            .pending_tidal_mix_queue
-            .lock()
-            .unwrap()
-            .is_empty(),
-        "pending TIDAL mix deque must be cleared"
+        "ephemeral TIDAL rows must not reappear after clear"
     );
 
     let _ = std::fs::remove_file(db_path);
@@ -5192,6 +5208,22 @@ async fn create_playlist_from_queue_imports_pending_tidal_rows_with_hint() {
 #[tokio::test]
 async fn create_playlist_from_queue_imports_ephemeral_tidal_overlay() {
     let (db, db_path) = fresh_migrated_db();
+    // The currently-playing ephemeral track plus two upcoming ephemeral rows.
+    insert_ephemeral_rows(
+        &db,
+        "tidal_mix",
+        &[
+            (
+                902,
+                "Next TIDAL",
+                Some("Next Artist"),
+                Some("Next Album"),
+                Some("https://resources.tidal.com/images/cover.jpg"),
+                Some(181_000),
+            ),
+            (903, "Third TIDAL", None, None, None, None),
+        ],
+    );
     let mut state = fresh_test_state(db.clone());
     let mut current = test_track(-901, "Current TIDAL");
     current.tidal_id = Some(901);
@@ -5199,25 +5231,6 @@ async fn create_playlist_from_queue_imports_ephemeral_tidal_overlay() {
     current.album_title = Some("Current Album".to_string());
     current.source = "tidal_ephemeral".to_string();
     state.ephemeral_tidal_track = Some(current);
-    {
-        let mut pending = state.pending_tidal_mix_queue.lock().unwrap();
-        pending.push_back(crate::PendingEphemeralTidalTrack {
-            tidal_track_id: 902,
-            title: "Next TIDAL".to_string(),
-            artist_name: Some("Next Artist".to_string()),
-            album_title: Some("Next Album".to_string()),
-            artwork_url: Some("https://resources.tidal.com/images/cover.jpg".to_string()),
-            duration_ms: Some(181_000),
-        });
-        pending.push_back(crate::PendingEphemeralTidalTrack {
-            tidal_track_id: 903,
-            title: "Third TIDAL".to_string(),
-            artist_name: None,
-            album_title: None,
-            artwork_url: None,
-            duration_ms: None,
-        });
-    }
 
     let app = api_routes(Arc::new(tokio::sync::RwLock::new(state)));
     let resp = app

--- a/scripts/repowise-sync.ps1
+++ b/scripts/repowise-sync.ps1
@@ -1,0 +1,129 @@
+<#
+.SYNOPSIS
+  Run a repowise wiki update with preflight + post-verify guards.
+
+.DESCRIPTION
+  Defends against the silent-stale regression where `repowise update` falls
+  back to its built-in default model (llama3.2, not pulled here), 404s every
+  page, yet still exits 0 and advances the sync pointer -- leaving a wiki that
+  looks current but was never regenerated.
+
+  Guards:
+    1. Model + provider are read from .repowise/config.yaml (single source of
+       truth) and passed to repowise explicitly, never left to env/defaults.
+    2. Preflight verifies ollama is up and the generation model + embedder
+       alias are actually pulled.
+    3. Post-verify scans the run output and FAILS LOUDLY (non-zero exit, error
+       marker) if any page generation errored, instead of trusting exit 0.
+
+.EXAMPLE
+  scripts\repowise-sync.ps1
+  scripts\repowise-sync.ps1 -Since 5e9dc7ca -CascadeBudget 300 -Reindex
+#>
+[CmdletBinding()]
+param(
+    [string]$Root = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path,
+    [string]$Since,
+    [int]$CascadeBudget,
+    [switch]$Reindex,
+    [switch]$SkipPreflight
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$repoRoot   = (Resolve-Path -LiteralPath $Root).Path
+$repowise   = Join-Path $repoRoot ".repowise"
+$configPath = Join-Path $repowise "config.yaml"
+$errMark    = Join-Path $repowise ".update.error"
+$runLog     = Join-Path $repowise ".update.run.log"
+
+if (-not (Test-Path -LiteralPath $configPath)) {
+    throw "No .repowise/config.yaml at $configPath. Run scripts\repowise-apply-local-config.ps1 first."
+}
+
+# --- single source of truth: model/provider/embedder from config.yaml ---
+$cfg = Get-Content -LiteralPath $configPath
+function Get-CfgValue([string]$key) {
+    $line = $cfg | Where-Object { $_ -match "^\s*$key\s*:" } | Select-Object -First 1
+    if ($line) { ($line -replace "^\s*$key\s*:\s*", "").Trim().Trim('"') } else { $null }
+}
+$provider = Get-CfgValue "provider"; if (-not $provider) { $provider = "ollama" }
+$model    = Get-CfgValue "model";    if (-not $model)    { $model    = "qwen2.5-coder:7b" }
+$embedder = Get-CfgValue "embedder"; if (-not $embedder) { $embedder = "openai" }
+# The openai-compatible endpoint resolves this alias (ollama cp) to the real
+# embedding model; preflight checks the alias is present.
+$embedAlias = "text-embedding-3-small"
+
+Write-Host "Repowise sync: provider=$provider model=$model embedder=$embedder"
+
+function Fail([string]$msg) {
+    $stamp = (Get-Date).ToString("s")
+    Set-Content -LiteralPath $errMark -Value "[$stamp] repowise-sync FAILED: $msg" -Encoding UTF8
+    Write-Error "repowise-sync FAILED: $msg"
+    exit 1
+}
+
+if (Test-Path -LiteralPath $errMark) { Remove-Item -LiteralPath $errMark -Force }
+
+# --- preflight ---
+if (-not $SkipPreflight) {
+    $ollama = (Get-Command "ollama" -ErrorAction SilentlyContinue)
+    $ollamaPath = if ($ollama) { $ollama.Source } else { Join-Path $env:LOCALAPPDATA "Programs\Ollama\ollama.exe" }
+    if ($provider -eq "ollama") {
+        if (-not (Test-Path -LiteralPath $ollamaPath)) { Fail "ollama executable not found ($ollamaPath)" }
+        try {
+            $null = Invoke-WebRequest -Uri "http://localhost:11434/api/tags" -UseBasicParsing -TimeoutSec 5
+        } catch {
+            Fail "ollama not reachable at localhost:11434 -- start it with: ollama serve"
+        }
+        $models = & $ollamaPath list
+        $modelBase = ($model -split ":")[0]
+        if (-not ($models -match [regex]::Escape($modelBase))) {
+            Fail "generation model '$model' not pulled -- run: ollama pull $model"
+        }
+        if (-not ($models -match [regex]::Escape($embedAlias))) {
+            Fail "embedder alias '$embedAlias' missing -- run scripts\repowise-apply-local-config.ps1 to re-create it"
+        }
+    }
+    if (-not (Get-Command "repowise" -ErrorAction SilentlyContinue)) { Fail "repowise CLI not on PATH" }
+    Write-Host "Preflight OK: ollama up, '$model' and '$embedAlias' present."
+}
+
+# --- run update with the model pinned explicitly ---
+$updateArgs = @("update", "--provider", $provider, "--model", $model)
+if ($Since)         { $updateArgs += @("--since", $Since) }
+if ($CascadeBudget) { $updateArgs += @("--cascade-budget", "$CascadeBudget") }
+
+Write-Host "Running: repowise $($updateArgs -join ' ')"
+Push-Location -LiteralPath $repoRoot
+try {
+    & repowise @updateArgs *>&1 | Tee-Object -FilePath $runLog
+    $rc = $LASTEXITCODE
+} finally {
+    Pop-Location
+}
+
+# --- post-verify: do not trust exit 0 ---
+if ($rc -ne 0) { Fail "repowise update exited $rc (see $runLog)" }
+$runText = if (Test-Path $runLog) { Get-Content -LiteralPath $runLog -Raw } else { "" }
+if ($runText -match "(?i)page_generation_failed|not_found_error|model .* not found|error code: 404") {
+    Fail "page generation errored (model/provider problem) -- see $runLog"
+}
+
+Write-Host "Update OK." -ForegroundColor Green
+
+if ($Reindex) {
+    Write-Host "Reindexing embeddings (embedder=$embedder)..."
+    Push-Location -LiteralPath $repoRoot
+    try {
+        & repowise reindex --embedder $embedder *>&1 | Tee-Object -FilePath (Join-Path $repowise ".reindex.run.log")
+        $rrc = $LASTEXITCODE
+    } finally {
+        Pop-Location
+    }
+    if ($rrc -ne 0) { Fail "repowise reindex exited $rrc" }
+    Write-Host "Reindex OK." -ForegroundColor Green
+}
+
+Write-Host "repowise-sync complete." -ForegroundColor Green

--- a/scripts/repowise-sync.ps1
+++ b/scripts/repowise-sync.ps1
@@ -64,6 +64,28 @@ function Fail([string]$msg) {
     exit 1
 }
 
+function Invoke-Repowise([string[]]$rwArgs, [string]$captureLog) {
+    # repowise logs progress to stderr. Under $ErrorActionPreference='Stop' a
+    # 2>&1 merge makes PowerShell raise a terminating NativeCommandError when
+    # the process exits (stderr was non-empty), aborting the script AFTER the
+    # run but BEFORE post-verify -- a silent "looked like it failed" even on a
+    # clean run. Drop to 'Continue' for the native call and key success off
+    # $LASTEXITCODE, which carries the real exit code.
+    $prev = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    Push-Location -LiteralPath $repoRoot
+    try {
+        # Tee to the log, then Out-Null: without discarding the passthrough,
+        # repowise's stdout would leak into the function's output stream and
+        # $rc would become @("...stdout...", exitcode) instead of just the int.
+        & repowise @rwArgs 2>&1 | Tee-Object -FilePath $captureLog | Out-Null
+        return $LASTEXITCODE
+    } finally {
+        Pop-Location
+        $ErrorActionPreference = $prev
+    }
+}
+
 if (Test-Path -LiteralPath $errMark) { Remove-Item -LiteralPath $errMark -Force }
 
 # --- preflight ---
@@ -96,13 +118,7 @@ if ($Since)         { $updateArgs += @("--since", $Since) }
 if ($CascadeBudget) { $updateArgs += @("--cascade-budget", "$CascadeBudget") }
 
 Write-Host "Running: repowise $($updateArgs -join ' ')"
-Push-Location -LiteralPath $repoRoot
-try {
-    & repowise @updateArgs *>&1 | Tee-Object -FilePath $runLog
-    $rc = $LASTEXITCODE
-} finally {
-    Pop-Location
-}
+$rc = Invoke-Repowise $updateArgs $runLog
 
 # --- post-verify: do not trust exit 0 ---
 if ($rc -ne 0) { Fail "repowise update exited $rc (see $runLog)" }
@@ -115,13 +131,7 @@ Write-Host "Update OK." -ForegroundColor Green
 
 if ($Reindex) {
     Write-Host "Reindexing embeddings (embedder=$embedder)..."
-    Push-Location -LiteralPath $repoRoot
-    try {
-        & repowise reindex --embedder $embedder *>&1 | Tee-Object -FilePath (Join-Path $repowise ".reindex.run.log")
-        $rrc = $LASTEXITCODE
-    } finally {
-        Pop-Location
-    }
+    $rrc = Invoke-Repowise @("reindex", "--embedder", $embedder) (Join-Path $repowise ".reindex.run.log")
     if ($rrc -ne 0) { Fail "repowise reindex exited $rrc" }
     Write-Host "Reindex OK." -ForegroundColor Green
 }


### PR DESCRIPTION
Playing a TIDAL mix (or any non-library TIDAL album/playlist) left the queue half-dead: clicking a song did nothing, dragging to reorder did nothing, send-to-top did nothing. The only thing that worked was right-click -> Play now. Turned out all three "play a collection" actions funneled into the legacy in-memory `pending_tidal_mix_queue` deque, which got painted into the snapshot as fake negative-id rows. Since those weren't real queue rows, every mutation hit a row the backend didn't have and silently no-oped.

## What changed

- **Retire the deque.** Mix/album/playlist tracks now persist as real ephemeral queue rows (migration 051). They still stream directly via `tidal_id` and are never imported into the library, so sampling a mix doesn't dump 50 tracks into your collection.
- **Engine swap, not a retune.** The tuned gapless / auto-advance / DJ-lookahead timing is untouched. The only change is where "what's the next track" comes from: a queue-table read (pop/peek/trim helpers in `playback/queue.rs`) instead of the deque. The resolver and GC skip these rows since they carry no `pending_at`.
- **Queue row redesign.** The whole row is one click target now, `draggable` moved to the grip (it was eating clicks on WebView2), and the five hover pills collapsed into a single overflow menu with the duration always visible. Every action still lives in the shared context menu, which gained Move next / Remove for ephemeral rows.

Same fix repairs TIDAL albums and playlists, which had the identical bug.

## Testing

- Frontend: `pnpm check`, `lint`, `test` (561 pass, rewrote 3 contract tests for the new layout), and production `build` all green.
- Rust: `cargo fmt` clean; `playback::player::tests` (108, the module that leans hardest on the `load_queue` change), the mix/ephemeral/playlist/clear/advance route tests, and 5 new `queue.rs` helper tests all pass.
- Caveat: the full `cargo test` suite is network-bound here (integration tests hang on TIDAL/Last.fm without creds), so I ran the affected tests individually rather than the whole suite end to end.

Note: migration 051 adds three columns to `queue` and runs on next server start. The queue is wiped on boot anyway, so there's no data to migrate.
