### PR TITLE
ci(release): prebuilt Tauri CLI + cache Windows target dir

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,11 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          cache-targets: false
+          # Cache compiled deps (not just the registry) so the from-scratch
+          # ~15 min portable build drops to a few min on a warm cache. Windows
+          # is the release bottleneck; the other jobs stay registry-only to keep
+          # the repo's 10 GB cache budget from thrashing pr-check's caches.
+          cache-targets: true
 
       - name: Sync version from tag
         shell: bash
@@ -143,15 +147,16 @@ jobs:
           $hash = (Get-FileHash $file -Algorithm SHA256).Hash.ToLower()
           "$hash  NOORwave-${{ github.ref_name }}-windows-x64.zip" | Out-File -Encoding utf8 dist\windows.sha256
 
-      - name: Install Tauri CLI
-        run: cargo install tauri-cli --version "=2.10.1" --locked
-
+      # Run the Tauri CLI from its prebuilt npm binary instead of
+      # `cargo install tauri-cli`, which compiled the CLI from source and cost
+      # ~9 min per release. Same CLI, same version pin; pnpm + Node are already
+      # set up above. The bundle output path the next step reads is unchanged.
       - name: Build NSIS installer
         working-directory: noor-app
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-        run: cargo tauri build --bundles nsis --config tauri.installer.conf.json
+        run: pnpm dlx --package=@tauri-apps/cli@2.10.1 tauri build --bundles nsis --config tauri.installer.conf.json
 
       - name: Package installer update metadata
         shell: pwsh


### PR DESCRIPTION
Release builds take ~28 minutes, and it turns out the entire wall-clock is one job. The other three platforms run in parallel and wrap up in 7-9 min; Windows alone takes 28. Pulling the step-level timings, two steps are 24 of those minutes:

| Windows step | Before |
|---|---|
| Install Tauri CLI | 9.4 min (compiling `tauri-cli` from source) |
| Build portable | 14.7 min (full dep graph from scratch, `target/` was never cached) |

## Changes
- **Tauri CLI from npm.** `cargo install tauri-cli` compiled the CLI from source every run. The same CLI ships prebuilt as `@tauri-apps/cli`, so this runs it via `pnpm dlx --package=@tauri-apps/cli@2.10.1` (pnpm and Node are already set up in the job). Same version pin, same `tauri build` invocation, same bundle output path the next step reads.
- **Cache the Windows `target/`.** Flipped `cache-targets: false` to `true` on the Windows job so a warm cache only recompiles changed crates instead of the whole graph.

Left the Linux/macOS jobs registry-only on purpose: four multi-GB release caches would thrash the repo's 10 GB cache budget and start evicting pr-check's caches. Windows is the only job on the critical path, so it is the only one worth caching.

Expected: **~28 min to ~10 min** (the CLI swap is the guaranteed ~9; the cache win depends on a warm cache, which holds at our release cadence).

## Heads up on validation
`release.yml` is tag-triggered, so this cannot be exercised by this PR's checks. The first real run is the next `v*` tag. Both changes fail safe: if the npm CLI fetch breaks, the step errors loudly rather than shipping a bad artifact, and the cache only affects build speed. To dry-run before trusting it, push a throwaway `vX.Y.Z-rc1` tag.
