### PR TITLE
Retry DASH segment fetch on transient CDN hiccups

### DIFF
--- a/noor-server/src/playback/decode/source.rs
+++ b/noor-server/src/playback/decode/source.rs
@@ -171,44 +171,74 @@ impl symphonia::core::io::MediaSource for StreamPipe {
     }
 }
 
+pub(crate) const DASH_SEGMENT_MAX_ATTEMPTS: u32 = 2;
+pub(crate) const DASH_SEGMENT_RETRY_BACKOFF_MS: u64 = 250;
+
 pub(crate) async fn append_stream_bytes(
     http: &reqwest::Client,
     url: &str,
     segment_index: usize,
 ) -> anyhow::Result<Vec<u8>> {
     let segment_label = dash_segment_debug_label(url);
-    tokio::time::timeout(
-        std::time::Duration::from_secs(DASH_SEGMENT_TIMEOUT_SECS),
-        async {
-            let response = http
-                .get(url)
-                .send()
-                .await
-                .with_context(|| {
-                    format!("DASH segment {segment_index} request failed ({segment_label})")
-                })?
-                .error_for_status()
-                .with_context(|| {
-                    format!("DASH segment {segment_index} returned error status ({segment_label})")
-                })?;
-            let content_length = response.content_length().unwrap_or(0) as usize;
-            let mut stream = response.bytes_stream();
-            let mut out = Vec::with_capacity(content_length);
-            while let Some(chunk) = stream.next().await {
-                let bytes = chunk.with_context(|| {
-                    format!("DASH segment {segment_index} chunk error ({segment_label})")
-                })?;
-                out.extend_from_slice(&bytes);
-            }
-            Ok(out)
-        },
-    )
-    .await
-    .with_context(|| {
-        format!(
-            "DASH segment {segment_index} timed out after {DASH_SEGMENT_TIMEOUT_SECS}s ({segment_label})"
+    // A single flaky TIDAL CDN segment (timeout or transient fetch/chunk error)
+    // used to abort the whole DJ profile rebuild / prebuffer. Retry once with a
+    // short backoff before giving up so one hiccup doesn't kill the transition.
+    let mut last_err: Option<anyhow::Error> = None;
+    for attempt in 1..=DASH_SEGMENT_MAX_ATTEMPTS {
+        let attempt_result: anyhow::Result<Vec<u8>> = tokio::time::timeout(
+            Duration::from_secs(DASH_SEGMENT_TIMEOUT_SECS),
+            async {
+                let response = http
+                    .get(url)
+                    .send()
+                    .await
+                    .with_context(|| {
+                        format!("DASH segment {segment_index} request failed ({segment_label})")
+                    })?
+                    .error_for_status()
+                    .with_context(|| {
+                        format!("DASH segment {segment_index} returned error status ({segment_label})")
+                    })?;
+                let content_length = response.content_length().unwrap_or(0) as usize;
+                let mut stream = response.bytes_stream();
+                let mut out = Vec::with_capacity(content_length);
+                while let Some(chunk) = stream.next().await {
+                    let bytes = chunk.with_context(|| {
+                        format!("DASH segment {segment_index} chunk error ({segment_label})")
+                    })?;
+                    out.extend_from_slice(&bytes);
+                }
+                anyhow::Ok(out)
+            },
         )
-    })?
+        .await
+        .map_err(|elapsed| {
+            anyhow::Error::new(elapsed).context(format!(
+                "DASH segment {segment_index} timed out after {DASH_SEGMENT_TIMEOUT_SECS}s ({segment_label})"
+            ))
+        })
+        .and_then(|inner| inner);
+
+        match attempt_result {
+            Ok(bytes) => return Ok(bytes),
+            Err(err) => {
+                if attempt < DASH_SEGMENT_MAX_ATTEMPTS {
+                    tracing::warn!(
+                        segment_index,
+                        segment_label = %segment_label,
+                        attempt,
+                        max_attempts = DASH_SEGMENT_MAX_ATTEMPTS,
+                        backoff_ms = DASH_SEGMENT_RETRY_BACKOFF_MS,
+                        error = %format!("{err:#}"),
+                        "DASH segment fetch failed, retrying"
+                    );
+                    tokio::time::sleep(Duration::from_millis(DASH_SEGMENT_RETRY_BACKOFF_MS)).await;
+                }
+                last_err = Some(err);
+            }
+        }
+    }
+    Err(last_err.expect("retry loop must produce a final error"))
 }
 
 pub(crate) fn dash_initial_media_count(total_segments: usize) -> usize {

--- a/noor-server/src/server/routes/dj_routes.rs
+++ b/noor-server/src/server/routes/dj_routes.rs
@@ -2937,10 +2937,7 @@ mod tests {
                 std::collections::HashMap::new(),
             )),
             embedding_cache: std::sync::Arc::new(std::sync::Mutex::new(None)),
-            master_key: crate::services::crypto::MasterKey::load_or_generate(
-                &std::env::temp_dir().join(format!("noor-test-key-{}", uuid::Uuid::new_v4())),
-            )
-            .expect("test master key"),
+            master_key: crate::services::crypto::MasterKey::ephemeral(),
             pending_tidal_mix_queue: std::sync::Arc::new(std::sync::Mutex::new(
                 std::collections::VecDeque::new(),
             )),

--- a/noor-server/src/server/routes/tests.rs
+++ b/noor-server/src/server/routes/tests.rs
@@ -280,7 +280,7 @@ fn stream_error_mapping_marks_manifest_decode_failures_as_bad_gateway() {
 
 #[tokio::test]
 async fn pause_and_resume_playback_invalidate_inflight_generation() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     let state = Arc::new(tokio::sync::RwLock::new(fresh_test_state(db)));
     let app = api_routes(state.clone());
 
@@ -323,8 +323,6 @@ async fn pause_and_resume_playback_invalidate_inflight_generation() {
         current_playback_generation(&guard)
     };
     assert!(after_resume > after_pause);
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[test]
@@ -797,7 +795,7 @@ fn test_tidal_track(id: i64, title: &str) -> crate::services::tidal::client::Tid
 
 #[test]
 fn insert_tidal_track_uses_favorite_created_as_date_added() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     db.with_conn(|conn| {
         let track = test_tidal_track(2001, "Newest favorite");
 
@@ -812,7 +810,6 @@ fn insert_tidal_track_uses_favorite_created_as_date_added() {
         Ok(())
     })
     .expect("inserted favorite track");
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[test]
@@ -871,8 +868,7 @@ fn extracts_genre_candidates_from_mixed_metadata_shapes() {
 
 #[tokio::test]
 async fn genre_heat_route_defaults_to_ninety_days() {
-    let db_path = std::env::temp_dir().join(format!("noor-genre-heat-{}.db", uuid::Uuid::new_v4()));
-    let db = Database::open(&db_path).expect("db opened");
+    let db = Database::open_in_memory().expect("db opened");
     db.run_migrations().expect("migrations");
     db.with_conn(|conn| {
             schema::run_migrations(conn)?;
@@ -935,8 +931,6 @@ async fn genre_heat_route_defaults_to_ninety_days() {
 
     assert_eq!(electronic["listen_count"], 1);
     assert_eq!(electronic["total_listened_ms"], 180000);
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 /// Build a fresh `AppState` backed by `db`. Single source of truth for test
@@ -1001,10 +995,7 @@ fn fresh_test_state(db: Database) -> crate::AppState {
         radio_similarity_running: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         refreshed_seeds: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         embedding_cache: Arc::new(std::sync::Mutex::new(None)),
-        master_key: crate::services::crypto::MasterKey::load_or_generate(
-            &std::env::temp_dir().join(format!("noor-test-key-{}", uuid::Uuid::new_v4())),
-        )
-        .expect("test master key"),
+        master_key: crate::services::crypto::MasterKey::ephemeral(),
         pending_tidal_mix_queue: Arc::new(std::sync::Mutex::new(std::collections::VecDeque::new())),
         prepared_ephemeral_tidal_next: None,
         lastfm_api_secret: None,
@@ -1021,21 +1012,21 @@ fn fresh_test_state(db: Database) -> crate::AppState {
 
 /// Build a minimal test app backed by a fresh in-memory database.
 async fn build_test_app() -> Router {
-    let db_path = std::env::temp_dir().join(format!("noor-test-{}.db", uuid::Uuid::new_v4()));
-    let db = Database::open(&db_path).expect("db opened");
-    db.run_migrations().expect("migrations");
-    db.with_conn(|conn| schema::run_migrations(conn))
-        .expect("schema migrations");
-    api_routes(Arc::new(tokio::sync::RwLock::new(fresh_test_state(db))))
+    api_routes(Arc::new(tokio::sync::RwLock::new(fresh_test_state(
+        fresh_migrated_db(),
+    ))))
 }
 
-fn fresh_migrated_db() -> (Database, std::path::PathBuf) {
-    let db_path = std::env::temp_dir().join(format!("noor-test-{}.db", uuid::Uuid::new_v4()));
-    let db = Database::open(&db_path).expect("db opened");
+/// A fresh, fully-migrated in-memory database. In-memory keeps the suite off
+/// the filesystem: a temp `.db` + WAL per test (1000+ cases) churns enough I/O
+/// that Windows Defender scanning can stall a normally-instant test past
+/// libtest's 60s warning.
+fn fresh_migrated_db() -> Database {
+    let db = Database::open_in_memory().expect("db opened");
     db.run_migrations().expect("migrations");
     db.with_conn(|conn| schema::run_migrations(conn))
         .expect("schema migrations");
-    (db, db_path)
+    db
 }
 
 fn app_for_db(db: Database) -> Router {
@@ -1044,7 +1035,7 @@ fn app_for_db(db: Database) -> Router {
 
 #[tokio::test]
 async fn tracks_route_treats_key_signature_filter_as_data() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     db.with_conn(|conn| {
         conn.execute("INSERT INTO artists (id, name) VALUES (9001, 'Filter Artist')", [])?;
         conn.execute(
@@ -1098,8 +1089,6 @@ async fn tracks_route_treats_key_signature_filter_as_data() {
         tracks.is_empty(),
         "key_signature must be treated as an exact string, got {tracks:?}"
     );
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 fn seed_dj_queue_pair(db: &Database) -> (i64, i64) {
@@ -1165,17 +1154,16 @@ async fn response_json(response: axum::response::Response) -> Value {
 
 #[tokio::test]
 async fn dj_enabled_defaults_false() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     let response = json_request(app_for_db(db), "GET", "/api/dj/enabled", "").await;
     assert_eq!(response.status(), StatusCode::OK);
     let body = response_json(response).await;
     assert_eq!(body["enabled"], false);
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn dj_enabled_can_be_toggled() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     let app = app_for_db(db);
     let response = json_request(app.clone(), "PUT", "/api/dj/enabled", r#"{"enabled":true}"#).await;
     assert_eq!(response.status(), StatusCode::OK);
@@ -1186,12 +1174,11 @@ async fn dj_enabled_can_be_toggled() {
     assert_eq!(response.status(), StatusCode::OK);
     let body = response_json(response).await;
     assert_eq!(body["enabled"], false);
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn chart_snapshots_return_latest_ranked_entries_without_zero_tidal_id() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     db.with_conn(|conn| {
         conn.execute(
             "INSERT INTO chart_snapshots
@@ -1242,13 +1229,11 @@ async fn chart_snapshots_return_latest_ranked_entries_without_zero_tidal_id() {
     assert_eq!(body["entries"][1]["title"], "Second Track");
     assert_eq!(body["entries"][1]["resolution_status"], "unresolved");
     assert!(body["entries"][1]["tidal_id"].is_null());
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn chart_matrix_returns_provider_cells_and_explicit_missing_cells() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     db.with_conn(|conn| {
         queries::upsert_chart_snapshot(
             conn,
@@ -1380,13 +1365,11 @@ async fn chart_matrix_returns_provider_cells_and_explicit_missing_cells() {
         .expect("AU row");
     assert_eq!(au["cells"]["shazam_daily"]["title"], "AU Shazam");
     assert!(au["cells"]["shazam_daily"]["tidal_id"].is_null());
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn spotify_daily_import_endpoint_persists_snapshot_for_matrix() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     let csv = r#"rank,uri,artist_names,track_name,peak_rank,previous_rank,days_on_chart,streams
 1,spotify:track:imported,"Import Artist","Import Track",1,2,3,12345
 "#;
@@ -1415,13 +1398,11 @@ async fn spotify_daily_import_endpoint_persists_snapshot_for_matrix() {
         .expect("AU row");
     assert_eq!(au["cells"]["spotify_daily"]["title"], "Import Track");
     assert_eq!(au["cells"]["spotify_daily"]["streams"], 12345);
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn dj_enabled_true_starts_current_pair_lookahead() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     let (_current, next) = seed_dj_queue_pair(&db);
     let app = app_for_db(db);
     let response = json_request(app.clone(), "PUT", "/api/dj/enabled", r#"{"enabled":true}"#).await;
@@ -1434,12 +1415,11 @@ async fn dj_enabled_true_starts_current_pair_lookahead() {
     assert_eq!(body["next"]["media_ref_kind"], "tidal_track");
     assert_eq!(body["next"]["media_ref_id"], "77002");
     assert!(next > 0);
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn persisted_dj_enabled_builds_current_pair_lookahead_without_toggle() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     seed_dj_queue_pair(&db);
     db.with_conn(|conn| queries::set_dj_engine_enabled(conn, true))
         .expect("enable dj");
@@ -1461,12 +1441,11 @@ async fn persisted_dj_enabled_builds_current_pair_lookahead_without_toggle() {
             track_id: Some(7002),
         })
     );
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn dj_lookahead_pairs_ephemeral_current_with_persisted_queue() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     db.with_conn(|conn| {
         conn.execute(
             "INSERT INTO artists (id, name) VALUES (7101, 'Queue Artist')",
@@ -1527,12 +1506,11 @@ async fn dj_lookahead_pairs_ephemeral_current_with_persisted_queue() {
             track_id: Some(7102),
         })
     );
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn dj_enabled_false_cancels_lookahead_and_discards_program() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     seed_dj_queue_pair(&db);
     let app = app_for_db(db);
     let response = json_request(app.clone(), "PUT", "/api/dj/enabled", r#"{"enabled":true}"#).await;
@@ -1549,12 +1527,11 @@ async fn dj_enabled_false_cancels_lookahead_and_discards_program() {
     let body = response_json(response).await;
     assert_eq!(body["enabled"], false);
     assert_eq!(body["fallback_reason"], "disabled");
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn dj_profile_rebuild_does_not_claim_accepted_without_job() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     seed_dj_queue_pair(&db);
     let app = app_for_db(db);
     let response = json_request(app.clone(), "PUT", "/api/dj/enabled", r#"{"enabled":true}"#).await;
@@ -1570,12 +1547,11 @@ async fn dj_profile_rebuild_does_not_claim_accepted_without_job() {
     let body = response_json(response).await;
     assert_eq!(body["accepted"], false);
     assert_eq!(body["status"], "source_unavailable");
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn dj_profile_rebuild_does_not_mutate_armed_transition() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     seed_dj_queue_pair(&db);
     db.with_conn(|conn| {
             conn.execute(
@@ -1608,28 +1584,24 @@ async fn dj_profile_rebuild_does_not_mutate_armed_transition() {
         })
         .expect("outcome");
     assert_eq!(outcome, "armed");
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn dj_profile_returns_404_for_missing_profile() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     let response = json_request(app_for_db(db), "GET", "/api/dj/profile/999", "").await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn dj_profile_rejects_non_positive_track_ids() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     let app = app_for_db(db);
 
     for uri in ["/api/dj/profile/0", "/api/dj/profile/-7"] {
         let response = json_request(app.clone(), "GET", uri, "").await;
         assert_eq!(response.status(), StatusCode::BAD_REQUEST, "uri: {uri}");
     }
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 fn seed_spotify_stats_track(
@@ -1700,7 +1672,7 @@ fn background_resolution_batches_are_bounded_by_concurrency() {
 
 #[tokio::test]
 async fn album_spotify_stats_returns_cached_playcounts() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     seed_spotify_stats_track(
         &db,
         Some(9),
@@ -1736,13 +1708,11 @@ async fn album_spotify_stats_returns_cached_playcounts() {
     assert_eq!(tracks[0]["title"], "Album Stats Track");
     assert_eq!(tracks[0]["playcount"], 1_234);
     assert!(body["monthly_listeners"].is_null());
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn artist_spotify_stats_returns_cached_playcounts() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     seed_spotify_stats_track(
         &db,
         None,
@@ -1778,8 +1748,6 @@ async fn artist_spotify_stats_returns_cached_playcounts() {
     assert_eq!(tracks[0]["title"], "Artist Stats Track");
     assert_eq!(tracks[0]["playcount"], 5_678);
     assert!(body["monthly_listeners"].is_null());
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
@@ -1853,7 +1821,7 @@ fn seed_basic_tracks(db: &Database) {
 
 #[tokio::test]
 async fn clear_queue_returns_snapshot_and_preserves_current() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     seed_basic_tracks(&db);
     let current_qid: i64 = db
         .with_conn(|conn| {
@@ -1919,13 +1887,11 @@ async fn clear_queue_returns_snapshot_and_preserves_current() {
         .with_conn(|conn| Ok(conn.query_row("SELECT COUNT(*) FROM queue", [], |row| row.get(0))?))
         .unwrap();
     assert_eq!(persisted_queue_count, 1);
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn clear_queue_preserves_only_current_queue_item_for_duplicate_track() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     seed_basic_tracks(&db);
     let (duplicate_qid, current_qid): (i64, i64) = db
         .with_conn(|conn| {
@@ -1992,13 +1958,11 @@ async fn clear_queue_preserves_only_current_queue_item_for_duplicate_track() {
         })
         .unwrap();
     assert_eq!(persisted_ids, vec![current_qid]);
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn clear_queue_repairs_mismatched_anchor_before_preserving_current() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     seed_basic_tracks(&db);
     let (current_qid, mismatched_qid): (i64, i64) = db
         .with_conn(|conn| {
@@ -2050,13 +2014,11 @@ async fn clear_queue_repairs_mismatched_anchor_before_preserving_current() {
     assert_ne!(queue[0]["id"], mismatched_qid);
     assert_eq!(queue[0]["track"]["id"], 1);
     assert_eq!(body["playback_state"]["current_queue_item_id"], current_qid);
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn clear_queue_falls_back_to_track_id_when_current_queue_item_is_stale() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     seed_basic_tracks(&db);
     let stale_qid = 999_999_i64;
     let preserved_qid = db
@@ -2129,13 +2091,11 @@ async fn clear_queue_falls_back_to_track_id_when_current_queue_item_is_stale() {
         .unwrap();
     assert_eq!(persisted_track_ids, vec![1]);
     assert_eq!(current_queue_item_id, Some(preserved_qid));
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn clear_queue_repairs_missing_anchor_and_removes_duplicate_track_rows() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     seed_basic_tracks(&db);
     let (first_qid, duplicate_qid): (i64, i64) = db
         .with_conn(|conn| {
@@ -2202,13 +2162,11 @@ async fn clear_queue_repairs_missing_anchor_and_removes_duplicate_track_rows() {
         })
         .unwrap();
     assert_eq!(persisted_ids, vec![first_qid]);
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn remove_current_queue_item_advances_and_switches_runtime() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     seed_basic_tracks(&db);
     let (current_qid, next_qid) = db
         .with_conn(|conn| {
@@ -2342,13 +2300,11 @@ async fn remove_current_queue_item_advances_and_switches_runtime() {
     assert_eq!(current_track_id, Some(2));
     assert_eq!(current_queue_item_id, Some(next_qid));
     assert!(is_playing);
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn remove_current_queue_item_repairs_stale_anchor_and_returns_playback_state() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     seed_basic_tracks(&db);
     let stale_qid = 999_999_i64;
     let (current_qid, next_qid) = db
@@ -2418,13 +2374,11 @@ async fn remove_current_queue_item_repairs_stale_anchor_and_returns_playback_sta
     assert_eq!(current_track_id, Some(2));
     assert_eq!(current_queue_item_id, Some(next_qid));
     assert!(!is_playing);
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn remove_current_queue_item_repairs_mismatched_anchor_and_returns_playback_state() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     seed_basic_tracks(&db);
     let (current_qid, next_qid) = db
         .with_conn(|conn| {
@@ -2478,13 +2432,11 @@ async fn remove_current_queue_item_repairs_mismatched_anchor_and_returns_playbac
     assert_eq!(body["playback_state"]["current_track"]["id"], 2);
     assert_eq!(body["playback_state"]["current_queue_item_id"], next_qid);
     assert_eq!(body["playback_state"]["is_playing"], false);
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn move_queue_item_repairs_stale_current_anchor_and_returns_playback_state() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     seed_basic_tracks(&db);
     let stale_qid = 999_999_i64;
     let (current_qid, next_qid) = db
@@ -2550,13 +2502,11 @@ async fn move_queue_item_repairs_stale_current_anchor_and_returns_playback_state
         })
         .unwrap();
     assert_eq!(current_queue_item_id, Some(current_qid));
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn move_queue_item_repairs_mismatched_current_anchor_and_returns_playback_state() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     seed_basic_tracks(&db);
     let (current_qid, mismatched_qid) = db
         .with_conn(|conn| {
@@ -2621,13 +2571,11 @@ async fn move_queue_item_repairs_mismatched_current_anchor_and_returns_playback_
         })
         .unwrap();
     assert_eq!(current_queue_item_id, Some(current_qid));
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn playback_shuffle_returns_debug_and_persists_seed() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     seed_basic_tracks(&db);
     db.with_conn(|conn| {
         conn.execute(
@@ -2681,13 +2629,11 @@ async fn playback_shuffle_returns_debug_and_persists_seed() {
         })
         .unwrap();
     assert_eq!(stored_seed, Some(seed));
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn replace_playback_queue_accepts_one_shot_shuffle_mode() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     seed_basic_tracks(&db);
 
     let app = api_routes(Arc::new(tokio::sync::RwLock::new(fresh_test_state(
@@ -2715,8 +2661,6 @@ async fn replace_playback_queue_accepts_one_shot_shuffle_mode() {
     assert_eq!(body["queue"].as_array().expect("queue").len(), 2);
     assert_eq!(body["shuffle_debug"]["mode"], "true");
     assert_eq!(body["shuffle_debug"]["scope"], "queue_replace");
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[test]
@@ -2792,7 +2736,7 @@ async fn genre_snapshot_route_returns_galaxy_payload() {
 
 #[tokio::test]
 async fn discovery_space_includes_resolved_sidecar_external_neighbors() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     db.with_conn(|conn| {
         conn.execute(
             "INSERT INTO artists (id, name) VALUES (1, 'Seed Artist')",
@@ -2909,13 +2853,11 @@ async fn discovery_space_includes_resolved_sidecar_external_neighbors() {
             .iter()
             .any(|edge| { edge["from_track_id"] == 1 && edge["to_track_id"] == 990_001 })
     );
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn discovery_blend_space_includes_pending_external_nodes_and_health() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     db.with_conn(|conn| {
         conn.execute(
             "INSERT INTO artists (id, name) VALUES (1, 'Seed Artist')",
@@ -3026,13 +2968,11 @@ async fn discovery_blend_space_includes_pending_external_nodes_and_health() {
     assert_eq!(body["health"]["pending_external_count"], 1);
     assert_eq!(body["health"]["playable_external_count"], 1);
     assert!(body["health"]["coverage_ratio"].as_f64().unwrap() > 0.0);
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn discovery_blend_space_uses_external_seed_anchors() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     db.with_conn(|conn| {
         conn.execute(
             "INSERT INTO artists (id, name) VALUES (1, 'Guide Artist')",
@@ -3176,13 +3116,11 @@ async fn discovery_blend_space_uses_external_seed_anchors() {
     );
     assert_eq!(body["health"]["playable_external_count"], 1);
     assert!(body["health"]["coverage_ratio"].as_f64().unwrap() > 0.0);
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn discovery_blend_add_appends_discoveries_without_replacing_queue() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     db.with_conn(|conn| {
         conn.execute(
             "INSERT INTO artists (id, name) VALUES (1, 'Seed Artist')",
@@ -3270,13 +3208,11 @@ async fn discovery_blend_add_appends_discoveries_without_replacing_queue() {
         Ok(())
     })
     .unwrap();
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn tidal_mix_overlay_preserves_pending_deque_order() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     db.with_conn(|conn| {
         conn.execute(
             "INSERT INTO artists (id, name) VALUES (8101, 'Old Playlist Artist')",
@@ -3378,13 +3314,11 @@ async fn tidal_mix_overlay_preserves_pending_deque_order() {
         snapshot.queue.iter().all(|item| item.source == "tidal_mix"),
         "active TIDAL mix overlay must shadow the stale durable playlist queue"
     );
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn tidal_mix_overlay_preserves_large_loaded_album_rows() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     db.with_conn(|conn| {
         conn.execute(
             "INSERT INTO artists (id, name) VALUES (8301, 'Unrelated Playlist Artist')",
@@ -3485,13 +3419,11 @@ async fn tidal_mix_overlay_preserves_large_loaded_album_rows() {
             .all(|item| !item.track.title.starts_with("Unrelated Queue")),
         "active TIDAL album overlay must not leak stale durable queue rows"
     );
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn tidal_mix_replacement_clears_stale_persisted_queue() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     db.with_conn(|conn| {
         conn.execute(
             "INSERT INTO artists (id, name) VALUES (8200, 'Old Queue Artist')",
@@ -3552,13 +3484,11 @@ async fn tidal_mix_replacement_clears_stale_persisted_queue() {
         1,
         "durable queue cleanup must preserve the active TIDAL continuation"
     );
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn clear_queue_clears_pending_tidal_mix_overlay() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     let state = Arc::new(tokio::sync::RwLock::new(fresh_test_state(db)));
     {
         let guard = state.read().await;
@@ -3619,13 +3549,11 @@ async fn clear_queue_clears_pending_tidal_mix_overlay() {
             .is_empty(),
         "pending TIDAL mix deque must be cleared"
     );
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn direct_tidal_finish_advances_persisted_queue_and_switches_runtime() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     db.with_conn(|conn| {
         conn.execute(
             "INSERT INTO artists (id, name) VALUES (8100, 'Queued Artist')",
@@ -3769,13 +3697,11 @@ async fn direct_tidal_finish_advances_persisted_queue_and_switches_runtime() {
             .and_then(|info| info.active_track_id),
         Some(8101)
     );
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn runtime_finish_skips_unresolved_pending_row_and_starts_next_library_track() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     let (current_qid, next_qid) = db
         .with_conn(|conn| {
             conn.execute(
@@ -3901,13 +3827,11 @@ async fn runtime_finish_skips_unresolved_pending_row_and_starts_next_library_tra
     assert_eq!(current_track_id, Some(8202));
     assert_eq!(current_queue_item_id, Some(next_qid));
     assert!(is_playing);
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn runtime_finish_adopts_pending_row_resolved_by_background_resolver() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     let (current_qid, pending_qid) = db
         .with_conn(|conn| {
             conn.execute(
@@ -4056,13 +3980,11 @@ async fn runtime_finish_adopts_pending_row_resolved_by_background_resolver() {
         .unwrap();
     assert_eq!(current_track_id, Some(8303));
     assert_eq!(current_queue_item_id, Some(pending_qid));
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn manual_previous_skips_unresolved_pending_rows_to_prior_library_track() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     let (previous_qid, current_qid) = db
         .with_conn(|conn| {
             conn.execute(
@@ -4131,13 +4053,11 @@ async fn manual_previous_skips_unresolved_pending_rows_to_prior_library_track() 
     );
     assert_eq!(snapshot.state.current_queue_item_id, Some(previous_qid));
     assert!(snapshot.state.is_playing);
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn manual_previous_stops_when_pending_rows_cannot_move_back() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     let current_qid = db
         .with_conn(|conn| {
             conn.execute(
@@ -4183,13 +4103,11 @@ async fn manual_previous_stops_when_pending_rows_cannot_move_back() {
     assert!(snapshot.state.current_track.is_none());
     assert_eq!(snapshot.state.current_queue_item_id, None);
     assert!(!snapshot.state.is_playing);
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn prepared_runtime_track_error_keeps_current_playback_running() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     seed_basic_tracks(&db);
     let current_qid: i64 = db
         .with_conn(|conn| {
@@ -4247,13 +4165,11 @@ async fn prepared_runtime_track_error_keeps_current_playback_running() {
     let info = guard.playback_runtime_info.as_ref().expect("runtime info");
     assert_eq!(info.active_track_id, Some(1));
     assert_eq!(info.last_error.as_deref(), Some("prebuffer decode failed"));
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn runtime_track_error_advances_to_next_library_track() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     seed_basic_tracks(&db);
     let (current_qid, next_qid) = db
         .with_conn(|conn| {
@@ -4364,13 +4280,11 @@ async fn runtime_track_error_advances_to_next_library_track() {
     assert_eq!(current_track_id, Some(2));
     assert_eq!(current_queue_item_id, Some(next_qid));
     assert!(is_playing);
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn disabling_exclusive_clears_runtime_engaged_state() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     db.with_conn(|conn| {
         let mut settings = crate::db::audio_settings::AudioSettings::default();
         settings.exclusive_mode = true;
@@ -4448,8 +4362,6 @@ async fn disabling_exclusive_clears_runtime_engaged_state() {
 
     assert_eq!(body["runtime"]["exclusive_engaged"], false);
     assert_eq!(body["runtime"]["exclusive_transport_format"], Value::Null);
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[test]
@@ -4552,7 +4464,7 @@ fn shared_sample_rate_follow_skips_prebuffer_on_rate_change() {
 
 #[tokio::test]
 async fn queue_append_library_track_returns_updated_queue() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     seed_basic_tracks(&db);
     let app = api_routes(Arc::new(tokio::sync::RwLock::new(fresh_test_state(
         db.clone(),
@@ -4593,13 +4505,11 @@ async fn queue_append_library_track_returns_updated_queue() {
         })
         .unwrap();
     assert_eq!(source, "user_queue");
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn queue_play_next_tidal_inserts_pending_row_after_current_with_hint() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     seed_basic_tracks(&db);
     let current_qid: i64 = db
         .with_conn(|conn| {
@@ -4690,13 +4600,11 @@ async fn queue_play_next_tidal_inserts_pending_row_after_current_with_hint() {
         })
         .unwrap();
     assert_eq!(shifted_pos, 2);
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn queue_play_next_uses_current_queue_item_for_duplicate_track() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     seed_basic_tracks(&db);
     let (duplicate_qid, current_qid, tail_qid): (i64, i64, i64) = db
         .with_conn(|conn| {
@@ -4767,13 +4675,11 @@ async fn queue_play_next_uses_current_queue_item_for_duplicate_track() {
     assert_eq!(rows[2].2.as_deref(), Some("Exact Current Next"));
     assert_eq!(rows[3], (tail_qid, Some(2), None));
     assert_eq!(current_queue_item_id, Some(current_qid));
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn queue_play_next_repairs_stale_anchor_before_insert() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     seed_basic_tracks(&db);
     let stale_qid = 999_999_i64;
     let (repaired_qid, duplicate_qid, tail_qid): (i64, i64, i64) = db
@@ -4845,13 +4751,11 @@ async fn queue_play_next_repairs_stale_anchor_before_insert() {
     assert_eq!(rows[2], (duplicate_qid, Some(1), None));
     assert_eq!(rows[3], (tail_qid, Some(2), None));
     assert_eq!(current_queue_item_id, Some(repaired_qid));
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn queue_play_next_repairs_mismatched_anchor_before_insert() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     seed_basic_tracks(&db);
     let (repaired_qid, mismatched_qid): (i64, i64) = db
         .with_conn(|conn| {
@@ -4916,13 +4820,11 @@ async fn queue_play_next_repairs_mismatched_anchor_before_insert() {
     assert_eq!(rows[1].2.as_deref(), Some("Repaired Mismatch Next"));
     assert_eq!(rows[2], (mismatched_qid, Some(2), None));
     assert_eq!(current_queue_item_id, Some(repaired_qid));
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn queue_play_next_many_preserves_requested_order() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     seed_basic_tracks(&db);
     db.with_conn(|conn| {
         conn.execute(
@@ -4996,13 +4898,11 @@ async fn queue_play_next_many_preserves_requested_order() {
             (2, "Second external".to_string(), Some(102)),
         ]
     );
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn queue_play_next_many_repairs_missing_anchor_and_preserves_order() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     seed_basic_tracks(&db);
     let (repaired_qid, duplicate_qid, tail_qid): (i64, i64, i64) = db
         .with_conn(|conn| {
@@ -5078,13 +4978,11 @@ async fn queue_play_next_many_repairs_missing_anchor_and_preserves_order() {
     assert_eq!(rows[3], (duplicate_qid, Some(1), None));
     assert_eq!(rows[4], (tail_qid, Some(2), None));
     assert_eq!(current_queue_item_id, Some(repaired_qid));
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn queue_append_external_track_creates_pending_row_without_hint() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     let app = api_routes(Arc::new(tokio::sync::RwLock::new(fresh_test_state(
         db.clone(),
     ))));
@@ -5125,13 +5023,11 @@ async fn queue_append_external_track_creates_pending_row_without_hint() {
         })
         .unwrap();
     assert_eq!(hint, None);
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn create_playlist_from_queue_imports_pending_tidal_rows_with_hint() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     db.with_conn(|conn| {
             conn.execute(
                 "INSERT INTO queue (
@@ -5185,13 +5081,11 @@ async fn create_playlist_from_queue_imports_pending_tidal_rows_with_hint() {
         })
         .unwrap();
     assert_eq!(saved, vec![(777, "Queued TIDAL".to_string())]);
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn create_playlist_from_queue_imports_ephemeral_tidal_overlay() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     let mut state = fresh_test_state(db.clone());
     let mut current = test_track(-901, "Current TIDAL");
     current.tidal_id = Some(901);
@@ -5266,14 +5160,11 @@ async fn create_playlist_from_queue_imports_ephemeral_tidal_overlay() {
             (903, "Third TIDAL".to_string())
         ]
     );
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn promote_pending_row_emit_broadcasts_queue_updated() {
-    let db_path = std::env::temp_dir().join(format!("noor-test-{}.db", uuid::Uuid::new_v4()));
-    let db = Database::open(&db_path).expect("db opened");
+    let db = Database::open_in_memory().expect("db opened");
     db.run_migrations().expect("migrations");
     db.with_conn(|conn| schema::run_migrations(conn))
         .expect("schema migrations");
@@ -5341,14 +5232,11 @@ async fn promote_pending_row_emit_broadcasts_queue_updated() {
         no_more.is_err(),
         "no second event should fire on idempotent retry"
     );
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn promote_pending_row_emit_marks_external_candidate_resolved() {
-    let db_path = std::env::temp_dir().join(format!("noor-test-{}.db", uuid::Uuid::new_v4()));
-    let db = Database::open(&db_path).expect("db opened");
+    let db = Database::open_in_memory().expect("db opened");
     db.run_migrations().expect("migrations");
     db.with_conn(|conn| schema::run_migrations(conn))
         .expect("schema migrations");
@@ -5404,8 +5292,6 @@ async fn promote_pending_row_emit_marks_external_candidate_resolved() {
         })
         .unwrap();
     assert_eq!(resolved, Some(1));
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[test]
@@ -5865,7 +5751,7 @@ async fn library_batch_routes_reject_impossible_ids_before_work() {
 
 #[tokio::test]
 async fn library_batch_set_genre_returns_not_found_for_missing_positive_genre() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     let app = api_routes(Arc::new(tokio::sync::RwLock::new(fresh_test_state(
         db.clone(),
     ))));
@@ -5908,13 +5794,11 @@ async fn library_batch_set_genre_returns_not_found_for_missing_positive_genre() 
         })
         .expect("count track genres");
     assert_eq!(assigned, 0, "missing genre must not assign tracks");
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn library_batch_add_to_playlist_returns_not_found_before_tidal_auth() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     let app = api_routes(Arc::new(tokio::sync::RwLock::new(fresh_test_state(
         db.clone(),
     ))));
@@ -5946,13 +5830,11 @@ async fn library_batch_add_to_playlist_returns_not_found_before_tidal_auth() {
         .unwrap();
 
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn library_batch_add_to_playlist_rejects_local_targets_before_tidal_auth() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     let app = api_routes(Arc::new(tokio::sync::RwLock::new(fresh_test_state(
         db.clone(),
     ))));
@@ -6000,13 +5882,11 @@ async fn library_batch_add_to_playlist_rejects_local_targets_before_tidal_auth()
         })
         .expect("count playlist tracks");
     assert_eq!(added, 0, "invalid local target must not mutate playlist");
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn library_batch_delete_removes_local_only_items_without_tidal_session() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     let app = api_routes(Arc::new(tokio::sync::RwLock::new(fresh_test_state(
         db.clone(),
     ))));
@@ -6064,13 +5944,11 @@ async fn library_batch_delete_removes_local_only_items_without_tidal_session() {
         remaining_albums, 0,
         "local-only delete must remove local album row"
     );
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn library_batch_delete_tidal_backed_track_without_session_keeps_local_row() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     let app = api_routes(Arc::new(tokio::sync::RwLock::new(fresh_test_state(
         db.clone(),
     ))));
@@ -6113,8 +5991,6 @@ async fn library_batch_delete_tidal_backed_track_without_session_keeps_local_row
         })
         .expect("count track");
     assert_eq!(remaining, 1, "failed remote delete must keep local row");
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
@@ -6489,7 +6365,7 @@ async fn sync_routes_reject_invalid_services() {
 
 #[tokio::test]
 async fn sync_routes_trim_tidal_service_before_mutation() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     let app = api_routes(Arc::new(tokio::sync::RwLock::new(fresh_test_state(
         db.clone(),
     ))));
@@ -6521,13 +6397,11 @@ async fn sync_routes_trim_tidal_service_before_mutation() {
         auto_sync_daily,
         "trimmed tidal service must update tidal row"
     );
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn discovery_training_rejects_unknown_mode_before_engine_work() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     crate::services::learning::set_discovery_engine(
         &db,
         crate::services::learning::DiscoveryEngine::V1,
@@ -6550,13 +6424,11 @@ async fn discovery_training_rejects_unknown_mode_before_engine_work() {
         .unwrap();
 
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn discovery_training_settings_reject_unknown_values_without_mutation() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     crate::services::learning::set_discovery_intensity(
         &db,
         crate::services::learning::DiscoveryIntensity::Max,
@@ -6615,13 +6487,11 @@ async fn discovery_training_settings_reject_unknown_values_without_mutation() {
         crate::services::learning::load_discovery_training_safety_profile(&db),
         crate::services::learning::DiscoveryTrainingSafetyProfile::Performance
     );
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
 async fn discovery_training_valid_settings_still_persist() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     let app = api_routes(Arc::new(tokio::sync::RwLock::new(fresh_test_state(
         db.clone(),
     ))));
@@ -6662,8 +6532,6 @@ async fn discovery_training_valid_settings_still_persist() {
         crate::services::learning::load_discovery_training_safety_profile(&db),
         crate::services::learning::DiscoveryTrainingSafetyProfile::LaptopSafe
     );
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
@@ -6707,7 +6575,7 @@ async fn discovery_request_routes_reject_unknown_modes_before_work() {
 
 #[tokio::test]
 async fn discovery_preset_valid_mode_still_persists() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     let app = api_routes(Arc::new(tokio::sync::RwLock::new(fresh_test_state(
         db.clone(),
     ))));
@@ -6737,8 +6605,6 @@ async fn discovery_preset_valid_mode_still_persists() {
         })
         .expect("load discovery preset mode");
     assert_eq!(saved_mode, "word-cloud");
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 // Characterization tests for TIDAL-handler failure shapes. These differ on
@@ -6749,7 +6615,7 @@ async fn discovery_preset_valid_mode_still_persists() {
 
 #[tokio::test]
 async fn get_album_tracks_returns_local_tracks_when_tidal_session_absent() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     // The album MUST have a tidal_id, otherwise the handler returns at
     // routes.rs:977 with album_tidal_id: null - which is a different code
     // path. To exercise the "no TIDAL session" branch (routes.rs:995) we
@@ -6810,8 +6676,6 @@ async fn get_album_tracks_returns_local_tracks_when_tidal_session_absent() {
         body["album_tidal_id"], 8888,
         "album_tidal_id must survive even when session is absent"
     );
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
@@ -7053,7 +6917,7 @@ async fn tidal_video_playback_positive_id_still_requires_session() {
 
 #[tokio::test]
 async fn tidal_track_import_rejects_non_positive_tidal_ids_without_db_insert() {
-    let (db, db_path) = fresh_migrated_db();
+    let db = fresh_migrated_db();
     let app = api_routes(Arc::new(tokio::sync::RwLock::new(fresh_test_state(
         db.clone(),
     ))));
@@ -7109,8 +6973,6 @@ async fn tidal_track_import_rejects_non_positive_tidal_ids_without_db_insert() {
         })
         .expect("count tracks");
     assert_eq!(count, 0, "invalid imports must not create track rows");
-
-    let _ = std::fs::remove_file(db_path);
 }
 
 #[tokio::test]
@@ -7184,7 +7046,7 @@ async fn tidal_track_import_rejects_invalid_metadata_without_db_insert() {
     ];
 
     for (case, body) in invalid_cases {
-        let (db, db_path) = fresh_migrated_db();
+        let db = fresh_migrated_db();
         let app = api_routes(Arc::new(tokio::sync::RwLock::new(fresh_test_state(
             db.clone(),
         ))));
@@ -7215,8 +7077,6 @@ async fn tidal_track_import_rejects_invalid_metadata_without_db_insert() {
         assert_eq!(track_count, 0, "{case} must not create track rows");
         assert_eq!(artist_count, 0, "{case} must not create artist rows");
         assert_eq!(album_count, 0, "{case} must not create album rows");
-
-        let _ = std::fs::remove_file(db_path);
     }
 }
 

--- a/noor-server/src/services/crypto.rs
+++ b/noor-server/src/services/crypto.rs
@@ -77,6 +77,20 @@ impl MasterKey {
         })
     }
 
+    /// Build a throwaway key from random bytes without touching disk. Tests use
+    /// this so a 1000+ test suite doesn't write a `.noor_secret` file per case:
+    /// under Windows Defender scanning, that temp-file churn intermittently
+    /// stalls a test past libtest's 60s warning threshold.
+    #[cfg(test)]
+    pub fn ephemeral() -> Self {
+        let mut buf = [0u8; 32];
+        OsRng.fill_bytes(&mut buf);
+        let key = Key::<Aes256Gcm>::from_slice(&buf);
+        Self {
+            cipher: Arc::new(Aes256Gcm::new(key)),
+        }
+    }
+
     /// Encrypt arbitrary bytes. Output layout: `nonce(12) || ciphertext+tag`.
     pub fn encrypt(&self, plaintext: &[u8]) -> Result<Vec<u8>> {
         let nonce = Aes256Gcm::generate_nonce(&mut OsRng);


### PR DESCRIPTION
While cleaning up old branches I found this fix stranded on a branch that never merged (it was made on top of an old base, so it never came forward). Master's `append_stream_bytes` is a single-attempt fetch: if one TIDAL CDN segment times out or returns a transient error mid-prebuffer, the whole DJ profile rebuild aborts and the transition falls back to a plain crossfade.

This re-applies the retry onto master's current function: one retry with a 250ms backoff on a timeout or transient fetch/chunk error before giving up. Timing and the per-segment timeout are unchanged; this only adds a second chance on failure.

Small and self-contained - one function in `decode/source.rs`. Compiles clean (`cargo check`). No behavior change on the happy path; only a flaky segment is affected.

Credit where due: the original fix was written earlier and just didn't make it into a release - this is a faithful forward-port, not new work.
