### PR TITLE
Video: keep audio playing across nav + fix exclusive-mode silence

### DIFF
--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -200,3 +200,17 @@ proxy with an on-disk cache (sibling to `noor.db`) + redirect-to-CDN fallback wo
 it deterministic, but the benefit is uncertain. Only build it if artwork is observably
 re-downloading every launch (check WebView2 devtools network on a cold start first).
 - Spawned by: app-speed pass on branch `fix/tidal-mix-real-queue-rows`
+
+## Video persistent mini-player: autoplay tail + position sync
+Two minor edges deferred from the persistent-video-dock work (branch `feat/app-speed-instant-paint`):
+- Off-route autoplay stops at the end of the already-loaded video queue. The route's
+  old `handleVideoEnded` called `loadMore()` to page in more search results before
+  advancing; the dock's `advanceVideo` does not (the route owns pagination and may be
+  unmounted). On `/videos` this is a small regression vs. before; off-route it just stops
+  at the loaded tail. Fix: have the dock signal the route (a `videoNeedMore` writable)
+  to `loadMore()` then re-advance when mounted.
+- `videoSession.positionMs` is stored but not wired to the player's `timeupdate`. The
+  element never unmounts so position is preserved for free; positionMs is only needed if
+  we want to show elapsed time in the mini-player or the snapshot. Wire an `onTime` prop
+  on VideoPlayer if that UI is wanted.
+- Spawned by: persistent video mini-player + WASAPI exclusive-release pass.

--- a/frontend/scripts/video-session-snapshot-contract.test.mjs
+++ b/frontend/scripts/video-session-snapshot-contract.test.mjs
@@ -12,15 +12,17 @@ describe('video session snapshot behavior', () => {
 	});
 
 	test('direct video sessions are not persisted without URL context', () => {
-		expect(source).toContain("videoSessionSource() !== 'direct'");
-		expect(source).toContain('if (selectedVideo && videoSessionSource() !==');
+		// A direct video (no search query, no active mix) has no restorable browse
+		// context, so it is not snapshotted.
+		expect(source).toContain('if (selectedVideo && (lastQuery || activeMixId)) saveSessionSnapshot();');
+		expect(source).toContain('else clearSessionSnapshot();');
 	});
 
