### PR TITLE
release: v0.3.3 - queue/up-next fixes + song-radio original-version match

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3303,7 +3303,7 @@ dependencies = [
 
 [[package]]
 name = "noor-app"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "reqwest 0.12.28",
  "serde",
@@ -3333,7 +3333,7 @@ dependencies = [
 
 [[package]]
 name = "noor-server"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/frontend/src/lib/stores/player.move_next.test.ts
+++ b/frontend/src/lib/stores/player.move_next.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from 'vitest';
-import { computePlayNextPos, normalizePlayerError, selectOptimisticNextItem } from './player';
+import {
+	computePlayNextPos,
+	normalizePlayerError,
+	reorderDropIndex,
+	selectAppendedQueueRow,
+	selectOptimisticNextItem
+} from './player';
 
 // Regression: moveQueueTrackNext used to rebuild the queue via
 // replacePlaybackQueue(track_ids), which silently dropped ephemeral TIDAL
@@ -66,6 +72,56 @@ describe('selectOptimisticNextItem', () => {
 
 		expect(selectOptimisticNextItem(queue, 1, 12)?.id).toBe(13);
 		expect(selectOptimisticNextItem(queue, 1, null)?.id).toBe(11);
+	});
+});
+
+describe('reorderDropIndex', () => {
+	// Regression: handleQueueDrop passed the pre-removal target index straight to
+	// moveQueueItem, which removes the dragged row first. Downward drags landed
+	// one slot too low. reorderDropIndex applies the removal-shift correction.
+	test('downward drag (source above target) subtracts one', () => {
+		// Queue [cur,A,B,C] (0..3). Drag A(1) onto C(3): after removing A the
+		// target slot is 2, so the row lands on C's top edge, not below it.
+		expect(reorderDropIndex(1, 3)).toBe(2);
+	});
+
+	test('upward drag (source below target) keeps the target index', () => {
+		// Drag C(3) onto A(1): removing C does not shift A, so insert at 1.
+		expect(reorderDropIndex(3, 1)).toBe(1);
+	});
+
+	test('missing source index keeps the target index', () => {
+		expect(reorderDropIndex(-1, 4)).toBe(4);
+	});
+
+	test('adjacent downward drag collapses to a no-op-ish same slot', () => {
+		// Drag A(1) onto B(2): subtract one -> 1, i.e. stays put (drop just below).
+		expect(reorderDropIndex(1, 2)).toBe(1);
+	});
+});
+
+describe('selectAppendedQueueRow', () => {
+	const row = (id: number, trackId: number) => ({ id, track: { id: trackId } });
+
+	test('picks the genuinely-new row when the track was already queued', () => {
+		// Regression: a track-id match returned the pre-existing earlier copy and
+		// the freshly appended row (id 99) was stranded at the bottom -> "Play
+		// next went to the bottom".
+		const before = [row(10, 1), row(11, 2)];
+		const after = [row(10, 1), row(11, 2), row(99, 1)];
+		expect(selectAppendedQueueRow(before, after, 1)?.id).toBe(99);
+	});
+
+	test('picks the new row for a track not previously queued', () => {
+		const before = [row(10, 1)];
+		const after = [row(10, 1), row(12, 5)];
+		expect(selectAppendedQueueRow(before, after, 5)?.id).toBe(12);
+	});
+
+	test('falls back to a track-id match when no new id appears', () => {
+		const before = [row(10, 1), row(11, 2)];
+		const after = [row(10, 1), row(11, 2)]; // dedupe: nothing appended
+		expect(selectAppendedQueueRow(before, after, 2)?.id).toBe(11);
 	});
 });
 

--- a/frontend/src/lib/stores/player.ts
+++ b/frontend/src/lib/stores/player.ts
@@ -17,6 +17,7 @@ import { showToast, dismissToast } from '$lib/stores/toast';
 import { announceQueue, announceResolved } from '$lib/stores/queue_announcer';
 import { offerUndo } from '$lib/stores/queue_undo';
 import { queueItemToTidalPlayable } from '$lib/utils/track';
+import { currentQueueAnchorItem } from '$lib/player/queue_active';
 import { wsConnected } from '$lib/api/ws';
 import { updateLibraryTrackFavorite } from '$lib/stores/library';
 import { clamp01 } from '$lib/utils/math';
@@ -806,6 +807,38 @@ export function computePlayNextPos(
 	return newPos;
 }
 
