### PR TITLE
fix(library): shuffle the whole library, not just the loaded page

### DIFF
--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -2098,6 +2098,12 @@ export interface AudioSearchParams {
 	year_max?: number | null;
 	genre_ids?: number[];
 	is_instrumental?: boolean | null;
+	limit?: number;
+	// Ask the server for a true random sample of the full matching set (library
+	// Shuffle) instead of the deterministic display ranking.
+	shuffle?: boolean;
+	// Restrict matches to user-liked tracks (the Liked tab).
+	liked_only?: boolean;
 }
 
 export interface AudioFeaturesStats {

--- a/frontend/src/lib/stores/player.ts
+++ b/frontend/src/lib/stores/player.ts
@@ -1148,7 +1148,9 @@ export async function playTracksInContext(
 // The catalog list endpoint caps a single page at 200 rows; that is a sensible
 // queue depth for "Play"/"Shuffle" on the whole library since automix extends
 // from there. Pulling every id (tens of thousands) into one POST is neither
-// necessary nor cheap.
+// necessary nor cheap. For Shuffle the server draws those 200 with ORDER BY
+// RANDOM() so the sample is a fresh random slice of the WHOLE library, not the
+// newest-200 prefix reshuffled in place.
 const LIBRARY_QUEUE_LIMIT = 200;
 
 /**
@@ -1166,8 +1168,11 @@ export async function playLibrary(options?: {
 	if (!assertOnline()) return;
 	playerError.set(null);
 	try {
+		// Shuffle pulls a random slice of the entire library; Play honors the
+		// active sort. Without 'random' here, Shuffle only ever saw the first 200
+		// rows of the current sort (e.g. the 200 newest) and reshuffled those.
 		const { tracks } = await api.getTracks(
-			options?.sortBy ?? 'date_added',
+			options?.shuffle ? 'random' : (options?.sortBy ?? 'date_added'),
 			options?.sortDir ?? 'desc',
 			LIBRARY_QUEUE_LIMIT,
 			0,

--- a/frontend/src/routes/library/+page.svelte
+++ b/frontend/src/routes/library/+page.svelte
@@ -113,6 +113,9 @@
 	}
 
 	const PAGE_SIZE = 100;
+	// Depth of the random sample Shuffle pulls from a filtered view. Matches the
+	// whole-library Shuffle queue depth; automix extends past it.
+	const SHUFFLE_SAMPLE_SIZE = 200;
 	const RECENT_TRACK_LIMIT = 10;
 	const HOME_MURAL_ITEM_LIMIT = 12;
 	const ALL_SEARCH_ARTIST_PREVIEW_LIMIT = 12;
@@ -359,7 +362,34 @@
 	async function playTrackView(shuffle = false) {
 		batchError = null;
 		batchMessage = null;
-		if ($searchQuery.trim()) {
+		const trimmed = $searchQuery.trim();
+		if (trimmed) {
+			// A filtered/searched Shuffle must randomize across the FULL matching
+			// set, not just the ~50 rows the search endpoints return for display.
+			// Re-query the audio search with random ordering and a deeper sample so
+			// "genre:dnb", "instrumental:true", or a plain-text query all shuffle
+			// through everything that matches (liked-only on the Liked tab).
+			if (shuffle) {
+				try {
+					const params = buildAudioParams(parseQuery(trimmed), genres);
+					const audio = await api.searchAudio({
+						...params,
+						shuffle: true,
+						liked_only: activeTab === 'liked',
+						limit: SHUFFLE_SAMPLE_SIZE,
+					});
+					const ids = audio.tracks.map((t) => t.id);
+					if (ids.length === 0) {
+						batchError = 'No tracks to play in the current view.';
+						return;
+					}
+					await playTracksInContext(ids, undefined, { shuffle: true });
+					return;
+				} catch (error) {
+					batchError = `Shuffle failed: ${error}`;
+					return;
+				}
+			}
 			const ids = visibleTracks.map((t) => t.id);
 			if (ids.length === 0) {
 				batchError = 'No tracks to play in the current view.';
@@ -777,14 +807,22 @@
 		batchError = null;
 		batchMessage = null;
 		try {
-			if ($searchQuery.trim()) {
-				const source = (activeTab === 'tracks' || activeTab === 'liked')
-					? visibleTracks
-					: searchResults.tracks;
-				if (source.length === 0) {
+			const trimmed = $searchQuery.trim();
+			if (trimmed) {
+				// Draw the random pick from the FULL matching set, not just the ~50
+				// rows on screen. Same server-side random sample the Shuffle button
+				// uses, capped at one track.
+				const params = buildAudioParams(parseQuery(trimmed), genres);
+				const audio = await api.searchAudio({
+					...params,
+					shuffle: true,
+					liked_only: activeTab === 'liked',
+					limit: 1,
+				});
+				const randomTrack = audio.tracks[0];
+				if (!randomTrack) {
 					throw new Error('No searchable tracks are available in the current library view.');
 				}
-				const randomTrack = source[Math.floor(Math.random() * source.length)];
 				await playTrackNow(randomTrack.id);
 				batchMessage = `Playing a random pick: ${randomTrack.title}.`;
 				return;

--- a/noor-server/src/db/queries.rs
+++ b/noor-server/src/db/queries.rs
@@ -558,6 +558,11 @@ fn favorite_predicate(favorite_only: bool, liked_only: bool) -> Option<&'static 
 fn track_order_clause(sort_by: &str, sort_dir: &str) -> String {
     let dir = if sort_dir == "asc" { "ASC" } else { "DESC" };
     match sort_by {
+        // True random sample across the whole matching set. Direction is
+        // meaningless for RANDOM(), so it's ignored. Used by the library
+        // Shuffle button so the queue isn't stuck reordering the newest 200
+        // rows; SQLite draws a fresh sample on every request.
+        "random" => "RANDOM()".to_string(),
         "title" => format!("t.title {dir}"),
         "artist" => format!("a_artists.name {dir}"),
         "album" => format!("al.title {dir}"),
@@ -9731,6 +9736,15 @@ mod tests {
     }
 
     #[test]
+    fn random_order_clause_ignores_direction() {
+        // Shuffle relies on this: the library Shuffle button sends sort_by=random
+        // so the queue is a fresh random slice of the whole library, not the
+        // newest-N prefix reshuffled.
+        assert_eq!(track_order_clause("random", "desc"), "RANDOM()");
+        assert_eq!(track_order_clause("random", "asc"), "RANDOM()");
+    }
+
+    #[test]
     fn artist_library_tracks_and_counts_use_library_union_behavior() {
         let conn = Connection::open_in_memory().expect("in-memory db");
         schema::run_migrations(&conn).expect("migrations");
@@ -9950,6 +9964,138 @@ mod tests {
         let results = search_with_audio_filters(&conn, "", &filters, 50).expect("search");
         let ids: Vec<i64> = results.iter().map(|r| r.id).collect();
         assert_eq!(ids, vec![4001]);
+    }
+
+    #[test]
+    fn shuffled_audio_search_covers_full_matching_set() {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        schema::run_migrations(&conn).expect("migrations");
+
+        conn.execute("INSERT INTO artists (id, name) VALUES (4101, 'Test')", [])
+            .expect("artist");
+        conn.execute(
+            "INSERT INTO albums (id, title, artist_id, source) VALUES (4101, 'A', 4101, 'tidal')",
+            [],
+        )
+        .expect("album");
+        // 8 matching tracks with varied play_count so the deterministic ranking
+        // would order them; shuffle must still surface every matching id.
+        for i in 0..8i64 {
+            let id = 4101 + i;
+            conn.execute(
+                &format!(
+                    "INSERT INTO tracks (
+                        id, title, artist_id, album_id, duration_ms, tidal_id, best_quality,
+                        best_source, fidelity_score, is_favorite, source, play_count
+                     ) VALUES ({id}, 'T{i}', 4101, 4101, 200000, {id}, 'LOSSLESS', 'tidal', 5, 0, 'tidal', {i})"
+                ),
+                [],
+            )
+            .expect("track");
+            conn.execute(
+                &format!("INSERT INTO audio_dsp_features (track_id, bpm) VALUES ({id}, 130.0)"),
+                [],
+            )
+            .expect("dsp");
+        }
+
+        let filters = AudioFilters {
+            bpm_min: Some(120.0),
+            ..Default::default()
+        };
+
+        let results =
+            search_with_audio_filters_shuffled(&conn, "", &filters, 200).expect("shuffle search");
+        let mut ids: Vec<i64> = results.iter().map(|r| r.id).collect();
+        ids.sort_unstable();
+        assert_eq!(ids, (4101..4109).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn shuffled_audio_search_respects_filters_and_limit() {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        schema::run_migrations(&conn).expect("migrations");
+
+        conn.execute("INSERT INTO artists (id, name) VALUES (4201, 'Test')", [])
+            .expect("artist");
+        conn.execute(
+            "INSERT INTO albums (id, title, artist_id, source) VALUES (4201, 'A', 4201, 'tidal')",
+            [],
+        )
+        .expect("album");
+        // Two fast (matching) tracks, two slow (non-matching).
+        conn.execute(
+            "INSERT INTO tracks (
+                id, title, artist_id, album_id, duration_ms, tidal_id, best_quality, best_source,
+                fidelity_score, is_favorite, source, play_count
+             ) VALUES
+                (4201, 'Fast A', 4201, 4201, 200000, 4201, 'LOSSLESS', 'tidal', 5, 0, 'tidal', 0),
+                (4202, 'Fast B', 4201, 4201, 200000, 4202, 'LOSSLESS', 'tidal', 5, 0, 'tidal', 0),
+                (4203, 'Slow A', 4201, 4201, 200000, 4203, 'LOSSLESS', 'tidal', 5, 0, 'tidal', 0),
+                (4204, 'Slow B', 4201, 4201, 200000, 4204, 'LOSSLESS', 'tidal', 5, 0, 'tidal', 0)",
+            [],
+        )
+        .expect("tracks");
+        conn.execute(
+            "INSERT INTO audio_dsp_features (track_id, bpm) VALUES
+                (4201, 140.0), (4202, 135.0), (4203, 70.0), (4204, 60.0)",
+            [],
+        )
+        .expect("dsp");
+
+        let filters = AudioFilters {
+            bpm_min: Some(120.0),
+            ..Default::default()
+        };
+
+        let results =
+            search_with_audio_filters_shuffled(&conn, "", &filters, 1).expect("shuffle search");
+        assert_eq!(results.len(), 1, "limit must cap the shuffled sample");
+        assert!(
+            matches!(results[0].id, 4201 | 4202),
+            "only the fast tracks should match, got {}",
+            results[0].id
+        );
+    }
+
+    #[test]
+    fn liked_only_audio_search_restricts_to_favorites() {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        schema::run_migrations(&conn).expect("migrations");
+
+        conn.execute("INSERT INTO artists (id, name) VALUES (4301, 'Test')", [])
+            .expect("artist");
+        conn.execute(
+            "INSERT INTO albums (id, title, artist_id, source) VALUES (4301, 'A', 4301, 'tidal')",
+            [],
+        )
+        .expect("album");
+        // Two liked, two not liked; all match the filter.
+        conn.execute(
+            "INSERT INTO tracks (
+                id, title, artist_id, album_id, duration_ms, tidal_id, best_quality, best_source,
+                fidelity_score, is_favorite, source, play_count
+             ) VALUES
+                (4301, 'Liked A',   4301, 4301, 200000, 4301, 'LOSSLESS', 'tidal', 5, 1, 'tidal', 0),
+                (4302, 'Liked B',   4301, 4301, 200000, 4302, 'LOSSLESS', 'tidal', 5, 1, 'tidal', 0),
+                (4303, 'Unliked A', 4301, 4301, 200000, 4303, 'LOSSLESS', 'tidal', 5, 0, 'tidal', 0),
+                (4304, 'Unliked B', 4301, 4301, 200000, 4304, 'LOSSLESS', 'tidal', 5, 0, 'tidal', 0)",
+            [],
+        )
+        .expect("tracks");
+
+        let filters = AudioFilters {
+            liked_only: true,
+            ..Default::default()
+        };
+
+        let mut ids: Vec<i64> = search_with_audio_filters_shuffled(&conn, "", &filters, 200)
+            .expect("shuffle search")
+            .iter()
+            .map(|r| r.id)
+            .collect();
+        ids.sort_unstable();
+        assert_eq!(ids, vec![4301, 4302], "liked_only must drop non-favorites");
     }
 
     #[test]
@@ -10419,6 +10565,7 @@ pub struct AudioFilters {
     pub genre_ids: Vec<i64>,           // track must belong to at least one
     pub track_type: Option<String>,    // placeholder, always "track"
     pub is_instrumental: Option<bool>, // true → vocal:false filter
+    pub liked_only: bool,              // restrict to user-liked tracks (Liked tab)
 }
 
 #[derive(Debug, Serialize)]
@@ -10660,6 +10807,11 @@ fn build_audio_filter_sql(filters: &AudioFilters, start_idx: usize) -> AudioFilt
         params.push(Box::new(if instrumental { 1i64 } else { 0i64 }));
         idx += 1;
     }
+    if filters.liked_only {
+        // Mirrors the Liked tab's client-side is_favorite filter so a filtered
+        // Shuffle on that tab samples only liked tracks, not the whole match set.
+        sql.push_str(" AND t.is_favorite = 1");
+    }
 
     AudioFilterSql {
         sql,
@@ -10674,11 +10826,35 @@ pub fn search_with_audio_filters(
     filters: &AudioFilters,
     limit: usize,
 ) -> Result<Vec<AudioSearchResult>> {
-    match search_with_audio_filters_fts(conn, free_text, filters, limit) {
+    search_with_audio_filters_ordered(conn, free_text, filters, limit, false)
+}
+
+/// Same matching as `search_with_audio_filters`, but returns a true random
+/// sample of the full matching set (`ORDER BY RANDOM()`) instead of the
+/// deterministic favorite / play-count ranking. Backs the library Shuffle
+/// button on a filtered view, so Shuffle randomizes across every matching track
+/// instead of reshuffling the same top rows the display query returns.
+pub fn search_with_audio_filters_shuffled(
+    conn: &Connection,
+    free_text: &str,
+    filters: &AudioFilters,
+    limit: usize,
+) -> Result<Vec<AudioSearchResult>> {
+    search_with_audio_filters_ordered(conn, free_text, filters, limit, true)
+}
+
+fn search_with_audio_filters_ordered(
+    conn: &Connection,
+    free_text: &str,
+    filters: &AudioFilters,
+    limit: usize,
+    shuffle: bool,
+) -> Result<Vec<AudioSearchResult>> {
+    match search_with_audio_filters_fts(conn, free_text, filters, limit, shuffle) {
         Ok(results) => Ok(results),
         Err(err) => {
             tracing::warn!(?err, query = %free_text, "FTS library search failed; falling back to LIKE");
-            search_with_audio_filters_like_fallback(conn, free_text, filters, limit)
+            search_with_audio_filters_like_fallback(conn, free_text, filters, limit, shuffle)
         }
     }
 }
@@ -10688,6 +10864,7 @@ fn search_with_audio_filters_fts(
     free_text: &str,
     filters: &AudioFilters,
     limit: usize,
+    shuffle: bool,
 ) -> Result<Vec<AudioSearchResult>> {
     if filters.track_type.as_deref().is_some_and(|t| t != "track") {
         return Ok(Vec::new());
@@ -10724,10 +10901,12 @@ fn search_with_audio_filters_fts(
     sql.push_str(&filter_sql.sql);
     params.extend(filter_sql.params);
 
-    sql.push_str(&format!(
-        " ORDER BY t.is_favorite DESC, t.play_count DESC, t.fidelity_score DESC, t.title ASC \
-         LIMIT ?{limit_idx}"
-    ));
+    let order = if shuffle {
+        "RANDOM()"
+    } else {
+        "t.is_favorite DESC, t.play_count DESC, t.fidelity_score DESC, t.title ASC"
+    };
+    sql.push_str(&format!(" ORDER BY {order} LIMIT ?{limit_idx}"));
     params.push(Box::new(limit as i64));
 
     let mut stmt = conn.prepare(&sql)?;
@@ -10765,6 +10944,7 @@ fn search_with_audio_filters_like_fallback(
     free_text: &str,
     filters: &AudioFilters,
     limit: usize,
+    shuffle: bool,
 ) -> Result<Vec<AudioSearchResult>> {
     let normalized = free_text.trim().to_ascii_lowercase();
 
@@ -10807,9 +10987,12 @@ fn search_with_audio_filters_like_fallback(
     sql.push_str(&filter_sql.sql);
     params.extend(filter_sql.params);
 
-    sql.push_str(&format!(
-        " ORDER BY t.play_count DESC, t.last_played_at DESC LIMIT ?{limit_idx}"
-    ));
+    let order = if shuffle {
+        "RANDOM()"
+    } else {
+        "t.play_count DESC, t.last_played_at DESC"
+    };
+    sql.push_str(&format!(" ORDER BY {order} LIMIT ?{limit_idx}"));
     params.push(Box::new(limit as i64));
 
     let mut stmt = conn.prepare(&sql)?;

--- a/noor-server/src/server/routes/search_routes.rs
+++ b/noor-server/src/server/routes/search_routes.rs
@@ -12,6 +12,10 @@ const SEARCH_LIMIT_DEFAULT: i64 = 20;
 const SEARCH_LIMIT_MAX: i64 = 50;
 const AUDIO_SEARCH_LIMIT_DEFAULT: usize = 50;
 const AUDIO_SEARCH_LIMIT_MAX: usize = 50;
+// Shuffle builds a play queue rather than a display list, so it pulls a deeper
+// random sample of the matching set than the 50-row display cap allows.
+const AUDIO_SHUFFLE_LIMIT_DEFAULT: usize = 200;
+const AUDIO_SHUFFLE_LIMIT_MAX: usize = 500;
 const VIBE_LIMIT_DEFAULT: usize = 6;
 const VIBE_LIMIT_MAX: usize = 50;
 const UNDERRATED_LIMIT_DEFAULT: usize = 5;
@@ -164,6 +168,11 @@ pub(super) struct AudioSearchRequest {
     track_type: Option<String>,
     is_instrumental: Option<bool>,
     limit: Option<usize>,
+    // When set, return a true random sample of the full matching set (for the
+    // library Shuffle button) instead of the deterministic display ranking.
+    shuffle: Option<bool>,
+    // Restrict matches to user-liked tracks (the Liked tab's Shuffle/Random).
+    liked_only: Option<bool>,
 }
 
 pub(super) async fn search_audio(
@@ -184,19 +193,33 @@ pub(super) async fn search_audio(
         genre_ids: body.genre_ids.unwrap_or_default(),
         track_type: body.track_type,
         is_instrumental: body.is_instrumental,
+        liked_only: body.liked_only.unwrap_or(false),
     };
     let free_text = body.free_text.unwrap_or_default();
-    let limit = clamp_usize_limit(
-        body.limit,
-        AUDIO_SEARCH_LIMIT_DEFAULT,
-        AUDIO_SEARCH_LIMIT_MAX,
-    );
+    let shuffle = body.shuffle.unwrap_or(false);
+    let limit = if shuffle {
+        clamp_usize_limit(
+            body.limit,
+            AUDIO_SHUFFLE_LIMIT_DEFAULT,
+            AUDIO_SHUFFLE_LIMIT_MAX,
+        )
+    } else {
+        clamp_usize_limit(
+            body.limit,
+            AUDIO_SEARCH_LIMIT_DEFAULT,
+            AUDIO_SEARCH_LIMIT_MAX,
+        )
+    };
 
     let state = state.read().await;
     state
         .db
         .with_conn(|conn| {
-            let tracks = queries::search_with_audio_filters(conn, &free_text, &filters, limit)?;
+            let tracks = if shuffle {
+                queries::search_with_audio_filters_shuffled(conn, &free_text, &filters, limit)?
+            } else {
+                queries::search_with_audio_filters(conn, &free_text, &filters, limit)?
+            };
             Ok(Json(json!({ "tracks": tracks })))
         })
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
## What was wrong

Library **Shuffle** never actually shuffled the library, it kept reordering the same small window of tracks. Two paths, same root cause:

- **Plain library:** `playLibrary` fetched the first 200 rows of the active sort (so, the newest 200 by date added) and shuffled those in JS. Same 200 every click.
- **Filtered view** (e.g. `genre:dnb instrumental:true`): it shuffled only the ~50 rows the audio-search endpoint returns for display.

So you'd hear the same handful of tracks loop, which is exactly what got reported.

## The fix

Let SQLite draw the random sample across the full matching set instead of reshuffling a prefix in the browser:

- `track_order_clause` gets a `random` arm → `ORDER BY RANDOM()`, so `GET /api/tracks?sort_by=random` returns a fresh random slice of the whole library (still respecting the library/liked filters).
- Audio search splits into a deterministic display path and `search_with_audio_filters_shuffled` (`ORDER BY RANDOM()`), with a deeper sample cap (200/500) and a server-side `liked_only` predicate.
- `playLibrary` asks for `sort_by=random` when shuffling; Play still honors your sort. A searched/filtered Shuffle, and the Random pick button, re-query the full matching set rather than the visible rows.

Covers plain library, DSP-filtered, plain-text search, and the Liked tab.

## Notes

I ran an adversarial review pass over the change, which caught three things I'd otherwise have missed and are fixed here: the Liked tab was dropping its liked filter on shuffle, plain-text search shuffle was still windowed, and the Random button had the same windowing in a filtered view.

## Testing

- New backend unit tests: random order clause, full-set coverage, the liked-only predicate, sample-limit cap. Full `cargo test` green.
- `pnpm check` clean.

`ORDER BY RANDOM() LIMIT 200` is a bounded sort over the filtered set, so it's a quick scan even on a large library; the queue depth stays 200 and automix extends from there as before.