-	test('clear request resets selected video, stream state, snapshot, and URL', () => {
+	test('clear request resets the video session, snapshot, and URL', () => {
 		expect(source).toContain('function clearVideoPageSession');
-		expect(source).toContain('selectedVideo = null');
-		expect(source).toContain('streamUrl = null');
-		expect(source).toContain('streamExpiresAt = null');
+		// Playback state lives in the dock/store now, so clearing routes through
+		// the controller rather than nulling local stream fields.
+		expect(source).toContain('clearVideoSession();');
 		expect(source).toContain('clearSessionSnapshot();');
 		expect(source).toContain("void goto('/videos', { replaceState: true, keepFocus: true });");
 		expect(source).toContain('clearVideoPageSession();');

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -3269,6 +3269,15 @@ export const api = {
 		});
 	},
 
+	/** Ask the server to drop the WASAPI exclusive device so the WebView can
+	 *  play a video's audio in shared mode. No-op when exclusive mode is off.
+	 *  Swallows failures: video startup must never block on it. */
+	releaseExclusivePlayback() {
+		return fetchApi<{ ok: boolean }>('/api/playback/exclusive/release', undefined, {
+			method: 'POST',
+		}).catch(() => ({ ok: false }));
+	},
+
 	previousTrack() {
 		return fetchApi<PlaybackSnapshot>('/api/playback/previous', undefined, {
 			method: 'POST',

--- a/frontend/src/lib/components/tidal/tidal_editorial_page_contract.test.ts
+++ b/frontend/src/lib/components/tidal/tidal_editorial_page_contract.test.ts
@@ -41,7 +41,7 @@ describe('TIDAL editorial page routes', () => {
 
 	test('does not replace existing genres or videos workflows', () => {
 		expect(routeSource('genres')).toContain('GenreGalaxy');
-		expect(routeSource('videos')).toContain('VideoPlayer');
+		expect(routeSource('videos')).toContain('VideoCard');
 		expect(routeSource('genres')).toContain('href="/tidal/genres"');
 		expect(routeSource('videos')).toContain('href="/tidal/videos"');
 	});

--- a/frontend/src/lib/components/video/VideoDock.svelte
+++ b/frontend/src/lib/components/video/VideoDock.svelte
@@ -1,0 +1,230 @@
+<script lang="ts">
+	import { onDestroy } from 'svelte';
+	import { goto } from '$app/navigation';
+	import { page } from '$app/state';
+	import { api } from '$lib/api/client';
+	import VideoPlayer from '$lib/components/video/VideoPlayer.svelte';
+	import { audioSettings } from '$lib/stores/audio_settings';
+	import { isPlaying } from '$lib/stores/player';
+	import {
+		advanceVideo,
+		clearVideoSession,
+		refreshVideoStream,
+		videoSession,
+		videoSessionUpcoming,
+		videoStageAnchor,
+		type PreloadedVideoStream,
+	} from '$lib/stores/video_session';
+
+	// The dock renders a single VideoPlayer that never unmounts while a session
+	// is active, so audio keeps playing across route changes. On /videos it is
+	// positioned over the route's placeholder (full); elsewhere it docks into
+	// the corner as a small moving thumbnail (mini).
+	let onVideosRoute = $derived(page.url.pathname.startsWith('/videos'));
+	let active = $derived($videoSession.active && Boolean($videoSession.streamUrl));
+	let mode = $derived(onVideosRoute ? 'full' : 'mini');
+
+	let qualityMode = $derived($audioSettings.settings?.video_quality_mode ?? 'MAX');
+	let upNext = $derived($videoSessionUpcoming[0] ?? null);
+	let hasNext = $derived($videoSessionUpcoming.length > 0);
+
+	// ─── Full-mode rect tracking ─────────────────────────────────────────────
+	let rect = $state<{ top: number; left: number; width: number; height: number } | null>(null);
+	let rafId = 0;
+
+	function trackAnchor() {
+		const anchor = $videoStageAnchor;
+		if (active && mode === 'full' && anchor) {
+			const r = anchor.getBoundingClientRect();
+			rect = { top: r.top, left: r.left, width: r.width, height: r.height };
+		} else if (rect !== null) {
+			rect = null;
+		}
+		rafId = requestAnimationFrame(trackAnchor);
+	}
+	rafId = requestAnimationFrame(trackAnchor);
+
+	// ─── Prefetch the next stream for gapless autoplay ───────────────────────
+	let prefetched = $state<PreloadedVideoStream & { videoId: number } | null>(null);
+	let prefetchSeq = 0;
+
+	$effect(() => {
+		const next = upNext;
+		const autoplay = $videoSession.autoplay;
+		if (!autoplay || !next) {
+			prefetchSeq += 1;
+			prefetched = null;
+			return;
+		}
+		if (prefetched?.videoId === next.tidal_id) return;
+		const seq = ++prefetchSeq;
+		void api
+			.getTidalVideoStream(next.tidal_id)
+			.then((stream) => {
+				if (seq !== prefetchSeq) return;
+				prefetched = { videoId: next.tidal_id, url: stream.hls_url, expiresAt: stream.expires_at };
+			})
+			.catch(() => {
+				if (seq === prefetchSeq) prefetched = null;
+			});
+	});
+
+	// ─── Music takes the device back: starting music stops the video ─────────
+	let wasPlayingAudio = $isPlaying;
+	$effect(() => {
+		const nowPlaying = $isPlaying;
+		if (nowPlaying && !wasPlayingAudio && $videoSession.active) {
+			clearVideoSession();
+		}
+		wasPlayingAudio = nowPlaying;
+	});
+
+	async function handleEnded() {
+		const preloaded = prefetched?.videoId === upNext?.tidal_id ? prefetched : null;
+		const advanced = await advanceVideo({ preloaded });
+		if (!advanced) videoSession.setAutoplay(false);
+	}
+
+	function handlePlay() {
+		// Free the WASAPI exclusive endpoint so the WebView can output the
+		// video's audio in shared mode. No-op server-side when exclusive is off.
+		void api.releaseExclusivePlayback();
+	}
+
+	function toggleAutoplay() {
+		videoSession.setAutoplay(!$videoSession.autoplay);
+	}
+
+	function returnToVideos() {
+		void goto('/videos');
+	}
+
+	function closeDock() {
+		clearVideoSession();
+	}
+
+	onDestroy(() => {
+		if (rafId) cancelAnimationFrame(rafId);
+	});
+</script>
+
+{#if active}
+	<div
+		class="video-dock"
+		class:mini={mode === 'mini'}
+		class:full={mode === 'full'}
+		class:positioned={mode === 'full' && rect !== null}
+		style:top={mode === 'full' && rect ? `${rect.top}px` : null}
+		style:left={mode === 'full' && rect ? `${rect.left}px` : null}
+		style:width={mode === 'full' && rect ? `${rect.width}px` : null}
+		style:height={mode === 'full' && rect ? `${rect.height}px` : null}
+	>
+		<VideoPlayer
+			src={$videoSession.streamUrl!}
+			poster={$videoSession.current?.artwork_url}
+			title={$videoSession.current?.title ?? 'Video'}
+			artist={$videoSession.current?.artist_name ?? null}
+			qualityMode={qualityMode}
+			variant={mode === 'mini' ? 'mini' : 'full'}
+			autoplayNext={$videoSession.autoplay}
+			hasNext={hasNext}
+			upNextTitle={upNext?.title ?? null}
+			upNextArtist={upNext?.artist_name ?? null}
+			onEnded={handleEnded}
+			onToggleAutoplay={toggleAutoplay}
+			onPlay={handlePlay}
+			refreshStream={refreshVideoStream}
+		/>
+
+		{#if mode === 'mini'}
+			<div class="mini-chrome">
+				<button type="button" class="mini-btn" title="Back to videos" onclick={returnToVideos}>⤢</button>
+				<button type="button" class="mini-btn" title="Close video" onclick={closeDock}>✕</button>
+			</div>
+		{/if}
+	</div>
+{/if}
+
+<style>
+	.video-dock {
+		z-index: 60;
+	}
+
+	/* Full mode: a fixed box copied each frame onto the route's placeholder rect,
+	   so it reads as inline while actually persisting across navigation. Hidden
+	   until the first rect lands to avoid a flash at (0,0). */
+	.video-dock.full {
+		position: fixed;
+		opacity: 0;
+		pointer-events: none;
+	}
+
+	.video-dock.full.positioned {
+		opacity: 1;
+		pointer-events: auto;
+	}
+
+	/* Mini mode: small docked moving thumbnail in the bottom-right corner. */
+	.video-dock.mini {
+		position: fixed;
+		right: 18px;
+		bottom: calc(18px + var(--safe-bottom, 0px));
+		width: clamp(248px, 24vw, 340px);
+		aspect-ratio: 16 / 9;
+		border-radius: 10px;
+		overflow: hidden;
+		box-shadow: 0 18px 50px rgba(0, 0, 0, 0.5);
+		border: 1px solid rgba(255, 255, 255, 0.12);
+		animation: dock-in 0.22s ease both;
+	}
+
+	.mini-chrome {
+		position: absolute;
+		top: 6px;
+		right: 6px;
+		z-index: 3;
+		display: flex;
+		gap: 5px;
+		opacity: 0;
+		transition: opacity 0.16s ease;
+	}
+
+	.video-dock.mini:hover .mini-chrome {
+		opacity: 1;
+	}
+
+	.mini-btn {
+		width: 26px;
+		height: 26px;
+		border-radius: 999px;
+		display: grid;
+		place-items: center;
+		background: rgba(10, 10, 14, 0.72);
+		color: rgba(255, 255, 255, 0.92);
+		border: 1px solid rgba(255, 255, 255, 0.16);
+		font-size: var(--font-size-xs);
+	}
+
+	.mini-btn:hover {
+		background: rgba(20, 20, 26, 0.92);
+	}
+
+	@keyframes dock-in {
+		from {
+			opacity: 0;
+			transform: translateY(14px) scale(0.96);
+		}
+		to {
+			opacity: 1;
+			transform: translateY(0) scale(1);
+		}
+	}
+
+	@media (max-width: 720px) {
+		.video-dock.mini {
+			right: 10px;
+			bottom: calc(76px + var(--safe-bottom, 0px));
+			width: min(64vw, 240px);
+		}
+	}
+</style>

--- a/frontend/src/lib/components/video/VideoPlayer.svelte
+++ b/frontend/src/lib/components/video/VideoPlayer.svelte
@@ -16,8 +16,10 @@
 		hasNext?: boolean;
 		upNextTitle?: string | null;
 		upNextArtist?: string | null;
+		variant?: 'full' | 'mini';
 		onEnded?: () => void;
 		onToggleAutoplay?: () => void;
+		onPlay?: () => void;
 		refreshStream?: () => Promise<string>;
 	};
 
@@ -32,8 +34,10 @@
 		hasNext = false,
 		upNextTitle = null,
 		upNextArtist = null,
+		variant = 'full',
 		onEnded,
 		onToggleAutoplay,
+		onPlay,
 		refreshStream,
 	}: Props = $props();
 
@@ -370,6 +374,7 @@
 	bind:this={container}
 	class="video-player"
 	class:fullscreen
+	class:mini={variant === 'mini'}
 	class:chrome-hidden={fullscreen && !chromeVisible && playing}
 	role="button"
 	aria-label="Video player"
@@ -388,6 +393,7 @@
 		onplay={() => {
 			playing = true;
 			void pauseAudioPlayback();
+			onPlay?.();
 		}}
 		onpause={() => (playing = false)}
 		onended={() => {
@@ -504,6 +510,32 @@
 		overflow: hidden;
 		background: #030305;
 		outline: none;
+	}
+
+	/* Mini (docked) variant: fill the dock's fixed box, no tall floor, tighter
+	   chrome so the small corner player stays usable. */
+	.video-player.mini {
+		min-height: 0;
+		height: 100%;
+		border-radius: 10px;
+	}
+
+	.video-player.mini .top-meta {
+		padding: 8px 10px 24px;
+	}
+
+	.video-player.mini .controls {
+		grid-template-columns: 32px 1fr;
+		gap: 6px;
+		padding: 22px 8px 8px;
+	}
+
+	.video-player.mini .time,
+	.video-player.mini .volume,
+	.video-player.mini .quality,
+	.video-player.mini .autoplay-pill,
+	.video-player.mini .icon-btn:not(.primary) {
+		display: none;
 	}
 
 	video {

--- a/frontend/src/lib/components/video/video_dock_contract.test.ts
+++ b/frontend/src/lib/components/video/video_dock_contract.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, test } from 'vitest';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const dock = readFileSync(join(here, 'VideoDock.svelte'), 'utf8');
+const store = readFileSync(join(here, '../../stores/video_session.ts'), 'utf8');
+const client = readFileSync(join(here, '../../api/client.ts'), 'utf8');
+const layout = readFileSync(join(here, '../../../routes/+layout.svelte'), 'utf8');
+
+describe('persistent video dock contract', () => {
+	test('renders a single persistent player mounted from the layout', () => {
+		// Exactly one VideoPlayer instance, and it lives in the dock (not the
+		// route) so navigation never unmounts the <video> and audio keeps going.
+		expect((dock.match(/<VideoPlayer/g) ?? []).length).toBe(1);
+		expect(layout).toContain('<VideoDock />');
+	});
+
+	test('docks into the route placeholder when on /videos, corner thumbnail off it', () => {
+		expect(dock).toContain("page.url.pathname.startsWith('/videos')");
+		expect(dock).toContain('videoStageAnchor');
+		expect(dock).toContain('getBoundingClientRect()');
+		expect(dock).toContain("class:mini={mode === 'mini'}");
+	});
+
+	test('frees the exclusive device when a video starts playing', () => {
+		expect(dock).toContain('api.releaseExclusivePlayback()');
+		expect(client).toContain("'/api/playback/exclusive/release'");
+	});
+
+	test('starting music stops the video session', () => {
+		expect(dock).toContain('$isPlaying');
+		expect(dock).toContain('clearVideoSession()');
+	});
+
+	test('controller owns the stream lifecycle in the store', () => {
+		for (const fn of ['export async function playVideo', 'export async function advanceVideo', 'export async function refreshVideoStream', 'export function clearVideoSession']) {
+			expect(store).toContain(fn);
+		}
+		// Stream URL persists in the store so the dock can keep playing it.
+		expect(store).toContain('streamUrl: string | null;');
+	});
+});

--- a/frontend/src/lib/stores/video_session.ts
+++ b/frontend/src/lib/stores/video_session.ts
@@ -1,4 +1,5 @@
-import { derived, writable } from 'svelte/store';
+import { derived, get, writable } from 'svelte/store';
+import { api } from '$lib/api/client';
 import type { TidalSearchVideo, TidalVideoMixItem } from '$lib/api/client';
 
 export type VideoSessionItem = TidalSearchVideo | TidalVideoMixItem;
@@ -14,16 +15,40 @@ export interface VideoSessionState {
 	autoplay: boolean;
 	loading: boolean;
 	error: string | null;
+	/** HLS stream URL for `current`. Lives in the store so the persistent dock
+	 *  can keep playing across route changes without the route owning it. */
+	streamUrl: string | null;
+	streamExpiresAt: string | null;
+	playing: boolean;
+	/** Last reported playback position, kept so returning to /videos resumes
+	 *  the picture in sync with the audio that never stopped. */
+	positionMs: number;
 }
 
-interface VideoSessionSyncInput {
-	current: VideoSessionItem | null;
+/** Browse context the route hands to the controller when it starts a video:
+ *  the queue to autoplay through and how it was sourced. */
+export interface VideoPlayContext {
 	queue: VideoSessionItem[];
 	source: VideoSessionSource;
 	sourceLabel: string | null;
-	autoplay: boolean;
-	loading: boolean;
-	error: string | null;
+	autoplay?: boolean;
+}
+
+export interface PreloadedVideoStream {
+	url: string;
+	expiresAt: string | null;
+}
+
+const AUTOPLAY_KEY = 'noor_video_autoplay_next';
+
+function loadAutoplayPreference(): boolean {
+	if (typeof localStorage === 'undefined') return false;
+	return localStorage.getItem(AUTOPLAY_KEY) === 'true';
+}
+
+function persistAutoplayPreference(autoplay: boolean) {
+	if (typeof localStorage === 'undefined') return;
+	localStorage.setItem(AUTOPLAY_KEY, String(autoplay));
 }
 
 const initialState: VideoSessionState = {
@@ -33,9 +58,13 @@ const initialState: VideoSessionState = {
 	currentIndex: -1,
 	source: 'none',
 	sourceLabel: null,
-	autoplay: false,
+	autoplay: loadAutoplayPreference(),
 	loading: false,
 	error: null,
+	streamUrl: null,
+	streamExpiresAt: null,
+	playing: false,
+	positionMs: 0,
 };
 
 function findCurrentIndex(queue: VideoSessionItem[], current: VideoSessionItem | null): number {
@@ -45,24 +74,34 @@ function findCurrentIndex(queue: VideoSessionItem[], current: VideoSessionItem |
 
 const session = writable<VideoSessionState>(initialState);
 
+function update(patch: Partial<VideoSessionState>) {
+	session.update((state) => {
+		const next = { ...state, ...patch };
+		next.currentIndex = findCurrentIndex(next.queue, next.current);
+		next.active = next.current !== null;
+		return next;
+	});
+}
+
 export const videoSession = {
 	subscribe: session.subscribe,
-	sync(input: VideoSessionSyncInput) {
-		const currentIndex = findCurrentIndex(input.queue, input.current);
-		session.set({
-			active: input.current !== null,
-			current: input.current,
-			queue: input.queue,
-			currentIndex,
-			source: input.source,
-			sourceLabel: input.sourceLabel,
-			autoplay: input.autoplay,
-			loading: input.loading,
-			error: input.error,
-		});
+	/** Refresh the autoplay queue + source attribution without touching the
+	 *  currently-playing video (called as the route's search results change). */
+	setContext(ctx: { queue: VideoSessionItem[]; source: VideoSessionSource; sourceLabel: string | null }) {
+		update({ queue: ctx.queue, source: ctx.source, sourceLabel: ctx.sourceLabel });
+	},
+	setAutoplay(autoplay: boolean) {
+		persistAutoplayPreference(autoplay);
+		update({ autoplay });
+	},
+	setPlaying(playing: boolean) {
+		update({ playing });
+	},
+	setPosition(positionMs: number) {
+		update({ positionMs });
 	},
 	reset() {
-		session.set(initialState);
+		session.set({ ...initialState, autoplay: loadAutoplayPreference() });
 	},
 };
 
@@ -70,6 +109,102 @@ export const videoSessionUpcoming = derived(session, ($session) => {
 	if ($session.currentIndex < 0) return $session.queue;
 	return $session.queue.slice($session.currentIndex + 1);
 });
+
+// ─── Controller: owns the stream lifecycle so playback survives navigation ───
+
+let streamSeq = 0;
+
+function sourceFor(item: VideoSessionItem, ctx: VideoPlayContext): VideoSessionSource {
+	if (ctx.source !== 'none') return ctx.source;
+	if ('mix_id' in item && item.mix_id != null) return 'mix';
+	return 'direct';
+}
+
+/** Start (or switch to) a video: set it current, fetch its HLS stream, and let
+ *  the persistent dock render it. Returns false if the request was superseded
+ *  or the stream failed. */
+export async function playVideo(
+	item: VideoSessionItem,
+	ctx: VideoPlayContext,
+	opts: { preloaded?: PreloadedVideoStream | null } = {}
+): Promise<boolean> {
+	const seq = ++streamSeq;
+	update({
+		current: item,
+		queue: ctx.queue,
+		source: sourceFor(item, ctx),
+		sourceLabel: ctx.sourceLabel,
+		autoplay: ctx.autoplay ?? get(session).autoplay,
+		loading: true,
+		error: null,
+		streamUrl: opts.preloaded?.url ?? null,
+		streamExpiresAt: opts.preloaded?.expiresAt ?? null,
+		positionMs: 0,
+	});
+
+	try {
+		let url = opts.preloaded?.url ?? null;
+		let expiresAt = opts.preloaded?.expiresAt ?? null;
+		if (!url) {
+			const stream = await api.getTidalVideoStream(item.tidal_id);
+			if (seq !== streamSeq) return false;
+			url = stream.hls_url;
+			expiresAt = stream.expires_at;
+		}
+		if (seq !== streamSeq) return false;
+		update({ streamUrl: url, streamExpiresAt: expiresAt, loading: false, error: null });
+		return true;
+	} catch (err) {
+		if (seq !== streamSeq) return false;
+		const message = err instanceof Error ? err.message : 'This video could not be loaded.';
+		update({ loading: false, error: message });
+		return false;
+	}
+}
+
+/** Re-fetch the current video's stream (expiry / network recovery). */
+export async function refreshVideoStream(): Promise<string> {
+	const current = get(session).current;
+	if (!current) throw new Error('No video selected.');
+	const seq = ++streamSeq;
+	const stream = await api.getTidalVideoStream(current.tidal_id);
+	if (seq !== streamSeq) throw Object.assign(new Error('Stream request superseded.'), { name: 'StaleStreamRequest' });
+	update({ streamUrl: stream.hls_url, streamExpiresAt: stream.expires_at });
+	return stream.hls_url;
+}
+
+/** Advance to the next queued video when autoplay is on. Returns false at the
+ *  end of the loaded queue (the route tops the queue up while it's mounted). */
+export async function advanceVideo(opts: { preloaded?: PreloadedVideoStream | null } = {}): Promise<boolean> {
+	const state = get(session);
+	if (!state.autoplay) return false;
+	const index = findCurrentIndex(state.queue, state.current);
+	if (index < 0) return false;
+	const next = state.queue[index + 1];
+	if (!next) {
+		update({ playing: false });
+		return false;
+	}
+	return playVideo(next, {
+		queue: state.queue,
+		source: state.source,
+		sourceLabel: state.sourceLabel,
+		autoplay: true,
+	}, opts);
+}
+
+/** Stop the video session entirely and free the dock. */
+export function clearVideoSession() {
+	streamSeq += 1;
+	session.set({ ...initialState, autoplay: loadAutoplayPreference() });
+}
+
+// ─── Cross-component requests (dispatched from layout, served by the dock) ───
+
+/** The /videos route's in-page placeholder. The persistent dock copies this
+ *  element's rect each frame so the live player appears docked into the hero
+ *  while actually being a fixed element that never unmounts on navigation. */
+export const videoStageAnchor = writable<HTMLElement | null>(null);
 
 export const videoJumpRequest = writable<{ videoId: number; nonce: number } | null>(null);
 export const videoAutoplayToggleRequest = writable(0);

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -104,6 +104,7 @@
 		videoSession,
 		videoSessionUpcoming,
 	} from '$lib/stores/video_session';
+	import VideoDock from '$lib/components/video/VideoDock.svelte';
 
 	let { children } = $props();
 
@@ -1319,6 +1320,8 @@
 	<main class="workspace">
 		{@render children()}
 	</main>
+
+	<VideoDock />
 
 	{#if videoChromeActive}
 		<aside class="now-playing-panel video-queue-panel" aria-label="Video queue">

--- a/frontend/src/routes/videos/+page.svelte
+++ b/frontend/src/routes/videos/+page.svelte
@@ -2,7 +2,6 @@
 	import { onDestroy, onMount } from 'svelte';
 	import { goto } from '$app/navigation';
 	import { api, ApiError, type TidalSearchVideo, type TidalVideoMixItem } from '$lib/api/client';
-	import VideoPlayer from '$lib/components/video/VideoPlayer.svelte';
 	import VideoCard from '$lib/components/video/VideoCard.svelte';
 	import EmptyState from '$lib/components/ui/EmptyState.svelte';
 	import Skeleton from '$lib/components/ui/Skeleton.svelte';
@@ -17,12 +16,15 @@
 		videoAutoplayToggleRequest,
 		videoJumpRequest,
 		videoSession,
+		videoStageAnchor,
+		playVideo,
+		clearVideoSession,
+		type VideoSessionItem,
 		type VideoSessionSource,
 	} from '$lib/stores/video_session';
 
 	const PAGE_SIZE = 40;
 	const RECENT_KEY = 'noor_recent_video_searches';
-	const AUTOPLAY_KEY = 'noor_video_autoplay_next';
 	const SESSION_SNAPSHOT_KEY = 'noor_video_session_snapshot';
 	const RECENT_MAX = 8;
 	const HINTS = ['music video', 'live session', 'official video', 'visualizer'];
@@ -74,22 +76,12 @@
 		);
 	}
 
-	type PrefetchedVideoStream = {
-		videoId: number;
-		hlsUrl: string;
-		expiresAt: string | null;
-	};
-
 	let query = $state('');
 	let inputEl = $state<HTMLInputElement | null>(null);
 	let videos = $state<TidalSearchVideo[]>([]);
 	let mixItems = $state<TidalVideoMixItem[]>([]);
-	let selectedVideo = $state<TidalSearchVideo | TidalVideoMixItem | null>(null);
-	let streamUrl = $state<string | null>(null);
-	let streamExpiresAt = $state<string | null>(null);
 	let loadingSearch = $state(false);
 	let loadingMore = $state(false);
-	let loadingStream = $state(false);
 	let loadingMix = $state(false);
 	let error = $state<string | null>(null);
 	let mixError = $state<string | null>(null);
@@ -99,27 +91,25 @@
 	let activeMixId = $state<string | null>(null);
 	let sentinel = $state<HTMLDivElement | null>(null);
 	let recent = $state<string[]>(loadRecent());
-	let autoplayNext = $state(loadAutoplayPreference());
+	let stageAnchor = $state<HTMLDivElement | null>(null);
 	let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 	let searchAbort: AbortController | null = null;
 	let loadMoreSeq = 0;
 	let mixLoadSeq = 0;
-	let streamRequestSeq = 0;
-	let prefetchRequestSeq = 0;
-	let prefetchedStream = $state<PrefetchedVideoStream | null>(null);
 	let handledJumpNonce = 0;
 	let handledAutoplayToggleNonce = 0;
 	let handledClearNonce = 0;
 
+	// The playing video lives in the persistent dock + store; the route reads it
+	// for hero meta and card highlighting, and writes picks via playVideo().
+	let selectedVideo = $derived($videoSession.current);
+	let streamUrl = $derived($videoSession.streamUrl);
+	let streamExpiresAt = $derived($videoSession.streamExpiresAt);
+	let loadingStream = $derived($videoSession.loading);
+	let autoplayNext = $derived($videoSession.autoplay);
+
 	let heroTitle = $derived(selectedVideo?.title ?? 'TIDAL video');
 	let heroArtist = $derived(selectedVideo?.artist_name ?? null);
-	let videoQualityMode = $derived($audioSettings.settings?.video_quality_mode ?? 'MAX');
-	let nextAutoplayVideo = $derived.by(() => getNextAutoplayVideo());
-	let hasAutoplayNext = $derived.by(() => {
-		const queue = activeVideoQueue();
-		const index = selectedQueueIndex(queue);
-		return index >= 0 && (nextAutoplayVideo !== null || (queue === videos && hasMore));
-	});
 	let hasVideoChoices = $derived(videos.length > 0 || mixItems.length > 0);
 	let showChooseVideoPrompt = $derived(
 		!selectedVideo &&
@@ -140,16 +130,6 @@
 		}
 	}
 
-	function loadAutoplayPreference(): boolean {
-		if (typeof localStorage === 'undefined') return false;
-		return localStorage.getItem(AUTOPLAY_KEY) === 'true';
-	}
-
-	function persistAutoplayPreference() {
-		if (typeof localStorage === 'undefined') return;
-		localStorage.setItem(AUTOPLAY_KEY, String(autoplayNext));
-	}
-
 	function pushRecent(value: string) {
 		const trimmed = value.trim();
 		if (!trimmed || typeof localStorage === 'undefined') return;
@@ -165,10 +145,6 @@
 	function clearVideoPageSession() {
 		videos = [];
 		mixItems = [];
-		selectedVideo = null;
-		streamUrl = null;
-		streamExpiresAt = null;
-		loadingStream = false;
 		query = '';
 		lastQuery = '';
 		activeMixId = null;
@@ -176,13 +152,10 @@
 		offset = 0;
 		error = null;
 		mixError = null;
-		prefetchedStream = null;
 		loadMoreSeq += 1;
 		mixLoadSeq += 1;
-		streamRequestSeq += 1;
-		prefetchRequestSeq += 1;
 		clearSessionSnapshot();
-		videoSession.reset();
+		clearVideoSession();
 		void goto('/videos', { replaceState: true, keepFocus: true });
 	}
 
@@ -269,71 +242,41 @@
 		}
 	}
 
-	async function fetchStream(videoId: number): Promise<string> {
-		if (!assertOnline()) throw new Error('Server is reconnecting.');
-		const seq = ++streamRequestSeq;
-		const stream = await api.getTidalVideoStream(videoId);
-		if (seq !== streamRequestSeq) {
-			const stale = new Error('Route changed before video loaded.');
-			stale.name = 'StaleStreamRequest';
-			throw stale;
-		}
-		streamUrl = stream.hls_url;
-		streamExpiresAt = stream.expires_at;
-		return stream.hls_url;
+	function buildPlayContext(video: VideoSessionItem) {
+		const isMix = 'mix_id' in video && video.mix_id != null;
+		return {
+			queue: isMix ? mixItems : videos,
+			source: (isMix ? 'mix' : lastQuery ? 'search' : 'direct') as VideoSessionSource,
+			sourceLabel: isMix
+				? activeMixId
+					? `Video mix ${activeMixId}`
+					: 'Video mix'
+				: lastQuery || null,
+			autoplay: $videoSession.autoplay,
+		};
 	}
 
-	async function selectVideo(
-		video: TidalSearchVideo | TidalVideoMixItem,
-		updateUrl = true,
-		options: { keepCurrentStream?: boolean; preloaded?: PrefetchedVideoStream | null } = {}
-	): Promise<boolean> {
-		const previousVideo = selectedVideo;
-		const previousStreamUrl = streamUrl;
-		const previousExpiresAt = streamExpiresAt;
-		selectedVideo = video;
-		if (!options.keepCurrentStream) streamUrl = null;
-		streamExpiresAt = null;
-		error = null;
-		loadingStream = true;
-		try {
-			if (options.preloaded?.videoId === video.tidal_id) {
-				streamRequestSeq += 1;
-				streamUrl = options.preloaded.hlsUrl;
-				streamExpiresAt = options.preloaded.expiresAt;
-				prefetchedStream = null;
-			} else {
-				await fetchStream(video.tidal_id);
-			}
-			if (updateUrl) {
-				const params = new URLSearchParams();
-				if ('mix_id' in video && video.mix_id) {
-					params.set('mixId', String(video.mix_id));
-				} else if (lastQuery) {
-					params.set('q', lastQuery);
-				}
-				params.set('videoId', String(video.tidal_id));
-				void goto(`/videos?${params.toString()}`, { keepFocus: true });
-			}
-			return true;
-		} catch (err) {
-			if ((err as Error)?.name === 'StaleStreamRequest') return false;
-			if (options.keepCurrentStream) {
-				selectedVideo = previousVideo;
-				streamUrl = previousStreamUrl;
-				streamExpiresAt = previousExpiresAt;
-			}
-			error = normalizeError(err, 'This video could not be loaded.');
-			showToast(error, 'error', 3200);
+	async function selectVideo(video: VideoSessionItem, updateUrl = true): Promise<boolean> {
+		if (!assertOnline()) {
+			showToast('Server is reconnecting.', 'error', 3200);
 			return false;
-		} finally {
-			loadingStream = false;
 		}
-	}
-
-	async function refreshSelectedStream() {
-		if (!selectedVideo) throw new Error('No video selected.');
-		return fetchStream(selectedVideo.tidal_id);
+		const ok = await playVideo(video, buildPlayContext(video));
+		if (!ok) {
+			showToast($videoSession.error ?? 'This video could not be loaded.', 'error', 3200);
+			return false;
+		}
+		if (updateUrl) {
+			const params = new URLSearchParams();
+			if ('mix_id' in video && video.mix_id) {
+				params.set('mixId', String(video.mix_id));
+			} else if (lastQuery) {
+				params.set('q', lastQuery);
+			}
+			params.set('videoId', String(video.tidal_id));
+			void goto(`/videos?${params.toString()}`, { keepFocus: true });
+		}
+		return true;
 	}
 
 	async function loadMix(mixId: string, autoPlayFirst = false) {
@@ -351,8 +294,7 @@
 			mixItems = result.items.map((item) => ({ ...item, mix_id: mixId }));
 			if (mixItems.length === 0) mixError = 'This mix did not return video items.';
 			if (autoPlayFirst && isCurrentMixLoad() && mixItems.length > 0) {
-				autoplayNext = true;
-				persistAutoplayPreference();
+				videoSession.setAutoplay(true);
 				await selectVideo(mixItems[0], false);
 			}
 		} catch (err) {
@@ -374,98 +316,12 @@
 		void selectVideo(video);
 	}
 
-	function activeVideoQueue(): (TidalSearchVideo | TidalVideoMixItem)[] {
-		if (selectedVideo && 'mix_id' in selectedVideo && selectedVideo.mix_id != null) return mixItems;
-		return videos;
-	}
-
-	function selectedQueueIndex(queue: (TidalSearchVideo | TidalVideoMixItem)[]): number {
-		if (!selectedVideo) return -1;
-		return queue.findIndex((item) => item.tidal_id === selectedVideo?.tidal_id);
-	}
-
-	function getNextAutoplayVideo(): TidalSearchVideo | TidalVideoMixItem | null {
-		const queue = activeVideoQueue();
-		const index = selectedQueueIndex(queue);
-		if (index < 0) return null;
-		return queue[index + 1] ?? null;
-	}
-
-	function videoSessionSource(): VideoSessionSource {
-		if (selectedVideo && 'mix_id' in selectedVideo && selectedVideo.mix_id != null) return 'mix';
-		if (lastQuery) return 'search';
-		if (selectedVideo) return 'direct';
-		return activeMixId ? 'mix' : 'none';
-	}
-
-	function videoSessionSourceLabel(): string | null {
-		const source = videoSessionSource();
-		if (source === 'mix') return activeMixId ? `Video mix ${activeMixId}` : 'Video mix';
-		if (source === 'search') return lastQuery;
-		if (source === 'direct') return 'Direct video';
-		return null;
-	}
-
-	function findVideoInCurrentContext(videoId: number): TidalSearchVideo | TidalVideoMixItem | null {
+	function findVideoInCurrentContext(videoId: number): VideoSessionItem | null {
 		return [...mixItems, ...videos].find((item) => item.tidal_id === videoId) ?? null;
 	}
 
 	function toggleVideoAutoplay() {
-		if (!autoplayNext && !hasAutoplayNext) {
-			showToast('Choose a video from search results or a video mix first.', 'info', 2400);
-			return;
-		}
-		autoplayNext = !autoplayNext;
-		persistAutoplayPreference();
-	}
-
-	async function prefetchNextStream(video: TidalSearchVideo | TidalVideoMixItem) {
-		if (prefetchedStream?.videoId === video.tidal_id) return;
-		if (!assertOnline()) return;
-		const seq = ++prefetchRequestSeq;
-		try {
-			const stream = await api.getTidalVideoStream(video.tidal_id);
-			if (seq !== prefetchRequestSeq || nextAutoplayVideo?.tidal_id !== video.tidal_id) return;
-			prefetchedStream = {
-				videoId: video.tidal_id,
-				hlsUrl: stream.hls_url,
-				expiresAt: stream.expires_at,
-			};
-		} catch {
-			if (seq === prefetchRequestSeq) prefetchedStream = null;
-		}
-	}
-
-	async function handleVideoEnded() {
-		if (!autoplayNext) return;
-		let queue = activeVideoQueue();
-		let index = selectedQueueIndex(queue);
-		if (index < 0) {
-			autoplayNext = false;
-			persistAutoplayPreference();
-			return;
-		}
-
-		if (index >= queue.length - 1 && queue === videos && hasMore) {
-			await loadMore();
-			queue = activeVideoQueue();
-			index = selectedQueueIndex(queue);
-		}
-
-		const next = queue[index + 1];
-		if (!next) {
-			showToast('End of video results.', 'info', 2200);
-			autoplayNext = false;
-			persistAutoplayPreference();
-			return;
-		}
-
-		const preloaded = prefetchedStream?.videoId === next.tidal_id ? prefetchedStream : null;
-		const loaded = await selectVideo(next, true, { keepCurrentStream: true, preloaded });
-		if (!loaded) {
-			autoplayNext = false;
-			persistAutoplayPreference();
-		}
+		videoSession.setAutoplay(!$videoSession.autoplay);
 	}
 
 	async function parseUrl() {
@@ -515,7 +371,6 @@
 		if (!hasExplicitParams) {
 			const snap = loadSessionSnapshot();
 			if (snap?.selectedVideo && snapshotHasRestorableContext(snap)) {
-				selectedVideo = snap.selectedVideo;
 				videos = snap.videos ?? [];
 				mixItems = snap.mixItems ?? [];
 				query = snap.query ?? '';
@@ -524,16 +379,10 @@
 				hasMore = snap.hasMore ?? false;
 				offset = snap.offset ?? 0;
 
-				const streamFresh =
-					snap.streamUrl &&
-					snap.streamExpiresAt &&
-					new Date(snap.streamExpiresAt).getTime() > Date.now() + 30_000;
-				if (streamFresh) {
-					streamUrl = snap.streamUrl;
-					streamExpiresAt = snap.streamExpiresAt;
-				} else {
-					void selectVideo(snap.selectedVideo, false);
-				}
+				// The dock unmounted on full reload, so rehydrate playback through
+				// the store (re-fetches a fresh stream rather than trusting a
+				// possibly-expired snapshot URL).
+				if (!$videoSession.active) void selectVideo(snap.selectedVideo, false);
 
 				const onPop = () => void parseUrl();
 				window.addEventListener('popstate', onPop);
@@ -557,26 +406,17 @@
 		return () => observer.disconnect();
 	});
 
+	// Hand the route's hero placeholder to the persistent dock so it can dock
+	// the live player into it while on /videos.
 	$effect(() => {
-		if (!autoplayNext || !nextAutoplayVideo) {
-			prefetchRequestSeq += 1;
-			prefetchedStream = null;
-			return;
-		}
-		void prefetchNextStream(nextAutoplayVideo);
+		videoStageAnchor.set(stageAnchor);
+		return () => videoStageAnchor.set(null);
 	});
 
+	// Snapshot for full-page reload recovery (in-app nav is handled by the
+	// persistent dock, which never unmounts).
 	$effect(() => {
-		videoSession.sync({
-			current: selectedVideo,
-			queue: activeVideoQueue(),
-			source: videoSessionSource(),
-			sourceLabel: videoSessionSourceLabel(),
-			autoplay: autoplayNext,
-			loading: loadingSearch || loadingMore || loadingStream || loadingMix,
-			error: error ?? mixError,
-		});
-		if (selectedVideo && videoSessionSource() !== 'direct') saveSessionSnapshot();
+		if (selectedVideo && (lastQuery || activeMixId)) saveSessionSnapshot();
 		else clearSessionSnapshot();
 	});
 
@@ -607,8 +447,6 @@
 		if (debounceTimer) clearTimeout(debounceTimer);
 		searchAbort?.abort();
 		mixLoadSeq += 1;
-		streamRequestSeq += 1;
-		prefetchRequestSeq += 1;
 	});
 </script>
 
@@ -630,29 +468,19 @@
 	{#if showVideoHero}
 	<section class="hero glass-panel" class:hero--prompt={showChooseVideoPrompt}>
 		<div class="player-shell">
-			{#if loadingStream && !streamUrl}
-				<Skeleton rows={4} label="Loading video" />
-			{:else if streamUrl}
-				<VideoPlayer
-					src={streamUrl}
-					poster={selectedVideo?.artwork_url}
-					title={heroTitle}
-					artist={heroArtist}
-					qualityMode={videoQualityMode}
-					autoplayNext={autoplayNext}
-					hasNext={hasAutoplayNext}
-					upNextTitle={nextAutoplayVideo?.title ?? null}
-					upNextArtist={nextAutoplayVideo?.artist_name ?? null}
-					onToggleAutoplay={toggleVideoAutoplay}
-					onEnded={handleVideoEnded}
-					refreshStream={refreshSelectedStream}
-				/>
-			{:else if showChooseVideoPrompt}
-				<div class="video-choice-prompt" aria-live="polite">
-					<strong>Choose a video</strong>
-					<span>Select any result to start playback.</span>
-				</div>
-			{/if}
+			<!-- Placeholder the persistent dock positions its live player over while
+			     on /videos. The actual <video> lives in VideoDock so it survives
+			     navigation. -->
+			<div class="stage-anchor" class:has-video={Boolean(streamUrl)} bind:this={stageAnchor}>
+				{#if loadingStream && !streamUrl}
+					<Skeleton rows={4} label="Loading video" />
+				{:else if showChooseVideoPrompt}
+					<div class="video-choice-prompt" aria-live="polite">
+						<strong>Choose a video</strong>
+						<span>Select any result to start playback.</span>
+					</div>
+				{/if}
+			</div>
 		</div>
 		{#if !showChooseVideoPrompt}
 		<div class="hero-meta">
@@ -862,6 +690,21 @@
 
 	.hero--prompt .player-shell {
 		min-height: 0;
+	}
+
+	.stage-anchor {
+		width: 100%;
+		display: grid;
+		align-items: center;
+	}
+
+	/* When a video is playing, this is an empty 16/9 frame the fixed dock sits
+	   on top of. Dark fill so the inline area reads as a video surface even in
+	   the frame between rect measurement and the dock painting over it. */
+	.stage-anchor.has-video {
+		aspect-ratio: 16 / 9;
+		border-radius: 8px;
+		background: #030305;
 	}
 
 	.video-choice-prompt {

--- a/frontend/src/routes/videos/videos_route_contract.test.ts
+++ b/frontend/src/routes/videos/videos_route_contract.test.ts
@@ -34,15 +34,24 @@ describe('videos route contract', () => {
 	});
 
 	test('keeps video selection, stream, and context actions wired', () => {
-		expect(source).toContain('await fetchStream(video.tidal_id);');
+		// Playback is delegated to the persistent dock via the controller; the
+		// route picks a video and hands it to playVideo() with a play context.
+		expect(source).toContain('const ok = await playVideo(video, buildPlayContext(video));');
 		expect(source).toContain('void selectVideo(video);');
 		expect(source).toContain('async function loadMix(mixId: string, autoPlayFirst = false)');
 		expect(source).toContain('await loadMix(mixId, shouldPlayMix);');
 		expect(source).toContain('event.preventDefault();');
 		expect(source).toContain('event.stopPropagation();');
 		expect(source).toContain('buildArtistMenu({ tidal_id: selectedVideo.artist_id');
-		expect(source).toContain('<VideoPlayer');
 		expect(source).toContain('<VideoCard {video}');
 		expect(source).not.toContain('$:');
+	});
+
+	test('hands the hero placeholder to the persistent video dock', () => {
+		// The live <video> lives in VideoDock so audio survives navigation; the
+		// route only exposes an anchor the dock positions its player over.
+		expect(source).toContain('bind:this={stageAnchor}');
+		expect(source).toContain('videoStageAnchor.set(stageAnchor)');
+		expect(source).not.toContain('<VideoPlayer');
 	});
 });

--- a/noor-server/src/playback/output/wasapi_exclusive.rs
+++ b/noor-server/src/playback/output/wasapi_exclusive.rs
@@ -31,6 +31,15 @@ impl ExclusiveRuntimeSink {
             .map(|stream| stream.is_released())
             .unwrap_or(true)
     }
+
+    /// Ask the live exclusive stream (if any) to drop the device now instead of
+    /// waiting out the idle grace, so another app can take it in shared mode.
+    /// No-op when no stream is active or it already released.
+    pub(crate) fn request_release(&self) {
+        if let Some(stream) = self.stream.as_ref() {
+            stream.request_release();
+        }
+    }
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/noor-server/src/playback/runtime/commands.rs
+++ b/noor-server/src/playback/runtime/commands.rs
@@ -10,6 +10,11 @@ pub enum PlaybackRuntimeCommand {
     Pause,
     Resume,
     Stop,
+    /// Drop the WASAPI exclusive device immediately (ahead of the idle grace)
+    /// so another app can take the endpoint in shared mode. Triggered when the
+    /// WebView needs to play a TIDAL video's audio while exclusive mode is on.
+    /// No-op outside Windows exclusive mode. The runtime re-grabs on next Play.
+    ReleaseExclusiveNow,
     /// Segment-aware seek (option C). The runtime's handler is the single
     /// decision point: in-buffer fast path, segment-restart transition, or
     /// rejection. `allow_segment_seek=false` preserves legacy "reject past

--- a/noor-server/src/playback/runtime/mod.rs
+++ b/noor-server/src/playback/runtime/mod.rs
@@ -219,6 +219,14 @@ impl PlaybackRuntimeHandle {
         self.send(PlaybackRuntimeCommand::Stop)
     }
 
+    /// Release the WASAPI exclusive device now (ahead of the idle grace) so the
+    /// WebView can play a video's audio in shared mode. No-op outside Windows
+    /// exclusive mode. Callers should pause playback first; the runtime
+    /// re-grabs exclusive on the next Resume/Play.
+    pub fn release_exclusive_now(&self) -> Result<()> {
+        self.send(PlaybackRuntimeCommand::ReleaseExclusiveNow)
+    }
+
     pub fn shutdown(&self) -> Result<()> {
         self.send(PlaybackRuntimeCommand::Shutdown)
     }
@@ -2259,6 +2267,28 @@ fn run_runtime_loop(
                     if let Some(engine) = state.drop_preview_engine.as_mut() {
                         if let Err(error) = engine.pause() {
                             report_runtime_command_error(&event_tx, "Pause", error);
+                        }
+                    }
+                }
+                PlaybackRuntimeCommand::ReleaseExclusiveNow => {
+                    // Yield the exclusive endpoint now so the WebView can play a
+                    // video in shared mode. Pause first (idempotent if already
+                    // paused) so the render thread isn't mid-fill when it drops
+                    // the device, then ask it to release ahead of the idle grace.
+                    if state.current_exclusive {
+                        if let Some(engine) = state.engine.as_mut() {
+                            let _ = engine.pause();
+                        }
+                        if let Some(engine) = state.fading_out_engine.as_mut() {
+                            let _ = engine.pause();
+                        }
+                        #[cfg(target_os = "windows")]
+                        {
+                            info!(
+                                "ReleaseExclusiveNow: dropping exclusive device on {} for shared-mode video playback",
+                                state.device_name
+                            );
+                            state.exclusive_sink.request_release();
                         }
                     }
                 }

--- a/noor-server/src/playback/wasapi_exclusive.rs
+++ b/noor-server/src/playback/wasapi_exclusive.rs
@@ -120,6 +120,7 @@ impl std::error::Error for ExclusiveInitFailure {}
 pub struct ExclusiveStream {
     shutdown: Arc<AtomicBool>,
     released: Arc<AtomicBool>,
+    force_release: Arc<AtomicBool>,
     thread: Option<JoinHandle<()>>,
     #[allow(dead_code)]
     pub effective_sample_rate: u32,
@@ -176,6 +177,15 @@ impl ExclusiveStream {
     /// uses this to know it must rebuild the stream before resuming.
     pub fn is_released(&self) -> bool {
         self.released.load(Ordering::Acquire)
+    }
+
+    /// Ask the render thread to drop the device now instead of waiting out the
+    /// idle grace window. Used when another app (e.g. the WebView playing a
+    /// TIDAL video) needs the endpoint in shared mode. The thread exits its
+    /// loop on the next tick, releases the `IAudioClient`, and flips
+    /// `is_released()`; the runtime re-grabs on the next Resume/Play.
+    pub fn request_release(&self) {
+        self.force_release.store(true, Ordering::Release);
     }
 }
 
@@ -307,6 +317,8 @@ pub fn build_exclusive_stream(
     let shutdown_clone = Arc::clone(&shutdown);
     let released = Arc::new(AtomicBool::new(false));
     let released_clone = Arc::clone(&released);
+    let force_release = Arc::new(AtomicBool::new(false));
+    let force_release_clone = Arc::clone(&force_release);
     let device_pref_owned = device_pref.map(|s| s.to_string());
 
     let (init_tx, init_rx) =
@@ -327,6 +339,7 @@ pub fn build_exclusive_stream(
                 event_tx,
                 shutdown_clone,
                 released_clone,
+                force_release_clone,
                 init_tx,
             );
         })
@@ -340,6 +353,7 @@ pub fn build_exclusive_stream(
         Ok((effective_rate, effective_channels, transport_format)) => Ok(ExclusiveStream {
             shutdown,
             released,
+            force_release,
             thread: Some(thread),
             effective_sample_rate: effective_rate,
             effective_channels,
@@ -365,6 +379,7 @@ fn run_render_thread(
     event_tx: tokio::sync::broadcast::Sender<PlaybackRuntimeEvent>,
     shutdown: Arc<AtomicBool>,
     released: Arc<AtomicBool>,
+    force_release: Arc<AtomicBool>,
     init_tx: mpsc::SyncSender<std::result::Result<(u32, u16, String), ExclusiveInitFailure>>,
 ) {
     let _mmcss = enter_mmcss();
@@ -442,6 +457,18 @@ fn run_render_thread(
     let mut logged_first_nonzero_fill = false;
 
     while !shutdown.load(Ordering::SeqCst) {
+        // Forced release: a caller (e.g. video playback needing the endpoint in
+        // shared mode) asked us to let go now, ahead of the idle grace. Same
+        // teardown as idle release: break, drop the IAudioClient, flip
+        // `is_released()`, re-grab on the next Resume/Play.
+        if force_release.load(Ordering::Acquire) {
+            info!(
+                target: "playback",
+                "WASAPI exclusive stream releasing device on external request"
+            );
+            break;
+        }
+
         // Idle-release: when paused for >= grace_secs, exit the loop and let
         // Drop chains release the IAudioClient so other apps can use the
         // device. The runtime detects the release via `is_released()` and

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -807,6 +807,10 @@ pub fn api_routes(state: SharedState) -> Router {
         .route("/api/playback/play", post(play_track))
         .route("/api/playback/pause", post(pause_playback))
         .route("/api/playback/resume", post(resume_playback))
+        .route(
+            "/api/playback/exclusive/release",
+            post(release_exclusive_playback),
+        )
         .route("/api/playback/previous", post(previous_track))
         .route("/api/playback/next", post(next_track))
         .route("/api/playback/position", post(set_playback_position))
@@ -6592,6 +6596,28 @@ async fn pause_playback(State(state): State<SharedState>) -> Result<Json<Value>,
 
     let snapshot = overlay_snapshot_with_external_track(&state, snapshot).await;
     Ok(Json(json!({ "state": snapshot.state })))
+}
+
+/// Drop the WASAPI exclusive device immediately so the WebView can play a
+/// TIDAL video's audio in shared mode. The frontend hits this when a video
+/// starts. No-op when there's no runtime or exclusive mode is off; the runtime
+/// re-grabs exclusive on the next Resume/Play. Returns ok even on a soft miss
+/// so video startup never blocks on it.
+async fn release_exclusive_playback(
+    State(state): State<SharedState>,
+) -> Result<Json<Value>, StatusCode> {
+    if let Some(runtime_handle) = current_playback_runtime(&state).await
+        && let Err(error) = runtime_handle.release_exclusive_now()
+    {
+        tracing::warn!(
+            target = "noor.playback",
+            event = "exclusive_release_failed",
+            "Failed to request exclusive release: {error}"
+        );
+        return Err(StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    Ok(Json(json!({ "ok": true })))
 }
 
 async fn resume_playback(State(state): State<SharedState>) -> Result<Json<Value>, StatusCode> {


### PR DESCRIPTION
Two related video fixes, stacked on `feat/app-speed-instant-paint`.

## The problem
With WASAPI exclusive mode on, videos played silent (or wouldn't start at all). The server holds the audio endpoint exclusively, so the WebView can't open a shared-mode stream for the video's own audio. Pausing music didn't help because the exclusive render thread only releases the device after ~30s of idle. And leaving the videos page killed playback entirely, since the `<video>` lived inside the route and unmounted on navigation.

## What changed

**Backend: release the device on demand**
- The exclusive render thread now checks a force-release flag at the top of its loop and drops the `IAudioClient` immediately instead of waiting out the idle grace.
- New `POST /api/playback/exclusive/release` (a `ReleaseExclusiveNow` runtime command). It's a no-op when exclusive mode is off, and the runtime re-grabs exclusive on the next Play/Resume, so music is unaffected.

**Frontend: a persistent video dock**
- Hoisted the player into a single `VideoDock` mounted in the layout, so the `<video>` element never unmounts. Audio keeps playing across navigation.
- On `/videos` the dock tracks the route's placeholder rect so it still reads as inline; everywhere else it docks into the corner as a small moving thumbnail with return/close.
- The `videoSession` store grew a controller that owns the stream lifecycle (`playVideo` / `advanceVideo` / `refreshVideoStream` / `clearVideoSession`), so autoplay and stream refresh keep working while you're off the videos page.
- Video start frees the exclusive device for audio; starting music stops the video and hands the device back. One thing plays at a time.

## Verifying
Backend builds clean and the new endpoint responds (`200 {"ok":true}` with auth, `401` without). Frontend type-checks, lints, and the full vitest suite (574 plus a new dock contract) passes; `/videos` renders with no console errors.

The audible behaviors can't be checked headlessly, so worth a quick manual pass in the app with exclusive mode on: play music, open a video (audio should come through), navigate away (audio continues, mini-player docks), come back (resumes in place), press play on a track (video stops). Two minor edges (off-route autoplay stops at the loaded queue tail; `positionMs` not wired to a time display) are noted in `FOLLOWUPS.md`.
