### PR TITLE
fix(spotify): harden cross-platform playlist + track search

### DIFF
--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -10,6 +10,43 @@ back to the PR or commit that flagged it.
 
 ## Open
 
+### Cross-platform playlist providers: SoundCloud + YouTube
+- Now that the Spotify (Sportify) search/resolve path is hardened (mirror failover, no
+  empty-cache poisoning, breaker on the anonymous GraphQL), extend the same pattern to other
+  sources. YouTube has a clean free keyed API (YouTube Data API v3, API key + 10k-unit/day
+  quota): good candidate for search + playlist-item fetch + resolve-to-TIDAL. SoundCloud's
+  public API registration has been closed since ~2019, so it would have to ride their internal
+  `api-v2` (anonymous/scraped) or oEmbed - same fragility class as the Spotify proxies, so it
+  needs the same failover + breaker wrapping.
+- Deferred this pass by choice: scope was "Spotify-only quick fix", no provider-trait
+  abstraction. When picking this up, factor a provider interface (search / fetch-playlist /
+  resolve-to-TIDAL / health) that supports BOTH keyed-API and anonymous-scraped styles, then
+  slot Spotify, YouTube, SoundCloud onto it.
+- Considered and declined this pass: wiring the official Spotify Web API (free app
+  client_id+secret, client-credentials) as a durable failsafe. Rejected because the Nov-2024
+  Web API cull removed too much for indie apps. Revisit only if the anonymous proxies stop being
+  viable.
+- Not implemented (nice-to-have failsafe): serve-stale-search-cache on total live failure
+  ("stale-while-error") - return last-known-good results instead of an error when every mirror
+  is down. Cheap and would make outages invisible to the user.
+- Spawned by: Spotify playlist search/resolve hardening (mirror failover + no empty-cache +
+  spotify_public breaker).
+
+### Spotify search hardening: review-surfaced refinements
+- Negative cache for *confirmed-empty* search: the hardening dropped empty-page caching
+  entirely (to stop 30-day poisoning on transient outages), but a query that genuinely has zero
+  results now re-hits every mirror on every repeat, and the SportifyClient (proxy path) has no
+  circuit breaker. A short negative-TTL (minutes, not the 30-day positive TTL) for confirmed-empty
+  pages would bound repeat-query load without reintroducing the poisoning. Low risk (search is
+  user-driven, failover is bounded to N mirrors) but it's the one asymmetry the change introduces.
+- Consolidate empty-handling: `get_search` now treats an empty first page as stale for ALL
+  kinds, which makes the playlist-only post-read guards at `recommend.rs:185` and
+  `sportify_routes.rs:86-91` dead. Remove them so empty-handling lives only in the cache layer.
+- Test gaps: the HTTP-400 self-heal branch (`spotify_public/client.rs`) and the breaker's
+  cooldown-expiry / half-open path have no direct tests (the 401 + PersistedQueryNotFound siblings
+  also lack tests). Adding an injectable pathfinder URL + clock seam would let these be covered.
+- Spawned by: 3-lens pre-PR review of the Spotify hardening change.
+
 ### chore: populate `album_title` at the `TidalPlayable` builders, not just the backstop
 
 Several launch surfaces build a `TidalPlayable` with title + artist + artwork but

--- a/noor-server/src/services/sportify/cache.rs
+++ b/noor-server/src/services/sportify/cache.rs
@@ -85,6 +85,18 @@ pub struct UnresolvedRecord {
     pub reason: Option<String>,
 }
 
