### PR TITLE
fix(queue): restore whole-row drag-to-reorder

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -802,11 +802,19 @@
 	let dragOverItemId = $state<number | null>(null);
 
 	function handleQueueDragStart(event: DragEvent, item: QueueItemType) {
+		if (item.is_pending === true) return;
 		dragItemId = item.id;
 		if (event.dataTransfer) {
 			event.dataTransfer.effectAllowed = 'move';
 			// Required for Firefox to actually start a drag.
 			event.dataTransfer.setData('text/plain', String(item.id));
+			// Drag the whole row as the ghost (not the bare grip glyph) so the
+			// preview reads as "moving this track", aligned under the cursor.
+			const row = event.currentTarget;
+			if (row instanceof HTMLElement && typeof event.dataTransfer.setDragImage === 'function') {
+				const rect = row.getBoundingClientRect();
+				event.dataTransfer.setDragImage(row, event.clientX - rect.left, event.clientY - rect.top);
+			}
 		}
 	}
 
@@ -1622,7 +1630,9 @@
 							class="queue-row"
 							title={isPending ? 'Resolving on TIDAL...' : undefined}
 							data-track-id={item.track.id}
+							draggable={!isPending}
 							oncontextmenu={(event) => openQueueRowMenu(item, event)}
+							ondragstart={(event) => handleQueueDragStart(event, item)}
 							ondragover={(event) => handleQueueDragOver(event, item)}
 							ondragleave={() => handleQueueDragLeave(item)}
 							ondrop={(event) => void handleQueueDrop(event, item)}
@@ -1639,13 +1649,7 @@
 								onclick={isPending ? undefined : () => void handleQueueTrackPlay(item)}
 								onkeydown={(event) => handleQueueTrackKeydown(item, event)}
 							></button>
-							<span
-								class="queue-grip"
-								aria-hidden="true"
-								title="Drag to reorder"
-								draggable={!isPending}
-								ondragstart={(event) => handleQueueDragStart(event, item)}
-							>⋮⋮</span>
+							<span class="queue-grip" aria-hidden="true" title="Drag to reorder">⋮⋮</span>
 							<div class="queue-art-wrap" title={formatQueueSource(item.source)}>
 								{#if isPending}
 									<div class="queue-art placeholder pending-art" title="Resolving track...">
@@ -2881,13 +2885,16 @@
 	}
 
 	.queue-row.dragging {
-		opacity: 0.55;
+		opacity: 0.4;
+		cursor: grabbing;
 	}
 
+	/* The dropped row lands at the target's index, i.e. above it, so the
+	   accent line sits on the target's top edge to read as "drops here". */
 	.queue-row.drag-over {
 		border-color: var(--accent-line);
-		background: color-mix(in srgb, var(--accent-soft) 70%, transparent);
-		box-shadow: 0 -2px 0 var(--accent-strong) inset;
+		background: color-mix(in srgb, var(--accent-soft) 55%, transparent);
+		box-shadow: inset 0 2px 0 var(--accent-strong);
 	}
 
 	.queue-row.pending {


### PR DESCRIPTION
## What
Restore whole-row drag-to-reorder in the queue. The mutable-queue-rows redesign (d6083e39) moved drag off the row body onto the 12px grip, so reordering basically felt gone: only a faint glyph was draggable, and the drag ghost was just that glyph (looked like you were dragging something you shouldn't).

## Changes (all in `frontend/src/routes/+layout.svelte`)
- Whole row is `draggable` again. The dedicated full-bleed hit button still owns click-to-play, so drag doesn't swallow clicks (the reason it was moved to the grip in the first place).
- Grip demoted back to a plain visual handle (no longer the drag source).
- Drag image is set to the row itself, aligned under the cursor, so the preview reads as the track lifting instead of a lone glyph.
- Drop target shows a top accent line where the row will actually land (rows insert above the target).

## Testing
Drag-and-drop can't be faithfully simulated headlessly, so this was verified by `pnpm check` (0 errors) + `pnpm lint`, plus a code-level trace of the handlers. Worth a quick manual drag in the running app.