+/**
+ * Translate a drag drop-target index into the index `moveQueueItem` (and the
+ * server's `move_queue_item`) expect, which is measured AFTER the dragged row is
+ * spliced out. Dragging downward (source sits above the target) shifts the
+ * target up one slot once the source is removed, so subtract one to land ON the
+ * target row's slot (the "drops here" top-edge indicator) instead of one below
+ * it. Upward drags keep the target's index. Exported for unit testing.
+ */
+export function reorderDropIndex(sourceIndex: number, targetIndex: number): number {
+	return sourceIndex !== -1 && sourceIndex < targetIndex ? targetIndex - 1 : targetIndex;
+}
+
+/**
+ * Pick the row that `addQueueTrack` just appended. The endpoint appends exactly
+ * one new row; identify it by "id not present before the add" rather than a
+ * track-id match, so a track that was already queued doesn't make us grab its
+ * pre-existing earlier copy and strand the freshly-added row at the bottom.
+ * Falls back to a track-id match when the diff is empty (e.g. server-side
+ * dedupe). Exported for unit testing.
+ */
+export function selectAppendedQueueRow<T extends { id: number; track: { id: number } }>(
+	before: T[],
+	after: T[],
+	trackId: number
+): T | undefined {
+	const beforeIds = new Set(before.map((item) => item.id));
+	return (
+		after.find((item) => !beforeIds.has(item.id)) ??
+		after.find((item) => item.track.id === trackId)
+	);
+}
+
 export async function moveQueueTrackNext(queueItemId: number) {
 	playerError.set(null);
 	const queue = get(playbackQueue);
@@ -816,10 +849,13 @@ export async function moveQueueTrackNext(queueItemId: number) {
 	// The latter drops queue rows whose track_id is negative (ephemeral TIDAL
 	// rows that haven't been imported into the library yet), silently corrupting
 	// a mixed library + TIDAL queue when the user picks "Play next".
-	const currentTrackId = get(currentTrack)?.id ?? null;
-	const currentIndex = currentTrackId
-		? queue.findIndex((item) => item.track.id === currentTrackId)
-		: -1;
+	//
+	// Anchor on the canonical queue-item anchor (queue-item-id first, track-id
+	// fallback), the same helper the active-row highlight and upcomingQueue use.
+	// A bare findIndex(track.id) lands on the FIRST duplicate copy of the current
+	// track, so "Play next" would compute its target relative to the wrong row.
+	const anchor = currentQueueAnchorItem(queue, get(currentTrack), get(currentQueueItemId));
+	const currentIndex = anchor ? queue.findIndex((item) => item.id === anchor.id) : -1;
 	const newPos = computePlayNextPos(targetIndex, currentIndex, queue.length);
 	if (newPos === null) return;
 
@@ -1444,9 +1480,14 @@ export async function playTrackNext(trackId: number) {
 	playerError.set(null);
 	// Add to queue, then move next to the currently-playing track.
 	try {
+		const before = get(playbackQueue);
 		const addResult = await api.addQueueTrack(trackId);
 		setPlaybackQueue(addResult.queue);
-		const justAdded = addResult.queue.find((item) => item.track.id === trackId);
+		// Pick the genuinely-new row (id not present before the add), not the first
+		// track-id match: if the track was already queued, a track-id match returns
+		// the pre-existing earlier copy and the freshly appended row is stranded at
+		// the bottom (the "Play next went to the bottom" bug).
+		const justAdded = selectAppendedQueueRow(before, addResult.queue, trackId);
 		if (justAdded) {
 			await moveQueueTrackNext(justAdded.id);
 		}

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -37,6 +37,7 @@
 		toggleTrackFavorite,
 		toggleMute,
 		moveQueueItem,
+		reorderDropIndex,
 		clearQueue as clearQueueAction,
 		restoreQueueItems,
 		saveQueueAsPlaylist,
@@ -838,7 +839,13 @@
 		const fullQueue = $playbackQueue;
 		const targetIndex = fullQueue.findIndex((q) => q.id === target.id);
 		if (targetIndex === -1) return;
-		await moveQueueItem(sourceId, targetIndex);
+		// moveQueueItem (and the server) interpret the index AFTER the dragged row
+		// is spliced out. For a downward drag (source sits above the target),
+		// removing the source shifts the target up one slot, so reorderDropIndex
+		// subtracts one to land ON the target's top edge (the "drops here"
+		// indicator) instead of one row below it. Upward drags keep the index.
+		const sourceIndex = fullQueue.findIndex((q) => q.id === sourceId);
+		await moveQueueItem(sourceId, reorderDropIndex(sourceIndex, targetIndex));
 	}
 
 	function handleQueueDragEnd() {
@@ -1618,7 +1625,7 @@
 
 			{#if upcomingQueue.length > 0}
 				<div class="queue-list" id="queue-list" role="list" bind:this={queueListEl} onscroll={handleQueueScroll}>
-					{#each upcomingQueue.slice(0, queueVisibleCount) as item, i (`${item.id}-${i}`)}
+					{#each upcomingQueue.slice(0, queueVisibleCount) as item (item.id)}
 						{@const aid = item.track.artist_id}
 						{@const isPending = item.is_pending === true}
 						<div
@@ -1944,7 +1951,7 @@
 
 			{#if upcomingQueue.length > 0}
 				<div class="mobile-np-queue-list" role="list">
-					{#each upcomingQueue.slice(0, queueVisibleCount) as item, i (`${item.id}-${i}`)}
+					{#each upcomingQueue.slice(0, queueVisibleCount) as item (item.id)}
 						{@const aid = item.track.artist_id}
 						{@const isPending = item.is_pending === true}
 						<div

--- a/noor-app/Cargo.toml
+++ b/noor-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noor-app"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 
 [[bin]]

--- a/noor-app/tauri.conf.json
+++ b/noor-app/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "NOORwave",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "identifier": "com.noorwave.app",
   "app": {
     "windows": [],

--- a/noor-server/Cargo.toml
+++ b/noor-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noor-server"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 description = "NOORwave - Multi-service music library manager and hi-fi player"
 

--- a/noor-server/src/playback/queue.rs
+++ b/noor-server/src/playback/queue.rs
@@ -303,6 +303,18 @@ pub fn append_external_tracks(
     Ok(results)
 }
 
+/// The lowest `position` currently in the queue, or `None` when the queue is
+/// empty. Used by "Play next" during ephemeral-mix playback: the live track has
+/// no queue row and the DB anchor is NULL, so "after current" has to mean "at
+/// the front of the remaining continuation".
+pub fn front_position(conn: &Connection) -> Result<Option<i32>> {
+    Ok(
+        conn.query_row("SELECT MIN(position) FROM queue", [], |row| {
+            row.get::<_, Option<i32>>(0)
+        })?,
+    )
+}
+
 /// Insert an external track immediately after `after_position`. Existing rows
 /// at that position or later are shifted by one. Used for "Play next" so the
 /// new row lands at `current_position + 1`.
@@ -1113,6 +1125,58 @@ mod tests {
         assert_eq!(queue.len(), 2);
         assert_eq!(queue[0].track.id, 1);
         assert_eq!(queue[1].track.id, 2);
+    }
+
+    #[test]
+    fn front_position_and_play_next_front_insert_during_mix() {
+        let conn = conn();
+        // Simulate a TIDAL mix continuation: ephemeral rows, no library/anchor.
+        for (pos, tidal) in [(0, 101_i64), (1, 102), (2, 103)] {
+            conn.execute(
+                "INSERT INTO queue (track_id, position, source, tidal_id_hint)
+                 VALUES (NULL, ?1, 'tidal_mix', ?2)",
+                params![pos, tidal],
+            )
+            .unwrap();
+        }
+        assert_eq!(front_position(&conn).unwrap(), Some(0));
+
+        // "Play next" during a mix inserts at front_position - 1, so the new row
+        // becomes the very next track instead of the bottom of the continuation.
+        let insert = ExternalTrackInsert {
+            artist: "New Artist",
+            title: "Play Next Pick",
+            source: "user_play_next",
+            reason: None,
+            tidal_id_hint: Some(999),
+            local_track_id: None,
+        };
+        let front = front_position(&conn).unwrap().unwrap();
+        insert_external_track_after(&conn, &insert, front - 1).unwrap();
+
+        let new_pos: i32 = conn
+            .query_row(
+                "SELECT position FROM queue WHERE tidal_id_hint = 999",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(new_pos, 0, "play-next row should land at the front");
+        let first_mix_pos: i32 = conn
+            .query_row(
+                "SELECT position FROM queue WHERE tidal_id_hint = 101",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(first_mix_pos, 1, "mix rows shift down by one");
+        assert_eq!(load_queue(&conn).unwrap().len(), 4);
+    }
+
+    #[test]
+    fn front_position_is_none_for_empty_queue() {
+        let conn = conn();
+        assert_eq!(front_position(&conn).unwrap(), None);
     }
 
     #[test]

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -6731,6 +6731,292 @@ fn import_metadata_from_tidal_track(t: TidalTrack) -> tidal_import::ImportTrackM
     }
 }
 
+// How many search hits to consider when resolving a pending row. Heavily
+// remixed songs push the plain studio cut well down TIDAL's relevance order, so
+// pulling only the top few can leave the original out of the candidate set
+// entirely. Ten is enough headroom without materially changing latency.
+const TIDAL_RESOLVE_POOL: i32 = 10;
+
+/// How a TIDAL track relates to the plain studio recording, inferred from its
+/// `version` field (authoritative) or a trailing descriptor in the title.
+///
+/// `Original` is the canonical performance: no version tag, or a marker that
+/// only describes mastering/format (remaster, mono, deluxe edition...) which is
+/// the *same* recording and stays eligible. Every other class is a different
+/// recording and gets demoted unless the request explicitly asked for it. This
+/// version axis is the only thing separating "American Pie" from "American Pie
+/// (L'Tric Remix)": they share a base title and artist, so title+artist scoring
+/// alone ties them at 1.0 and the remix can win by listing order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum VersionClass {
+    Original,
+    Remix,
+    Live,
+    Acoustic,
+    Instrumental,
+    Cover,
+    SpedSlowed,
+    Edit,
+    OtherVariant,
+}
+
+fn normalize_version_text(s: &str) -> String {
+    s.to_ascii_lowercase()
+        .chars()
+        .map(|c| if c.is_alphanumeric() { c } else { ' ' })
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn version_text_has_word(normalized: &str, word: &str) -> bool {
+    normalized.split(' ').any(|tok| tok == word)
+}
+
+/// Classify a free-text version descriptor. Returns `None` when nothing is
+/// recognized, so callers decide what an unknown tag means in context: a
+/// populated TIDAL `version` field is a deliberate variant flag, while a bare
+/// title parenthetical like "(Pt. 1)" is probably just part of the title.
+fn classify_version_descriptor(descriptor: &str) -> Option<VersionClass> {
+    let d = normalize_version_text(descriptor);
+    if d.is_empty() {
+        return None;
+    }
+    // Mastering / format / explicitly-original markers describe the same
+    // performance, so they resolve to Original. Checked first so "Original Mix"
+    // and "Deluxe Edition" never fall through to the "mix"/"edit" branches.
+    const MASTERING: &[&str] = &[
+        "original mix",
+        "original version",
+        "album version",
+        "single version",
+        "original",
+        "remaster",
+        "remastered",
+        "mono",
+        "stereo",
+        "deluxe",
+        "anniversary",
+        "expanded",
+        "reissue",
+        "edition",
+        "bonus",
+    ];
+    if MASTERING.iter().any(|m| d.contains(m)) {
+        return Some(VersionClass::Original);
+    }
+    const REMIX: &[&str] = &[
+        "remix", "rmx", "bootleg", "rework", "flip", "vip", "mashup", "mash up", "club mix", "dub",
+    ];
+    if REMIX.iter().any(|m| d.contains(m)) {
+        return Some(VersionClass::Remix);
+    }
+    if version_text_has_word(&d, "live") || d.contains("in concert") {
+        return Some(VersionClass::Live);
+    }
+    if d.contains("acoustic") || d.contains("unplugged") {
+        return Some(VersionClass::Acoustic);
+    }
+    if d.contains("instrumental") || d.contains("karaoke") {
+        return Some(VersionClass::Instrumental);
+    }
+    if d.contains("cover")
+        || d.contains("originally performed")
+        || d.contains("made famous")
+        || d.contains("tribute")
+    {
+        return Some(VersionClass::Cover);
+    }
+    if d.contains("sped up")
+        || d.contains("spedup")
+        || d.contains("slowed")
+        || d.contains("nightcore")
+    {
+        return Some(VersionClass::SpedSlowed);
+    }
+    if version_text_has_word(&d, "edit") || d.contains("extended") {
+        return Some(VersionClass::Edit);
+    }
+    None
+}
+
+/// Split a trailing variant descriptor off a title. Only the last bracketed
+/// group or a " - " tail is considered:
+/// "American Pie (L'Tric Remix)" -> ("American Pie", Some("L'Tric Remix")).
+fn split_title_descriptor(title: &str) -> (String, Option<String>) {
+    let t = title.trim();
+    if let Some(open) = t.rfind(['(', '[']) {
+        let want_close = if t.as_bytes()[open] == b'(' {
+            b')'
+        } else {
+            b']'
+        };
+        if t.as_bytes().last() == Some(&want_close) {
+            let inner = t[open + 1..t.len() - 1].trim();
+            let base = t[..open].trim();
+            if !inner.is_empty() && !base.is_empty() {
+                return (base.to_string(), Some(inner.to_string()));
+            }
+        }
+    }
+    if let Some(idx) = t.rfind(" - ") {
+        let desc = t[idx + 3..].trim();
+        let base = t[..idx].trim();
+        if !desc.is_empty() && !base.is_empty() {
+            return (base.to_string(), Some(desc.to_string()));
+        }
+    }
+    (t.to_string(), None)
+}
+
+/// Base title (for fuzzy scoring) plus version class for a search candidate. The
+/// `version` field wins; a populated-but-unrecognized version still means "not
+/// the plain original" and demotes. Without a version field we read a title
+/// descriptor, where an unrecognized parenthetical is kept as part of the title.
+fn classify_candidate(track: &TidalSearchTrack) -> (String, VersionClass) {
+    let version = track
+        .extra
+        .get("version")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    if let Some(version) = version {
+        let class = classify_version_descriptor(version).unwrap_or(VersionClass::OtherVariant);
+        return (track.title.clone(), class);
+    }
+    classify_title_field(&track.title)
+}
+
+/// Base title plus version class for a free title string with no separate
+/// version field (e.g. a Last.fm suggestion). Unrecognized descriptors stay
+/// Original so genuine titles like "Shine On You Crazy Diamond (Pt. 1)" match.
+fn classify_title_field(title: &str) -> (String, VersionClass) {
+    let (base, desc) = split_title_descriptor(title);
+    match desc.as_deref().and_then(classify_version_descriptor) {
+        Some(class) => (base, class),
+        None => (title.trim().to_string(), VersionClass::Original),
+    }
+}
+
+fn version_quality_rank(quality: Option<&str>) -> u8 {
+    match quality.map(str::to_ascii_uppercase).as_deref() {
+        Some("HI_RES_LOSSLESS") | Some("HI_RES") => 3,
+        Some("LOSSLESS") => 2,
+        Some("HIGH") => 1,
+        _ => 0,
+    }
+}
+
+/// Pick the best TIDAL search result for a pending `(artist, title)`, preferring
+/// the version the request actually implies. Pure (no network) so it can be unit
+/// tested against synthetic candidate sets.
+///
+/// 1. Score every candidate on base-title + artist Jaro-Winkler (variant
+///    descriptors stripped first), keeping those that clear the threshold.
+/// 2. Partition by whether the candidate's version class matches the request.
+///    Prefer the matching set; fall back to the rest only when nothing matched,
+///    so a song that exists *only* as a remix still resolves instead of stalling.
+/// 3. Within the chosen set, rank by score, then descriptor closeness when a
+///    specific variant was named (so a named remix beats a different one), then
+///    audio quality as a hi-fi-friendly final tiebreak.
+fn select_best_tidal_match(
+    pending_artist: &str,
+    pending_title: &str,
+    results: Vec<TidalSearchTrack>,
+) -> Option<(f64, TidalSearchTrack)> {
+    let (pending_base, pending_class) = classify_title_field(pending_title);
+    let pending_desc_norm = split_title_descriptor(pending_title)
+        .1
+        .map(|d| normalize_version_text(&d))
+        .unwrap_or_default();
+
+    struct Scored {
+        score: f64,
+        class: VersionClass,
+        desc_sim: f64,
+        quality: u8,
+        track: TidalSearchTrack,
+    }
+
+    let mut scored: Vec<Scored> = results
+        .into_iter()
+        .filter_map(|track| {
+            let (cand_base, class) = classify_candidate(&track);
+            let score = score_tidal_candidate(
+                track.artist_name.as_deref().unwrap_or(""),
+                &cand_base,
+                pending_artist,
+                &pending_base,
+            );
+            if score < MATCH_QUALITY_THRESHOLD {
+                return None;
+            }
+            let cand_desc_norm = track
+                .extra
+                .get("version")
+                .and_then(|v| v.as_str())
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+                .or_else(|| split_title_descriptor(&track.title).1)
+                .map(|d| normalize_version_text(&d))
+                .unwrap_or_default();
+            let desc_sim = if pending_desc_norm.is_empty() {
+                0.0
+            } else {
+                strsim::jaro_winkler(&pending_desc_norm, &cand_desc_norm)
+            };
+            Some(Scored {
+                score,
+                class,
+                desc_sim,
+                quality: version_quality_rank(track.audio_quality.as_deref()),
+                track,
+            })
+        })
+        .collect();
+
+    if scored.is_empty() {
+        return None;
+    }
+
+    // Prefer candidates whose version class matches the request; only keep the
+    // mismatched ones if nothing matched at all (the fallback).
+    if scored
+        .iter()
+        .any(|s| version_intent_matches(pending_class, s.class))
+    {
+        scored.retain(|s| version_intent_matches(pending_class, s.class));
+    }
+
+    let want_desc = !pending_desc_norm.is_empty();
+    scored.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| {
+                if want_desc {
+                    b.desc_sim
+                        .partial_cmp(&a.desc_sim)
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                } else {
+                    std::cmp::Ordering::Equal
+                }
+            })
+            .then(b.quality.cmp(&a.quality))
+    });
+
+    scored.into_iter().next().map(|s| (s.score, s.track))
+}
+
+/// A candidate satisfies the request when its version class is the same. A clean
+/// request (`Original`) only accepts originals; a request that named a variant
+/// (remix, acoustic...) only accepts that same kind.
+fn version_intent_matches(pending: VersionClass, candidate: VersionClass) -> bool {
+    pending == candidate
+}
+
 async fn find_pending_tidal_match(
     client: &TidalClient,
     pending_artist: &str,
@@ -6743,25 +7029,157 @@ async fn find_pending_tidal_match(
     }
 
     let query = format!("{} {}", pending_artist, pending_title);
-    let results = client.search(&query, 5).await?;
-    let best = results
-        .into_iter()
-        .filter_map(|t| {
-            let s = score_tidal_candidate(
-                t.artist_name.as_deref().unwrap_or(""),
-                &t.title,
-                pending_artist,
-                pending_title,
-            );
-            if s >= MATCH_QUALITY_THRESHOLD {
-                Some((s, t))
-            } else {
-                None
-            }
-        })
-        .max_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+    let results = client.search(&query, TIDAL_RESOLVE_POOL).await?;
+    Ok(
+        select_best_tidal_match(pending_artist, pending_title, results)
+            .map(|(score, track)| (score, import_metadata_from_search_track(track))),
+    )
+}
 
-    Ok(best.map(|(score, track)| (score, import_metadata_from_search_track(track))))
+#[cfg(test)]
+mod version_match_tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn track(
+        id: i64,
+        title: &str,
+        artist: &str,
+        version: Option<&str>,
+        quality: &str,
+    ) -> TidalSearchTrack {
+        let mut extra = HashMap::new();
+        if let Some(v) = version {
+            extra.insert(
+                "version".to_string(),
+                serde_json::Value::String(v.to_string()),
+            );
+        }
+        TidalSearchTrack {
+            id,
+            title: title.to_string(),
+            duration: 200,
+            artist_name: Some(artist.to_string()),
+            audio_quality: Some(quality.to_string()),
+            extra,
+            ..Default::default()
+        }
+    }
+
+    fn pick(artist: &str, title: &str, results: Vec<TidalSearchTrack>) -> Option<i64> {
+        select_best_tidal_match(artist, title, results).map(|(_, t)| t.id)
+    }
+
+    #[test]
+    fn clean_request_prefers_original_over_remix_regardless_of_order() {
+        // The bug: both share base title "American Pie", so title+artist tie at
+        // 1.0 and listing order decided the winner.
+        let original = || track(1, "American Pie", "Don McLean", None, "LOSSLESS");
+        let remix = || {
+            track(
+                2,
+                "American Pie",
+                "Don McLean",
+                Some("L'Tric Remix"),
+                "LOSSLESS",
+            )
+        };
+        assert_eq!(
+            pick("Don McLean", "American Pie", vec![original(), remix()]),
+            Some(1)
+        );
+        assert_eq!(
+            pick("Don McLean", "American Pie", vec![remix(), original()]),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn remix_only_results_resolve_as_fallback() {
+        let results = vec![track(
+            2,
+            "American Pie",
+            "Don McLean",
+            Some("L'Tric Remix"),
+            "LOSSLESS",
+        )];
+        assert_eq!(pick("Don McLean", "American Pie", results), Some(2));
+    }
+
+    #[test]
+    fn explicit_variant_request_takes_the_variant_not_the_original() {
+        let results = vec![
+            track(1, "Layla", "Eric Clapton", None, "LOSSLESS"),
+            track(2, "Layla", "Eric Clapton", Some("Acoustic"), "LOSSLESS"),
+        ];
+        assert_eq!(pick("Eric Clapton", "Layla (Acoustic)", results), Some(2));
+    }
+
+    #[test]
+    fn named_remix_request_prefers_the_matching_name() {
+        let results = vec![
+            track(1, "Song", "Artist", Some("Someone Else Remix"), "LOSSLESS"),
+            track(2, "Song", "Artist", Some("L'Tric Remix"), "LOSSLESS"),
+            track(3, "Song", "Artist", None, "LOSSLESS"),
+        ];
+        assert_eq!(pick("Artist", "Song (L'Tric Remix)", results), Some(2));
+    }
+
+    #[test]
+    fn remaster_is_not_demoted() {
+        // Remaster is the same performance; for a clean request with only a
+        // remaster and a remix available, the remaster must win.
+        let results = vec![
+            track(1, "Heroes", "David Bowie", Some("2017 Remaster"), "HI_RES"),
+            track(2, "Heroes", "David Bowie", Some("Club Mix"), "LOSSLESS"),
+        ];
+        assert_eq!(pick("David Bowie", "Heroes", results), Some(1));
+    }
+
+    #[test]
+    fn live_version_does_not_leak_into_a_clean_request() {
+        let results = vec![
+            track(
+                1,
+                "Wish You Were Here",
+                "Pink Floyd",
+                Some("Live"),
+                "LOSSLESS",
+            ),
+            track(2, "Wish You Were Here", "Pink Floyd", None, "LOSSLESS"),
+        ];
+        assert_eq!(pick("Pink Floyd", "Wish You Were Here", results), Some(2));
+    }
+
+    #[test]
+    fn variant_in_title_is_detected_without_a_version_field() {
+        let results = vec![
+            track(1, "Get Lucky (Radio Edit)", "Daft Punk", None, "LOSSLESS"),
+            track(2, "Get Lucky", "Daft Punk", None, "LOSSLESS"),
+        ];
+        assert_eq!(pick("Daft Punk", "Get Lucky", results), Some(2));
+    }
+
+    #[test]
+    fn unrecognized_parenthetical_is_treated_as_title_not_variant() {
+        let results = vec![track(
+            1,
+            "Shine On You Crazy Diamond (Pt. 1)",
+            "Pink Floyd",
+            None,
+            "LOSSLESS",
+        )];
+        assert_eq!(
+            pick("Pink Floyd", "Shine On You Crazy Diamond (Pt. 1)", results),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn wrong_artist_below_threshold_is_rejected() {
+        let results = vec![track(1, "American Pie", "Madonna", None, "LOSSLESS")];
+        assert_eq!(pick("Don McLean", "American Pie", results), None);
+    }
 }
 
 /// Atomically promote a pending queue row to a resolved library row, then

--- a/noor-server/src/server/routes.rs
+++ b/noor-server/src/server/routes.rs
@@ -6143,6 +6143,27 @@ async fn play_track(
         "playback start requested"
     );
 
+    // Was this track already a row in the queue BEFORE play_track_now (which
+    // appends it if absent)? An in-queue jump (e.g. clicking a library row that
+    // is sitting alongside a TIDAL mix continuation) must NOT wipe the ephemeral
+    // rows: the user is moving within one Up Next list, not abandoning the mix.
+    // We only clear the continuation when starting a track that is genuinely
+    // outside the current queue. The "Play all / load queue" path already does a
+    // full `DELETE FROM queue` in replace_queue, so by the time it reaches here
+    // the played row is in the fresh queue and there are no ephemeral rows left
+    // to clear anyway.
+    let track_already_queued = {
+        let state_guard = state.read().await;
+        state_guard
+            .db
+            .with_conn(|conn| {
+                Ok::<bool, anyhow::Error>(
+                    first_queue_item_id_for_track(conn, payload.track_id)?.is_some(),
+                )
+            })
+            .unwrap_or(false)
+    };
+
     let snapshot = {
         let state_guard = state.read().await;
         state_guard
@@ -6166,7 +6187,10 @@ async fn play_track(
                 )
             })?
     };
-    clear_ephemeral_playback_markers(&state, true).await;
+    // Always drop the in-memory ephemeral/external overlay (we're switching to a
+    // library track), but only delete the persisted mix continuation rows when
+    // this is not an in-queue jump. See `track_already_queued` above.
+    clear_ephemeral_playback_markers(&state, !track_already_queued).await;
 
     let user_quality = current_user_audio_quality(&state).await;
     let stream_request = match player::build_tidal_stream_request(&track, user_quality.clone()) {
@@ -8696,6 +8720,29 @@ async fn queue_append_many(
     Ok(Json(json!({ "queue": queue })))
 }
 
+/// Decide the `after_position` for a "Play next" insert. Returns `Some(pos)` to
+/// insert right after `pos`, or `None` to append at the end of the queue.
+///
+/// - `current_pos`: position of the currently-playing queue row, if any
+///   (`current_queue_position`).
+/// - `front_pos`: the lowest position in the queue (`queue::front_position`).
+/// - `ephemeral_active`: whether a TIDAL mix/external overlay is the live track.
+///   During a mix the playing track has no queue row and the DB anchor is NULL,
+///   so `current_pos` is `None` even though something is playing; "after current"
+///   then means the front of the remaining continuation (`front - 1`), not the
+///   bottom of the queue.
+fn play_next_after_position(
+    current_pos: Option<i32>,
+    front_pos: Option<i32>,
+    ephemeral_active: bool,
+) -> Option<i32> {
+    match (current_pos, ephemeral_active, front_pos) {
+        (Some(pos), _, _) => Some(pos),
+        (None, true, Some(front)) => Some(front - 1),
+        _ => None,
+    }
+}
+
 async fn queue_play_next(
     State(state): State<SharedState>,
     Json(payload): Json<QueueExternalRequest>,
@@ -8708,12 +8755,24 @@ async fn queue_play_next(
         state_guard
             .user_cleared_at
             .store(0, std::sync::atomic::Ordering::Relaxed);
+        // During an ephemeral TIDAL mix the playing track has no queue row and the
+        // DB anchor is NULL, so current_queue_position() returns None. Without this
+        // flag "Play next" would fall through to append-at-bottom; instead we
+        // insert at the front of the remaining continuation (the visible top of
+        // Up Next during a mix).
+        let ephemeral_active = state_guard.ephemeral_tidal_track.is_some()
+            || state_guard.external_playback_track.is_some();
         let event_tx = state_guard.event_tx.clone();
         state_guard
             .db
             .with_conn(|conn| {
-                let inserted = match current_queue_position(conn)? {
-                    Some(position) => queue::insert_external_track_after(conn, &insert, position)?,
+                let after = play_next_after_position(
+                    current_queue_position(conn)?,
+                    queue::front_position(conn)?,
+                    ephemeral_active,
+                );
+                let inserted = match after {
+                    Some(after) => queue::insert_external_track_after(conn, &insert, after)?,
                     None => queue::append_external_track(conn, &insert)?,
                 };
                 let queue = queue::load_queue(conn)?;
@@ -8761,14 +8820,21 @@ async fn queue_play_next_many(
         state_guard
             .user_cleared_at
             .store(0, std::sync::atomic::Ordering::Relaxed);
+        // See queue_play_next: insert at the front of the continuation during an
+        // ephemeral mix instead of appending to the bottom.
+        let ephemeral_active = state_guard.ephemeral_tidal_track.is_some()
+            || state_guard.external_playback_track.is_some();
         let event_tx = state_guard.event_tx.clone();
         state_guard
             .db
             .with_conn(|conn| {
-                let inserted = match current_queue_position(conn)? {
-                    Some(position) => {
-                        queue::insert_external_tracks_after(conn, &inserts, position)?
-                    }
+                let after = play_next_after_position(
+                    current_queue_position(conn)?,
+                    queue::front_position(conn)?,
+                    ephemeral_active,
+                );
+                let inserted = match after {
+                    Some(after) => queue::insert_external_tracks_after(conn, &inserts, after)?,
                     None => queue::append_external_tracks(conn, &inserts)?,
                 };
                 let queue = queue::load_queue(conn)?;

--- a/noor-server/src/server/routes/tests.rs
+++ b/noor-server/src/server/routes/tests.rs
@@ -7451,3 +7451,29 @@ async fn all_api_routes_are_registered() {
         missing.join("\n  ")
     );
 }
+
+#[test]
+fn play_next_inserts_after_current_when_anchored() {
+    // Normal library playback: there is a resolved current position, so "Play
+    // next" inserts right after it regardless of the ephemeral flag.
+    assert_eq!(play_next_after_position(Some(3), Some(0), false), Some(3));
+    assert_eq!(play_next_after_position(Some(3), Some(0), true), Some(3));
+}
+
+#[test]
+fn play_next_inserts_at_front_during_ephemeral_mix() {
+    // Regression (S1): during a TIDAL mix the DB anchor is NULL so current_pos is
+    // None, but the live track has no queue row. "Play next" must land at the
+    // front of the remaining continuation (front - 1, so insert_external_track_after
+    // targets `front`), not append to the bottom.
+    assert_eq!(play_next_after_position(None, Some(0), true), Some(-1));
+    assert_eq!(play_next_after_position(None, Some(5), true), Some(4));
+}
+
+#[test]
+fn play_next_appends_when_no_anchor_and_no_mix() {
+    // No current row and no ephemeral overlay (e.g. idle/empty): append.
+    assert_eq!(play_next_after_position(None, Some(0), false), None);
+    // Empty queue during a mix can't resolve a front position: append.
+    assert_eq!(play_next_after_position(None, None, true), None);
+}


### PR DESCRIPTION
Ships v0.3.3 with the queue/up-next fixes plus the song-radio version-aware match that was still on its own branch.

## Queue / up next
Full audit of the queue stack after the recurring reports (play-next going to the bottom, clicking a track wiping the queue, drag not working). The rows were never the problem - there is one queue table. The bugs were in how "now playing" is anchored and how clicks/drags map onto it.

- **Clicking a queued track cleared the queue.** `play_track` always ran `delete_all_ephemeral_tidal_rows`, so jumping to a library row that sat alongside a TIDAL mix nuked the whole continuation. The wipe now only fires when you start a track that is not already in the queue.
- **"Play next" landed at the bottom.** Two causes: during a TIDAL mix the DB anchor is NULL so the insert fell through to append-at-end (now inserts at the front of the continuation); and `playTrackNext` grabbed the first track-id match when a duplicate existed, stranding the new row (now picks the genuinely-new row).
- **"Move next" mis-anchored on duplicates** - now uses the canonical queue-item anchor that the active-row highlight already uses.
- **Drag-to-reorder landed one slot too low** on downward drags (a pre-removal index handed to a post-removal API). Fixed the off-by-one and keyed the list by row id so nodes move instead of being recreated mid-drag.

Regression tests on both sides: `play_next_after_position`, `front_position` + front-insert, `reorderDropIndex`, `selectAppendedQueueRow`.

## Radio
Includes the song-radio fix: seeds resolve to original versions instead of remixes.

## Deferred
The deeper root cause - during a mix the live "now playing" is held in memory while the DB anchor is NULL, and two advance engines run over one queue - is left for a follow-up. It touches the gapless/ephemeral runtime and needs audible verification before shipping. Notes are in the queue commit body.

Tests: backend 1329 pass, frontend 583 pass, lint and types clean.