+/// True when the search payload has no rows for the *requested* kind. A
+/// search call only ever populates the bucket matching `kind`, so this is the
+/// emptiness test the cache and mirror-failover logic both care about.
+fn search_results_empty(kind: SportifySearchKind, results: &SportifySearchResults) -> bool {
+    match kind {
+        SportifySearchKind::Track => results.tracks.is_empty(),
+        SportifySearchKind::Album => results.albums.is_empty(),
+        SportifySearchKind::Artist => results.artists.is_empty(),
+        SportifySearchKind::Playlist => results.playlists.is_empty(),
+    }
+}
+
 fn hash_query(query: &str, kind: SportifySearchKind, limit: u32, offset: u32) -> String {
     let mut hasher = Sha256::new();
     hasher.update(kind.as_str().as_bytes());
@@ -284,14 +296,12 @@ pub fn get_search(
         Some((json, fetched_at)) if fresh(fetched_at, cfg.meta_ttl_secs) => {
             let parsed: SportifySearchResults =
                 serde_json::from_str(&json).context("decode cached search payload")?;
-            // A previous playlist parser could cache an empty first page even
-            // though Sportify returned rows in an unhandled shape. Treat that
-            // specific cache entry as stale so search can recover immediately
-            // after parser fixes, while preserving empty later pages.
-            if matches!(kind, SportifySearchKind::Playlist)
-                && offset == 0
-                && parsed.playlists.is_empty()
-            {
+            // A flapping mirror or an unhandled response shape can cache an
+            // empty first page. Treat any empty first page (for the requested
+            // kind) as stale so search recovers on the next request instead of
+            // serving the miss for the full TTL. Later pages are allowed to be
+            // legitimately empty (end of results).
+            if offset == 0 && search_results_empty(kind, &parsed) {
                 Ok(None)
             } else {
                 Ok(Some(parsed))
@@ -309,6 +319,14 @@ pub fn put_search(
     offset: u32,
     payload: &SportifySearchResults,
 ) -> Result<()> {
+    // Never persist an empty/failed page. Mirrors flap and response shapes
+    // drift; caching a miss for the 30-day TTL is how search silently "stops
+    // working" for a query until the entry expires. Skipping the write lets
+    // the next request re-fetch (and try the other mirror).
+    if search_results_empty(kind, payload) {
+        return Ok(());
+    }
+
     let key = hash_query(query, kind, limit, offset);
     let json = serde_json::to_string(payload).context("serialize search results")?;
     conn.execute(
@@ -540,7 +558,14 @@ mod tests {
     fn search_cache_round_trip() {
         let conn = open_test_db();
         let cfg = SportifyCacheConfig::default();
-        let payload = SportifySearchResults::default();
+        let payload = SportifySearchResults {
+            tracks: vec![SportifyTrack {
+                id: Some("t1".into()),
+                name: Some("One More Time".into()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
         put_search(
             &conn,
             "daft punk",
@@ -560,6 +585,43 @@ mod tests {
             get_search(&conn, &cfg, " Daft Punk ", SportifySearchKind::Track, 10, 0)
                 .unwrap()
                 .is_some()
+        );
+    }
+
+    #[test]
+    fn empty_first_page_is_never_cached() {
+        // A failed/empty page must not poison the cache for the full TTL, or
+        // a transient mirror outage makes a query "dead" for 30 days.
+        let conn = open_test_db();
+        let cfg = SportifyCacheConfig::default();
+        let empty = SportifySearchResults::default();
+        put_search(&conn, "obscure", SportifySearchKind::Track, 10, 0, &empty).unwrap();
+        assert!(
+            get_search(&conn, &cfg, "obscure", SportifySearchKind::Track, 10, 0)
+                .unwrap()
+                .is_none(),
+            "empty result should not be served from cache"
+        );
+    }
+
+    #[test]
+    fn empty_first_page_treated_stale_even_if_present() {
+        // Defends against rows cached by an older build before the put-side
+        // guard existed: an empty first page reads back as a miss.
+        let conn = open_test_db();
+        let cfg = SportifyCacheConfig::default();
+        let key = hash_query("legacy", SportifySearchKind::Artist, 10, 0);
+        let json = serde_json::to_string(&SportifySearchResults::default()).unwrap();
+        conn.execute(
+            "INSERT INTO sportify_search_cache (query_hash, kind, payload, fetched_at)
+             VALUES (?1, ?2, ?3, ?4)",
+            params![key, "artist", json, now_secs()],
+        )
+        .unwrap();
+        assert!(
+            get_search(&conn, &cfg, "legacy", SportifySearchKind::Artist, 10, 0)
+                .unwrap()
+                .is_none()
         );
     }
 }

--- a/noor-server/src/services/sportify/client.rs
+++ b/noor-server/src/services/sportify/client.rs
@@ -121,6 +121,83 @@ mod tests {
         assert!(truncated.ends_with("..."));
         assert!(truncated.len() <= 259);
     }
+
+    /// Spawn a one-shot mock mirror serving `/api/search` with a fixed
+    /// status + body, and return its base URL.
+    async fn spawn_mirror(status: axum::http::StatusCode, body: &'static str) -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind mock mirror");
+        let addr = listener.local_addr().expect("read mock mirror addr");
+        let app = axum::Router::new().route(
+            "/api/search",
+            axum::routing::get(move || async move { (status, body) }),
+        );
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("serve mock mirror");
+        });
+        format!("http://{addr}")
+    }
+
+    fn client_for(primary: String, fallback: String) -> SportifyClient {
+        SportifyClient::new(SportifyClientConfig {
+            base_url: primary,
+            fallback_base_urls: vec![fallback],
+            user_agent: "noor-test".to_string(),
+        })
+        .expect("client")
+    }
+
+    #[tokio::test]
+    async fn track_search_fails_over_to_next_mirror_on_http_error() {
+        // Mirror 1 is dead (the xcasper-style upstream-401 -> 500). Track
+        // search must fall over to mirror 2 instead of erroring out.
+        let dead = spawn_mirror(
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            r#"{"success":false,"error":"GraphQL searchDesktop failed: 401"}"#,
+        )
+        .await;
+        let live = spawn_mirror(
+            axum::http::StatusCode::OK,
+            r#"{"success":true,"results":[{"id":"t1"}]}"#,
+        )
+        .await;
+        let client = client_for(dead, live);
+
+        let out = client
+            .search("daft punk", SportifySearchKind::Track, 10, 0)
+            .await
+            .expect("search should succeed via fallback mirror");
+
+        assert_eq!(out.tracks.len(), 1);
+        assert_eq!(out.tracks[0].id.as_deref(), Some("t1"));
+    }
+
+    #[tokio::test]
+    async fn track_search_fails_over_to_next_mirror_on_empty_results() {
+        // The regression: a mirror answering 200-but-empty used to be accepted
+        // for non-playlist kinds, dead-ending track search. It must now try the
+        // next mirror, which has rows.
+        let empty = spawn_mirror(
+            axum::http::StatusCode::OK,
+            r#"{"success":true,"results":[]}"#,
+        )
+        .await;
+        let live = spawn_mirror(
+            axum::http::StatusCode::OK,
+            r#"{"success":true,"results":[{"id":"t1"}]}"#,
+        )
+        .await;
+        let client = client_for(empty, live);
+
+        let out = client
+            .search("daft punk", SportifySearchKind::Track, 10, 0)
+            .await
+            .expect("search should succeed via fallback mirror");
+
+        assert_eq!(out.tracks.len(), 1);
+        assert_eq!(out.tracks[0].id.as_deref(), Some("t1"));
+    }
 }
 
 impl Default for SportifyClientConfig {
@@ -293,12 +370,14 @@ impl SportifyClient {
             {
                 Ok(value) => {
                     let out = search_results_from_value(&value, kind);
-                    if matches!(kind, SportifySearchKind::Playlist)
-                        && out.playlists.is_empty()
-                        && idx + 1 < self.base_urls.len()
-                    {
+                    // A mirror can answer 200-but-empty when its upstream token
+                    // is degraded. Don't accept an empty first page if another
+                    // mirror might still have rows; only the last mirror's empty
+                    // result is authoritative.
+                    if results_empty_for_kind(&out, kind) && idx + 1 < self.base_urls.len() {
                         tracing::debug!(
-                            "sportify playlist search via {} returned no playlist rows",
+                            "sportify {} search via {} returned no rows; trying next mirror",
+                            kind.as_str(),
                             base_url
                         );
                         continue;
@@ -357,6 +436,15 @@ impl SportifyClient {
             return serde_json::from_value(inner).context("parse sportify top-tracks `items`");
         }
         Ok(Vec::new())
+    }
+}
+
+fn results_empty_for_kind(results: &SportifySearchResults, kind: SportifySearchKind) -> bool {
+    match kind {
+        SportifySearchKind::Track => results.tracks.is_empty(),
+        SportifySearchKind::Album => results.albums.is_empty(),
+        SportifySearchKind::Artist => results.artists.is_empty(),
+        SportifySearchKind::Playlist => results.playlists.is_empty(),
     }
 }
 

--- a/noor-server/src/services/sportify/models.rs
+++ b/noor-server/src/services/sportify/models.rs
@@ -61,8 +61,9 @@ pub struct SportifyTrack {
     /// Alias picks up either form into one field.
     #[serde(default, alias = "title")]
     pub name: Option<String>,
-    /// Some endpoints (track detail) ship a structured `artists` array.
-    #[serde(default)]
+    /// Track detail / playlist ship a structured `artists` object array;
+    /// search ships a flat string array. The custom path accepts both.
+    #[serde(default, deserialize_with = "deserialize_artists_field")]
     pub artists: Vec<SportifyArtistRef>,
     /// Other endpoints (playlist body, search results) ship a flat `artist`
     /// string only. Consumers go through [`SportifyTrack::primary_artist`].
@@ -320,6 +321,37 @@ where
     }))
 }
 
+/// `artists` ships as a structured object array on the track-detail and
+/// playlist shapes (`[{"id","name",...}]`), but the *search* shape ships a
+/// flat string array (`["Tame Impala"]`). Without this the whole
+/// `Vec<SportifyTrack>` deserialization fails on the first search row and the
+/// caller's `unwrap_or_default()` silently returns zero tracks - which is why
+/// track search looked dead while artist/playlist search worked.
+fn deserialize_artists_field<'de, D>(deserializer: D) -> Result<Vec<SportifyArtistRef>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum ArtistRepr {
+        Name(String),
+        Object(SportifyArtistRef),
+    }
+    let opt = Option::<Vec<ArtistRepr>>::deserialize(deserializer)?;
+    Ok(opt
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|r| match r {
+            ArtistRepr::Name(s) if s.trim().is_empty() => None,
+            ArtistRepr::Name(s) => Some(SportifyArtistRef {
+                name: Some(s),
+                ..Default::default()
+            }),
+            ArtistRepr::Object(o) => Some(o),
+        })
+        .collect())
+}
+
 fn extra_string(extra: &HashMap<String, serde_json::Value>, key: &str) -> Option<String> {
     extra.get(key).and_then(|v| v.as_str()).map(str::to_string)
 }
@@ -389,6 +421,40 @@ mod tests {
         }"#;
         let track: SportifyTrack = serde_json::from_str(json).expect("parse");
         assert_eq!(track.primary_artist(), Some("Structured Name"));
+    }
+
+    /// Regression: the search-track shape ships `artists` as a flat STRING
+    /// array. Before the custom deserializer this failed the whole
+    /// `Vec<SportifyTrack>` parse, so track search silently returned zero rows
+    /// while artist/playlist search worked.
+    #[test]
+    fn deserializes_search_track_shape_with_string_artists() {
+        let json = r#"{
+            "id": "5hM5arv9KDbCHS0k9uqwjr",
+            "title": "Borderline",
+            "artist": "Tame Impala",
+            "artists": ["Tame Impala"],
+            "album": "The Slow Rush"
+        }"#;
+        let track: SportifyTrack = serde_json::from_str(json).expect("search track parse");
+        assert_eq!(track.name.as_deref(), Some("Borderline"));
+        assert_eq!(track.primary_artist(), Some("Tame Impala"));
+        assert_eq!(
+            track.album.as_ref().and_then(|a| a.name.as_deref()),
+            Some("The Slow Rush"),
+        );
+
+        // And a whole results array of this shape must parse, not collapse to
+        // empty (the actual failure mode the user saw).
+        let results: SportifySearchResults = serde_json::from_str(
+            r#"{ "tracks": [
+                { "id": "a", "title": "One", "artists": ["X"] },
+                { "id": "b", "title": "Two", "artists": ["Y", "Z"] }
+            ] }"#,
+        )
+        .expect("search results parse");
+        assert_eq!(results.tracks.len(), 2);
+        assert_eq!(results.tracks[1].primary_artist(), Some("Y"));
     }
 
     #[test]

--- a/noor-server/src/services/spotify_public/client.rs
+++ b/noor-server/src/services/spotify_public/client.rs
@@ -28,6 +28,22 @@ const PATHFINDER_URL: &str = "https://api-partner.spotify.com/pathfinder/v1/quer
 /// Refresh the token this many seconds before its declared expiry.
 const TOKEN_REFRESH_SLACK_SECS: i64 = 60;
 
+/// Open the breaker after this many consecutive hard failures. Spotify's
+/// anonymous surface either works or is fully rejecting us; a handful of
+/// failures in a row means "rejecting", not "unlucky".
+const BREAKER_FAILURE_THRESHOLD: u32 = 5;
+
+/// While the breaker is open, every call short-circuits for this long instead
+/// of hammering a dead upstream (and spamming the log once per seed).
+const BREAKER_COOLDOWN_MS: i64 = 5 * 60 * 1000;
+
+fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
 #[derive(Clone)]
 pub struct SpotifyPublicClient {
     inner: Arc<Inner>,
@@ -38,6 +54,15 @@ struct Inner {
     db: Database,
     token: RwLock<Option<TokenResponse>>,
     hashes: RwLock<RefreshedHashes>,
+    breaker: RwLock<Breaker>,
+}
+
+/// Trips after repeated failures so a broken anonymous surface degrades to a
+/// quiet no-op instead of a per-seed warn storm.
+#[derive(Default)]
+struct Breaker {
+    consecutive_failures: u32,
+    open_until_ms: i64,
 }
 
 #[derive(Debug)]
@@ -84,8 +109,34 @@ impl SpotifyPublicClient {
                 db,
                 token: RwLock::new(None),
                 hashes: RwLock::new(persisted.unwrap_or_default()),
+                breaker: RwLock::new(Breaker::default()),
             }),
         })
+    }
+
+    /// True while the breaker is open after recent hard failures. Network
+    /// code paths gate on this and serve whatever the cache already holds;
+    /// cached hits are still returned. The stats fan-out checks this per seed
+    /// (not before spawning), so the first batch against a freshly-dead
+    /// upstream still issues one bounded burst before the breaker trips;
+    /// every batch after that is quiet.
+    pub async fn circuit_open(&self) -> bool {
+        self.inner.breaker.read().await.open_until_ms > now_ms()
+    }
+
+    async fn record_success(&self) {
+        let mut b = self.inner.breaker.write().await;
+        if b.consecutive_failures != 0 || b.open_until_ms != 0 {
+            *b = Breaker::default();
+        }
+    }
+
+    async fn record_failure(&self) {
+        let mut b = self.inner.breaker.write().await;
+        b.consecutive_failures = b.consecutive_failures.saturating_add(1);
+        if b.consecutive_failures >= BREAKER_FAILURE_THRESHOLD {
+            b.open_until_ms = now_ms() + BREAKER_COOLDOWN_MS;
+        }
     }
 
     async fn current_hashes(&self) -> OpHashes {
@@ -149,9 +200,33 @@ impl SpotifyPublicClient {
         *self.inner.token.write().await = None;
     }
 
-    /// Run a persisted-query GET. Handles 401 (re-mint token) and
-    /// `PersistedQueryNotFound` (refresh hashes, retry once).
+    /// Run a persisted-query GET behind the circuit breaker. Short-circuits
+    /// while the breaker is open, and records the outcome so repeated hard
+    /// failures trip it (and let it close again after a success).
     async fn persisted_query(
+        &self,
+        op_name: &str,
+        sha256_hash: &str,
+        variables: &Value,
+    ) -> Result<Value> {
+        if self.circuit_open().await {
+            return Err(anyhow!(
+                "{op_name}: spotify_public circuit open (paused after repeated failures)"
+            ));
+        }
+        let result = self
+            .persisted_query_inner(op_name, sha256_hash, variables)
+            .await;
+        match &result {
+            Ok(_) => self.record_success().await,
+            Err(_) => self.record_failure().await,
+        }
+        result
+    }
+
+    /// Handles 401 (re-mint token), HTTP 400, and `PersistedQueryNotFound`
+    /// (refresh hashes, retry once).
+    async fn persisted_query_inner(
         &self,
         op_name: &str,
         sha256_hash: &str,
@@ -192,6 +267,17 @@ impl SpotifyPublicClient {
                     continue;
                 }
                 return Err(anyhow!("{op_name}: 401 even after token refresh"));
+            }
+            // A hard 400 from pathfinder usually means the persisted-query
+            // hash or variable shape drifted (Spotify changed the op). The
+            // PersistedQueryNotFound JSON check below only runs on a 200 body,
+            // so a 400 never reaches it: refresh hashes and retry once.
+            if status == StatusCode::BAD_REQUEST && attempt == 0 {
+                debug!("spotify_public: HTTP 400 on {op_name}; refreshing hashes and retrying");
+                if let Err(e) = self.refresh_hashes().await {
+                    return Err(anyhow!("{op_name}: HTTP 400 and hash refresh failed: {e}"));
+                }
+                continue;
             }
             if !status.is_success() {
                 return Err(anyhow!("{op_name}: HTTP {status}"));
@@ -274,4 +360,32 @@ fn persisted_query_not_found(body: &Value) -> bool {
             })
         })
         .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_client() -> SpotifyPublicClient {
+        let db = crate::db::Database::open_in_memory().expect("open in-memory db");
+        SpotifyPublicClient::new(db).expect("construct client")
+    }
+
+    #[tokio::test]
+    async fn breaker_opens_after_threshold_and_closes_on_success() {
+        let client = test_client();
+        assert!(!client.circuit_open().await, "starts closed");
+
+        for _ in 0..BREAKER_FAILURE_THRESHOLD - 1 {
+            client.record_failure().await;
+        }
+        assert!(!client.circuit_open().await, "still closed below threshold");
+
+        client.record_failure().await;
+        assert!(client.circuit_open().await, "opens at threshold");
+
+        // A success closes it again so recovery is automatic.
+        client.record_success().await;
+        assert!(!client.circuit_open().await, "closes after success");
+    }
 }

