### PR TITLE
ci: add per-job timeout-minutes to PR checks

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   rust-fmt:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -27,6 +28,7 @@ jobs:
 
   rust-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -57,6 +59,7 @@ jobs:
 
   rust-clippy:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     continue-on-error: true
     steps:
       - name: Checkout
@@ -88,6 +91,7 @@ jobs:
 
   frontend:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
@@ -138,6 +142,7 @@ jobs:
 
   promo-showcase:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:


### PR DESCRIPTION
## What

Adds `timeout-minutes` to every job in `pr-check.yml`:

| Job | Timeout |
|-----|---------|
| `rust-test` | 20m |
| `rust-clippy` | 20m |
| `rust-fmt` | 10m |
| `frontend` | 15m |
| `promo-showcase` | 10m |

## Why

The `rust-test` job (`cargo test --workspace --locked`) had no timeout. When a test deadlocked recently (a re-entrant `Mutex<Connection>` lock in the DJ lookahead path on another branch), the job didn't fail - it just sat there running toward GitHub's default 6-hour job cap, burning Actions minutes and leaving the PR stuck in a "check started, never finishes" state.

A per-job timeout turns that failure mode loud and fast: a genuine hang now fails in minutes instead of hours.

## Notes

- Values are generous headroom over a normal cold-cache run (clippy currently takes ~3m, the test suite ~1-2m after compile), so this won't bite healthy runs.
- `rust-clippy` keeps its existing `continue-on-error: true`; the timeout just bounds how long it can hang.
- YAML validated locally.
