### PR TITLE
Fix library/search track-list hover lag

### DIFF
--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -288,3 +288,38 @@ hardening:
 - Consider making `ACTIVE_STALL_RECOVERY_SECS` configurable and/or a brief "skipped, slow
   connection" toast so the auto-skip is visible.
 - Spawned by: crossfade-stall diagnosis + 4-agent audit (this session).
+
+## Library/search list virtualization (perf, deferred 2026-06-17)
+
+Fixed: library + search track-list hover lag. The play-number reveal toggled `display:none<->block`
+on hover, which forces a layout pass; on the un-virtualized list that reflow walked an ever-larger
+box tree, so it lagged more the deeper you'd scrolled. Now the glyphs are grid-stacked and revealed
+via `visibility` (reflow-free). (`frontend/src/routes/library/+page.svelte` ~4467,
+`frontend/src/routes/search/+page.svelte` ~2759.)
+
+Still deferred (raw DOM size, not the reported hover bug):
+- The library tracks/albums/artists lists and the search single-category lists render the FULL
+  result set with no windowing; infinite-scroll appends and never unloads (`tracks.update((t) =>
+  [...t, ...data.tracks])` at `frontend/src/lib/stores/library.ts:44`). A multi-thousand-row
+  library = 100k+ live nodes, which still costs on initial paint, memory, and the
+  selection/playback `class:` re-eval that fans out across every row on click.
+- Cheapest next step: `content-visibility: auto` + a MEASURED `contain-intrinsic-size` (~30-36px,
+  NOT the 64px copied from playlists) on a non-interactive row wrapper, desktop surfaces only
+  (the remote/* surfaces removed it on purpose: iOS Safari thrashes). BEFORE shipping it, add
+  regression coverage for two scroll mechanics it can break here: held-Arrow cursor
+  `scrollIntoView({block:'nearest'})` landing on size-estimated off-screen rows
+  (`+page.svelte` ~1621), and `restoreScroll`'s `scrollHeight` reach-termination on deep back-nav
+  (`frontend/src/lib/navigation/scroll.ts:36`). Selection is keyed by `track.id`, so it is NOT
+  at risk.
+- Ancestor amplifier: `.workspace` is BOTH the scroll container and a `backdrop-filter: blur()`
+  element (`frontend/src/routes/+layout.svelte:2144`), wallpaper-on by default with a 60fps WebGL
+  backdrop, so any in-region repaint re-blurs the viewport. Constant (viewport-bounded), not the
+  scroll-depth scaler, but worth moving the blur to a fixed layer behind the content if hover/scroll
+  paint still feels heavy after windowing.
+- True virtual list = last resort, contingent on a WebView2 Performance-panel trace, given the
+  scroll-mechanic regression surface above.
+- Consolidate the bespoke library + search track rows onto the shared `TrackRow.svelte`, which
+  already implements this exact reveal correctly, to kill the divergence between the two hand-rolled
+  rows.
+- Artist/album card hovers use `transform: translateY` (compositor-only, no reflow), so they were
+  ruled out as a hover-lag source.

--- a/frontend/src/routes/library/+page.svelte
+++ b/frontend/src/routes/library/+page.svelte
@@ -4435,11 +4435,9 @@
 
 	.track-play-num {
 		position: relative;
-		display: flex;
-		align-items: center;
-		justify-content: center;
+		display: grid;
+		place-items: center;
 		width: 100%;
-		height: 100%;
 		background: none;
 		border: none;
 		color: inherit;
@@ -4447,24 +4445,41 @@
 		padding: 0;
 	}
 
+	/* Stack the number and the play glyph in the SAME grid cell so both stay
+	   in normal flow and the taller one gives the button real height (an
+	   absolutely-positioned pair collapsed the button to 0px, leaving the play
+	   control a zero-height click target). */
+	.track-num-label,
+	.track-num-play {
+		grid-area: 1 / 1;
+		display: grid;
+		place-items: center;
+	}
+
 	.track-num-label {
-		display: block;
 		color: var(--text-tertiary);
 		font-size: var(--font-size-sm);
+		visibility: visible;
 	}
 
 	.track-num-play {
-		display: none;
 		color: var(--accent);
 		font-size: var(--font-size-xs);
+		visibility: hidden;
 	}
 
+	/* Reveal the play glyph on hover by swapping visibility, not display. The old
+	   display:none<->block swap forced a layout pass on every hover enter/leave;
+	   on the un-virtualized track list that reflow walked an ever-larger box tree,
+	   so hovering lagged more the deeper you'd scrolled. visibility is paint-only
+	   (no reflow) and, unlike opacity, keeps the hidden glyph out of layout-affecting
+	   recomputes while staying constant-cost. */
 	.track-row:hover .track-num-label {
-		display: none;
+		visibility: hidden;
 	}
 
 	.track-row:hover .track-num-play {
-		display: block;
+		visibility: visible;
 	}
 
 	/* ─── Empty State ────────────────────── */

--- a/frontend/src/routes/search/+page.svelte
+++ b/frontend/src/routes/search/+page.svelte
@@ -2758,14 +2758,27 @@
   .search-track-row.disabled { cursor: default; opacity: 0.62; }
   .search-track-row .col-num {
     position: relative;
+    display: grid;
+    place-items: center;
     text-align: center;
     color: var(--text-muted);
     font-size: var(--font-size-xs);
     font-variant-numeric: tabular-nums;
   }
-  .search-track-row .track-num-label { display: inline; }
+  /* Stack the number and play glyph in the same grid cell so both stay in flow
+     (an absolutely-positioned pair collapsed .col-num to 0px, leaving the play
+     button a zero-height target). Reveal via visibility, not display or opacity:
+     visibility is reflow-free (keeps the perf win) AND removes the hidden <button>
+     from the tab order and a11y tree, which opacity:0 did not. */
+  .search-track-row .track-num-label,
   .search-track-row .track-num-play {
-    display: none;
+    grid-area: 1 / 1;
+    display: grid;
+    place-items: center;
+  }
+  .search-track-row .track-num-label { visibility: visible; }
+  .search-track-row .track-num-play {
+    visibility: hidden;
     background: none;
     border: none;
     color: var(--text-primary);
@@ -2773,9 +2786,9 @@
     cursor: pointer;
     padding: 0;
   }
-  .search-track-row:hover .track-num-label { display: none; }
-  .search-track-row:hover .track-num-play { display: inline; }
-  .search-track-row .track-num-play:disabled { opacity: 0.4; cursor: not-allowed; }
+  .search-track-row:hover .track-num-label { visibility: hidden; }
+  .search-track-row:hover .track-num-play { visibility: visible; }
+  .search-track-row:hover .track-num-play:disabled { opacity: 0.4; cursor: not-allowed; }
   .search-track-row .col-title {
     display: flex;
     align-items: center;


### PR DESCRIPTION
## What

Hovering a row in the library track list lagged a little, and got worse the deeper you'd scrolled. Same code smell on the search results rows, so this fixes both.

## Why

The play-number reveal toggled `display: none <-> block` on hover. A `display` change forces a layout pass, and neither list is virtualized: infinite-scroll keeps appending rows and never unloads them. So every hover triggered a reflow that walked an ever-larger box tree, and the cost grew with scroll depth.

## Fix

Stack the number and the play glyph in one grid cell (`grid-area: 1 / 1`, both in flow) and reveal via `visibility` instead of `display`:

- `visibility` is paint-only, so hovering no longer forces a reflow. That removes the part that scaled with row count.
- Unlike `opacity`, `visibility: hidden` also keeps the hidden play control out of the tab order and the accessibility tree, so we don't leak an invisible focus stop through every row.

## Verification

Measured the real geometry in headless WebView2 (the engine the app ships on): the play button keeps a real height (an absolute-positioned variant I tried first collapsed it to 0px, dead click target), the hidden play button is not keyboard-focusable, and there is no layout shift on the hover swap. `pnpm check` is clean.

Raw DOM size (no list windowing at all) is a separate, bigger perf item left for a follow-up. Notes are in FOLLOWUPS.md, including the `content-visibility` approach and the two scroll-mechanic traps to cover first.