--- a/noor-server/src/services/spotify_public/mod.rs
+++ b/noor-server/src/services/spotify_public/mod.rs
@@ -146,6 +146,9 @@ async fn resolve_and_writeback_track(
         TrackState::NegativeFresh => None,
         TrackState::StaleStats { spotify_track_id }
         | TrackState::NeedsStatsFetch { spotify_track_id } => {
+            if client.circuit_open().await {
+                return None;
+            }
             match fetch_playcount(client, &spotify_track_id).await {
                 Some(pc) => {
                     if let Err(e) =
@@ -159,6 +162,9 @@ async fn resolve_and_writeback_track(
             }
         }
         TrackState::NeedsResolution => {
+            if client.circuit_open().await {
+                return None;
+            }
             let resolution = resolver::resolve_track_for_isrc(
                 client,
                 &seed.isrc,
@@ -248,6 +254,9 @@ pub async fn fetch_artist_stats(
         cache::ArtistMapState::Resolved(id) => id,
         cache::ArtistMapState::NegativeFresh => return result,
         cache::ArtistMapState::Missing => {
+            if client.circuit_open().await {
+                return result;
+            }
             let pairs: Vec<(String, String)> = seeds
                 .iter()
                 .map(|s| (s.isrc.clone(), s.title.clone()))
@@ -287,7 +296,7 @@ pub async fn fetch_artist_stats(
         Some((_, stale)) => *stale,
     };
 
-    if need_fetch {
+    if need_fetch && !client.circuit_open().await {
         match client.query_artist_overview(&spotify_artist_id).await {
             Ok(body) => {
                 let parsed = parse_artist_overview(&body);


### PR DESCRIPTION
Spotify search in the discover/search surface was unreliable: sometimes playlists resolved, often they didn't, and track search came back empty for no obvious reason.

It turned out all of it leans on anonymous Spotify access that flaps. The installed server's live log was full of `assistedCurationSearch: HTTP 400` (so, not 404s), and probing the proxies directly showed their `searchDesktop` upstream 401ing on and off. Three weak spots stacked on top of each other:

- **Empty/failed pages were cached for 30 days.** One transient miss made a query silently dead for a month, which is exactly the "works sometimes" behaviour.
- **Mirror failover was playlist-only.** Track/album/artist accepted the first mirror's empty `200` and gave up instead of trying the next mirror.
- **Track rows failed to parse outright.** The search API ships `artists` as a flat string array (`["Tame Impala"]`) while our model only accepted objects, so the whole results array fell back to empty. This is why track search looked completely dead while artist/playlist worked.
- **Our own anonymous GraphQL never recovered from a 400** (the self-heal only fired on `PersistedQueryNotFound`) and warned ~700 times in the log.

### What's in here
- Don't cache or serve an empty search page for any kind; treat an empty first page as stale so it re-fetches.
- Extend mirror-failover-on-empty to every search kind, not just playlists.
- Parse `artists` from string arrays as well as object arrays.
- Make a `400` trigger a hash-refresh + retry, and add a circuit breaker so a dead upstream degrades to a quiet no-op instead of a warn storm.

### Verification
Ran this against a throwaway server instance (separate port + DB, so nothing running was touched): track, artist, and playlist search all return results, and failover correctly took over when the primary mirror hit its rate limit. `cargo test` is green (79 sportify + spotify_public tests, including new coverage for the empty-cache, failover, string-artist parse, and breaker behaviours).

### Scope
Deliberately Spotify-only. SoundCloud + YouTube, and a few refinements a pre-merge review surfaced (a short negative-TTL for genuinely-empty queries, removing now-dead playlist-empty guards, and test seams for the 400/cooldown paths), are noted in `FOLLOWUPS.md` for a later pass.
